### PR TITLE
DevEnv: Update AGENTS.md with corrected Go version and startup ordering gotcha

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -139,7 +139,7 @@ Build a specific plugin: `yarn workspace @grafana-plugins/<name> dev`
 ### Prerequisites
 
 - **Node.js v24.x** (see `.nvmrc` for exact version). Use `nvm install` / `nvm use` to match.
-- **Go 1.25.7** (see `go.mod`). Pre-installed in the VM.
+- **Go 1.25.8** (see `go.mod`). Pre-installed in the VM.
 - **Yarn 4.11.0** via corepack (bundled in `.yarn/releases/`). Run `corepack enable` if `yarn` is not found.
 - **GCC** required for CGo/SQLite compilation of the backend.
 
@@ -152,5 +152,6 @@ Build a specific plugin: `yarn workspace @grafana-plugins/<name> dev`
 ### Testing gotchas
 
 - **Frontend tests**: The `yarn test` script includes `--watch` by default. Always use `yarn jest --no-watch` or add `--watchAll=false` to run tests once and exit.
-- **Backend tests**: Some packages (e.g. `pkg/api/`) have slow test compilation (~2 min) due to large dependency graphs. Use targeted test runs with `-run TestName` where possible.
+- **Backend tests**: Some packages (e.g. `pkg/api/`) have slow test compilation (~3–4 min on first run) due to large dependency graphs. Use targeted test runs with `-run TestName` where possible.
+- **Startup ordering**: If `make run` starts before `yarn start` finishes its first compile, the backend logs `Failed to detect generated javascript files in public/build` and `/login` returns 500. Wait for webpack to populate `public/build/` (or retry the curl check) before using the UI.
 - All standard build/test/lint commands are documented in the Commands section above.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
**What is this feature?**

Updates `AGENTS.md` Cursor Cloud specific instructions with two corrections:
- Fix Go version from 1.25.7 to 1.25.8 to match `go.mod`
- Add startup ordering note: if `make run` starts before `yarn start` finishes its first compile, the backend returns 500 on `/login` until `public/build/` is populated

**Why do we need this feature?**

Ensures future cloud agents have accurate environment prerequisites and avoid a non-obvious startup timing issue.

**Who is this feature for?**

AI agents and developers using Cursor Cloud to work on this repository.

**Which issue(s) does this PR fix?**:

N/A — documentation improvement.

**Special notes for your reviewer:**

- [ ] It works as expected from a user's perspective.
- [x] This is a docs-only change to `AGENTS.md`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e4a63385-9bf5-4bb4-aa87-8d53e8f87921"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e4a63385-9bf5-4bb4-aa87-8d53e8f87921"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

