### PR TITLE
feat(dashboard): home page info banner

### DIFF
--- a/public/app/features/dashboard-scene/pages/DashboardScenePage.tsx
+++ b/public/app/features/dashboard-scene/pages/DashboardScenePage.tsx
@@ -9,6 +9,7 @@ import { Box } from '@grafana/ui';
 import { Page } from 'app/core/components/Page/Page';
 import PageLoader from 'app/core/components/PageLoader/PageLoader';
 import { GrafanaRouteComponentProps } from 'app/core/navigation/types';
+import { HomePageBanner } from 'app/features/dashboard/components/HomePageBanner/HomePageBanner';
 import {
   DashboardBrandingFooter,
   DashboardBrandingFooterVariant,
@@ -122,6 +123,7 @@ export function DashboardScenePage({ route, queryParams, location }: Props) {
   return (
     <UrlSyncContextProvider scene={dashboard} updateUrlOnInit={true} createBrowserHistorySteps={true}>
       <DashboardPreviewBanner queryParams={queryParams} route={route.routeName} slug={slug} path={path} />
+      {route.routeName === DashboardRoutes.Home && !isKioskMode && <HomePageBanner />}
       <DashboardConversionWarningBanner dashboard={dashboard} />
       <dashboard.Component model={dashboard} key={dashboard.state.key} />
       <DashboardPrompt dashboard={dashboard} />

--- a/public/app/features/dashboard/components/HomePageBanner/HomePageBanner.test.tsx
+++ b/public/app/features/dashboard/components/HomePageBanner/HomePageBanner.test.tsx
@@ -14,7 +14,7 @@ describe('HomePageBanner', () => {
 
     expect(screen.getByText('Welcome home')).toBeInTheDocument();
     expect(
-      screen.getByText('This banner appears only on the Grafana home dashboard.')
+      screen.getByText('Use this home dashboard to discover, create, and organize your dashboards.')
     ).toBeInTheDocument();
   });
 });

--- a/public/app/features/dashboard/components/HomePageBanner/HomePageBanner.test.tsx
+++ b/public/app/features/dashboard/components/HomePageBanner/HomePageBanner.test.tsx
@@ -1,0 +1,20 @@
+import { render, screen } from '@testing-library/react';
+import { TestProvider } from 'test/helpers/TestProvider';
+import { getGrafanaContextMock } from 'test/mocks/getGrafanaContextMock';
+
+import { HomePageBanner } from './HomePageBanner';
+
+describe('HomePageBanner', () => {
+  it('renders home banner messaging', () => {
+    render(
+      <TestProvider grafanaContext={getGrafanaContextMock()}>
+        <HomePageBanner />
+      </TestProvider>
+    );
+
+    expect(screen.getByText('Welcome home')).toBeInTheDocument();
+    expect(
+      screen.getByText('This banner appears only on the Grafana home dashboard.')
+    ).toBeInTheDocument();
+  });
+});

--- a/public/app/features/dashboard/components/HomePageBanner/HomePageBanner.tsx
+++ b/public/app/features/dashboard/components/HomePageBanner/HomePageBanner.tsx
@@ -1,0 +1,17 @@
+import { t } from '@grafana/i18n';
+import { Alert } from '@grafana/ui';
+
+export function HomePageBanner() {
+  return (
+    <Alert
+      title={t('dashboard.home-page-banner.title', 'Welcome home')}
+      severity="info"
+      style={{ flex: 0 }}
+    >
+      {t(
+        'dashboard.home-page-banner.body',
+        'This banner appears only on the Grafana home dashboard.'
+      )}
+    </Alert>
+  );
+}

--- a/public/app/features/dashboard/components/HomePageBanner/HomePageBanner.tsx
+++ b/public/app/features/dashboard/components/HomePageBanner/HomePageBanner.tsx
@@ -10,7 +10,7 @@ export function HomePageBanner() {
     >
       {t(
         'dashboard.home-page-banner.body',
-        'This banner appears only on the Grafana home dashboard.'
+        'Use this home dashboard to discover, create, and organize your dashboards.'
       )}
     </Alert>
   );

--- a/public/app/features/dashboard/containers/DashboardPage.tsx
+++ b/public/app/features/dashboard/containers/DashboardPage.tsx
@@ -17,7 +17,7 @@ import { ID_PREFIX } from 'app/core/reducers/navBarTree';
 import { getNavModel } from 'app/core/selectors/navModel';
 import { PanelModel } from 'app/features/dashboard/state/PanelModel';
 import { dashboardWatcher } from 'app/features/live/dashboard/dashboardWatcher';
-import { KioskMode } from 'app/types/dashboard';
+import { DashboardRoutes, KioskMode } from 'app/types/dashboard';
 import { PanelEditEnteredEvent, PanelEditExitedEvent } from 'app/types/events';
 import { StoreState } from 'app/types/store';
 
@@ -27,6 +27,7 @@ import DashNav from '../components/DashNav/DashNav';
 import { DashboardLoading } from '../components/DashboardLoading/DashboardLoading';
 import { DashboardPrompt } from '../components/DashboardPrompt/DashboardPrompt';
 import { DashboardSettings } from '../components/DashboardSettings/DashboardSettings';
+import { HomePageBanner } from '../components/HomePageBanner/HomePageBanner';
 import { PanelInspector } from '../components/Inspector/PanelInspector';
 import { PanelEditor } from '../components/PanelEditor/PanelEditor';
 import { ShareModal } from '../components/ShareModal/ShareModal';
@@ -396,6 +397,7 @@ export class UnthemedDashboardPage extends PureComponent<Props, State> {
             </header>
           )}
           <DashboardPrompt dashboard={dashboard} />
+          {this.props.route.routeName === DashboardRoutes.Home && !kioskMode && <HomePageBanner />}
           {initError && <DashboardPageError error={initError.error} type={params.type} />}
           {showSubMenu && (
             <section aria-label={selectors.pages.Dashboard.SubMenu.submenu}>


### PR DESCRIPTION
## Summary
Adds a small informational `Alert` banner on the Grafana **home dashboard** (route `/`, `DashboardRoutes.Home`).

## Details
- New `HomePageBanner` component using `@grafana/ui` `Alert` (matches existing dashboard banner patterns).
- Rendered from `DashboardScenePage` (default path) and legacy `DashboardPage` when scenes are off.
- Hidden when **kiosk** mode is active (same idea as other top-of-dashboard notices).

## Testing
- [x] `yarn test public/app/features/dashboard/components/HomePageBanner/HomePageBanner.test.tsx`

## Notes
- Copy is i18n-wrapped with English defaults (`dashboard.home-page-banner.*`).

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a small UI-only `Alert` on the home dashboard and gates it behind route/kiosk checks, with no data/auth logic changes.
> 
> **Overview**
> Adds a new `HomePageBanner` info `Alert` (i18n-wrapped copy) and renders it on the home dashboard route (`DashboardRoutes.Home`).
> 
> The banner is integrated in both the scenes-based `DashboardScenePage` and legacy `DashboardPage`, and is suppressed in kiosk mode. Includes a basic RTL test to assert the banner messaging renders.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7abae5e93442c2c38f26f7aaf756e148fe42281b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->