### PR TITLE
Navigation: add Labs feature flags page

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -167,6 +167,7 @@ func (hs *HTTPServer) registerRoutes() {
 	// Plugin details pages
 	r.Get("/connections/datasources/:id", middleware.CanAdminPlugins(hs.Cfg, hs.AccessControl), hs.Index)
 	r.Get("/connections/datasources/:id/page/:page", middleware.CanAdminPlugins(hs.Cfg, hs.AccessControl), hs.Index)
+	r.Get("/labs", authorize(ac.EvalPermission(ac.ActionFeatureManagementRead)), hs.Index)
 
 	// App Root Page
 	appPluginIDScope := pluginaccesscontrol.ScopeProvider.GetResourceScope(ac.Parameter(":id"))
@@ -474,6 +475,7 @@ func (hs *HTTPServer) registerRoutes() {
 
 		apiRoute.Get("/frontend/settings/", hs.GetFrontendSettings)
 		apiRoute.Get("/frontend/assets", hs.GetFrontendAssets)
+		apiRoute.Get("/labs/feature-toggles", authorize(ac.EvalPermission(ac.ActionFeatureManagementRead)), routing.Wrap(hs.GetLabsFeatureToggles))
 
 		// Folders
 		hs.registerFolderAPI(apiRoute, authorize)

--- a/pkg/api/frontendsettings_test.go
+++ b/pkg/api/frontendsettings_test.go
@@ -34,6 +34,7 @@ import (
 	"github.com/grafana/grafana/pkg/services/datasources"
 	datafakes "github.com/grafana/grafana/pkg/services/datasources/fakes"
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
+	featuretoggleapi "github.com/grafana/grafana/pkg/services/featuremgmt/feature_toggle_api"
 	"github.com/grafana/grafana/pkg/services/licensing"
 	"github.com/grafana/grafana/pkg/services/pluginsintegration/managedplugins"
 	"github.com/grafana/grafana/pkg/services/pluginsintegration/pluginassets"
@@ -188,6 +189,53 @@ func TestIntegrationHTTPServer_GetFrontendSettings_hideVersionAnonymous(t *testi
 			assert.EqualValues(t, expected, got)
 		})
 	}
+}
+
+func TestIntegrationHTTPServer_GetLabsFeatureToggles(t *testing.T) {
+	testutil.SkipIntegrationTestInShortMode(t)
+
+	cfg := setting.NewCfg()
+	_, err := cfg.Raw.NewSection("feature_toggles")
+	require.NoError(t, err)
+	_, err = cfg.Raw.Section("feature_toggles").NewKey("customUnknownFlag", "true")
+	require.NoError(t, err)
+
+	m, hs := setupTestEnvironment(t, cfg, featuremgmt.WithFeatures("dashgpt", "customUnknownFlag"), nil, nil, nil)
+	m.Get("/api/labs/feature-toggles", hs.GetLabsFeatureToggles)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/labs/feature-toggles", nil)
+	recorder := httptest.NewRecorder()
+
+	m.ServeHTTP(recorder, req)
+
+	require.Equal(t, http.StatusOK, recorder.Code)
+
+	var got featuretoggleapi.ResolvedToggleState
+	err = json.Unmarshal(recorder.Body.Bytes(), &got)
+	require.NoError(t, err)
+
+	require.True(t, got.Enabled["dashgpt"])
+	require.True(t, got.Enabled["customUnknownFlag"])
+
+	var dashgpt *featuretoggleapi.ToggleStatus
+	var customUnknown *featuretoggleapi.ToggleStatus
+	for i := range got.Toggles {
+		switch got.Toggles[i].Name {
+		case "dashgpt":
+			dashgpt = &got.Toggles[i]
+		case "customUnknownFlag":
+			customUnknown = &got.Toggles[i]
+		}
+	}
+
+	require.NotNil(t, dashgpt)
+	assert.Equal(t, "GA", dashgpt.Stage)
+	assert.True(t, dashgpt.Enabled)
+	assert.Equal(t, "Enable AI powered features in dashboards", dashgpt.Description)
+
+	require.NotNil(t, customUnknown)
+	assert.True(t, customUnknown.Enabled)
+	assert.Equal(t, "Unknown flag configured in [feature_toggles]", customUnknown.Warning)
 }
 
 func TestIntegrationHTTPServer_GetFrontendSettings_pluginsCDNBaseURL(t *testing.T) {

--- a/pkg/api/labs.go
+++ b/pkg/api/labs.go
@@ -1,0 +1,89 @@
+package api
+
+import (
+	"net/http"
+	"slices"
+
+	"github.com/grafana/grafana/pkg/api/response"
+	common "github.com/grafana/grafana/pkg/apimachinery/apis/common/v0alpha1"
+	contextmodel "github.com/grafana/grafana/pkg/services/contexthandler/model"
+	"github.com/grafana/grafana/pkg/services/featuremgmt"
+	featuretoggleapi "github.com/grafana/grafana/pkg/services/featuremgmt/feature_toggle_api"
+	"github.com/grafana/grafana/pkg/setting"
+)
+
+func (hs *HTTPServer) GetLabsFeatureToggles(c *contextmodel.ReqContext) response.Response {
+	featureList, err := featuremgmt.GetEmbeddedFeatureList()
+	if err != nil {
+		return response.Error(http.StatusInternalServerError, "Failed to load feature toggle registry", err)
+	}
+
+	configuredFlags, err := setting.ReadFeatureTogglesFromInitFile(hs.Cfg.Raw.Section("feature_toggles"))
+	if err != nil {
+		return response.Error(http.StatusInternalServerError, "Failed to read configured feature toggles", err)
+	}
+
+	configuredFlagNames := make(map[string]struct{}, len(configuredFlags))
+	for name := range configuredFlags {
+		if name == "enable" {
+			continue
+		}
+		configuredFlagNames[name] = struct{}{}
+	}
+
+	statuses := make([]featuretoggleapi.ToggleStatus, 0, len(featureList.Items)+len(configuredFlagNames))
+	for _, feature := range featureList.Items {
+		delete(configuredFlagNames, feature.Name)
+		statuses = append(statuses, featuretoggleapi.ToggleStatus{
+			Name:        feature.Name,
+			Description: feature.Spec.Description,
+			Stage:       feature.Spec.Stage,
+			Enabled:     hs.Features.IsEnabled(c.Req.Context(), feature.Name),
+			Writeable:   true,
+		})
+	}
+
+	if len(configuredFlagNames) > 0 {
+		unknownSource := &common.ObjectReference{
+			Kind: "ConfigFile",
+			Name: "feature_toggles",
+		}
+
+		for name := range configuredFlagNames {
+			statuses = append(statuses, featuretoggleapi.ToggleStatus{
+				Name:      name,
+				Enabled:   hs.Features.IsEnabled(c.Req.Context(), name),
+				Writeable: true,
+				Source:    unknownSource,
+				Warning:   "Unknown flag configured in [feature_toggles]",
+			})
+		}
+	}
+
+	slices.SortFunc(statuses, func(a, b featuretoggleapi.ToggleStatus) int {
+		switch {
+		case a.Enabled == b.Enabled:
+			return compareStrings(a.Name, b.Name)
+		case a.Enabled:
+			return -1
+		default:
+			return 1
+		}
+	})
+
+	return response.JSON(http.StatusOK, featuretoggleapi.ResolvedToggleState{
+		Enabled: hs.Features.GetEnabled(c.Req.Context()),
+		Toggles: statuses,
+	})
+}
+
+func compareStrings(a, b string) int {
+	switch {
+	case a < b:
+		return -1
+	case a > b:
+		return 1
+	default:
+		return 0
+	}
+}

--- a/pkg/services/navtree/models.go
+++ b/pkg/services/navtree/models.go
@@ -30,6 +30,7 @@ const (
 	WeightApplication
 	WeightAsserts
 	WeightDataConnections
+	WeightLabs
 	WeightApps
 	WeightPlugin
 	WeightConfig
@@ -49,6 +50,7 @@ const (
 	NavIDAlerting             = "alerting"
 	NavIDObservability        = "observability"
 	NavIDInfrastructure       = "infrastructure"
+	NavIDLabs                 = "labs"
 	NavIDReporting            = "reports"
 	NavIDApps                 = "apps"
 	NavIDCfgGeneral           = "cfg/general"

--- a/pkg/services/navtree/navtreeimpl/navtree.go
+++ b/pkg/services/navtree/navtreeimpl/navtree.go
@@ -162,6 +162,18 @@ func (s *ServiceImpl) GetNavTree(c *contextmodel.ReqContext, prefs *pref.Prefere
 		treeRoot.AddSection(connectionsSection)
 	}
 
+	if hasAccess(ac.EvalPermission(ac.ActionFeatureManagementRead)) {
+		treeRoot.AddSection(&navtree.NavLink{
+			Text:       "Labs",
+			Id:         navtree.NavIDLabs,
+			SubTitle:   "Browse feature flags and their current status",
+			Icon:       "apps",
+			SortWeight: navtree.WeightLabs,
+			Url:        s.cfg.AppSubURL + "/labs",
+			IsNew:      true,
+		})
+	}
+
 	orgAdminNode, err := s.getAdminNode(c)
 
 	if orgAdminNode != nil && len(orgAdminNode.Children) > 0 {

--- a/public/app/core/utils/navBarItem-translations.ts
+++ b/public/app/core/utils/navBarItem-translations.ts
@@ -181,6 +181,8 @@ export function getNavTitle(navId: string | undefined) {
       return t('nav.search-dashboards.title', 'Search dashboards');
     case 'connections':
       return t('nav.connections.title', 'Connections');
+    case 'labs':
+      return t('nav.labs.title', 'Labs');
     case 'connections-add-new-connection':
       return t('nav.add-new-connections.title', 'Add new connection');
     case 'standalone-plugin-page-/connections/collector':
@@ -308,6 +310,8 @@ export function getNavSubTitle(navId: string | undefined) {
       return t('nav.alerts-and-incidents.subtitle', 'Alerting and incident management apps');
     case 'testing-and-synthetics':
       return t('nav.testing-and-synthetics.subtitle', 'Optimize performance with k6 and Synthetic Monitoring insights');
+    case 'labs':
+      return t('nav.labs.subtitle', 'Browse feature flags and their current status');
     case 'connections-add-new-connection':
       return t('nav.connections.subtitle', 'Browse and create new connections');
     case 'connections-datasources':

--- a/public/app/features/labs/LabsPage.test.tsx
+++ b/public/app/features/labs/LabsPage.test.tsx
@@ -1,0 +1,71 @@
+import { screen, waitFor } from '@testing-library/react';
+import { render } from 'test/test-utils';
+
+import { getBackendSrv } from '@grafana/runtime';
+
+import LabsPage from './LabsPage';
+
+jest.mock('@grafana/runtime', () => {
+  const actual = jest.requireActual('@grafana/runtime');
+
+  return {
+    ...actual,
+    getBackendSrv: jest.fn(),
+  };
+});
+
+const getBackendSrvMock = getBackendSrv as jest.MockedFunction<typeof getBackendSrv>;
+
+describe('LabsPage', () => {
+  beforeEach(() => {
+    getBackendSrvMock.mockReturnValue({
+      get: jest.fn().mockResolvedValue({
+        toggles: [
+          {
+            name: 'dashgpt',
+            description: 'Enable AI powered features in dashboards',
+            stage: 'GA',
+            enabled: true,
+          },
+          {
+            name: 'panelTitleSearch',
+            description: 'Search for dashboards using panel title',
+            stage: 'preview',
+            enabled: false,
+          },
+        ],
+      }),
+    } as unknown as ReturnType<typeof getBackendSrv>);
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it('renders feature flags returned by the Labs API', async () => {
+    render(<LabsPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText('dashgpt')).toBeInTheDocument();
+    });
+
+    expect(screen.getByText('panelTitleSearch')).toBeInTheDocument();
+    expect(screen.getByText('Enabled')).toBeInTheDocument();
+    expect(screen.getByText('Disabled')).toBeInTheDocument();
+    expect(screen.getByText('2 flags')).toBeInTheDocument();
+  });
+
+  it('filters feature flags by search query', async () => {
+    const { user } = render(<LabsPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText('dashgpt')).toBeInTheDocument();
+    });
+
+    await user.type(screen.getByPlaceholderText('Filter flags by name, status, stage, or description'), 'disabled');
+
+    expect(screen.queryByText('dashgpt')).not.toBeInTheDocument();
+    expect(screen.getByText('panelTitleSearch')).toBeInTheDocument();
+    expect(screen.getByText('1 flags')).toBeInTheDocument();
+  });
+});

--- a/public/app/features/labs/LabsPage.tsx
+++ b/public/app/features/labs/LabsPage.tsx
@@ -79,7 +79,7 @@ const stageColors: Record<string, 'blue' | 'orange' | 'purple' | 'red' | 'darkgr
 };
 
 function getStageLabel(stage: string) {
-  return stageLabels[stage] ?? stage || 'Unknown';
+  return stageLabels[stage] ?? (stage || 'Unknown');
 }
 
 function getStageColor(stage: string): 'blue' | 'orange' | 'purple' | 'red' | 'darkgrey' | 'green' {

--- a/public/app/features/labs/LabsPage.tsx
+++ b/public/app/features/labs/LabsPage.tsx
@@ -166,8 +166,10 @@ export default function LabsPage() {
       navId="labs"
       subTitle={
         <>
-          {t('labs.subtitle.long', 'Review every registered feature flag in this Grafana instance and its current status.')}
-          {' '}
+          {t(
+            'labs.subtitle.long',
+            'Review every registered feature flag in this Grafana instance and its current status.'
+          )}{' '}
           <TextLink href="https://grafana.com/docs/grafana/latest/administration/feature-toggles/" external>
             {t('labs.docs-link', 'Feature toggle documentation')}
           </TextLink>

--- a/public/app/features/labs/LabsPage.tsx
+++ b/public/app/features/labs/LabsPage.tsx
@@ -1,0 +1,212 @@
+import { css } from '@emotion/css';
+import { useMemo, useState } from 'react';
+import { useAsync } from 'react-use';
+
+import { GrafanaTheme2 } from '@grafana/data';
+import { t } from '@grafana/i18n';
+import { getBackendSrv } from '@grafana/runtime';
+import {
+  Alert,
+  Badge,
+  FilterInput,
+  InteractiveTable,
+  LoadingPlaceholder,
+  Stack,
+  TextLink,
+  useStyles2,
+  type Column,
+} from '@grafana/ui';
+import { Page } from 'app/core/components/Page/Page';
+
+type LabsToggle = {
+  name: string;
+  description: string;
+  stage: string;
+  enabled: boolean;
+  warning?: string;
+};
+
+type LabsFeatureTogglesResponse = {
+  toggles: LabsToggle[];
+};
+
+function getStyles(theme: GrafanaTheme2) {
+  return {
+    controls: css({
+      marginBottom: theme.spacing(2),
+      maxWidth: theme.spacing(40),
+    }),
+    loader: css({
+      display: 'flex',
+      justifyContent: 'center',
+    }),
+    meta: css({
+      color: theme.colors.text.secondary,
+      marginBottom: theme.spacing(2),
+    }),
+    nameCell: css({
+      display: 'flex',
+      flexDirection: 'column',
+      gap: theme.spacing(0.5),
+    }),
+    muted: css({
+      color: theme.colors.text.secondary,
+    }),
+    noWrap: css({
+      whiteSpace: 'nowrap',
+    }),
+  };
+}
+
+const collator = new Intl.Collator();
+
+const stageLabels: Record<string, string> = {
+  GA: 'GA',
+  preview: 'Preview',
+  privatePreview: 'Private preview',
+  experimental: 'Experimental',
+  deprecated: 'Deprecated',
+  unknown: 'Unknown',
+};
+
+const stageColors: Record<string, 'blue' | 'orange' | 'purple' | 'red' | 'darkgrey' | 'green'> = {
+  GA: 'green',
+  preview: 'blue',
+  privatePreview: 'purple',
+  experimental: 'orange',
+  deprecated: 'red',
+  unknown: 'darkgrey',
+};
+
+function getStageLabel(stage: string) {
+  return stageLabels[stage] ?? stage || 'Unknown';
+}
+
+function getStageColor(stage: string): 'blue' | 'orange' | 'purple' | 'red' | 'darkgrey' | 'green' {
+  return stageColors[stage] ?? 'darkgrey';
+}
+
+function statusToSearch(toggle: LabsToggle) {
+  return [toggle.name, toggle.description, toggle.stage, toggle.warning, toggle.enabled ? 'enabled' : 'disabled']
+    .filter(Boolean)
+    .join(' ')
+    .toLowerCase();
+}
+
+export default function LabsPage() {
+  const styles = useStyles2(getStyles);
+  const [query, setQuery] = useState('');
+
+  const { value, loading, error } = useAsync(async () => {
+    return await getBackendSrv().get<LabsFeatureTogglesResponse>('/api/labs/feature-toggles');
+  }, []);
+
+  const normalizedQuery = query.trim().toLowerCase();
+
+  const filteredToggles = useMemo(() => {
+    const toggles = value?.toggles ?? [];
+
+    if (!normalizedQuery) {
+      return toggles;
+    }
+
+    return toggles.filter((toggle) => statusToSearch(toggle).includes(normalizedQuery));
+  }, [normalizedQuery, value?.toggles]);
+
+  const columns = useMemo<Array<Column<LabsToggle>>>(
+    () => [
+      {
+        id: 'name',
+        header: t('labs.table.column.flag', 'Flag'),
+        sortType: (a, b) => collator.compare(a.original.name, b.original.name),
+        cell: ({ row }) => (
+          <div className={styles.nameCell}>
+            <strong>{row.original.name}</strong>
+            {row.original.warning && <span className={styles.muted}>{row.original.warning}</span>}
+          </div>
+        ),
+      },
+      {
+        id: 'enabled',
+        header: t('labs.table.column.status', 'Status'),
+        disableGrow: true,
+        sortType: (a, b) => Number(b.original.enabled) - Number(a.original.enabled),
+        cell: ({ row }) => (
+          <Badge
+            className={styles.noWrap}
+            color={row.original.enabled ? 'green' : 'darkgrey'}
+            text={row.original.enabled ? t('labs.status.enabled', 'Enabled') : t('labs.status.disabled', 'Disabled')}
+          />
+        ),
+      },
+      {
+        id: 'stage',
+        header: t('labs.table.column.stage', 'Stage'),
+        disableGrow: true,
+        sortType: (a, b) => collator.compare(getStageLabel(a.original.stage), getStageLabel(b.original.stage)),
+        cell: ({ row }) => (
+          <Badge
+            className={styles.noWrap}
+            color={getStageColor(row.original.stage)}
+            text={getStageLabel(row.original.stage)}
+          />
+        ),
+      },
+      {
+        id: 'description',
+        header: t('labs.table.column.description', 'Description'),
+        sortType: (a, b) => collator.compare(a.original.description ?? '', b.original.description ?? ''),
+      },
+    ],
+    [styles.muted, styles.nameCell, styles.noWrap]
+  );
+
+  return (
+    <Page
+      navId="labs"
+      subTitle={
+        <>
+          {t('labs.subtitle.long', 'Review every registered feature flag in this Grafana instance and its current status.')}
+          {' '}
+          <TextLink href="https://grafana.com/docs/grafana/latest/administration/feature-toggles/" external>
+            {t('labs.docs-link', 'Feature toggle documentation')}
+          </TextLink>
+        </>
+      }
+    >
+      <Page.Contents>
+        <div className={styles.controls}>
+          <FilterInput
+            placeholder={t('labs.filter.placeholder', 'Filter flags by name, status, stage, or description')}
+            value={query}
+            onChange={setQuery}
+          />
+        </div>
+
+        {loading && (
+          <div className={styles.loader}>
+            <LoadingPlaceholder text={t('common.loading', 'Loading...')} />
+          </div>
+        )}
+
+        {error && (
+          <Alert severity="error" title={t('labs.error.title', 'Failed to load feature flags')}>
+            {t(
+              'labs.error.body',
+              'Grafana could not load the Labs feature flag list. Refresh the page or check the server logs for more details.'
+            )}
+          </Alert>
+        )}
+
+        {!loading && !error && (
+          <Stack direction="column" gap={2}>
+            <div className={styles.meta}>
+              {t('labs.results-count', '{{count}} flags', { count: filteredToggles.length })}
+            </div>
+            <InteractiveTable columns={columns} data={filteredToggles} getRowId={(toggle) => toggle.name} />
+          </Stack>
+        )}
+      </Page.Contents>
+    </Page>
+  );
+}

--- a/public/app/routes/routes.tsx
+++ b/public/app/routes/routes.tsx
@@ -314,6 +314,11 @@ export function getAppRoutes(): RouteDescriptor[] {
         contextSrv.evaluatePermission([AccessControlAction.ActionTeamsRead, AccessControlAction.ActionTeamsCreate]),
       component: SafeDynamicImport(() => import(/* webpackChunkName: "TeamPages" */ 'app/features/teams/TeamPages')),
     },
+    {
+      path: '/labs',
+      roles: () => contextSrv.evaluatePermission([AccessControlAction.FeatureManagementRead]),
+      component: SafeDynamicImport(() => import(/* webpackChunkName: "LabsPage" */ 'app/features/labs/LabsPage')),
+    },
     // ADMIN
     {
       path: '/admin',

--- a/public/app/types/accessControl.ts
+++ b/public/app/types/accessControl.ts
@@ -180,6 +180,10 @@ export enum AccessControlAction {
   // Saved Queries
   QueriesRead = 'queries:read',
   QueriesWrite = 'queries:write',
+
+  // Feature management
+  FeatureManagementRead = 'featuremgmt.read',
+  FeatureManagementWrite = 'featuremgmt.write',
 }
 
 export interface Role extends RoleDto {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
**What is this feature?**

Adds a new top-level Labs page in Grafana navigation. The page is marked as new in the nav and shows registered feature flags together with their current enabled or disabled status.

**Why do we need this feature?**

The issue calls for a first-class Labs destination similar to Administration and Connections so users can discover feature flags and see their current state in one place.

**Who is this feature for?**

Grafana admins and other users with feature-management read access who need to inspect experimental and staged functionality enabled in an instance.

**Which issue(s) does this PR fix?**:

Fixes CS-451

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a notable improvement, it's added to the What's New doc.

Additional notes:
- Adds a dedicated read-only Labs API endpoint that combines the generated feature flag registry with current enabled-state data, including configured unknown flags.
- Adds a new top-level Labs nav item with the built-in New badge.
- Adds focused backend and frontend tests for the new Labs surface.
- Manual verification was completed against the live Grafana dev app after resolving a frontend bundler syntax issue in the new page component.
- A follow-up formatting commit fixes the `prettier:check` failure reported by CI for `public/app/features/labs/LabsPage.tsx`.

<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [CS-451](https://linear.app/cursor-solutions/issue/CS-451/add-labs-page)

<div><a href="https://cursor.com/agents/bc-1b1892f6-16b1-4a30-ad27-6f8c068b7cb0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1b1892f6-16b1-4a30-ad27-6f8c068b7cb0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

