### PR TITLE
Themes: add nineties experimental theme

### DIFF
--- a/packages/grafana-data/src/themes/registry.ts
+++ b/packages/grafana-data/src/themes/registry.ts
@@ -8,6 +8,7 @@ import gildedgrove from './themeDefinitions/gildedgrove.json';
 import gloom from './themeDefinitions/gloom.json';
 import mars from './themeDefinitions/mars.json';
 import matrix from './themeDefinitions/matrix.json';
+import nineties from './themeDefinitions/nineties.json';
 import sapphiredusk from './themeDefinitions/sapphiredusk.json';
 import synthwave from './themeDefinitions/synthwave.json';
 import tron from './themeDefinitions/tron.json';
@@ -28,6 +29,7 @@ const extraThemes: { [key: string]: unknown } = {
   gloom,
   mars,
   matrix,
+  nineties,
   sapphiredusk,
   synthwave,
   tron,

--- a/packages/grafana-data/src/themes/themeDefinitions/nineties.json
+++ b/packages/grafana-data/src/themes/themeDefinitions/nineties.json
@@ -1,0 +1,74 @@
+{
+  "name": "Nineties",
+  "id": "nineties",
+  "colors": {
+    "mode": "dark",
+    "border": {
+      "weak": "rgba(0, 255, 255, 0.14)",
+      "medium": "rgba(0, 255, 255, 0.24)",
+      "strong": "rgba(255, 0, 255, 0.34)"
+    },
+    "text": {
+      "primary": "#F7F3FF",
+      "secondary": "rgba(247, 243, 255, 0.78)",
+      "disabled": "rgba(247, 243, 255, 0.52)",
+      "link": "#00F5FF",
+      "maxContrast": "#FFFFFF"
+    },
+    "primary": {
+      "main": "#FF2BD6",
+      "text": "#FF8CF0",
+      "border": "#FF2BD6",
+      "name": "primary",
+      "shade": "#D81FB5",
+      "transparent": "rgba(255, 43, 214, 0.16)",
+      "contrastText": "#FFFFFF",
+      "borderTransparent": "rgba(255, 43, 214, 0.28)"
+    },
+    "secondary": {
+      "main": "#23134A",
+      "text": "#97F9FF",
+      "border": "rgba(0, 245, 255, 0.18)",
+      "name": "secondary",
+      "shade": "#311A63",
+      "transparent": "rgba(35, 19, 74, 0.18)",
+      "contrastText": "#F7F3FF",
+      "borderTransparent": "rgba(0, 245, 255, 0.28)"
+    },
+    "success": {
+      "main": "#7CFF6B"
+    },
+    "warning": {
+      "main": "#FFD84D"
+    },
+    "error": {
+      "main": "#FF6B8A"
+    },
+    "info": {
+      "main": "#00F5FF"
+    },
+    "background": {
+      "canvas": "#12002B",
+      "primary": "#1C0F3A",
+      "secondary": "#2A1457",
+      "elevated": "#33186B"
+    },
+    "action": {
+      "hover": "rgba(0, 245, 255, 0.12)",
+      "selected": "rgba(255, 43, 214, 0.14)",
+      "selectedBorder": "#00F5FF",
+      "focus": "rgba(0, 245, 255, 0.18)",
+      "hoverOpacity": 0.08,
+      "disabledText": "rgba(247, 243, 255, 0.52)",
+      "disabledBackground": "rgba(0, 245, 255, 0.07)",
+      "disabledOpacity": 0.38
+    },
+    "gradients": {
+      "brandHorizontal": "linear-gradient(270deg, #FF2BD6 0%, #00F5FF 100%)",
+      "brandVertical": "linear-gradient(0deg, #FF2BD6 0%, #00F5FF 100%)"
+    },
+    "contrastThreshold": 3,
+    "hoverFactor": 0.03,
+    "tonalOffset": 0.15
+  }
+}

--- a/pkg/services/preference/themes_generated.go
+++ b/pkg/services/preference/themes_generated.go
@@ -13,6 +13,7 @@ var themes = []ThemeDTO{
 	{ID: "gloom", Type: "dark", IsExtra: true},
 	{ID: "mars", Type: "dark", IsExtra: true},
 	{ID: "matrix", Type: "dark", IsExtra: true},
+	{ID: "nineties", Type: "dark", IsExtra: true},
 	{ID: "sapphiredusk", Type: "dark", IsExtra: true},
 	{ID: "synthwave", Type: "dark", IsExtra: true},
 	{ID: "tron", Type: "dark", IsExtra: true},

--- a/public/app/core/components/ThemeSelector/getSelectableThemes.test.ts
+++ b/public/app/core/components/ThemeSelector/getSelectableThemes.test.ts
@@ -1,0 +1,23 @@
+import { config } from '@grafana/runtime';
+
+import { getSelectableThemes } from './getSelectableThemes';
+
+describe('getSelectableThemes', () => {
+  const originalGrafanaconThemes = config.featureToggles.grafanaconThemes;
+
+  afterEach(() => {
+    config.featureToggles.grafanaconThemes = originalGrafanaconThemes;
+  });
+
+  it('includes the nineties theme when experimental themes are enabled', () => {
+    config.featureToggles.grafanaconThemes = true;
+
+    expect(getSelectableThemes().map((theme) => theme.id)).toContain('nineties');
+  });
+
+  it('excludes extra themes when experimental themes are disabled', () => {
+    config.featureToggles.grafanaconThemes = false;
+
+    expect(getSelectableThemes().map((theme) => theme.id)).not.toContain('nineties');
+  });
+});

--- a/public/app/core/components/ThemeSelector/getSelectableThemes.ts
+++ b/public/app/core/components/ThemeSelector/getSelectableThemes.ts
@@ -8,6 +8,7 @@ export function getSelectableThemes() {
     allowedExtraThemes.push('desertbloom');
     allowedExtraThemes.push('gildedgrove');
     allowedExtraThemes.push('sapphiredusk');
+    allowedExtraThemes.push('nineties');
     allowedExtraThemes.push('tron');
     allowedExtraThemes.push('gloom');
   }

--- a/public/app/features/theme-playground/ThemePlayground.tsx
+++ b/public/app/features/theme-playground/ThemePlayground.tsx
@@ -10,6 +10,7 @@ import gildedgrove from '@grafana/data/themes/definitions/gildedgrove.json';
 import gloom from '@grafana/data/themes/definitions/gloom.json';
 import mars from '@grafana/data/themes/definitions/mars.json';
 import matrix from '@grafana/data/themes/definitions/matrix.json';
+import nineties from '@grafana/data/themes/definitions/nineties.json';
 import sapphiredusk from '@grafana/data/themes/definitions/sapphiredusk.json';
 import synthwave from '@grafana/data/themes/definitions/synthwave.json';
 import tron from '@grafana/data/themes/definitions/tron.json';
@@ -54,6 +55,7 @@ const experimentalDefinitions: Record<string, unknown> = {
   gloom,
   mars,
   matrix,
+  nineties,
   sapphiredusk,
   synthwave,
   tron,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
**What is this feature?**

This adds a new experimental extra theme named `Nineties` to Grafana's theme registry, makes it selectable from the Change theme drawer when the `grafanaconThemes` feature toggle is enabled, and exposes it in the theme playground for visual previewing.

**Why do we need this feature?**

A playful 90s-inspired theme was requested for the project. This implements it with a minimal, targeted change that follows the existing experimental theme pattern.

**Who is this feature for?**

Grafana users and internal teams who want an optional retro visual theme in environments where experimental themes are enabled, plus developers who want to preview that theme in the built-in playground.

**Which issue(s) does this PR fix?**:

Fixes #

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a notable improvement, it's added to the What's New doc.

Automated tests run:
- `yarn jest --no-watch --runInBand public/app/core/components/ThemeSelector/getSelectableThemes.test.ts`
- `go test ./pkg/services/preference/...`

Manual verification:
- Opened `http://localhost:3000/theme-playground`
- Selected `Nineties` in the Base theme combobox
- Verified the retro palette renders across layers, rich colors, forms, and buttons

<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://cursor-demo.slack.com/archives/C096N4TMDJL/p1774453397578309?thread_ts=1774453397.578309&cid=C096N4TMDJL)

<div><a href="https://cursor.com/agents/bc-13e9fcb5-e15f-521d-ab8c-1a08d1e5d168"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-13e9fcb5-e15f-521d-ab8c-1a08d1e5d168"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

