### PR TITLE
Admin: add Labs page for feature flags

### DIFF
--- a/pkg/api/admin.go
+++ b/pkg/api/admin.go
@@ -2,13 +2,16 @@ package api
 
 import (
 	"context"
+	"fmt"
 	"net/http"
+	"sort"
 	"time"
 
 	"github.com/grafana/grafana/pkg/api/response"
 	"github.com/grafana/grafana/pkg/apimachinery/identity"
 	ac "github.com/grafana/grafana/pkg/services/accesscontrol"
 	contextmodel "github.com/grafana/grafana/pkg/services/contexthandler/model"
+	"github.com/grafana/grafana/pkg/services/featuremgmt"
 	"github.com/grafana/grafana/pkg/services/stats"
 	"github.com/grafana/grafana/pkg/setting"
 )
@@ -45,6 +48,46 @@ func (hs *HTTPServer) AdminGetVerboseSettings(c *contextmodel.ReqContext) respon
 		return response.Error(http.StatusForbidden, "Failed to authorize settings", err)
 	}
 	return response.JSON(http.StatusOK, verboseSettings)
+}
+
+type AdminFeatureToggle struct {
+	Name            string                       `json:"name"`
+	Description     string                       `json:"description"`
+	Stage           featuremgmt.FeatureFlagStage `json:"stage"`
+	Expression      string                       `json:"expression"`
+	Enabled         bool                         `json:"enabled"`
+	FrontendOnly    bool                         `json:"frontendOnly"`
+	RequiresDevMode bool                         `json:"requiresDevMode"`
+	RequiresRestart bool                         `json:"requiresRestart"`
+}
+
+func (hs *HTTPServer) AdminGetFeatureToggles(c *contextmodel.ReqContext) response.Response {
+	manager, ok := hs.Features.(*featuremgmt.FeatureManager)
+	if !ok {
+		return response.Error(http.StatusInternalServerError, "Failed to load feature flags", fmt.Errorf("feature registry unavailable"))
+	}
+
+	enabled := hs.Features.GetEnabled(c.Req.Context())
+	flags := manager.GetFlags()
+	sort.Slice(flags, func(i, j int) bool {
+		return flags[i].Name < flags[j].Name
+	})
+
+	toggles := make([]AdminFeatureToggle, 0, len(flags))
+	for _, flag := range flags {
+		toggles = append(toggles, AdminFeatureToggle{
+			Name:            flag.Name,
+			Description:     flag.Description,
+			Stage:           flag.Stage,
+			Expression:      flag.Expression,
+			Enabled:         enabled[flag.Name],
+			FrontendOnly:    flag.FrontendOnly,
+			RequiresDevMode: flag.RequiresDevMode,
+			RequiresRestart: flag.RequiresRestart,
+		})
+	}
+
+	return response.JSON(http.StatusOK, toggles)
 }
 
 // swagger:route GET /admin/stats admin adminGetStats

--- a/pkg/api/admin_test.go
+++ b/pkg/api/admin_test.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"encoding/json"
 	"io"
 	"net/http"
 	"testing"
@@ -11,6 +12,7 @@ import (
 	"github.com/grafana/grafana/pkg/infra/db/dbtest"
 	"github.com/grafana/grafana/pkg/services/accesscontrol"
 	"github.com/grafana/grafana/pkg/services/anonymous/anontest"
+	"github.com/grafana/grafana/pkg/services/featuremgmt"
 	"github.com/grafana/grafana/pkg/services/stats"
 	"github.com/grafana/grafana/pkg/services/stats/statstest"
 	"github.com/grafana/grafana/pkg/setting"
@@ -99,6 +101,45 @@ func TestAPI_AdminGetSettings(t *testing.T) {
 	}
 }
 
+func TestAPI_AdminGetFeatureToggles(t *testing.T) {
+	server := SetupAPITestServer(t, func(hs *HTTPServer) {
+		hs.Features = featuremgmt.WithFeatures(featuremgmt.FlagStorage)
+	})
+
+	res, err := server.Send(
+		webtest.RequestWithSignedInUser(
+			server.NewGetRequest("/api/admin/feature-toggles"),
+			userWithPermissions(1, []accesscontrol.Permission{{Action: accesscontrol.ActionSettingsRead}}),
+		),
+	)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, res.StatusCode)
+
+	var body []AdminFeatureToggle
+	require.NoError(t, json.NewDecoder(res.Body).Decode(&body))
+	require.NoError(t, res.Body.Close())
+
+	require.NotEmpty(t, body)
+
+	var storageFlag *AdminFeatureToggle
+	var panelTitleSearchFlag *AdminFeatureToggle
+	for i := range body {
+		switch body[i].Name {
+		case featuremgmt.FlagStorage:
+			storageFlag = &body[i]
+		case featuremgmt.FlagPanelTitleSearch:
+			panelTitleSearchFlag = &body[i]
+		}
+	}
+
+	require.NotNil(t, storageFlag)
+	assert.True(t, storageFlag.Enabled)
+	assert.Equal(t, "Configurable storage for dashboards, datasources, and resources", storageFlag.Description)
+
+	require.NotNil(t, panelTitleSearchFlag)
+	assert.False(t, panelTitleSearchFlag.Enabled)
+}
+
 func TestAdmin_AccessControl(t *testing.T) {
 	type testCase struct {
 		desc         string
@@ -139,9 +180,29 @@ func TestAdmin_AccessControl(t *testing.T) {
 			},
 		},
 		{
+			expectedCode: http.StatusOK,
+			desc:         "AdminGetFeatureToggles should return 200 for user with correct permissions",
+			url:          "/api/admin/feature-toggles",
+			permissions: []accesscontrol.Permission{
+				{
+					Action: accesscontrol.ActionSettingsRead,
+				},
+			},
+		},
+		{
 			expectedCode: http.StatusForbidden,
 			desc:         "AdminGetSettings should return 403 for user without required permissions",
 			url:          "/api/admin/settings",
+			permissions: []accesscontrol.Permission{
+				{
+					Action: "wrong",
+				},
+			},
+		},
+		{
+			expectedCode: http.StatusForbidden,
+			desc:         "AdminGetFeatureToggles should return 403 for user without required permissions",
+			url:          "/api/admin/feature-toggles",
 			permissions: []accesscontrol.Permission{
 				{
 					Action: "wrong",
@@ -162,6 +223,7 @@ func TestAdmin_AccessControl(t *testing.T) {
 				hs.SettingsProvider = &setting.OSSImpl{Cfg: hs.Cfg}
 				hs.statsService = fakeStatsService
 				hs.anonService = fakeAnonService
+				hs.Features = featuremgmt.WithFeatures()
 			})
 
 			res, err := server.Send(webtest.RequestWithSignedInUser(server.NewGetRequest(tt.url), userWithPermissions(1, tt.permissions)))

--- a/pkg/api/admin_test.go
+++ b/pkg/api/admin_test.go
@@ -130,20 +130,20 @@ enable = panelTitleSearch
 
 	require.NotEmpty(t, body)
 
-	var storageFlag *AdminFeatureToggle
+	var enabledByDefaultFlag *AdminFeatureToggle
 	var panelTitleSearchFlag *AdminFeatureToggle
 	for i := range body {
 		switch body[i].Name {
-		case featuremgmt.FlagStorage:
-			storageFlag = &body[i]
+		case featuremgmt.FlagCloudWatchCrossAccountQuerying:
+			enabledByDefaultFlag = &body[i]
 		case featuremgmt.FlagPanelTitleSearch:
 			panelTitleSearchFlag = &body[i]
 		}
 	}
 
-	require.NotNil(t, storageFlag)
-	assert.False(t, storageFlag.Enabled)
-	assert.Equal(t, "Configurable storage for dashboards, datasources, and resources", storageFlag.Description)
+	require.NotNil(t, enabledByDefaultFlag)
+	assert.True(t, enabledByDefaultFlag.Enabled)
+	assert.Equal(t, "Enables cross-account querying in CloudWatch datasources", enabledByDefaultFlag.Description)
 
 	require.NotNil(t, panelTitleSearchFlag)
 	assert.True(t, panelTitleSearchFlag.Enabled)

--- a/pkg/api/admin_test.go
+++ b/pkg/api/admin_test.go
@@ -102,8 +102,17 @@ func TestAPI_AdminGetSettings(t *testing.T) {
 }
 
 func TestAPI_AdminGetFeatureToggles(t *testing.T) {
+	cfg, err := setting.NewCfgFromBytes([]byte(`
+[feature_toggles]
+enable = panelTitleSearch
+`))
+	require.NoError(t, err)
+
+	features, err := featuremgmt.ProvideManagerService(cfg)
+	require.NoError(t, err)
+
 	server := SetupAPITestServer(t, func(hs *HTTPServer) {
-		hs.Features = featuremgmt.WithFeatures(featuremgmt.FlagStorage)
+		hs.Features = features
 	})
 
 	res, err := server.Send(
@@ -133,11 +142,11 @@ func TestAPI_AdminGetFeatureToggles(t *testing.T) {
 	}
 
 	require.NotNil(t, storageFlag)
-	assert.True(t, storageFlag.Enabled)
+	assert.False(t, storageFlag.Enabled)
 	assert.Equal(t, "Configurable storage for dashboards, datasources, and resources", storageFlag.Description)
 
 	require.NotNil(t, panelTitleSearchFlag)
-	assert.False(t, panelTitleSearchFlag.Enabled)
+	assert.True(t, panelTitleSearchFlag.Enabled)
 }
 
 func TestAdmin_AccessControl(t *testing.T) {

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -560,6 +560,7 @@ func (hs *HTTPServer) registerRoutes() {
 		// There is additional filter which will ensure that user sees only settings that they are allowed to see, so we don't need provide additional scope here for ActionSettingsRead.
 		adminRoute.Get("/settings", authorize(ac.EvalPermission(ac.ActionSettingsRead)), routing.Wrap(hs.AdminGetSettings))
 		adminRoute.Get("/settings-verbose", authorize(ac.EvalPermission(ac.ActionSettingsRead)), routing.Wrap(hs.AdminGetVerboseSettings))
+		adminRoute.Get("/feature-toggles", authorize(ac.EvalPermission(ac.ActionSettingsRead)), routing.Wrap(hs.AdminGetFeatureToggles))
 		adminRoute.Get("/stats", authorize(ac.EvalPermission(ac.ActionServerStatsRead)), routing.Wrap(hs.AdminGetStats))
 
 		adminRoute.Post("/encryption/rotate-data-keys", reqGrafanaAdmin, routing.Wrap(hs.AdminRotateDataEncryptionKeys))

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -112,6 +112,7 @@ func (hs *HTTPServer) registerRoutes() {
 	r.Get("/configuration", reqGrafanaAdmin, hs.Index)
 	r.Get("/admin", reqOrgAdmin, hs.Index)
 	r.Get("/admin/settings", authorize(ac.EvalPermission(ac.ActionSettingsRead, ac.ScopeSettingsAll)), hs.Index)
+	r.Get("/admin/labs", authorize(ac.EvalPermission(ac.ActionSettingsRead, ac.ScopeSettingsAll)), hs.Index)
 	r.Get("/admin/users", authorize(ac.EvalAny(ac.EvalPermission(ac.ActionOrgUsersRead), ac.EvalPermission(ac.ActionUsersRead, ac.ScopeGlobalUsersAll))), hs.Index)
 	r.Get("/admin/users/create", authorize(ac.EvalPermission(ac.ActionUsersCreate)), hs.Index)
 	r.Get("/admin/users/edit/:id", authorize(ac.EvalPermission(ac.ActionUsersRead)), hs.Index)

--- a/pkg/services/navtree/navtreeimpl/admin.go
+++ b/pkg/services/navtree/navtreeimpl/admin.go
@@ -38,6 +38,9 @@ func (s *ServiceImpl) getAdminNode(c *contextmodel.ReqContext) (*navtree.NavLink
 		generalNodeLinks = append(generalNodeLinks, &navtree.NavLink{
 			Text: "Settings", SubTitle: "View the settings defined in your Grafana config", Id: "server-settings", Url: s.cfg.AppSubURL + "/admin/settings", Icon: "sliders-v-alt",
 		})
+		generalNodeLinks = append(generalNodeLinks, &navtree.NavLink{
+			Text: "Labs", SubTitle: "Inspect feature flags and their current runtime state", Id: "labs", Url: s.cfg.AppSubURL + "/admin/labs", Icon: "flask",
+		})
 	}
 	if hasGlobalAccess(orgsAccessEvaluator) {
 		generalNodeLinks = append(generalNodeLinks, &navtree.NavLink{

--- a/public/app/core/utils/navBarItem-translations.ts
+++ b/public/app/core/utils/navBarItem-translations.ts
@@ -129,6 +129,8 @@ export function getNavTitle(navId: string | undefined) {
       return t('nav.global-orgs.title', 'Organizations');
     case 'server-settings':
       return t('nav.server-settings.title', 'Settings');
+    case 'labs':
+      return t('nav.labs.title', 'Labs');
     case 'storage':
       return t('nav.storage.title', 'Storage');
     case 'migrate-to-cloud':
@@ -279,6 +281,8 @@ export function getNavSubTitle(navId: string | undefined) {
       return t('nav.global-orgs.subtitle', 'Isolated instances of Grafana running on the same server');
     case 'server-settings':
       return t('nav.server-settings.subtitle', 'View the settings defined in your Grafana config');
+    case 'labs':
+      return t('nav.labs.subtitle', 'Inspect feature flags and their current runtime state');
     case 'storage':
       return t('nav.storage.subtitle', 'Manage file storage');
     case 'migrate-to-cloud':

--- a/public/app/features/admin/LabsPage.test.tsx
+++ b/public/app/features/admin/LabsPage.test.tsx
@@ -1,13 +1,13 @@
 import { render, screen } from '@testing-library/react';
 
 import LabsPage from './LabsPage';
-import { getFeatureToggles, type AdminFeatureToggle } from './state/apis';
+import { getAdminFeatureToggles, type AdminFeatureToggle } from './state/apis';
 
 jest.mock('./state/apis', () => ({
-  getFeatureToggles: jest.fn(),
+  getAdminFeatureToggles: jest.fn(),
 }));
 
-const mockedGetFeatureToggles = jest.mocked(getFeatureToggles);
+const mockedGetFeatureToggles = jest.mocked(getAdminFeatureToggles);
 
 describe('LabsPage', () => {
   it('renders feature flags and their states', async () => {

--- a/public/app/features/admin/LabsPage.test.tsx
+++ b/public/app/features/admin/LabsPage.test.tsx
@@ -1,4 +1,5 @@
-import { render, screen } from '@testing-library/react';
+import { screen } from '@testing-library/react';
+import { render } from 'test/test-utils';
 
 import LabsPage from './LabsPage';
 import { getAdminFeatureToggles, type AdminFeatureToggle } from './state/apis';

--- a/public/app/features/admin/LabsPage.test.tsx
+++ b/public/app/features/admin/LabsPage.test.tsx
@@ -1,0 +1,51 @@
+import { render, screen } from '@testing-library/react';
+
+import LabsPage from './LabsPage';
+import { getFeatureToggles, type AdminFeatureToggle } from './state/apis';
+
+jest.mock('./state/apis', () => ({
+  getFeatureToggles: jest.fn(),
+}));
+
+const mockedGetFeatureToggles = jest.mocked(getFeatureToggles);
+
+describe('LabsPage', () => {
+  it('renders feature flags and their states', async () => {
+    const toggles: AdminFeatureToggle[] = [
+      {
+        name: 'alphaFeature',
+        description: 'Alpha feature description',
+        stage: 'experimental',
+        expression: 'false',
+        enabled: false,
+        frontendOnly: true,
+        requiresDevMode: false,
+        requiresRestart: false,
+      },
+      {
+        name: 'betaFeature',
+        description: 'Beta feature description',
+        stage: 'preview',
+        expression: 'true',
+        enabled: true,
+        frontendOnly: false,
+        requiresDevMode: true,
+        requiresRestart: true,
+      },
+    ];
+
+    mockedGetFeatureToggles.mockResolvedValue(toggles);
+
+    render(<LabsPage />);
+
+    expect(await screen.findByText('alphaFeature')).toBeInTheDocument();
+    expect(screen.getByText('alphaFeature')).toBeInTheDocument();
+    expect(screen.getByText('betaFeature')).toBeInTheDocument();
+    expect(screen.getByText('Alpha feature description')).toBeInTheDocument();
+    expect(screen.getByText('Beta feature description')).toBeInTheDocument();
+    expect(screen.getByText('Frontend only')).toBeInTheDocument();
+    expect(screen.getByText('Requires dev mode')).toBeInTheDocument();
+    expect(screen.getByText('Requires restart')).toBeInTheDocument();
+    expect(screen.getByPlaceholderText('Search feature flags')).toBeInTheDocument();
+  });
+});

--- a/public/app/features/admin/LabsPage.tsx
+++ b/public/app/features/admin/LabsPage.tsx
@@ -1,19 +1,18 @@
+import { css } from '@emotion/css';
 import { useMemo, useState } from 'react';
 import { useAsync } from 'react-use';
-
-import { css } from '@emotion/css';
 
 import { GrafanaTheme2 } from '@grafana/data';
 import { t } from '@grafana/i18n';
 import { Alert, Badge, FilterInput, InteractiveTable, type Column, Stack, useStyles2 } from '@grafana/ui';
 import { Page } from 'app/core/components/Page/Page';
 
-import { getFeatureToggles, type AdminFeatureToggle } from './state/apis';
+import { getAdminFeatureToggles, type AdminFeatureToggle } from './state/apis';
 
 export function LabsPage() {
   const styles = useStyles2(getStyles);
   const [query, setQuery] = useState('');
-  const { loading, value, error } = useAsync(() => getFeatureToggles(), []);
+  const { loading, value, error } = useAsync(() => getAdminFeatureToggles(), []);
 
   const data = useMemo(() => {
     const toggles = value ?? [];

--- a/public/app/features/admin/LabsPage.tsx
+++ b/public/app/features/admin/LabsPage.tsx
@@ -1,0 +1,153 @@
+import { useMemo, useState } from 'react';
+import { useAsync } from 'react-use';
+
+import { css } from '@emotion/css';
+
+import { GrafanaTheme2 } from '@grafana/data';
+import { t } from '@grafana/i18n';
+import { Alert, Badge, FilterInput, InteractiveTable, type Column, Stack, useStyles2 } from '@grafana/ui';
+import { Page } from 'app/core/components/Page/Page';
+
+import { getFeatureToggles, type AdminFeatureToggle } from './state/apis';
+
+export function LabsPage() {
+  const styles = useStyles2(getStyles);
+  const [query, setQuery] = useState('');
+  const { loading, value, error } = useAsync(() => getFeatureToggles(), []);
+
+  const data = useMemo(() => {
+    const toggles = value ?? [];
+    const normalized = query.trim().toLowerCase();
+
+    if (!normalized) {
+      return toggles;
+    }
+
+    return toggles.filter((toggle) =>
+      [toggle.name, toggle.description, toggle.stage, toggle.expression]
+        .filter(Boolean)
+        .some((field) => field.toLowerCase().includes(normalized))
+    );
+  }, [query, value]);
+
+  const columns = useMemo<Array<Column<AdminFeatureToggle>>>(
+    () => [
+      {
+        id: 'name',
+        header: t('admin.labs-page.columns.flag', 'Flag'),
+        accessorKey: 'name',
+        cell: ({ row }) => <code>{row.original.name}</code>,
+      },
+      {
+        id: 'status',
+        header: t('admin.labs-page.columns.status', 'Status'),
+        cell: ({ row }) => (
+          <Badge
+            text={row.original.enabled ? t('admin.labs-page.enabled', 'Enabled') : t('admin.labs-page.disabled', 'Disabled')}
+            color={row.original.enabled ? 'green' : 'red'}
+          />
+        ),
+      },
+      {
+        id: 'stage',
+        header: t('admin.labs-page.columns.stage', 'Stage'),
+        accessorKey: 'stage',
+        cell: ({ row }) => row.original.stage || t('admin.labs-page.unknown', 'unknown'),
+      },
+      {
+        id: 'description',
+        header: t('admin.labs-page.columns.description', 'Description'),
+        accessorKey: 'description',
+        cell: ({ row }) => <span className={styles.description}>{row.original.description || '-'}</span>,
+      },
+      {
+        id: 'attributes',
+        header: t('admin.labs-page.columns.attributes', 'Attributes'),
+        cell: ({ row }) => <FeatureAttributes toggle={row.original} />,
+      },
+    ],
+    [styles.description]
+  );
+
+  return (
+    <Page navId="labs">
+      <Page.Contents isLoading={loading}>
+        <Stack direction="column" gap={2}>
+          <Alert severity="info" title={t('admin.labs-page.alert.title', 'Labs feature flags')}>
+            {t(
+              'admin.labs-page.alert.body',
+              'This page lists all registered feature flags and their current effective state in this Grafana instance.'
+            )}
+          </Alert>
+
+          <div className={styles.toolbar}>
+            <FilterInput
+              placeholder={t('admin.labs-page.search.placeholder', 'Search feature flags')}
+              aria-label={t('admin.labs-page.search.aria-label', 'Search feature flags')}
+              value={query}
+              onChange={setQuery}
+              escapeRegex={false}
+            />
+            <div className={styles.summary}>
+              {t(
+                'admin.labs-page.summary',
+                '{{shown}} of {{total}} flags',
+                { shown: data.length, total: value?.length ?? 0 }
+              )}
+            </div>
+          </div>
+
+          {error && (
+            <Alert severity="error" title={t('admin.labs-page.error.title', 'Unable to load feature flags')}>
+              {t(
+                'admin.labs-page.error.body',
+                'Grafana could not fetch the feature-flag registry for this page.'
+              )}
+            </Alert>
+          )}
+
+          {!error && <InteractiveTable columns={columns} data={data} getRowId={(row) => row.name} pageSize={25} />}
+        </Stack>
+      </Page.Contents>
+    </Page>
+  );
+}
+
+export default LabsPage;
+
+function FeatureAttributes({ toggle }: { toggle: AdminFeatureToggle }) {
+  const attrs = [
+    toggle.frontendOnly && t('admin.labs-page.attributes.frontend', 'Frontend only'),
+    toggle.requiresDevMode && t('admin.labs-page.attributes.dev-mode', 'Requires dev mode'),
+    toggle.requiresRestart && t('admin.labs-page.attributes.restart', 'Requires restart'),
+    toggle.expression && `${t('admin.labs-page.attributes.default', 'Default')}: ${toggle.expression}`,
+  ].filter(Boolean);
+
+  if (attrs.length === 0) {
+    return <span>-</span>;
+  }
+
+  return (
+    <Stack wrap="wrap" gap={1}>
+      {attrs.map((attr) => (
+        <Badge key={attr} text={attr} color="blue" />
+      ))}
+    </Stack>
+  );
+}
+
+const getStyles = (theme: GrafanaTheme2) => ({
+  toolbar: css({
+    display: 'flex',
+    justifyContent: 'space-between',
+    gap: theme.spacing(2),
+    alignItems: 'center',
+    flexWrap: 'wrap',
+  }),
+  summary: css({
+    color: theme.colors.text.secondary,
+  }),
+  description: css({
+    color: theme.colors.text.secondary,
+  }),
+});

--- a/public/app/features/admin/state/apis.tsx
+++ b/public/app/features/admin/state/apis.tsx
@@ -24,9 +24,29 @@ export interface ServerStat extends AnonServerStat {
   viewers: number;
 }
 
+export interface AdminFeatureToggle {
+  name: string;
+  description: string;
+  stage: string;
+  expression: string;
+  enabled: boolean;
+  frontendOnly: boolean;
+  requiresDevMode: boolean;
+  requiresRestart: boolean;
+}
+
 export const getServerStats = async (): Promise<ServerStat | null> => {
   return getBackendSrv()
     .get('api/admin/stats')
+    .catch((err) => {
+      console.error(err);
+      return null;
+    });
+};
+
+export const getAdminFeatureToggles = async (): Promise<AdminFeatureToggle[] | null> => {
+  return getBackendSrv()
+    .get<AdminFeatureToggle[]>('/api/admin/feature-toggles')
     .catch((err) => {
       console.error(err);
       return null;

--- a/public/app/features/admin/state/apis.tsx
+++ b/public/app/features/admin/state/apis.tsx
@@ -44,11 +44,6 @@ export const getServerStats = async (): Promise<ServerStat | null> => {
     });
 };
 
-export const getAdminFeatureToggles = async (): Promise<AdminFeatureToggle[] | null> => {
-  return getBackendSrv()
-    .get<AdminFeatureToggle[]>('/api/admin/feature-toggles')
-    .catch((err) => {
-      console.error(err);
-      return null;
-    });
+export const getAdminFeatureToggles = async (): Promise<AdminFeatureToggle[]> => {
+  return getBackendSrv().get<AdminFeatureToggle[]>('/api/admin/feature-toggles');
 };

--- a/public/app/routes/routes.tsx
+++ b/public/app/routes/routes.tsx
@@ -346,6 +346,10 @@ export function getAppRoutes(): RouteDescriptor[] {
       ),
     },
     {
+      path: '/admin/labs',
+      component: SafeDynamicImport(() => import(/* webpackChunkName: "LabsPage" */ 'app/features/admin/LabsPage')),
+    },
+    {
       path: '/admin/upgrading',
       component: SafeDynamicImport(() => import('app/features/admin/UpgradePage')),
     },

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -136,6 +136,37 @@
       "team-sync-details": "LDAP, GitHub OAuth, Auth Proxy, Okta",
       "title": "Get Grafana Enterprise"
     },
+    "labs-page": {
+      "alert": {
+        "body": "This page lists all registered feature flags and their current effective state in this Grafana instance.",
+        "title": "Labs feature flags"
+      },
+      "attributes": {
+        "default": "Default",
+        "dev-mode": "Requires dev mode",
+        "frontend": "Frontend only",
+        "restart": "Requires restart"
+      },
+      "columns": {
+        "attributes": "Attributes",
+        "description": "Description",
+        "flag": "Flag",
+        "stage": "Stage",
+        "status": "Status"
+      },
+      "disabled": "Disabled",
+      "enabled": "Enabled",
+      "error": {
+        "body": "Grafana could not fetch the feature-flag registry for this page.",
+        "title": "Unable to load feature flags"
+      },
+      "search": {
+        "aria-label": "Search feature flags",
+        "placeholder": "Search feature flags"
+      },
+      "summary": "{{shown}} of {{total}} flags",
+      "unknown": "unknown"
+    },
     "ldap": {
       "debug-subtitle": "Verify your LDAP and user mapping configuration.",
       "debug-title": "LDAP Diagnostics",
@@ -11604,6 +11635,10 @@
     },
     "kubernetes": {
       "title": "Kubernetes"
+    },
+    "labs": {
+      "subtitle": "Inspect feature flags and their current runtime state",
+      "title": "Labs"
     },
     "library-panels": {
       "subtitle": "Reusable panels that can be added to multiple dashboards",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
**What is this feature?**

Adds an Administration > General > Labs page that lists Grafana feature flags and shows whether each flag is currently enabled or disabled.

**Why do we need this feature?**

The frontend boot config only exposes enabled flags, which makes it hard to inspect the full feature-flag registry from Grafana itself. This adds a small admin API and UI so operators can inspect the full registry and current runtime state in one place.

**Who is this feature for?**

Grafana administrators and developers who need to inspect feature-flag state in a running instance.

**Which issue(s) does this PR fix?**:

Fixes #

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a notable improvement, it's added to our What's New doc.

Additional notes:
- Added `/api/admin/feature-toggles` to expose the full feature registry plus effective enabled state.
- Added both frontend and backend routing so `/admin/labs` works for in-app navigation and direct page loads.
- Committed the generated `public/locales/en-US/grafana.json` updates required by `Verify i18n`.
- Validated with targeted Go and Jest tests, plus live runtime checks against a local Grafana instance.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9b2c35fe-2001-43e4-87b0-762a0500872f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9b2c35fe-2001-43e4-87b0-762a0500872f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

