### PR TITLE
New purple theme

### DIFF
--- a/packages/grafana-data/src/themes/registry.ts
+++ b/packages/grafana-data/src/themes/registry.ts
@@ -8,6 +8,7 @@ import gildedgrove from './themeDefinitions/gildedgrove.json';
 import gloom from './themeDefinitions/gloom.json';
 import mars from './themeDefinitions/mars.json';
 import matrix from './themeDefinitions/matrix.json';
+import purple from './themeDefinitions/purple.json';
 import sapphiredusk from './themeDefinitions/sapphiredusk.json';
 import synthwave from './themeDefinitions/synthwave.json';
 import tron from './themeDefinitions/tron.json';
@@ -28,6 +29,7 @@ const extraThemes: { [key: string]: unknown } = {
   gloom,
   mars,
   matrix,
+  purple,
   sapphiredusk,
   synthwave,
   tron,

--- a/packages/grafana-data/src/themes/themeDefinitions/purple.json
+++ b/packages/grafana-data/src/themes/themeDefinitions/purple.json
@@ -1,0 +1,76 @@
+{
+  "name": "Purple",
+  "id": "purple",
+  "colors": {
+    "mode": "dark",
+    "border": {
+      "weak": "#3b2e57",
+      "medium": "#4b3a70",
+      "strong": "#66508f"
+    },
+    "text": {
+      "primary": "#f3eefe",
+      "secondary": "#c8bbeb",
+      "disabled": "#9f94bf",
+      "link": "#b59cff",
+      "maxContrast": "#ffffff"
+    },
+    "primary": {
+      "main": "#9370db",
+      "text": "#b59cff",
+      "border": "#9370db",
+      "name": "primary",
+      "shade": "#7b68ee",
+      "transparent": "#9370db29",
+      "contrastText": "#141120",
+      "borderTransparent": "#9370db40"
+    },
+    "secondary": {
+      "main": "#3b2f59",
+      "shade": "#463769",
+      "transparent": "rgba(204, 187, 235, 0.08)",
+      "text": "#d8caf6",
+      "contrastText": "#efe8ff",
+      "border": "rgba(204, 187, 235, 0.1)",
+      "name": "secondary",
+      "borderTransparent": "rgba(204, 187, 235, 0.25)"
+    },
+    "info": {
+      "main": "#5c4e8a",
+      "text": "#c8bbeb",
+      "border": "#705ea3"
+    },
+    "error": {
+      "main": "#c0437f"
+    },
+    "success": {
+      "main": "#2b8a5b"
+    },
+    "warning": {
+      "main": "#d07a23"
+    },
+    "background": {
+      "canvas": "#261d38",
+      "primary": "#1b1529",
+      "secondary": "#2a2040",
+      "elevated": "#2a2040"
+    },
+    "action": {
+      "hover": "#403156",
+      "selected": "#4a3966",
+      "selectedBorder": "#b59cff",
+      "focus": "#4a3966",
+      "hoverOpacity": 0.08,
+      "disabledText": "#9f94bf",
+      "disabledBackground": "rgba(74, 57, 102, 0.2)",
+      "disabledOpacity": 0.38
+    },
+    "gradients": {
+      "brandHorizontal": "linear-gradient(270deg, #b59cff 0%, #7b68ee 100%)",
+      "brandVertical": "linear-gradient(0deg, #b59cff 0%, #7b68ee 100%)"
+    },
+    "contrastThreshold": 3,
+    "hoverFactor": 0.03,
+    "tonalOffset": 0.15
+  }
+}

--- a/pkg/services/preference/themes_generated.go
+++ b/pkg/services/preference/themes_generated.go
@@ -13,6 +13,7 @@ var themes = []ThemeDTO{
 	{ID: "gloom", Type: "dark", IsExtra: true},
 	{ID: "mars", Type: "dark", IsExtra: true},
 	{ID: "matrix", Type: "dark", IsExtra: true},
+	{ID: "purple", Type: "dark", IsExtra: true},
 	{ID: "sapphiredusk", Type: "dark", IsExtra: true},
 	{ID: "synthwave", Type: "dark", IsExtra: true},
 	{ID: "tron", Type: "dark", IsExtra: true},

--- a/public/app/core/components/ThemeSelector/getSelectableThemes.ts
+++ b/public/app/core/components/ThemeSelector/getSelectableThemes.ts
@@ -10,6 +10,7 @@ export function getSelectableThemes() {
     allowedExtraThemes.push('sapphiredusk');
     allowedExtraThemes.push('tron');
     allowedExtraThemes.push('gloom');
+    allowedExtraThemes.push('purple');
   }
 
   return getBuiltInThemes(allowedExtraThemes);

--- a/public/app/features/theme-playground/ThemePlayground.tsx
+++ b/public/app/features/theme-playground/ThemePlayground.tsx
@@ -10,6 +10,7 @@ import gildedgrove from '@grafana/data/themes/definitions/gildedgrove.json';
 import gloom from '@grafana/data/themes/definitions/gloom.json';
 import mars from '@grafana/data/themes/definitions/mars.json';
 import matrix from '@grafana/data/themes/definitions/matrix.json';
+import purple from '@grafana/data/themes/definitions/purple.json';
 import sapphiredusk from '@grafana/data/themes/definitions/sapphiredusk.json';
 import synthwave from '@grafana/data/themes/definitions/synthwave.json';
 import tron from '@grafana/data/themes/definitions/tron.json';
@@ -54,6 +55,7 @@ const experimentalDefinitions: Record<string, unknown> = {
   gloom,
   mars,
   matrix,
+  purple,
   sapphiredusk,
   synthwave,
   tron,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
**Theming: Add experimental Purple theme**

**What is this feature?**

This PR introduces a new "Purple" theme to Grafana, making it available as a selectable option in the theme switcher.

**Why do we need this feature?**

To provide users with additional visual customization choices and expand the range of available themes in Grafana. This theme is added experimentally to explore interest in new color palettes.

**Who is this feature for?**

Grafana users who desire more diverse aesthetic options for their Grafana interface.

**Which issue(s) does this PR fix?**:

Fixes #

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective. The "Purple" theme should appear in the theme switcher and apply correctly when selected.
- [ ] If this is a pre-GA feature, it is behind a feature toggle. (This theme is added as an experimental option directly to the theme list).
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.

<div><a href="https://cursor.com/agents/bc-93bede0c-6f82-41f7-93b9-ae2171ac9737"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-93bede0c-6f82-41f7-93b9-ae2171ac9737"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>


<!-- CURSOR_AGENT_PR_BODY_END -->