### PR TITLE
Amethyst experimental theme

### DIFF
--- a/packages/grafana-data/src/themes/registry.ts
+++ b/packages/grafana-data/src/themes/registry.ts
@@ -1,6 +1,7 @@
 import { Registry, RegistryItem } from '../utils/Registry';
 
 import { createTheme, NewThemeOptionsSchema } from './createTheme';
+import amethyst from './themeDefinitions/amethyst.json';
 import aubergine from './themeDefinitions/aubergine.json';
 import debug from './themeDefinitions/debug.json';
 import desertbloom from './themeDefinitions/desertbloom.json';
@@ -21,6 +22,7 @@ export interface ThemeRegistryItem extends RegistryItem {
 }
 
 const extraThemes: { [key: string]: unknown } = {
+  amethyst,
   aubergine,
   debug,
   desertbloom,

--- a/packages/grafana-data/src/themes/themeDefinitions/amethyst.json
+++ b/packages/grafana-data/src/themes/themeDefinitions/amethyst.json
@@ -1,0 +1,76 @@
+{
+  "name": "Amethyst",
+  "id": "amethyst",
+  "colors": {
+    "mode": "dark",
+    "border": {
+      "weak": "#2d2145",
+      "medium": "#3a2d55",
+      "strong": "#4d3f6b"
+    },
+    "text": {
+      "primary": "#FFFFFF",
+      "secondary": "#d4c7f6",
+      "disabled": "#8f7faf",
+      "link": "#c8a8ff",
+      "maxContrast": "#FFFFFF"
+    },
+    "primary": {
+      "main": "#b48afe",
+      "text": "#dcc7ff",
+      "border": "#b48afe",
+      "name": "primary",
+      "shade": "#e7d7ff",
+      "transparent": "#b48afe29",
+      "contrastText": "#120e1e",
+      "borderTransparent": "#b48afe40"
+    },
+    "secondary": {
+      "main": "#2a1f42",
+      "shade": "#32264c",
+      "transparent": "rgba(180, 138, 254, 0.08)",
+      "text": "#e4d6ff",
+      "contrastText": "#f3e9ff",
+      "border": "rgba(180, 138, 254, 0.08)",
+      "name": "secondary",
+      "borderTransparent": "rgba(180, 138, 254, 0.25)"
+    },
+    "info": {
+      "main": "#7a63c7",
+      "text": "#dcc7ff",
+      "border": "#9278de"
+    },
+    "error": {
+      "main": "#cf4f9f"
+    },
+    "success": {
+      "main": "#4c9e6f"
+    },
+    "warning": {
+      "main": "#e58fe2"
+    },
+    "background": {
+      "canvas": "#1a1225",
+      "primary": "#120e1e",
+      "secondary": "#211836",
+      "elevated": "#211836"
+    },
+    "action": {
+      "hover": "#34284e",
+      "selected": "#40305f",
+      "selectedBorder": "#b48afe",
+      "focus": "#34284e",
+      "hoverOpacity": 0.08,
+      "disabledText": "#8f7faf",
+      "disabledBackground": "rgba(52, 40, 78, 0.2)",
+      "disabledOpacity": 0.38
+    },
+    "gradients": {
+      "brandHorizontal": "linear-gradient(270deg, #F472B6 0%, #8B5CF6 100%)",
+      "brandVertical": "linear-gradient(0deg, #F472B6 0%, #8B5CF6 100%)"
+    },
+    "contrastThreshold": 3,
+    "hoverFactor": 0.03,
+    "tonalOffset": 0.15
+  }
+}

--- a/pkg/services/preference/themes_generated.go
+++ b/pkg/services/preference/themes_generated.go
@@ -6,6 +6,7 @@ var themes = []ThemeDTO{
 	{ID: "light", Type: "light"},
 	{ID: "dark", Type: "dark"},
 	{ID: "system", Type: "dark"},
+	{ID: "amethyst", Type: "dark", IsExtra: true},
 	{ID: "aubergine", Type: "dark", IsExtra: true},
 	{ID: "debug", Type: "dark", IsExtra: true},
 	{ID: "desertbloom", Type: "light", IsExtra: true},

--- a/public/app/core/components/ThemeSelector/getSelectableThemes.ts
+++ b/public/app/core/components/ThemeSelector/getSelectableThemes.ts
@@ -5,6 +5,7 @@ export function getSelectableThemes() {
   const allowedExtraThemes = [];
 
   if (config.featureToggles.grafanaconThemes) {
+    allowedExtraThemes.push('amethyst');
     allowedExtraThemes.push('desertbloom');
     allowedExtraThemes.push('gildedgrove');
     allowedExtraThemes.push('sapphiredusk');


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
**Theme: Add Amethyst experimental dark theme**

**What is this feature?**

This PR introduces a new experimental dark theme named "Amethyst" to Grafana, featuring a purple-based color palette.

**Why do we need this feature?**

It provides an additional aesthetic option for users who prefer a dark theme with purple tones, allowing for early feedback on new theme styles and expanding the visual customization choices within Grafana.

**Who is this feature for?**

Grafana users who prefer dark mode and are interested in exploring alternative color schemes, particularly those with a preference for purple hues.

**Which issue(s) does this PR fix?**:

Fixes #

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective. (Validated via manual UI check and artifacts)
- [x] If this is a pre-GA feature, it is behind a feature toggle. (The theme is exposed behind the `grafanaconThemes` feature toggle.)
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc. (As an experimental theme, it might not require immediate extensive documentation or inclusion in "What's New".)

<div><a href="https://cursor.com/agents/bc-55155aa9-704d-4868-8137-4da216a2e543"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-55155aa9-704d-4868-8137-4da216a2e543"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>


<!-- CURSOR_AGENT_PR_BODY_END -->