### PR TITLE
feat(labs): add Labs nav page for feature flags

### DIFF
--- a/pkg/services/navtree/models.go
+++ b/pkg/services/navtree/models.go
@@ -37,6 +37,8 @@ const (
 	WeightHelp
 )
 
+const WeightLabs = WeightConfig - 10
+
 const (
 	NavIDRoot                 = "root"
 	NavIDDashboards           = "dashboards/browse"
@@ -51,6 +53,7 @@ const (
 	NavIDInfrastructure       = "infrastructure"
 	NavIDReporting            = "reports"
 	NavIDApps                 = "apps"
+	NavIDLabs                 = "labs"
 	NavIDCfgGeneral           = "cfg/general"
 	NavIDCfgPlugins           = "cfg/plugins"
 	NavIDCfgAccess            = "cfg/access"

--- a/pkg/services/navtree/navtreeimpl/navtree.go
+++ b/pkg/services/navtree/navtreeimpl/navtree.go
@@ -162,6 +162,10 @@ func (s *ServiceImpl) GetNavTree(c *contextmodel.ReqContext, prefs *pref.Prefere
 		treeRoot.AddSection(connectionsSection)
 	}
 
+	if labsSection := s.buildLabsNavLink(c); labsSection != nil {
+		treeRoot.AddSection(labsSection)
+	}
+
 	orgAdminNode, err := s.getAdminNode(c)
 
 	if orgAdminNode != nil && len(orgAdminNode.Children) > 0 {
@@ -639,4 +643,20 @@ func (s *ServiceImpl) buildDataConnectionsNavLink(c *contextmodel.ReqContext) *n
 		return navLink
 	}
 	return nil
+}
+
+func (s *ServiceImpl) buildLabsNavLink(c *contextmodel.ReqContext) *navtree.NavLink {
+	if !c.IsSignedIn {
+		return nil
+	}
+
+	return &navtree.NavLink{
+		Text:       "Labs",
+		SubTitle:   "View feature flags and experimental capabilities",
+		Icon:       "rocket",
+		Id:         navtree.NavIDLabs,
+		Url:        s.cfg.AppSubURL + "/labs",
+		SortWeight: navtree.WeightLabs,
+		IsNew:      true,
+	}
 }

--- a/pkg/services/navtree/navtreeimpl/navtree.go
+++ b/pkg/services/navtree/navtreeimpl/navtree.go
@@ -646,7 +646,8 @@ func (s *ServiceImpl) buildDataConnectionsNavLink(c *contextmodel.ReqContext) *n
 }
 
 func (s *ServiceImpl) buildLabsNavLink(c *contextmodel.ReqContext) *navtree.NavLink {
-	if !c.IsSignedIn {
+	hasAccess := ac.HasAccess(s.accessControl, c)
+	if !hasAccess(ac.EvalPermission(ac.ActionSettingsRead, ac.ScopeSettingsAll)) {
 		return nil
 	}
 

--- a/pkg/services/navtree/navtreeimpl/navtree_test.go
+++ b/pkg/services/navtree/navtreeimpl/navtree_test.go
@@ -9,6 +9,8 @@ import (
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 
+	"github.com/grafana/grafana/pkg/services/accesscontrol"
+	acmock "github.com/grafana/grafana/pkg/services/accesscontrol/mock"
 	contextmodel "github.com/grafana/grafana/pkg/services/contexthandler/model"
 	"github.com/grafana/grafana/pkg/services/dashboards"
 	"github.com/grafana/grafana/pkg/services/search/model"
@@ -161,16 +163,21 @@ func TestBuildStarredItemsNavLinks(t *testing.T) {
 }
 
 func TestBuildLabsNavLink(t *testing.T) {
-	service := ServiceImpl{
-		cfg: setting.NewCfg(),
-	}
-
 	httpReq, _ := http.NewRequest(http.MethodGet, "", nil)
 
-	t.Run("shows Labs for signed-in users", func(t *testing.T) {
+	t.Run("shows Labs for users with settings:read permission", func(t *testing.T) {
+		acMock := acmock.New().WithPermissions([]accesscontrol.Permission{
+			{Action: accesscontrol.ActionSettingsRead, Scope: accesscontrol.ScopeSettingsAll},
+		})
+
+		service := ServiceImpl{
+			cfg:           setting.NewCfg(),
+			accessControl: acMock,
+		}
+
 		reqCtx := &contextmodel.ReqContext{
-			IsSignedIn: true,
-			Context:    &web.Context{Req: httpReq},
+			SignedInUser: &user.SignedInUser{UserID: 1, OrgID: 1},
+			Context:      &web.Context{Req: httpReq},
 		}
 
 		navLink := service.buildLabsNavLink(reqCtx)
@@ -180,10 +187,17 @@ func TestBuildLabsNavLink(t *testing.T) {
 		require.True(t, navLink.IsNew)
 	})
 
-	t.Run("hides Labs for signed-out users", func(t *testing.T) {
+	t.Run("hides Labs for users without settings:read permission", func(t *testing.T) {
+		acMock := acmock.New().WithPermissions([]accesscontrol.Permission{})
+
+		service := ServiceImpl{
+			cfg:           setting.NewCfg(),
+			accessControl: acMock,
+		}
+
 		reqCtx := &contextmodel.ReqContext{
-			IsSignedIn: false,
-			Context:    &web.Context{Req: httpReq},
+			SignedInUser: &user.SignedInUser{UserID: 1, OrgID: 1},
+			Context:      &web.Context{Req: httpReq},
 		}
 
 		navLink := service.buildLabsNavLink(reqCtx)

--- a/pkg/services/navtree/navtreeimpl/navtree_test.go
+++ b/pkg/services/navtree/navtreeimpl/navtree_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/grafana/grafana/pkg/services/star"
 	"github.com/grafana/grafana/pkg/services/star/startest"
 	"github.com/grafana/grafana/pkg/services/user"
+	"github.com/grafana/grafana/pkg/setting"
 	"github.com/grafana/grafana/pkg/web"
 )
 
@@ -156,5 +157,36 @@ func TestBuildStarredItemsNavLinks(t *testing.T) {
 		require.Equal(t, "A Dashboard", navLinks[0].Text)
 		require.Equal(t, "B Dashboard", navLinks[1].Text)
 		require.Equal(t, "C Dashboard", navLinks[2].Text)
+	})
+}
+
+func TestBuildLabsNavLink(t *testing.T) {
+	service := ServiceImpl{
+		cfg: setting.NewCfg(),
+	}
+
+	httpReq, _ := http.NewRequest(http.MethodGet, "", nil)
+
+	t.Run("shows Labs for signed-in users", func(t *testing.T) {
+		reqCtx := &contextmodel.ReqContext{
+			IsSignedIn: true,
+			Context:    &web.Context{Req: httpReq},
+		}
+
+		navLink := service.buildLabsNavLink(reqCtx)
+		require.NotNil(t, navLink)
+		require.Equal(t, "labs", navLink.Id)
+		require.Equal(t, "/labs", navLink.Url)
+		require.True(t, navLink.IsNew)
+	})
+
+	t.Run("hides Labs for signed-out users", func(t *testing.T) {
+		reqCtx := &contextmodel.ReqContext{
+			IsSignedIn: false,
+			Context:    &web.Context{Req: httpReq},
+		}
+
+		navLink := service.buildLabsNavLink(reqCtx)
+		require.Nil(t, navLink)
 	})
 }

--- a/public/app/core/utils/navBarItem-translations.ts
+++ b/public/app/core/utils/navBarItem-translations.ts
@@ -177,6 +177,8 @@ export function getNavTitle(navId: string | undefined) {
       return t('nav.search-dashboards.title', 'Search dashboards');
     case 'connections':
       return t('nav.connections.title', 'Connections');
+    case 'labs':
+      return t('nav.labs.title', 'Labs');
     case 'connections-add-new-connection':
       return t('nav.add-new-connections.title', 'Add new connection');
     case 'standalone-plugin-page-/connections/collector':
@@ -290,6 +292,8 @@ export function getNavSubTitle(navId: string | undefined) {
       return t('nav.config-access.subtitle', 'Configure access for individual users, teams, and service accounts');
     case 'apps':
       return t('nav.apps.subtitle', 'App plugins that extend the Grafana experience');
+    case 'labs':
+      return t('nav.labs.subtitle', 'View feature flags and experimental capabilities');
     case 'monitoring':
       return t('nav.monitoring.subtitle', 'Out-of-the-box observability solutions');
     case 'infrastructure':

--- a/public/app/features/labs/LabsPage.test.tsx
+++ b/public/app/features/labs/LabsPage.test.tsx
@@ -1,0 +1,52 @@
+import { render, screen } from '@testing-library/react';
+import { TestProvider } from 'test/helpers/TestProvider';
+
+import config from 'app/core/config';
+
+import LabsPage from './LabsPage';
+
+describe('LabsPage', () => {
+  const originalFeatureToggles = config.featureToggles;
+  const originalNavTree = config.bootData.navTree;
+
+  beforeEach(() => {
+    config.bootData.navTree = [{ id: 'labs', text: 'Labs', url: '/labs' }];
+  });
+
+  afterEach(() => {
+    config.featureToggles = originalFeatureToggles;
+    config.bootData.navTree = originalNavTree;
+  });
+
+  it('renders feature flags from config in sorted order', () => {
+    config.featureToggles = {
+      panelTitleSearch: true,
+      featureHighlights: false,
+    };
+
+    const { container } = render(
+      <TestProvider>
+        <LabsPage />
+      </TestProvider>
+    );
+
+    expect(screen.getByRole('heading', { name: 'Labs' })).toBeInTheDocument();
+    expect(screen.getByText('featureHighlights')).toBeInTheDocument();
+    expect(screen.getByText('panelTitleSearch')).toBeInTheDocument();
+    expect(container.textContent?.indexOf('featureHighlights')).toBeLessThan(
+      container.textContent?.indexOf('panelTitleSearch') ?? -1
+    );
+  });
+
+  it('shows empty state when no feature flags are enabled', () => {
+    config.featureToggles = {};
+
+    render(
+      <TestProvider>
+        <LabsPage />
+      </TestProvider>
+    );
+
+    expect(screen.getByText('No feature flags are enabled.')).toBeInTheDocument();
+  });
+});

--- a/public/app/features/labs/LabsPage.test.tsx
+++ b/public/app/features/labs/LabsPage.test.tsx
@@ -47,6 +47,6 @@ describe('LabsPage', () => {
       </TestProvider>
     );
 
-    expect(screen.getByText('No feature flags are enabled.')).toBeInTheDocument();
+    expect(screen.getByText('No feature flags are configured.')).toBeInTheDocument();
   });
 });

--- a/public/app/features/labs/LabsPage.tsx
+++ b/public/app/features/labs/LabsPage.tsx
@@ -57,7 +57,7 @@ export default function LabsPage() {
       <Page.Contents>
         <p className={styles.pageDescription}>Read-only view of feature flags currently active in this Grafana instance.</p>
         {featureToggles.length === 0 ? (
-          <p>No feature flags are enabled.</p>
+          <p>No feature flags are configured.</p>
         ) : (
           <table className={styles.table}>
             <thead>

--- a/public/app/features/labs/LabsPage.tsx
+++ b/public/app/features/labs/LabsPage.tsx
@@ -1,0 +1,84 @@
+import { css } from '@emotion/css';
+import { useMemo } from 'react';
+
+import { GrafanaTheme2 } from '@grafana/data';
+import config from 'app/core/config';
+import { Page } from 'app/core/components/Page/Page';
+import { useNavModel } from 'app/core/hooks/useNavModel';
+import { useStyles2 } from '@grafana/ui';
+
+interface FeatureToggleItem {
+  enabled: boolean;
+  name: string;
+}
+
+function getStyles(theme: GrafanaTheme2) {
+  return {
+    pageDescription: css({
+      color: theme.colors.text.secondary,
+      marginBottom: theme.spacing(2),
+    }),
+    table: css({
+      borderCollapse: 'collapse',
+      width: '100%',
+    }),
+    tableCell: css({
+      borderBottom: `1px solid ${theme.colors.border.weak}`,
+      padding: `${theme.spacing(1)} ${theme.spacing(1.5)}`,
+      textAlign: 'left',
+    }),
+    tableHeaderCell: css({
+      borderBottom: `1px solid ${theme.colors.border.medium}`,
+      color: theme.colors.text.secondary,
+      fontSize: theme.typography.bodySmall.fontSize,
+      fontWeight: theme.typography.fontWeightMedium,
+      padding: `${theme.spacing(1)} ${theme.spacing(1.5)}`,
+      textAlign: 'left',
+      textTransform: 'uppercase',
+    }),
+  };
+}
+
+export default function LabsPage() {
+  const navModel = useNavModel('labs');
+  const styles = useStyles2(getStyles);
+
+  const featureToggles = useMemo<FeatureToggleItem[]>(() => {
+    return Object.entries(config.featureToggles ?? {})
+      .map(([name, value]) => ({
+        enabled: value === true,
+        name,
+      }))
+      .sort((left, right) => left.name.localeCompare(right.name));
+  }, []);
+
+  return (
+    <Page navModel={navModel}>
+      <Page.Contents>
+        <p className={styles.pageDescription}>Read-only view of feature flags currently active in this Grafana instance.</p>
+        {featureToggles.length === 0 ? (
+          <p>No feature flags are enabled.</p>
+        ) : (
+          <table className={styles.table}>
+            <thead>
+              <tr>
+                <th className={styles.tableHeaderCell}>Feature flag</th>
+                <th className={styles.tableHeaderCell}>Enabled</th>
+              </tr>
+            </thead>
+            <tbody>
+              {featureToggles.map((featureToggle) => (
+                <tr key={featureToggle.name}>
+                  <td className={styles.tableCell}>
+                    <code>{featureToggle.name}</code>
+                  </td>
+                  <td className={styles.tableCell}>{featureToggle.enabled ? 'Yes' : 'No'}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        )}
+      </Page.Contents>
+    </Page>
+  );
+}

--- a/public/app/routes/routes.test.tsx
+++ b/public/app/routes/routes.test.tsx
@@ -1,0 +1,14 @@
+import { getAppRoutes } from './routes';
+
+jest.mock('app/features/plugins/routes', () => ({
+  getAppPluginRoutes: () => [],
+}));
+
+describe('getAppRoutes', () => {
+  it('includes the Labs route', () => {
+    const routes = getAppRoutes();
+    const labsRoute = routes.find((route) => route.path === '/labs');
+
+    expect(labsRoute).toBeDefined();
+  });
+});

--- a/public/app/routes/routes.tsx
+++ b/public/app/routes/routes.tsx
@@ -188,6 +188,7 @@ export function getAppRoutes(): RouteDescriptor[] {
     },
     {
       path: '/labs',
+      roles: () => contextSrv.evaluatePermission([AccessControlAction.SettingsRead]),
       component: SafeDynamicImport(() => import(/* webpackChunkName: "LabsPage" */ 'app/features/labs/LabsPage')),
     },
     {

--- a/public/app/routes/routes.tsx
+++ b/public/app/routes/routes.tsx
@@ -188,7 +188,7 @@ export function getAppRoutes(): RouteDescriptor[] {
     },
     {
       path: '/labs',
-      roles: () => contextSrv.evaluatePermission([AccessControlAction.SettingsRead]),
+      roles: () => (contextSrv.isGrafanaAdmin ? [] : ['Reject']),
       component: SafeDynamicImport(() => import(/* webpackChunkName: "LabsPage" */ 'app/features/labs/LabsPage')),
     },
     {

--- a/public/app/routes/routes.tsx
+++ b/public/app/routes/routes.tsx
@@ -187,6 +187,10 @@ export function getAppRoutes(): RouteDescriptor[] {
       component: () => <NavLandingPage navId="drilldown" />,
     },
     {
+      path: '/labs',
+      component: SafeDynamicImport(() => import(/* webpackChunkName: "LabsPage" */ 'app/features/labs/LabsPage')),
+    },
+    {
       path: '/apps',
       component: () => <NavLandingPage navId="apps" />,
     },


### PR DESCRIPTION
## Summary
- add a new top-level `Labs` nav section between `Connections` and `Administration` with `IsNew` enabled so the sidebar shows the `New!` badge
- add `/labs` routing and a new read-only Labs page that lists current `config.featureToggles` states in a sorted table
- add backend/frontend tests for Labs nav visibility, route registration, and Labs page rendering

## Test plan
- [x] `go test ./pkg/services/navtree/navtreeimpl`
- [x] `yarn test public/app/features/labs/LabsPage.test.tsx public/app/routes/routes.test.tsx --watch=false`
- [x] verify no lints in changed files via IDE diagnostics

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches navigation and access-control gating (backend permission check vs. frontend admin-only route), so misconfiguration could expose or hide the page unexpectedly; otherwise changes are additive and read-only.
> 
> **Overview**
> Adds a new top-level **`Labs`** nav section (with *New!* badge) placed ahead of `Administration`, plus translations for its title/subtitle.
> 
> Introduces a `/labs` route and `LabsPage` UI that renders a read-only, alphabetically-sorted table of `config.featureToggles` (with an empty-state message), along with backend/frontend tests covering nav visibility, route registration, and page rendering.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6142f1001d5a9b2095efb2da30c0f161ec55e78e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->