### PR TITLE
Themes: Add 90s experimental theme

### DIFF
--- a/packages/grafana-data/src/themes/registry.ts
+++ b/packages/grafana-data/src/themes/registry.ts
@@ -10,6 +10,7 @@ import gildedgrove from './themeDefinitions/gildedgrove.json';
 import gloom from './themeDefinitions/gloom.json';
 import mars from './themeDefinitions/mars.json';
 import matrix from './themeDefinitions/matrix.json';
+import nineties from './themeDefinitions/nineties.json';
 import sapphiredusk from './themeDefinitions/sapphiredusk.json';
 import synthwave from './themeDefinitions/synthwave.json';
 import tritanopia_dark from './themeDefinitions/tritanopia_dark.json';
@@ -34,6 +35,7 @@ const extraThemes: { [key: string]: unknown } = {
   gloom,
   mars,
   matrix,
+  nineties,
   sapphiredusk,
   synthwave,
   tritanopia_dark,

--- a/packages/grafana-data/src/themes/themeDefinitions/nineties.json
+++ b/packages/grafana-data/src/themes/themeDefinitions/nineties.json
@@ -1,0 +1,50 @@
+{
+  "name": "90s",
+  "id": "nineties",
+  "colors": {
+    "mode": "dark",
+    "border": {
+      "weak": "rgba(0, 217, 255, 0.12)",
+      "medium": "rgba(0, 217, 255, 0.22)",
+      "strong": "rgba(0, 217, 255, 0.35)"
+    },
+    "text": {
+      "primary": "#E8E8E8",
+      "secondary": "rgba(232, 232, 232, 0.72)",
+      "disabled": "rgba(232, 232, 232, 0.48)",
+      "link": "#FFDD00",
+      "maxContrast": "#FFFFFF"
+    },
+    "primary": {
+      "main": "#00D9FF"
+    },
+    "secondary": {
+      "main": "#2D1B69",
+      "text": "rgba(232, 232, 232, 0.75)",
+      "border": "rgba(0, 217, 255, 0.12)"
+    },
+    "background": {
+      "canvas": "#0F0820",
+      "primary": "#1A0F3D",
+      "secondary": "#251456",
+      "elevated": "#2D1868"
+    },
+    "action": {
+      "hover": "rgba(0, 217, 255, 0.14)",
+      "selected": "rgba(255, 0, 170, 0.14)",
+      "selectedBorder": "#FF00AA",
+      "focus": "rgba(0, 217, 255, 0.2)",
+      "hoverOpacity": 0.08,
+      "disabledText": "rgba(232, 232, 232, 0.45)",
+      "disabledBackground": "rgba(0, 217, 255, 0.06)",
+      "disabledOpacity": 0.38
+    },
+    "gradients": {
+      "brandHorizontal": "linear-gradient(270deg, #00D9FF 0%, #FF00AA 100%)",
+      "brandVertical": "linear-gradient(0.01deg, #00D9FF 0.01%, #FF00AA 99.99%)"
+    },
+    "contrastThreshold": 3,
+    "hoverFactor": 0.03,
+    "tonalOffset": 0.15
+  }
+}

--- a/packages/grafana-flamegraph/.storybook/preview.ts
+++ b/packages/grafana-flamegraph/.storybook/preview.ts
@@ -12,6 +12,7 @@ if (process.env.NODE_ENV === 'development') {
   allowedExtraThemes.push('desertbloom');
   allowedExtraThemes.push('gildedgrove');
   allowedExtraThemes.push('gloom');
+  allowedExtraThemes.push('nineties');
   allowedExtraThemes.push('sapphiredusk');
   allowedExtraThemes.push('tron');
 }

--- a/packages/grafana-ui/.storybook/preview.ts
+++ b/packages/grafana-ui/.storybook/preview.ts
@@ -45,6 +45,7 @@ if (process.env.NODE_ENV === 'development') {
   allowedExtraThemes.push('desertbloom');
   allowedExtraThemes.push('gildedgrove');
   allowedExtraThemes.push('gloom');
+  allowedExtraThemes.push('nineties');
   allowedExtraThemes.push('sapphiredusk');
   allowedExtraThemes.push('tron');
 }

--- a/pkg/services/preference/themes_generated.go
+++ b/pkg/services/preference/themes_generated.go
@@ -15,6 +15,7 @@ var themes = []ThemeDTO{
 	{ID: "gloom", Type: "dark", IsExtra: true},
 	{ID: "mars", Type: "dark", IsExtra: true},
 	{ID: "matrix", Type: "dark", IsExtra: true},
+	{ID: "nineties", Type: "dark", IsExtra: true},
 	{ID: "sapphiredusk", Type: "dark", IsExtra: true},
 	{ID: "synthwave", Type: "dark", IsExtra: true},
 	{ID: "tritanopia_dark", Type: "dark", IsExtra: true},

--- a/public/app/core/components/ThemeSelector/getSelectableThemes.ts
+++ b/public/app/core/components/ThemeSelector/getSelectableThemes.ts
@@ -14,6 +14,7 @@ export function getSelectableThemes() {
   if (config.featureToggles.grafanaconThemes) {
     allowedExtraThemes.push('desertbloom');
     allowedExtraThemes.push('gildedgrove');
+    allowedExtraThemes.push('nineties');
     allowedExtraThemes.push('sapphiredusk');
     allowedExtraThemes.push('tron');
     allowedExtraThemes.push('gloom');

--- a/public/app/features/theme-playground/ThemePlayground.tsx
+++ b/public/app/features/theme-playground/ThemePlayground.tsx
@@ -12,6 +12,7 @@ import gildedgrove from '@grafana/data/themes/definitions/gildedgrove.json';
 import gloom from '@grafana/data/themes/definitions/gloom.json';
 import mars from '@grafana/data/themes/definitions/mars.json';
 import matrix from '@grafana/data/themes/definitions/matrix.json';
+import nineties from '@grafana/data/themes/definitions/nineties.json';
 import sapphiredusk from '@grafana/data/themes/definitions/sapphiredusk.json';
 import synthwave from '@grafana/data/themes/definitions/synthwave.json';
 import tritanopia_dark from '@grafana/data/themes/definitions/tritanopia_dark.json';
@@ -60,6 +61,7 @@ const experimentalDefinitions: Record<string, unknown> = {
   gloom,
   mars,
   matrix,
+  nineties,
   sapphiredusk,
   synthwave,
   tritanopia_dark,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
**What is this feature?**

Adds a new optional dark theme named **90s** (`id`: `nineties`) with a 1990s-inspired palette: deep purple UI chrome, cyan and magenta accents, and yellow links. It is registered in `@grafana/data`, included in the theme playground, and listed for the profile theme picker when `grafanaconThemes` is enabled (same path as other experimental Grafanacon themes). Backend theme IDs were regenerated so user preferences accept `nineties`.

**Why do we need this feature?**

Expands the set of built-in experimental themes for users who want a distinct retro look.

**Who is this feature for?**

Users who enable experimental Grafanacon themes and pick a theme from **Profile → Change theme** (or the theme playground).

**Which issue(s) does this PR fix?**:

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle. (Uses existing `grafanaconThemes` toggle.)
- [ ] The docs are updated, and if this is a notable improvement, it's added to What's New.

**Testing:** `yarn jest packages/grafana-data/src/themes/createTheme.test.ts --no-watch --watchAll=false`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-43cb0404-81d0-4173-8757-d6fabdc66d6d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-43cb0404-81d0-4173-8757-d6fabdc66d6d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

