### PR TITLE
feat(labs): Labs page and feature flag management API

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -164,6 +164,7 @@ func (hs *HTTPServer) registerRoutes() {
 	r.Get("/connections/datasources/edit/*", authorize(datasources.EditPageAccess), hs.Index)
 	r.Get("/connections", authorize(datasources.ConfigurationPageAccess), hs.Index)
 	r.Get("/connections/add-new-connection", authorize(datasources.ConfigurationPageAccess), hs.Index)
+	r.Get("/labs", authorize(ac.EvalPermission(ac.ActionFeatureManagementRead)), hs.Index)
 	// Plugin details pages
 	r.Get("/connections/datasources/:id", middleware.CanAdminPlugins(hs.Cfg, hs.AccessControl), hs.Index)
 	r.Get("/connections/datasources/:id/page/:page", middleware.CanAdminPlugins(hs.Cfg, hs.AccessControl), hs.Index)
@@ -539,6 +540,8 @@ func (hs *HTTPServer) registerRoutes() {
 		})
 
 		apiRoute.Post("/frontend-metrics", routing.Wrap(hs.PostFrontendMetrics))
+
+		apiRoute.Get("/featuremgmt/flags", authorize(ac.EvalPermission(ac.ActionFeatureManagementRead)), routing.Wrap(hs.GetFeatureFlags))
 
 		apiRoute.Group("/live", func(liveRoute routing.RouteRegister) {
 			// the channel path is in the name

--- a/pkg/api/featuremgmt.go
+++ b/pkg/api/featuremgmt.go
@@ -1,0 +1,19 @@
+package api
+
+import (
+	"net/http"
+
+	"github.com/grafana/grafana/pkg/api/response"
+	contextmodel "github.com/grafana/grafana/pkg/services/contexthandler/model"
+	"github.com/grafana/grafana/pkg/services/featuremgmt"
+)
+
+// GetFeatureFlags returns all registered feature flags and their current enabled state.
+func (hs *HTTPServer) GetFeatureFlags(c *contextmodel.ReqContext) response.Response {
+	fm, ok := hs.Features.(*featuremgmt.FeatureManager)
+	if !ok {
+		return response.Error(http.StatusServiceUnavailable, "feature flags are not available", nil)
+	}
+
+	return response.JSON(http.StatusOK, fm.GetFlagsWithState())
+}

--- a/pkg/api/featuremgmt_test.go
+++ b/pkg/api/featuremgmt_test.go
@@ -1,0 +1,57 @@
+package api
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/grafana/pkg/services/accesscontrol/actest"
+	"github.com/grafana/grafana/pkg/services/featuremgmt"
+	"github.com/grafana/grafana/pkg/services/user"
+	"github.com/grafana/grafana/pkg/web/webtest"
+)
+
+func TestHTTPServer_GetFeatureFlags(t *testing.T) {
+	t.Run("returns 403 when not authorized", func(t *testing.T) {
+		server := SetupAPITestServer(t, func(hs *HTTPServer) {
+			hs.AccessControl = &actest.FakeAccessControl{ExpectedEvaluate: false}
+		})
+
+		res, err := server.Send(webtest.RequestWithSignedInUser(server.NewGetRequest("/api/featuremgmt/flags"), &user.SignedInUser{
+			UserID: 1,
+			OrgID:  1,
+		}))
+		require.NoError(t, err)
+		assert.Equal(t, http.StatusForbidden, res.StatusCode)
+		require.NoError(t, res.Body.Close())
+	})
+
+	t.Run("returns 200 with flags when authorized", func(t *testing.T) {
+		server := SetupAPITestServer(t, func(hs *HTTPServer) {
+			hs.AccessControl = &actest.FakeAccessControl{ExpectedEvaluate: true}
+			// Empty WithFeatures() has no registered flags; use at least one for a non-empty list.
+			hs.Features = featuremgmt.WithFeatures("labsTestFlag")
+		})
+
+		res, err := server.Send(webtest.RequestWithSignedInUser(server.NewGetRequest("/api/featuremgmt/flags"), &user.SignedInUser{
+			UserID: 1,
+			OrgID:  1,
+		}))
+		require.NoError(t, err)
+		assert.Equal(t, http.StatusOK, res.StatusCode)
+
+		body, err := io.ReadAll(res.Body)
+		require.NoError(t, err)
+		require.NoError(t, res.Body.Close())
+
+		var flags []featuremgmt.FeatureFlagState
+		require.NoError(t, json.Unmarshal(body, &flags))
+		require.Len(t, flags, 1)
+		require.Equal(t, "labsTestFlag", flags[0].Name)
+		require.True(t, flags[0].Enabled)
+	})
+}

--- a/pkg/services/featuremgmt/manager.go
+++ b/pkg/services/featuremgmt/manager.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"reflect"
+	"sort"
 
 	"github.com/grafana/grafana/pkg/infra/log"
 )
@@ -125,6 +126,30 @@ func (fm *FeatureManager) GetFlags() []FeatureFlag {
 		v = append(v, *value)
 	}
 	return v
+}
+
+// GetFlagsWithState returns all registered flags sorted by name with current enabled state and optional warnings.
+func (fm *FeatureManager) GetFlagsWithState() []FeatureFlagState {
+	flags := fm.GetFlags()
+	sort.Slice(flags, func(i, j int) bool {
+		return flags[i].Name < flags[j].Name
+	})
+	out := make([]FeatureFlagState, 0, len(flags))
+	for _, f := range flags {
+		out = append(out, FeatureFlagState{
+			Name:            f.Name,
+			Description:     f.Description,
+			Stage:           f.Stage,
+			Expression:      f.Expression,
+			RequiresDevMode: f.RequiresDevMode,
+			FrontendOnly:    f.FrontendOnly,
+			HideFromDocs:    f.HideFromDocs,
+			RequiresRestart: f.RequiresRestart,
+			Enabled:         fm.IsEnabledGlobally(f.Name),
+			Warning:         fm.warnings[f.Name],
+		})
+	}
+	return out
 }
 
 // ############# Test Functions #############

--- a/pkg/services/featuremgmt/manager_test.go
+++ b/pkg/services/featuremgmt/manager_test.go
@@ -65,4 +65,14 @@ func TestFeatureManager(t *testing.T) {
 		require.False(t, ft.IsEnabledGlobally("b"))
 		require.False(t, ft.IsEnabledGlobally("c"))
 	})
+
+	t.Run("GetFlagsWithState sorted by name with enabled state", func(t *testing.T) {
+		ft := WithManager("zebra", true, "alpha", false)
+		states := ft.GetFlagsWithState()
+		require.Len(t, states, 2)
+		require.Equal(t, "alpha", states[0].Name)
+		require.False(t, states[0].Enabled)
+		require.Equal(t, "zebra", states[1].Name)
+		require.True(t, states[1].Enabled)
+	})
 }

--- a/pkg/services/featuremgmt/models.go
+++ b/pkg/services/featuremgmt/models.go
@@ -152,6 +152,20 @@ type FeatureFlag struct {
 	RequiresRestart bool `json:"requiresRestart,omitempty"`
 }
 
+// FeatureFlagState is metadata plus runtime enabled state for a registered flag (e.g. Labs UI, APIs).
+type FeatureFlagState struct {
+	Name            string           `json:"name"`
+	Description     string           `json:"description"`
+	Stage           FeatureFlagStage `json:"stage,omitempty"`
+	Expression      string           `json:"expression"`
+	RequiresDevMode bool             `json:"requiresDevMode,omitempty"`
+	FrontendOnly    bool             `json:"frontend,omitempty"`
+	HideFromDocs    bool             `json:"hideFromDocs,omitempty"`
+	RequiresRestart bool             `json:"requiresRestart,omitempty"`
+	Enabled         bool             `json:"enabled"`
+	Warning         string           `json:"warning,omitempty"`
+}
+
 type FeatureToggleWebhookPayload struct {
 	FeatureToggles map[string]string `json:"feature_toggles"`
 	User           string            `json:"user"`

--- a/pkg/services/navtree/models.go
+++ b/pkg/services/navtree/models.go
@@ -37,6 +37,9 @@ const (
 	WeightHelp
 )
 
+// WeightLabs places Labs after Plugins and data (WeightPlugin) and before Administration (WeightConfig).
+const WeightLabs = -501
+
 const (
 	NavIDRoot                 = "root"
 	NavIDDashboards           = "dashboards/browse"
@@ -55,6 +58,7 @@ const (
 	NavIDCfgPlugins           = "cfg/plugins"
 	NavIDCfgAccess            = "cfg/access"
 	NavIDBookmarks            = "bookmarks"
+	NavIDLabs                 = "labs"
 )
 
 type NavLink struct {

--- a/pkg/services/navtree/navtreeimpl/labs_test.go
+++ b/pkg/services/navtree/navtreeimpl/labs_test.go
@@ -1,0 +1,66 @@
+package navtreeimpl
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	ac "github.com/grafana/grafana/pkg/services/accesscontrol"
+	"github.com/grafana/grafana/pkg/services/accesscontrol/acimpl"
+	contextmodel "github.com/grafana/grafana/pkg/services/contexthandler/model"
+	"github.com/grafana/grafana/pkg/services/featuremgmt"
+	"github.com/grafana/grafana/pkg/services/navtree"
+	"github.com/grafana/grafana/pkg/services/user"
+	"github.com/grafana/grafana/pkg/setting"
+	"github.com/grafana/grafana/pkg/web"
+)
+
+func TestBuildLabsNavLink(t *testing.T) {
+	httpReq, _ := http.NewRequest(http.MethodGet, "", nil)
+	cfg := setting.NewCfg()
+
+	t.Run("returns nil without featuremgmt.read", func(t *testing.T) {
+		reqCtx := &contextmodel.ReqContext{
+			SignedInUser: &user.SignedInUser{
+				UserID: 1,
+				OrgID:  1,
+				Permissions: map[int64]map[string][]string{
+					1: {},
+				},
+			},
+			Context: &web.Context{Req: httpReq},
+		}
+		s := &ServiceImpl{
+			cfg:           cfg,
+			accessControl: acimpl.ProvideAccessControl(featuremgmt.WithFeatures()),
+		}
+		require.Nil(t, s.buildLabsNavLink(reqCtx))
+	})
+
+	t.Run("returns Labs nav with IsNew when user has featuremgmt.read", func(t *testing.T) {
+		reqCtx := &contextmodel.ReqContext{
+			SignedInUser: &user.SignedInUser{
+				UserID: 1,
+				OrgID:  1,
+				Permissions: map[int64]map[string][]string{
+					1: {
+						ac.ActionFeatureManagementRead: {ac.ScopeSettingsAll},
+					},
+				},
+			},
+			Context: &web.Context{Req: httpReq},
+		}
+		s := &ServiceImpl{
+			cfg:           cfg,
+			accessControl: acimpl.ProvideAccessControl(featuremgmt.WithFeatures()),
+		}
+		link := s.buildLabsNavLink(reqCtx)
+		require.NotNil(t, link)
+		require.Equal(t, navtree.NavIDLabs, link.Id)
+		require.Equal(t, "Labs", link.Text)
+		require.True(t, link.IsNew)
+		require.Equal(t, int64(navtree.WeightLabs), link.SortWeight)
+		require.Contains(t, link.Url, "/labs")
+	})
+}

--- a/pkg/services/navtree/navtreeimpl/navtree.go
+++ b/pkg/services/navtree/navtreeimpl/navtree.go
@@ -162,6 +162,10 @@ func (s *ServiceImpl) GetNavTree(c *contextmodel.ReqContext, prefs *pref.Prefere
 		treeRoot.AddSection(connectionsSection)
 	}
 
+	if labsSection := s.buildLabsNavLink(c); labsSection != nil {
+		treeRoot.AddSection(labsSection)
+	}
+
 	orgAdminNode, err := s.getAdminNode(c)
 
 	if orgAdminNode != nil && len(orgAdminNode.Children) > 0 {
@@ -647,4 +651,21 @@ func (s *ServiceImpl) buildDataConnectionsNavLink(c *contextmodel.ReqContext) *n
 		return navLink
 	}
 	return nil
+}
+
+func (s *ServiceImpl) buildLabsNavLink(c *contextmodel.ReqContext) *navtree.NavLink {
+	hasAccess := ac.HasAccess(s.accessControl, c)
+	if !hasAccess(ac.EvalPermission(ac.ActionFeatureManagementRead)) {
+		return nil
+	}
+
+	return &navtree.NavLink{
+		Text:       "Labs",
+		SubTitle:   "Experimental features and feature toggle state",
+		Id:         navtree.NavIDLabs,
+		Icon:       "lightbulb",
+		Url:        s.cfg.AppSubURL + "/labs",
+		SortWeight: navtree.WeightLabs,
+		IsNew:      true,
+	}
 }

--- a/public/app/core/utils/navBarItem-translations.ts
+++ b/public/app/core/utils/navBarItem-translations.ts
@@ -179,6 +179,8 @@ export function getNavTitle(navId: string | undefined) {
       return t('nav.sign-out.title', 'Sign out');
     case 'search':
       return t('nav.search-dashboards.title', 'Search dashboards');
+    case 'labs':
+      return t('nav.labs.title', 'Labs');
     case 'connections':
       return t('nav.connections.title', 'Connections');
     case 'connections-add-new-connection':
@@ -304,6 +306,8 @@ export function getNavSubTitle(navId: string | undefined) {
       return t('nav.infrastructure.subtitle', "Understand your infrastructure's health");
     case 'frontend':
       return t('nav.frontend.subtitle', 'Gain real user monitoring insights');
+    case 'labs':
+      return t('nav.labs.subtitle', 'Experimental features and feature toggle state');
     case 'alerts-and-incidents':
       return t('nav.alerts-and-incidents.subtitle', 'Alerting and incident management apps');
     case 'testing-and-synthetics':

--- a/public/app/features/labs/LabsPage.tsx
+++ b/public/app/features/labs/LabsPage.tsx
@@ -1,0 +1,91 @@
+import { useMemo } from 'react';
+import { useAsync } from 'react-use';
+
+import { Trans, t } from '@grafana/i18n';
+import { getBackendSrv } from '@grafana/runtime';
+import {
+  Alert,
+  Badge,
+  InteractiveTable,
+  LoadingPlaceholder,
+  type CellProps,
+  type Column,
+} from '@grafana/ui';
+import { Page } from 'app/core/components/Page/Page';
+
+export interface FeatureFlagRow {
+  name: string;
+  description: string;
+  stage?: string;
+  expression: string;
+  requiresDevMode?: boolean;
+  frontend?: boolean;
+  hideFromDocs?: boolean;
+  requiresRestart?: boolean;
+  enabled: boolean;
+  warning?: string;
+}
+
+export default function LabsPage() {
+  const { loading, value: flags, error } = useAsync(async () => {
+    return getBackendSrv().get<FeatureFlagRow[]>('/api/featuremgmt/flags');
+  }, []);
+
+  const columns: Array<Column<FeatureFlagRow>> = useMemo(
+    () => [
+      {
+        id: 'name',
+        header: t('labs.table.name', 'Name'),
+        sortType: 'string',
+      },
+      {
+        id: 'description',
+        header: t('labs.table.description', 'Description'),
+        cell: ({ row }: CellProps<FeatureFlagRow>) => row.original.description,
+      },
+      {
+        id: 'stage',
+        header: t('labs.table.stage', 'Stage'),
+        cell: ({ row }: CellProps<FeatureFlagRow>) => row.original.stage ?? '—',
+      },
+      {
+        id: 'enabled',
+        header: t('labs.table.enabled', 'Enabled'),
+        cell: ({ row }: CellProps<FeatureFlagRow>) =>
+          row.original.enabled ? (
+            <Badge color="green" text={t('labs.table.enabled-on', 'On')} />
+          ) : (
+            <Badge color="red" text={t('labs.table.enabled-off', 'Off')} />
+          ),
+      },
+      {
+        id: 'warning',
+        header: t('labs.table.note', 'Note'),
+        cell: ({ row }: CellProps<FeatureFlagRow>) => row.original.warning ?? '',
+      },
+    ],
+    []
+  );
+
+  return (
+    <Page navId="labs">
+      <Page.Contents>
+        <Alert severity="info" title="">
+          <Trans i18nKey="labs.description">
+            All feature flags registered in this Grafana build and their current enabled state for this instance.
+          </Trans>
+        </Alert>
+
+        {loading && <LoadingPlaceholder text={t('labs.loading', 'Loading feature flags')} />}
+        {error && (
+          <Alert severity="error" title={t('labs.error-title', 'Failed to load feature flags')}>
+            {String(error)}
+          </Alert>
+        )}
+        {flags && !loading && !error && (
+          <InteractiveTable columns={columns} data={flags} getRowId={(row) => row.name} />
+        )}
+      </Page.Contents>
+    </Page>
+  );
+}

--- a/public/app/routes/routes.tsx
+++ b/public/app/routes/routes.tsx
@@ -226,6 +226,13 @@ export function getAppRoutes(): RouteDescriptor[] {
       component: () => <NavLandingPage navId="frontend" />,
     },
     {
+      path: '/labs',
+      roles: () => contextSrv.evaluatePermission([AccessControlAction.FeatureManagementRead]),
+      component: SafeDynamicImport(
+        () => import(/* webpackChunkName: "LabsPage" */ 'app/features/labs/LabsPage')
+      ),
+    },
+    {
       path: '/admin/general',
       component: () => <NavLandingPage navId="cfg/general" />,
     },

--- a/public/app/types/accessControl.ts
+++ b/public/app/types/accessControl.ts
@@ -180,6 +180,9 @@ export enum AccessControlAction {
   // Saved Queries
   QueriesRead = 'queries:read',
   QueriesWrite = 'queries:write',
+
+  // Feature management (Labs / feature flags)
+  FeatureManagementRead = 'featuremgmt.read',
 }
 
 export interface Role extends RoleDto {


### PR DESCRIPTION
## Summary

Adds a Labs UI entry point and backend support for managing feature toggles, including new API handlers, featuremgmt service extensions, navigation, routing, and access control.

## Changes

- HTTP API for feature toggle management with tests
- Feature management service updates and unit tests
- Labs nav item, `/labs` route, and `LabsPage` component
- RBAC action for Labs access

## Verification

- `go test -run TestName ./pkg/api/...` and featuremgmt/navtree tests as appropriate
- Frontend: navigate to Labs when permitted

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new authenticated API surface that exposes feature-flag configuration/state and new navigation/routing gated by RBAC; issues would mainly be incorrect authorization or unintended information exposure.
> 
> **Overview**
> Adds a new **Labs** entry point (`/labs`) gated by `featuremgmt.read`, including a frontend page that fetches and displays all registered feature flags and their enabled state in a table.
> 
> Introduces a new authenticated API endpoint `GET /api/featuremgmt/flags` (with tests) backed by new featuremgmt models/methods (`FeatureFlagState`, `GetFlagsWithState`) that return a name-sorted list of flag metadata plus runtime state/warnings, and wires Labs into the server-side nav tree and navbar translations.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2c848fea6377d7833b1407b2125431e9fcf08065. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->