### PR TITLE
Themes: Add Midnight Aurora theme to theme switcher

### DIFF
--- a/packages/grafana-data/src/themes/registry.ts
+++ b/packages/grafana-data/src/themes/registry.ts
@@ -8,6 +8,7 @@ import gildedgrove from './themeDefinitions/gildedgrove.json';
 import gloom from './themeDefinitions/gloom.json';
 import mars from './themeDefinitions/mars.json';
 import matrix from './themeDefinitions/matrix.json';
+import midnightaurora from './themeDefinitions/midnightaurora.json';
 import sapphiredusk from './themeDefinitions/sapphiredusk.json';
 import synthwave from './themeDefinitions/synthwave.json';
 import tron from './themeDefinitions/tron.json';
@@ -28,6 +29,7 @@ const extraThemes: { [key: string]: unknown } = {
   gloom,
   mars,
   matrix,
+  midnightaurora,
   sapphiredusk,
   synthwave,
   tron,

--- a/packages/grafana-data/src/themes/themeDefinitions/midnightaurora.json
+++ b/packages/grafana-data/src/themes/themeDefinitions/midnightaurora.json
@@ -1,0 +1,79 @@
+{
+  "name": "Midnight aurora",
+  "id": "midnightaurora",
+  "colors": {
+    "mode": "dark",
+    "border": {
+      "weak": "rgba(100, 220, 180, 0.10)",
+      "medium": "rgba(100, 220, 180, 0.18)",
+      "strong": "rgba(100, 220, 180, 0.28)"
+    },
+    "text": {
+      "primary": "#E2E8F0",
+      "secondary": "rgba(226, 232, 240, 0.72)",
+      "disabled": "rgba(226, 232, 240, 0.45)",
+      "link": "#6EE7B7",
+      "maxContrast": "#FFFFFF"
+    },
+    "primary": {
+      "main": "#6EE7B7",
+      "text": "#86EFAC",
+      "border": "#6EE7B7",
+      "name": "primary",
+      "shade": "#A7F3D0",
+      "transparent": "#6EE7B726",
+      "contrastText": "#0F172A",
+      "borderTransparent": "#6EE7B740"
+    },
+    "secondary": {
+      "main": "#1E293B",
+      "shade": "#283548",
+      "transparent": "rgba(148, 163, 184, 0.08)",
+      "text": "#CBD5E1",
+      "contrastText": "#E2E8F0",
+      "border": "rgba(148, 163, 184, 0.10)",
+      "name": "secondary",
+      "borderTransparent": "rgba(148, 163, 184, 0.22)"
+    },
+    "info": {
+      "main": "#7C3AED",
+      "text": "#A78BFA",
+      "border": "#8B5CF6"
+    },
+    "error": {
+      "main": "#F43F5E",
+      "text": "#FB7185"
+    },
+    "success": {
+      "main": "#10B981",
+      "text": "#34D399"
+    },
+    "warning": {
+      "main": "#C084FC",
+      "text": "#D8B4FE"
+    },
+    "background": {
+      "canvas": "#0B1120",
+      "primary": "#0F172A",
+      "secondary": "#162033",
+      "elevated": "#1A2540"
+    },
+    "action": {
+      "hover": "rgba(110, 231, 183, 0.12)",
+      "selected": "rgba(110, 231, 183, 0.10)",
+      "selectedBorder": "#C084FC",
+      "focus": "rgba(110, 231, 183, 0.14)",
+      "hoverOpacity": 0.08,
+      "disabledText": "rgba(226, 232, 240, 0.45)",
+      "disabledBackground": "rgba(110, 231, 183, 0.06)",
+      "disabledOpacity": 0.38
+    },
+    "gradients": {
+      "brandHorizontal": "linear-gradient(270deg, #C084FC 0%, #6EE7B7 100%)",
+      "brandVertical": "linear-gradient(0.01deg, #C084FC 0.01%, #6EE7B7 99.99%)"
+    },
+    "contrastThreshold": 3,
+    "hoverFactor": 0.04,
+    "tonalOffset": 0.18
+  }
+}

--- a/pkg/services/preference/themes_generated.go
+++ b/pkg/services/preference/themes_generated.go
@@ -13,6 +13,7 @@ var themes = []ThemeDTO{
 	{ID: "gloom", Type: "dark", IsExtra: true},
 	{ID: "mars", Type: "dark", IsExtra: true},
 	{ID: "matrix", Type: "dark", IsExtra: true},
+	{ID: "midnightaurora", Type: "dark", IsExtra: true},
 	{ID: "sapphiredusk", Type: "dark", IsExtra: true},
 	{ID: "synthwave", Type: "dark", IsExtra: true},
 	{ID: "tron", Type: "dark", IsExtra: true},

--- a/public/app/core/components/ThemeSelector/getSelectableThemes.ts
+++ b/public/app/core/components/ThemeSelector/getSelectableThemes.ts
@@ -10,6 +10,7 @@ export function getSelectableThemes() {
     allowedExtraThemes.push('sapphiredusk');
     allowedExtraThemes.push('tron');
     allowedExtraThemes.push('gloom');
+    allowedExtraThemes.push('midnightaurora');
   }
 
   return getBuiltInThemes(allowedExtraThemes);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
**What is this feature?**

Adds a new "Midnight Aurora" dark theme to the Grafana theme switcher. The theme features deep midnight backgrounds (`#0B1120` / `#0F172A`) with aurora-inspired green (`#6EE7B7`) and purple (`#C084FC`) accents, reminiscent of the northern lights.

**Why do we need this feature?**

Expands the set of extra themes available behind the `grafanaconThemes` feature toggle, giving users more visual variety.

**Who is this feature for?**

Users who want a dark theme with softer, nature-inspired accent colors.

**Which issue(s) does this PR fix?**:

N/A

**Special notes for your reviewer:**

The theme is gated behind the existing `grafanaconThemes` feature toggle.

Files changed:
- `packages/grafana-data/src/themes/themeDefinitions/midnightaurora.json` — theme definition
- `packages/grafana-data/src/themes/registry.ts` — import + register the theme
- `public/app/core/components/ThemeSelector/getSelectableThemes.ts` — add to allowlist
- `pkg/services/preference/themes_generated.go` — regenerated via `go run generate_themes.go`

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5ed3b081-6af4-46a4-b4a0-1531e6c6a180"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5ed3b081-6af4-46a4-b4a0-1531e6c6a180"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

