### PR TITLE
Labs page: navigation, API, and feature-flag UI

### DIFF
--- a/pkg/api/admin_feature_toggles.go
+++ b/pkg/api/admin_feature_toggles.go
@@ -1,0 +1,56 @@
+package api
+
+import (
+	"net/http"
+	"sort"
+
+	"github.com/grafana/grafana/pkg/api/response"
+	contextmodel "github.com/grafana/grafana/pkg/services/contexthandler/model"
+	"github.com/grafana/grafana/pkg/services/featuremgmt"
+)
+
+// FeatureToggleListItem is a single feature flag for the Labs UI and API consumers.
+type FeatureToggleListItem struct {
+	Name            string `json:"name"`
+	Description     string `json:"description,omitempty"`
+	Stage           string `json:"stage"`
+	Enabled         bool   `json:"enabled"`
+	RequiresDevMode bool   `json:"requiresDevMode,omitempty"`
+	RequiresRestart bool   `json:"requiresRestart,omitempty"`
+	FrontendOnly    bool   `json:"frontend,omitempty"`
+	Expression      string `json:"expression,omitempty"`
+}
+
+// FeatureToggleListResponse is the body for GET /api/admin/feature-toggles.
+type FeatureToggleListResponse struct {
+	Flags []FeatureToggleListItem `json:"flags"`
+}
+
+func (hs *HTTPServer) AdminGetFeatureToggles(c *contextmodel.ReqContext) response.Response {
+	fm, ok := hs.Features.(*featuremgmt.FeatureManager)
+	if !ok {
+		return response.Error(http.StatusInternalServerError, "Feature toggle service unavailable", nil)
+	}
+
+	ctx := c.Req.Context()
+	defs := fm.GetFlags()
+	items := make([]FeatureToggleListItem, 0, len(defs))
+	for _, f := range defs {
+		items = append(items, FeatureToggleListItem{
+			Name:            f.Name,
+			Description:     f.Description,
+			Stage:           f.Stage.String(),
+			Enabled:         hs.Features.IsEnabled(ctx, f.Name),
+			RequiresDevMode: f.RequiresDevMode,
+			RequiresRestart: f.RequiresRestart,
+			FrontendOnly:    f.FrontendOnly,
+			Expression:      f.Expression,
+		})
+	}
+
+	sort.Slice(items, func(i, j int) bool {
+		return items[i].Name < items[j].Name
+	})
+
+	return response.JSON(http.StatusOK, FeatureToggleListResponse{Flags: items})
+}

--- a/pkg/api/admin_feature_toggles_test.go
+++ b/pkg/api/admin_feature_toggles_test.go
@@ -1,0 +1,54 @@
+package api
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/grafana/pkg/services/featuremgmt"
+	"github.com/grafana/grafana/pkg/setting"
+	"github.com/grafana/grafana/pkg/web/webtest"
+)
+
+func TestAPI_AdminGetFeatureToggles(t *testing.T) {
+	t.Run("returns 401 when not signed in", func(t *testing.T) {
+		server := SetupAPITestServer(t, func(hs *HTTPServer) {
+			hs.Cfg = setting.NewCfg()
+		})
+
+		res, err := server.Send(server.NewGetRequest("/api/admin/feature-toggles"))
+		require.NoError(t, err)
+		assert.Equal(t, http.StatusUnauthorized, res.StatusCode)
+		require.NoError(t, res.Body.Close())
+	})
+
+	t.Run("returns 200 for viewer and sorted flag names", func(t *testing.T) {
+		server := SetupAPITestServer(t, func(hs *HTTPServer) {
+			hs.Cfg = setting.NewCfg()
+			hs.Features = featuremgmt.WithFeatures("zebra", true, "alpha", false)
+		})
+
+		res, err := server.Send(webtest.RequestWithSignedInUser(
+			server.NewGetRequest("/api/admin/feature-toggles"),
+			authedUserWithPermissions(1, 1, nil),
+		))
+		require.NoError(t, err)
+		assert.Equal(t, http.StatusOK, res.StatusCode)
+
+		body, err := io.ReadAll(res.Body)
+		require.NoError(t, err)
+		require.NoError(t, res.Body.Close())
+
+		var parsed FeatureToggleListResponse
+		require.NoError(t, json.Unmarshal(body, &parsed))
+		require.Len(t, parsed.Flags, 2)
+		assert.Equal(t, "alpha", parsed.Flags[0].Name)
+		assert.False(t, parsed.Flags[0].Enabled)
+		assert.Equal(t, "zebra", parsed.Flags[1].Name)
+		assert.True(t, parsed.Flags[1].Enabled)
+	})
+}

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -112,6 +112,7 @@ func (hs *HTTPServer) registerRoutes() {
 	r.Get("/configuration", reqGrafanaAdmin, hs.Index)
 	r.Get("/admin", reqOrgAdmin, hs.Index)
 	r.Get("/admin/settings", authorize(ac.EvalPermission(ac.ActionSettingsRead, ac.ScopeSettingsAll)), hs.Index)
+	r.Get("/admin/labs", reqSignedIn, hs.Index)
 	r.Get("/admin/users", authorize(ac.EvalAny(ac.EvalPermission(ac.ActionOrgUsersRead), ac.EvalPermission(ac.ActionUsersRead, ac.ScopeGlobalUsersAll))), hs.Index)
 	r.Get("/admin/users/create", authorize(ac.EvalPermission(ac.ActionUsersCreate)), hs.Index)
 	r.Get("/admin/users/edit/:id", authorize(ac.EvalPermission(ac.ActionUsersRead)), hs.Index)
@@ -561,6 +562,7 @@ func (hs *HTTPServer) registerRoutes() {
 		adminRoute.Get("/settings", authorize(ac.EvalPermission(ac.ActionSettingsRead)), routing.Wrap(hs.AdminGetSettings))
 		adminRoute.Get("/settings-verbose", authorize(ac.EvalPermission(ac.ActionSettingsRead)), routing.Wrap(hs.AdminGetVerboseSettings))
 		adminRoute.Get("/stats", authorize(ac.EvalPermission(ac.ActionServerStatsRead)), routing.Wrap(hs.AdminGetStats))
+		adminRoute.Get("/feature-toggles", routing.Wrap(hs.AdminGetFeatureToggles))
 
 		adminRoute.Post("/encryption/rotate-data-keys", reqGrafanaAdmin, routing.Wrap(hs.AdminRotateDataEncryptionKeys))
 		adminRoute.Post("/encryption/reencrypt-data-keys", reqGrafanaAdmin, routing.Wrap(hs.AdminReEncryptEncryptionKeys))

--- a/pkg/services/navtree/models.go
+++ b/pkg/services/navtree/models.go
@@ -55,6 +55,7 @@ const (
 	NavIDCfgPlugins           = "cfg/plugins"
 	NavIDCfgAccess            = "cfg/access"
 	NavIDBookmarks            = "bookmarks"
+	NavIDLabs                 = "labs"
 )
 
 type NavLink struct {

--- a/pkg/services/navtree/navtreeimpl/navtree.go
+++ b/pkg/services/navtree/navtreeimpl/navtree.go
@@ -170,6 +170,18 @@ func (s *ServiceImpl) GetNavTree(c *contextmodel.ReqContext, prefs *pref.Prefere
 		return nil, err
 	}
 
+	if c.IsSignedIn {
+		treeRoot.AddSection(&navtree.NavLink{
+			Text:          "Labs",
+			Id:            navtree.NavIDLabs,
+			SubTitle:      "View feature toggles enabled on this Grafana instance",
+			Icon:          "flask",
+			Url:           s.cfg.AppSubURL + "/admin/labs",
+			SortWeight:    navtree.WeightConfig + 50,
+			HighlightText: "Experimental",
+		})
+	}
+
 	s.addHelpLinks(treeRoot, c)
 
 	if err := s.addAppLinks(treeRoot, c); err != nil {

--- a/public/app/core/components/AppChrome/MegaMenu/MegaMenuItem.tsx
+++ b/public/app/core/components/AppChrome/MegaMenu/MegaMenuItem.tsx
@@ -6,7 +6,7 @@ import { useLocalStorage } from 'react-use';
 
 import { FeatureState, GrafanaTheme2, NavModelItem, toIconName } from '@grafana/data';
 import { t } from '@grafana/i18n';
-import { useStyles2, Text, IconButton, Icon, Stack, FeatureBadge } from '@grafana/ui';
+import { useStyles2, Text, IconButton, Icon, Stack, FeatureBadge, Tag } from '@grafana/ui';
 import { useGrafana } from 'app/core/context/GrafanaContext';
 
 import { Indent } from '../../Indent/Indent';
@@ -105,6 +105,7 @@ export function MegaMenuItem({ link, activeItem, level = 0, onClick, onPin, isPi
               <Text truncate element="p">
                 {link.text}
               </Text>
+              {link.highlightText && <Tag name={link.highlightText} />}
               {link.isNew && <FeatureBadge featureState={FeatureState.new} />}
             </div>
           </MegaMenuItemText>

--- a/public/app/core/utils/navBarItem-translations.ts
+++ b/public/app/core/utils/navBarItem-translations.ts
@@ -91,6 +91,8 @@ export function getNavTitle(navId: string | undefined) {
       return t('nav.alerting-admin.title', 'Settings');
     case 'alerts/recently-deleted':
       return t('nav.alerts-recently-deleted.title', 'Recently deleted');
+    case 'labs':
+      return t('nav.labs.title', 'Labs');
     case 'cfg':
       return t('nav.config.title', 'Administration');
     case 'cfg/general':
@@ -319,6 +321,8 @@ export function getNavSubTitle(navId: string | undefined) {
       );
     case 'plugin-page-grafana-ml-app':
       return t('nav.machine-learning.subtitle', 'Explore AI and machine learning features');
+    case 'labs':
+      return t('nav.labs.subtitle', 'View feature toggles enabled on this Grafana instance');
     default:
       return undefined;
   }

--- a/public/app/features/admin/labs/LabsPage.tsx
+++ b/public/app/features/admin/labs/LabsPage.tsx
@@ -1,0 +1,102 @@
+import { useMemo, useState } from 'react';
+import { useAsync } from 'react-use';
+
+import { Trans, t } from '@grafana/i18n';
+import { getBackendSrv } from '@grafana/runtime';
+import { Alert, Badge, Column, Input, InteractiveTable, Spinner, Stack } from '@grafana/ui';
+import { Page } from 'app/core/components/Page/Page';
+
+export interface FeatureToggleListItem {
+  name: string;
+  description?: string;
+  stage: string;
+  enabled: boolean;
+  requiresDevMode?: boolean;
+  requiresRestart?: boolean;
+  frontend?: boolean;
+  expression?: string;
+}
+
+interface FeatureToggleListResponse {
+  flags: FeatureToggleListItem[];
+}
+
+export default function LabsPage() {
+  const { loading, value, error } = useAsync(async () => {
+    return await getBackendSrv().get<FeatureToggleListResponse>('/api/admin/feature-toggles');
+  }, []);
+
+  const [filter, setFilter] = useState('');
+
+  const columns: Array<Column<FeatureToggleListItem>> = useMemo(
+    () => [
+      { id: 'name', header: t('admin.labs.column-name', 'Name'), sortType: 'alphanumeric' },
+      {
+        id: 'enabled',
+        header: t('admin.labs.column-enabled', 'Enabled'),
+        sortType: 'basic',
+        cell: function EnabledCell({ row }) {
+          return row.original.enabled ? (
+            <Badge color="green" text={t('admin.labs.enabled-yes', 'Yes')} />
+          ) : (
+            <Badge color="red" text={t('admin.labs.enabled-no', 'No')} />
+          );
+        },
+      },
+      { id: 'stage', header: t('admin.labs.column-stage', 'Stage'), sortType: 'alphanumeric' },
+      { id: 'description', header: t('admin.labs.column-description', 'Description'), sortType: 'alphanumeric' },
+    ],
+    []
+  );
+
+  const filteredFlags = useMemo(() => {
+    const flags = value?.flags ?? [];
+    const q = filter.trim().toLowerCase();
+    if (!q) {
+      return flags;
+    }
+    return flags.filter(
+      (f) =>
+        f.name.toLowerCase().includes(q) ||
+        (f.description ?? '').toLowerCase().includes(q) ||
+        f.stage.toLowerCase().includes(q)
+    );
+  }, [value, filter]);
+
+  return (
+    <Page navId="labs">
+      <Page.Contents>
+        <Stack direction="column" gap={2}>
+          <Alert severity="info" title="">
+            <Trans i18nKey="admin.labs.info">
+              Feature toggles are configured for this Grafana instance. Changes usually require a server restart or come
+              from your hosting provider.
+            </Trans>
+          </Alert>
+          {error != null && (
+            <Alert severity="error" title={t('admin.labs.load-error-title', 'Failed to load feature toggles')}>
+              {String(error)}
+            </Alert>
+          )}
+          {loading && <Spinner />}
+          {!loading && value != null && (
+            <>
+              <Input
+                width={50}
+                placeholder={t('admin.labs.filter-placeholder', 'Filter by name, stage, or description')}
+                value={filter}
+                onChange={(e) => setFilter(e.currentTarget.value)}
+              />
+              <InteractiveTable
+                columns={columns}
+                data={filteredFlags}
+                getRowId={(row) => row.name}
+                pageSize={0}
+              />
+            </>
+          )}
+        </Stack>
+      </Page.Contents>
+    </Page>
+  );
+}

--- a/public/app/routes/routes.tsx
+++ b/public/app/routes/routes.tsx
@@ -346,6 +346,12 @@ export function getAppRoutes(): RouteDescriptor[] {
       ),
     },
     {
+      path: '/admin/labs',
+      component: SafeDynamicImport(
+        () => import(/* webpackChunkName: "LabsPage" */ 'app/features/admin/labs/LabsPage')
+      ),
+    },
+    {
       path: '/admin/upgrading',
       component: SafeDynamicImport(() => import('app/features/admin/UpgradePage')),
     },


### PR DESCRIPTION
## Summary

Adds a **Labs** top-level sidebar item directly under **Administration**, with an **Experimental** label (via `highlightText` rendered as a `Tag` in the mega menu). The page at `/admin/labs` lists all registered feature toggles with name, enabled state, stage, and description, including a filter field.

## Backend

- `GET /admin/labs` and `GET /api/admin/feature-toggles` (signed-in users only; no `settings:read` required on the feature-toggles API).
- Handler uses `FeatureManager.GetFlags()` and `IsEnabled` for the response body.
- Tests cover unauthenticated (401) and Viewer (200) with sorted flag names.

## Frontend

- `LabsPage` with `InteractiveTable`, filter input, and i18n keys.
- `MegaMenuItem` supports optional `highlightText` for nav badges.

**Target repo:** fieldsphere/grafana

Made with [Cursor](https://cursor.com)