### PR TITLE
feat(labs): Labs page listing feature toggles

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -168,7 +168,7 @@ func (hs *HTTPServer) registerRoutes() {
 	r.Get("/connections/datasources/:id", middleware.CanAdminPlugins(hs.Cfg, hs.AccessControl), hs.Index)
 	r.Get("/connections/datasources/:id/page/:page", middleware.CanAdminPlugins(hs.Cfg, hs.AccessControl), hs.Index)
 
-	r.Get("/labs", reqSignedIn, hs.Index)
+	r.Get("/labs", authorize(ac.EvalPermission(ac.ActionFeatureManagementRead)), hs.Index)
 
 	// App Root Page
 	appPluginIDScope := pluginaccesscontrol.ScopeProvider.GetResourceScope(ac.Parameter(":id"))
@@ -476,7 +476,7 @@ func (hs *HTTPServer) registerRoutes() {
 
 		apiRoute.Get("/frontend/settings/", hs.GetFrontendSettings)
 		apiRoute.Get("/frontend/assets", hs.GetFrontendAssets)
-		apiRoute.Get("/feature-toggles", routing.Wrap(hs.GetFeatureTogglesList))
+		apiRoute.Get("/feature-toggles", authorize(ac.EvalPermission(ac.ActionFeatureManagementRead)), routing.Wrap(hs.GetFeatureTogglesList))
 
 		// Folders
 		hs.registerFolderAPI(apiRoute, authorize)

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -168,6 +168,8 @@ func (hs *HTTPServer) registerRoutes() {
 	r.Get("/connections/datasources/:id", middleware.CanAdminPlugins(hs.Cfg, hs.AccessControl), hs.Index)
 	r.Get("/connections/datasources/:id/page/:page", middleware.CanAdminPlugins(hs.Cfg, hs.AccessControl), hs.Index)
 
+	r.Get("/labs", reqSignedIn, hs.Index)
+
 	// App Root Page
 	appPluginIDScope := pluginaccesscontrol.ScopeProvider.GetResourceScope(ac.Parameter(":id"))
 	r.Get("/a/:id/*", authorize(ac.EvalPermission(pluginaccesscontrol.ActionAppAccess, appPluginIDScope)), reqSignedIn, reqRoleForAppRoute, hs.Index)
@@ -474,6 +476,7 @@ func (hs *HTTPServer) registerRoutes() {
 
 		apiRoute.Get("/frontend/settings/", hs.GetFrontendSettings)
 		apiRoute.Get("/frontend/assets", hs.GetFrontendAssets)
+		apiRoute.Get("/feature-toggles", routing.Wrap(hs.GetFeatureTogglesList))
 
 		// Folders
 		hs.registerFolderAPI(apiRoute, authorize)

--- a/pkg/api/feature_toggles.go
+++ b/pkg/api/feature_toggles.go
@@ -1,0 +1,55 @@
+package api
+
+import (
+	"net/http"
+	"sort"
+
+	"github.com/grafana/grafana/pkg/api/response"
+	contextmodel "github.com/grafana/grafana/pkg/services/contexthandler/model"
+	"github.com/grafana/grafana/pkg/services/featuremgmt"
+)
+
+type FeatureToggleListItem struct {
+	Name            string                       `json:"name"`
+	Description     string                       `json:"description"`
+	Stage           featuremgmt.FeatureFlagStage `json:"stage"`
+	Enabled         bool                         `json:"enabled"`
+	Expression      string                       `json:"expression"`
+	FrontendOnly    bool                         `json:"frontendOnly"`
+	RequiresDevMode bool                         `json:"requiresDevMode"`
+	RequiresRestart bool                         `json:"requiresRestart"`
+}
+
+type FeatureToggleListResponse struct {
+	Toggles []FeatureToggleListItem `json:"toggles"`
+}
+
+func (hs *HTTPServer) GetFeatureTogglesList(c *contextmodel.ReqContext) response.Response {
+	fm, ok := hs.Features.(*featuremgmt.FeatureManager)
+	if !ok {
+		return response.Error(http.StatusNotImplemented, "Feature toggle registry not available", nil)
+	}
+
+	flags := fm.GetFlags()
+	out := make([]FeatureToggleListItem, 0, len(flags))
+	ctx := c.Req.Context()
+
+	for _, f := range flags {
+		out = append(out, FeatureToggleListItem{
+			Name:            f.Name,
+			Description:     f.Description,
+			Stage:           f.Stage,
+			Enabled:         hs.Features.IsEnabled(ctx, f.Name),
+			Expression:      f.Expression,
+			FrontendOnly:    f.FrontendOnly,
+			RequiresDevMode: f.RequiresDevMode,
+			RequiresRestart: f.RequiresRestart,
+		})
+	}
+
+	sort.Slice(out, func(i, j int) bool {
+		return out[i].Name < out[j].Name
+	})
+
+	return response.JSON(http.StatusOK, FeatureToggleListResponse{Toggles: out})
+}

--- a/pkg/api/feature_toggles_test.go
+++ b/pkg/api/feature_toggles_test.go
@@ -15,7 +15,7 @@ import (
 )
 
 func TestAPI_GetFeatureToggles(t *testing.T) {
-	t.Run("signed-in user gets 200 with toggles list", func(t *testing.T) {
+	t.Run("user with feature management read gets 200 with toggles list", func(t *testing.T) {
 		server := SetupAPITestServer(t, func(hs *HTTPServer) {
 			hs.Features = featuremgmt.WithManager("alpha", true, "beta", false)
 		})
@@ -23,7 +23,7 @@ func TestAPI_GetFeatureToggles(t *testing.T) {
 		res, err := server.Send(
 			webtest.RequestWithSignedInUser(
 				server.NewGetRequest("/api/feature-toggles"),
-				userWithPermissions(1, []accesscontrol.Permission{}),
+				userWithPermissions(1, []accesscontrol.Permission{{Action: accesscontrol.ActionFeatureManagementRead}}),
 			),
 		)
 		require.NoError(t, err)
@@ -40,6 +40,22 @@ func TestAPI_GetFeatureToggles(t *testing.T) {
 		assert.True(t, parsed.Toggles[0].Enabled)
 		assert.Equal(t, "beta", parsed.Toggles[1].Name)
 		assert.False(t, parsed.Toggles[1].Enabled)
+	})
+
+	t.Run("signed-in user without feature management read gets 403", func(t *testing.T) {
+		server := SetupAPITestServer(t, func(hs *HTTPServer) {
+			hs.Features = featuremgmt.WithManager("alpha", true)
+		})
+
+		res, err := server.Send(
+			webtest.RequestWithSignedInUser(
+				server.NewGetRequest("/api/feature-toggles"),
+				userWithPermissions(1, []accesscontrol.Permission{}),
+			),
+		)
+		require.NoError(t, err)
+		assert.Equal(t, http.StatusForbidden, res.StatusCode)
+		require.NoError(t, res.Body.Close())
 	})
 
 	t.Run("unsigned request gets 401", func(t *testing.T) {

--- a/pkg/api/feature_toggles_test.go
+++ b/pkg/api/feature_toggles_test.go
@@ -1,0 +1,53 @@
+package api
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/grafana/pkg/services/accesscontrol"
+	"github.com/grafana/grafana/pkg/services/featuremgmt"
+	"github.com/grafana/grafana/pkg/web/webtest"
+)
+
+func TestAPI_GetFeatureToggles(t *testing.T) {
+	t.Run("signed-in user gets 200 with toggles list", func(t *testing.T) {
+		server := SetupAPITestServer(t, func(hs *HTTPServer) {
+			hs.Features = featuremgmt.WithManager("alpha", true, "beta", false)
+		})
+
+		res, err := server.Send(
+			webtest.RequestWithSignedInUser(
+				server.NewGetRequest("/api/feature-toggles"),
+				userWithPermissions(1, []accesscontrol.Permission{}),
+			),
+		)
+		require.NoError(t, err)
+		assert.Equal(t, http.StatusOK, res.StatusCode)
+
+		body, err := io.ReadAll(res.Body)
+		require.NoError(t, err)
+		require.NoError(t, res.Body.Close())
+
+		var parsed FeatureToggleListResponse
+		require.NoError(t, json.Unmarshal(body, &parsed))
+		require.Len(t, parsed.Toggles, 2)
+		assert.Equal(t, "alpha", parsed.Toggles[0].Name)
+		assert.True(t, parsed.Toggles[0].Enabled)
+		assert.Equal(t, "beta", parsed.Toggles[1].Name)
+		assert.False(t, parsed.Toggles[1].Enabled)
+	})
+
+	t.Run("unsigned request gets 401", func(t *testing.T) {
+		server := SetupAPITestServer(t)
+
+		res, err := server.Send(server.NewGetRequest("/api/feature-toggles"))
+		require.NoError(t, err)
+		assert.Equal(t, http.StatusUnauthorized, res.StatusCode)
+		require.NoError(t, res.Body.Close())
+	})
+}

--- a/pkg/services/navtree/models.go
+++ b/pkg/services/navtree/models.go
@@ -37,6 +37,8 @@ const (
 	WeightHelp
 )
 
+const WeightLabs = -2150
+
 const (
 	NavIDRoot                 = "root"
 	NavIDDashboards           = "dashboards/browse"
@@ -55,6 +57,7 @@ const (
 	NavIDCfgPlugins           = "cfg/plugins"
 	NavIDCfgAccess            = "cfg/access"
 	NavIDBookmarks            = "bookmarks"
+	NavIDLabs                 = "labs"
 )
 
 type NavLink struct {

--- a/pkg/services/navtree/navtreeimpl/navtree.go
+++ b/pkg/services/navtree/navtreeimpl/navtree.go
@@ -654,7 +654,8 @@ func (s *ServiceImpl) buildDataConnectionsNavLink(c *contextmodel.ReqContext) *n
 }
 
 func (s *ServiceImpl) buildLabsNavLink(c *contextmodel.ReqContext) *navtree.NavLink {
-	if !c.IsSignedIn {
+	hasAccess := ac.HasAccess(s.accessControl, c)
+	if !c.IsSignedIn || !hasAccess(ac.EvalPermission(ac.ActionFeatureManagementRead)) {
 		return nil
 	}
 

--- a/pkg/services/navtree/navtreeimpl/navtree.go
+++ b/pkg/services/navtree/navtreeimpl/navtree.go
@@ -162,6 +162,10 @@ func (s *ServiceImpl) GetNavTree(c *contextmodel.ReqContext, prefs *pref.Prefere
 		treeRoot.AddSection(connectionsSection)
 	}
 
+	if labsSection := s.buildLabsNavLink(c); labsSection != nil {
+		treeRoot.AddSection(labsSection)
+	}
+
 	orgAdminNode, err := s.getAdminNode(c)
 
 	if orgAdminNode != nil && len(orgAdminNode.Children) > 0 {
@@ -647,4 +651,20 @@ func (s *ServiceImpl) buildDataConnectionsNavLink(c *contextmodel.ReqContext) *n
 		return navLink
 	}
 	return nil
+}
+
+func (s *ServiceImpl) buildLabsNavLink(c *contextmodel.ReqContext) *navtree.NavLink {
+	if !c.IsSignedIn {
+		return nil
+	}
+
+	return &navtree.NavLink{
+		Text:       "Labs",
+		SubTitle:   "View feature flags and experimental features in this Grafana instance",
+		Id:         navtree.NavIDLabs,
+		Icon:       "rocket",
+		Url:        s.cfg.AppSubURL + "/labs",
+		SortWeight: navtree.WeightLabs,
+		IsNew:      true,
+	}
 }

--- a/pkg/services/navtree/navtreeimpl/navtree_test.go
+++ b/pkg/services/navtree/navtreeimpl/navtree_test.go
@@ -9,12 +9,17 @@ import (
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 
+	ac "github.com/grafana/grafana/pkg/services/accesscontrol"
+	"github.com/grafana/grafana/pkg/services/accesscontrol/acimpl"
 	contextmodel "github.com/grafana/grafana/pkg/services/contexthandler/model"
 	"github.com/grafana/grafana/pkg/services/dashboards"
+	"github.com/grafana/grafana/pkg/services/featuremgmt"
+	"github.com/grafana/grafana/pkg/services/navtree"
 	"github.com/grafana/grafana/pkg/services/search/model"
 	"github.com/grafana/grafana/pkg/services/star"
 	"github.com/grafana/grafana/pkg/services/star/startest"
 	"github.com/grafana/grafana/pkg/services/user"
+	"github.com/grafana/grafana/pkg/setting"
 	"github.com/grafana/grafana/pkg/web"
 )
 
@@ -156,5 +161,48 @@ func TestBuildStarredItemsNavLinks(t *testing.T) {
 		require.Equal(t, "A Dashboard", navLinks[0].Text)
 		require.Equal(t, "B Dashboard", navLinks[1].Text)
 		require.Equal(t, "C Dashboard", navLinks[2].Text)
+	})
+}
+
+func TestBuildLabsNavLink(t *testing.T) {
+	httpReq, _ := http.NewRequest(http.MethodGet, "", nil)
+	reqCtx := &contextmodel.ReqContext{
+		SignedInUser: &user.SignedInUser{
+			UserID: 1,
+			OrgID:  1,
+		},
+		Context: &web.Context{Req: httpReq},
+	}
+	service := ServiceImpl{
+		cfg:           setting.NewCfg(),
+		accessControl: acimpl.ProvideAccessControl(featuremgmt.WithFeatures()),
+	}
+
+	t.Run("returns nil when user is not signed in", func(t *testing.T) {
+		reqCtx.IsSignedIn = false
+		reqCtx.SignedInUser.Permissions = nil
+
+		require.Nil(t, service.buildLabsNavLink(reqCtx))
+	})
+
+	t.Run("returns nil without feature management read permission", func(t *testing.T) {
+		reqCtx.IsSignedIn = true
+		reqCtx.SignedInUser.Permissions = map[int64]map[string][]string{
+			1: {"dashboards:read": {"*"}},
+		}
+
+		require.Nil(t, service.buildLabsNavLink(reqCtx))
+	})
+
+	t.Run("returns labs link with feature management read permission", func(t *testing.T) {
+		reqCtx.IsSignedIn = true
+		reqCtx.SignedInUser.Permissions = map[int64]map[string][]string{
+			1: ac.GroupScopesByActionContext(context.Background(), []ac.Permission{{Action: ac.ActionFeatureManagementRead}}),
+		}
+
+		link := service.buildLabsNavLink(reqCtx)
+		require.NotNil(t, link)
+		require.Equal(t, navtree.NavIDLabs, link.Id)
+		require.Equal(t, "/labs", link.Url)
 	})
 }

--- a/public/app/core/utils/navBarItem-translations.ts
+++ b/public/app/core/utils/navBarItem-translations.ts
@@ -311,10 +311,7 @@ export function getNavSubTitle(navId: string | undefined) {
     case 'testing-and-synthetics':
       return t('nav.testing-and-synthetics.subtitle', 'Optimize performance with k6 and Synthetic Monitoring insights');
     case 'labs':
-      return t(
-        'nav.labs.subtitle',
-        'View feature flags and experimental features in this Grafana instance'
-      );
+      return t('nav.labs.subtitle', 'View feature flags and experimental features in this Grafana instance');
     case 'connections-add-new-connection':
       return t('nav.connections.subtitle', 'Browse and create new connections');
     case 'connections-datasources':

--- a/public/app/core/utils/navBarItem-translations.ts
+++ b/public/app/core/utils/navBarItem-translations.ts
@@ -181,6 +181,8 @@ export function getNavTitle(navId: string | undefined) {
       return t('nav.search-dashboards.title', 'Search dashboards');
     case 'connections':
       return t('nav.connections.title', 'Connections');
+    case 'labs':
+      return t('nav.labs.title', 'Labs');
     case 'connections-add-new-connection':
       return t('nav.add-new-connections.title', 'Add new connection');
     case 'standalone-plugin-page-/connections/collector':
@@ -308,6 +310,11 @@ export function getNavSubTitle(navId: string | undefined) {
       return t('nav.alerts-and-incidents.subtitle', 'Alerting and incident management apps');
     case 'testing-and-synthetics':
       return t('nav.testing-and-synthetics.subtitle', 'Optimize performance with k6 and Synthetic Monitoring insights');
+    case 'labs':
+      return t(
+        'nav.labs.subtitle',
+        'View feature flags and experimental features in this Grafana instance'
+      );
     case 'connections-add-new-connection':
       return t('nav.connections.subtitle', 'Browse and create new connections');
     case 'connections-datasources':

--- a/public/app/features/labs/LabsPage.test.tsx
+++ b/public/app/features/labs/LabsPage.test.tsx
@@ -1,0 +1,41 @@
+import { screen, waitFor } from '@testing-library/react';
+import { render } from 'test/test-utils';
+
+import LabsPage from './LabsPage';
+
+jest.mock('@grafana/runtime', () => ({
+  ...jest.requireActual('@grafana/runtime'),
+  getBackendSrv: () => ({
+    get: jest.fn().mockResolvedValue({
+      toggles: [
+        {
+          name: 'fooFlag',
+          description: 'Foo description',
+          stage: 'experimental',
+          enabled: true,
+          expression: 'false',
+          frontendOnly: false,
+          requiresDevMode: false,
+          requiresRestart: false,
+        },
+      ],
+    }),
+  }),
+}));
+
+describe('LabsPage', () => {
+  it('loads and lists feature toggles from the API', async () => {
+    render(<LabsPage />, {
+      preloadedState: {
+        navIndex: {
+          labs: { id: 'labs', text: 'Labs', subTitle: 'Labs subtitle', url: '/labs' },
+        },
+      },
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText('fooFlag')).toBeInTheDocument();
+    });
+    expect(screen.getByText('Foo description')).toBeInTheDocument();
+  });
+});

--- a/public/app/features/labs/LabsPage.tsx
+++ b/public/app/features/labs/LabsPage.tsx
@@ -1,0 +1,149 @@
+import { useEffect, useMemo, useState } from 'react';
+
+import { Trans, t } from '@grafana/i18n';
+import { getBackendSrv } from '@grafana/runtime';
+import {
+  Badge,
+  CellProps,
+  Column,
+  FilterInput,
+  InteractiveTable,
+  LoadingPlaceholder,
+  Stack,
+  Switch,
+  Text,
+} from '@grafana/ui';
+import { Page } from 'app/core/components/Page/Page';
+
+import { FeatureToggleListItem, FeatureToggleListResponse } from './types';
+
+type Cell<T extends keyof FeatureToggleListItem> = CellProps<FeatureToggleListItem, FeatureToggleListItem[T]>;
+
+export default function LabsPage() {
+  const [items, setItems] = useState<FeatureToggleListItem[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [loadError, setLoadError] = useState<string | null>(null);
+  const [query, setQuery] = useState('');
+  const [enabledOnly, setEnabledOnly] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    getBackendSrv()
+      .get<FeatureToggleListResponse>('/api/feature-toggles')
+      .then((res) => {
+        if (!cancelled) {
+          setItems(res.toggles);
+          setLoadError(null);
+        }
+      })
+      .catch((err: unknown) => {
+        if (!cancelled) {
+          const message = err instanceof Error ? err.message : t('labs.load-error', 'Failed to load feature toggles');
+          setLoadError(message);
+        }
+      })
+      .finally(() => {
+        if (!cancelled) {
+          setLoading(false);
+        }
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const filtered = useMemo(() => {
+    let rows = items;
+    if (enabledOnly) {
+      rows = rows.filter((r) => r.enabled);
+    }
+    const q = query.trim().toLowerCase();
+    if (q) {
+      rows = rows.filter(
+        (r) =>
+          r.name.toLowerCase().includes(q) ||
+          r.description.toLowerCase().includes(q) ||
+          String(r.stage).toLowerCase().includes(q)
+      );
+    }
+    return rows;
+  }, [items, query, enabledOnly]);
+
+  const columns: Array<Column<FeatureToggleListItem>> = useMemo(
+    () => [
+      {
+        id: 'name',
+        header: t('labs.table.column-name', 'Name'),
+        cell: ({ cell: { value } }: Cell<'name'>) => (
+          <Text element="span" variant="bodySmall">
+            {value}
+          </Text>
+        ),
+        sortType: 'string',
+      },
+      {
+        id: 'enabled',
+        header: t('labs.table.column-enabled', 'Enabled'),
+        cell: ({ cell: { value } }: Cell<'enabled'>) => (
+          <Badge
+            color={value ? 'green' : 'darkgrey'}
+            text={value ? t('labs.badge-on', 'On') : t('labs.badge-off', 'Off')}
+          />
+        ),
+        sortType: 'basic',
+      },
+      {
+        id: 'stage',
+        header: t('labs.table.column-stage', 'Stage'),
+        cell: ({ cell: { value } }: Cell<'stage'>) => value || t('labs.empty-value', '—'),
+        sortType: 'string',
+      },
+      {
+        id: 'description',
+        header: t('labs.table.column-description', 'Description'),
+        cell: ({ cell: { value } }: Cell<'description'>) => value || t('labs.empty-value', '—'),
+        sortType: 'string',
+      },
+    ],
+    []
+  );
+
+  return (
+    <Page navId="labs">
+      <Page.Contents>
+        <Stack direction="column" gap={2}>
+          <Text element="p">
+            <Trans i18nKey="labs.intro">
+              Feature flags registered in this Grafana build and whether each is enabled for your current session.
+            </Trans>
+          </Text>
+
+          <Stack gap={2} alignItems="center" wrap="wrap">
+            <FilterInput
+              placeholder={t('labs.filter-placeholder', 'Search by name, description, or stage')}
+              value={query}
+              width={40}
+              onChange={(value) => setQuery(value)}
+            />
+            <Switch
+              id="labs-enabled-only"
+              label={t('labs.enabled-only', 'Enabled only')}
+              value={enabledOnly}
+              onChange={(e) => setEnabledOnly(e.currentTarget.checked)}
+            />
+          </Stack>
+
+          {loading && <LoadingPlaceholder text={t('labs.loading', 'Loading feature toggles')} />}
+          {loadError && (
+            <Text color="error" element="p">
+              {loadError}
+            </Text>
+          )}
+          {!loading && !loadError && (
+            <InteractiveTable columns={columns} data={filtered} getRowId={(row) => row.name} />
+          )}
+        </Stack>
+      </Page.Contents>
+    </Page>
+  );
+}

--- a/public/app/features/labs/types.ts
+++ b/public/app/features/labs/types.ts
@@ -1,0 +1,14 @@
+export interface FeatureToggleListItem {
+  name: string;
+  description: string;
+  stage: string;
+  enabled: boolean;
+  expression: string;
+  frontendOnly: boolean;
+  requiresDevMode: boolean;
+  requiresRestart: boolean;
+}
+
+export interface FeatureToggleListResponse {
+  toggles: FeatureToggleListItem[];
+}

--- a/public/app/routes/routes.tsx
+++ b/public/app/routes/routes.tsx
@@ -226,6 +226,12 @@ export function getAppRoutes(): RouteDescriptor[] {
       component: () => <NavLandingPage navId="frontend" />,
     },
     {
+      path: '/labs',
+      component: SafeDynamicImport(
+        () => import(/* webpackChunkName: "LabsPage" */ 'app/features/labs/LabsPage')
+      ),
+    },
+    {
       path: '/admin/general',
       component: () => <NavLandingPage navId="cfg/general" />,
     },

--- a/public/app/routes/routes.tsx
+++ b/public/app/routes/routes.tsx
@@ -227,6 +227,7 @@ export function getAppRoutes(): RouteDescriptor[] {
     },
     {
       path: '/labs',
+      roles: () => contextSrv.evaluatePermission([AccessControlAction.FeatureManagementRead]),
       component: SafeDynamicImport(
         () => import(/* webpackChunkName: "LabsPage" */ 'app/features/labs/LabsPage')
       ),

--- a/public/app/routes/routes.tsx
+++ b/public/app/routes/routes.tsx
@@ -228,9 +228,7 @@ export function getAppRoutes(): RouteDescriptor[] {
     {
       path: '/labs',
       roles: () => contextSrv.evaluatePermission([AccessControlAction.FeatureManagementRead]),
-      component: SafeDynamicImport(
-        () => import(/* webpackChunkName: "LabsPage" */ 'app/features/labs/LabsPage')
-      ),
+      component: SafeDynamicImport(() => import(/* webpackChunkName: "LabsPage" */ 'app/features/labs/LabsPage')),
     },
     {
       path: '/admin/general',

--- a/public/app/types/accessControl.ts
+++ b/public/app/types/accessControl.ts
@@ -177,6 +177,9 @@ export enum AccessControlAction {
   // Migration Assistant
   MigrationAssistantMigrate = 'migrationassistant:migrate',
 
+  // Feature management
+  FeatureManagementRead = 'featuremgmt.read',
+
   // Saved Queries
   QueriesRead = 'queries:read',
   QueriesWrite = 'queries:write',


### PR DESCRIPTION
## Summary

Adds a **Labs** top-level nav item (with the standard **New** badge) and a `/labs` page that lists all registered feature flags with enabled state, backed by `GET /api/feature-toggles` for any signed-in user.

## Changes

- **Backend:** `GetFeatureTogglesList` returns the full flag registry from `FeatureManager` plus `IsEnabled` per flag; route registered on the signed-in API group. `GET /labs` serves the SPA shell.
- **Nav:** `NavIDLabs`, `WeightLabs` between Connections and Apps, rocket icon, i18n for title/subtitle.
- **Frontend:** `LabsPage` with filter, "enabled only" switch, and `InteractiveTable`.

## Verification

- `go test -run TestAPI_GetFeatureToggles ./pkg/api/`
- `yarn jest public/app/features/labs/LabsPage.test.tsx --no-watch --watchAll=false`
- `yarn eslint public/app/features/labs/ --max-warnings 0`

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new authenticated API that exposes the full feature-flag registry (including expressions/metadata) and wires it into navigation and routing; risk is mainly around unintended information exposure or permission misconfiguration.
> 
> **Overview**
> Adds a new **Labs** top-level page (`/labs`) gated by `featuremgmt.read`, plus a backend `GET /api/feature-toggles` endpoint that returns all registered feature flags with per-request enabled state.
> 
> Updates nav tree and i18n to surface the Labs entry (with *New* badge) only for users with feature-management read access, and introduces a frontend `LabsPage` that fetches and displays toggles in a searchable/table view. Includes backend and frontend tests covering auth/permissions and basic rendering.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 90df026d14a2f8abb4879166854363ea1cf11947. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->