### PR TITLE
Administration: Add feature toggles management page

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -118,6 +118,7 @@ func (hs *HTTPServer) registerRoutes() {
 	r.Get("/admin/orgs", authorizeInOrg(ac.UseGlobalOrg, ac.OrgsAccessEvaluator), hs.Index)
 	r.Get("/admin/orgs/edit/:id", authorizeInOrg(ac.UseGlobalOrg, ac.OrgsAccessEvaluator), hs.Index)
 	r.Get("/admin/stats", authorize(ac.EvalPermission(ac.ActionServerStatsRead)), hs.Index)
+	r.Get("/admin/feature-toggles", authorize(ac.EvalPermission(ac.ActionFeatureManagementRead)), hs.Index)
 	r.Get("/admin/provisioning", reqOrgAdmin, hs.Index)
 	r.Get("/admin/provisioning/*", middleware.ProvisioningAuth(reqOrgAdmin), hs.Index)
 
@@ -468,6 +469,8 @@ func (hs *HTTPServer) registerRoutes() {
 
 		apiRoute.Get("/frontend/settings/", hs.GetFrontendSettings)
 		apiRoute.Get("/frontend/assets", hs.GetFrontendAssets)
+		apiRoute.Get("/feature-toggles", authorize(ac.EvalPermission(ac.ActionFeatureManagementRead)), routing.Wrap(hs.GetFeatureToggles))
+		apiRoute.Put("/feature-toggles/:name", authorize(ac.EvalPermission(ac.ActionFeatureManagementWrite)), routing.Wrap(hs.UpdateFeatureToggle))
 
 		// Folders
 		hs.registerFolderAPI(apiRoute, authorize)

--- a/pkg/api/feature_toggles.go
+++ b/pkg/api/feature_toggles.go
@@ -36,8 +36,7 @@ func (hs *HTTPServer) GetFeatureToggles(c *contextmodel.ReqContext) response.Res
 		return response.Error(http.StatusNotImplemented, "Feature toggle management is unavailable", nil)
 	}
 
-	enabled := manager.GetEnabled(c.Req.Context())
-	flags := manager.GetFlags()
+	flags, enabled := manager.GetSnapshot()
 
 	items := make([]featureToggleDTO, 0, len(flags))
 	for _, flag := range flags {

--- a/pkg/api/feature_toggles.go
+++ b/pkg/api/feature_toggles.go
@@ -1,0 +1,89 @@
+package api
+
+import (
+	"errors"
+	"net/http"
+	"sort"
+
+	"github.com/grafana/grafana/pkg/api/response"
+	contextmodel "github.com/grafana/grafana/pkg/services/contexthandler/model"
+	"github.com/grafana/grafana/pkg/services/featuremgmt"
+	"github.com/grafana/grafana/pkg/web"
+)
+
+type featureToggleDTO struct {
+	Name          string `json:"name"`
+	Description   string `json:"description"`
+	Stage         string `json:"stage"`
+	RequiresDev   bool   `json:"requiresDevMode"`
+	RequiresStart bool   `json:"requiresRestart"`
+	Enabled       bool   `json:"enabled"`
+}
+
+type updateFeatureToggleCommand struct {
+	Enabled bool `json:"enabled"`
+}
+
+type updateFeatureToggleResponse struct {
+	Name    string `json:"name"`
+	Enabled bool   `json:"enabled"`
+}
+
+// GetFeatureToggles returns all known feature flags with current runtime state.
+func (hs *HTTPServer) GetFeatureToggles(c *contextmodel.ReqContext) response.Response {
+	manager, ok := hs.Features.(*featuremgmt.FeatureManager)
+	if !ok {
+		return response.Error(http.StatusNotImplemented, "Feature toggle management is unavailable", nil)
+	}
+
+	enabled := manager.GetEnabled(c.Req.Context())
+	flags := manager.GetFlags()
+
+	items := make([]featureToggleDTO, 0, len(flags))
+	for _, flag := range flags {
+		items = append(items, featureToggleDTO{
+			Name:          flag.Name,
+			Description:   flag.Description,
+			Stage:         flag.Stage.String(),
+			RequiresDev:   flag.RequiresDevMode,
+			RequiresStart: flag.RequiresRestart,
+			Enabled:       enabled[flag.Name],
+		})
+	}
+
+	sort.Slice(items, func(i, j int) bool {
+		return items[i].Name < items[j].Name
+	})
+
+	return response.JSON(http.StatusOK, items)
+}
+
+// UpdateFeatureToggle updates in-memory runtime state for a feature flag.
+func (hs *HTTPServer) UpdateFeatureToggle(c *contextmodel.ReqContext) response.Response {
+	manager, ok := hs.Features.(*featuremgmt.FeatureManager)
+	if !ok {
+		return response.Error(http.StatusNotImplemented, "Feature toggle management is unavailable", nil)
+	}
+
+	var cmd updateFeatureToggleCommand
+	if err := web.Bind(c.Req, &cmd); err != nil {
+		return response.Error(http.StatusBadRequest, "bad request data", err)
+	}
+
+	name := web.Params(c.Req)[":name"]
+	if name == "" {
+		return response.Error(http.StatusBadRequest, "Feature toggle name is required", nil)
+	}
+
+	if err := manager.SetStartupState(name, cmd.Enabled); err != nil {
+		if errors.Is(err, featuremgmt.ErrFeatureFlagNotFound) {
+			return response.Error(http.StatusNotFound, "Feature toggle not found", err)
+		}
+		return response.Error(http.StatusInternalServerError, "Failed to update feature toggle", err)
+	}
+
+	return response.JSON(http.StatusOK, updateFeatureToggleResponse{
+		Name:    name,
+		Enabled: cmd.Enabled,
+	})
+}

--- a/pkg/api/feature_toggles.go
+++ b/pkg/api/feature_toggles.go
@@ -84,6 +84,6 @@ func (hs *HTTPServer) UpdateFeatureToggle(c *contextmodel.ReqContext) response.R
 
 	return response.JSON(http.StatusOK, updateFeatureToggleResponse{
 		Name:    name,
-		Enabled: cmd.Enabled,
+		Enabled: manager.IsEnabledGlobally(name),
 	})
 }

--- a/pkg/api/feature_toggles_test.go
+++ b/pkg/api/feature_toggles_test.go
@@ -11,6 +11,7 @@ import (
 
 	contextmodel "github.com/grafana/grafana/pkg/services/contexthandler/model"
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
+	"github.com/grafana/grafana/pkg/setting"
 	"github.com/grafana/grafana/pkg/web"
 )
 
@@ -50,6 +51,34 @@ func TestUpdateFeatureToggle(t *testing.T) {
 	resp := server.UpdateFeatureToggle(ctx)
 	require.Equal(t, http.StatusOK, resp.Status())
 	require.True(t, manager.IsEnabledGlobally("beta"))
+
+	var body updateFeatureToggleResponse
+	require.NoError(t, json.Unmarshal(resp.Body(), &body))
+	require.Equal(t, updateFeatureToggleResponse{Name: "beta", Enabled: true}, body)
+}
+
+func TestUpdateFeatureToggleReturnsActualEnabledState(t *testing.T) {
+	cfg := setting.NewCfg()
+	cfg.Env = setting.Prod
+	manager, err := featuremgmt.ProvideManagerService(cfg)
+	require.NoError(t, err)
+	server := setupSimpleHTTPServer(manager)
+
+	request := httptest.NewRequest(http.MethodPut, "/api/feature-toggles/liveAPIServer", strings.NewReader(`{"enabled":true}`))
+	request = web.SetURLParams(request, map[string]string{":name": "liveAPIServer"})
+	request.Header.Set("Content-Type", "application/json")
+	responseWriter := web.NewResponseWriter(http.MethodPut, httptest.NewRecorder())
+	ctx := &contextmodel.ReqContext{
+		Context: &web.Context{Req: request, Resp: responseWriter},
+	}
+
+	resp := server.UpdateFeatureToggle(ctx)
+	require.Equal(t, http.StatusOK, resp.Status())
+	require.False(t, manager.IsEnabledGlobally("liveAPIServer"))
+
+	var body updateFeatureToggleResponse
+	require.NoError(t, json.Unmarshal(resp.Body(), &body))
+	require.Equal(t, updateFeatureToggleResponse{Name: "liveAPIServer", Enabled: false}, body)
 }
 
 func TestUpdateFeatureToggleNotFound(t *testing.T) {

--- a/pkg/api/feature_toggles_test.go
+++ b/pkg/api/feature_toggles_test.go
@@ -1,0 +1,67 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	contextmodel "github.com/grafana/grafana/pkg/services/contexthandler/model"
+	"github.com/grafana/grafana/pkg/services/featuremgmt"
+	"github.com/grafana/grafana/pkg/web"
+)
+
+func TestGetFeatureToggles(t *testing.T) {
+	manager := featuremgmt.WithManager("alpha", true, "beta", false)
+	server := setupSimpleHTTPServer(manager)
+	responseWriter := web.NewResponseWriter(http.MethodGet, httptest.NewRecorder())
+	request := httptest.NewRequest(http.MethodGet, "/api/feature-toggles", nil)
+	ctx := &contextmodel.ReqContext{
+		Context: &web.Context{Req: request, Resp: responseWriter},
+	}
+
+	resp := server.GetFeatureToggles(ctx)
+	require.Equal(t, http.StatusOK, resp.Status())
+
+	var body []map[string]any
+	require.NoError(t, json.Unmarshal(resp.Body(), &body))
+	require.Len(t, body, 2)
+	require.Equal(t, "alpha", body[0]["name"])
+	require.Equal(t, true, body[0]["enabled"])
+	require.Equal(t, "beta", body[1]["name"])
+	require.Equal(t, false, body[1]["enabled"])
+}
+
+func TestUpdateFeatureToggle(t *testing.T) {
+	manager := featuremgmt.WithManager("alpha", true, "beta", false)
+	server := setupSimpleHTTPServer(manager)
+
+	request := httptest.NewRequest(http.MethodPut, "/api/feature-toggles/beta", strings.NewReader(`{"enabled":true}`))
+	request = web.SetURLParams(request, map[string]string{":name": "beta"})
+	responseWriter := web.NewResponseWriter(http.MethodPut, httptest.NewRecorder())
+	ctx := &contextmodel.ReqContext{
+		Context: &web.Context{Req: request, Resp: responseWriter},
+	}
+
+	resp := server.UpdateFeatureToggle(ctx)
+	require.Equal(t, http.StatusOK, resp.Status())
+	require.True(t, manager.IsEnabledGlobally("beta"))
+}
+
+func TestUpdateFeatureToggleNotFound(t *testing.T) {
+	manager := featuremgmt.WithManager("alpha", true)
+	server := setupSimpleHTTPServer(manager)
+
+	request := httptest.NewRequest(http.MethodPut, "/api/feature-toggles/missing", strings.NewReader(`{"enabled":true}`))
+	request = web.SetURLParams(request, map[string]string{":name": "missing"})
+	responseWriter := web.NewResponseWriter(http.MethodPut, httptest.NewRecorder())
+	ctx := &contextmodel.ReqContext{
+		Context: &web.Context{Req: request, Resp: responseWriter},
+	}
+
+	resp := server.UpdateFeatureToggle(ctx)
+	require.Equal(t, http.StatusNotFound, resp.Status())
+}

--- a/pkg/api/feature_toggles_test.go
+++ b/pkg/api/feature_toggles_test.go
@@ -41,6 +41,7 @@ func TestUpdateFeatureToggle(t *testing.T) {
 
 	request := httptest.NewRequest(http.MethodPut, "/api/feature-toggles/beta", strings.NewReader(`{"enabled":true}`))
 	request = web.SetURLParams(request, map[string]string{":name": "beta"})
+	request.Header.Set("Content-Type", "application/json")
 	responseWriter := web.NewResponseWriter(http.MethodPut, httptest.NewRecorder())
 	ctx := &contextmodel.ReqContext{
 		Context: &web.Context{Req: request, Resp: responseWriter},
@@ -57,6 +58,7 @@ func TestUpdateFeatureToggleNotFound(t *testing.T) {
 
 	request := httptest.NewRequest(http.MethodPut, "/api/feature-toggles/missing", strings.NewReader(`{"enabled":true}`))
 	request = web.SetURLParams(request, map[string]string{":name": "missing"})
+	request.Header.Set("Content-Type", "application/json")
 	responseWriter := web.NewResponseWriter(http.MethodPut, httptest.NewRecorder())
 	ctx := &contextmodel.ReqContext{
 		Context: &web.Context{Req: request, Resp: responseWriter},

--- a/pkg/services/featuremgmt/manager.go
+++ b/pkg/services/featuremgmt/manager.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"reflect"
+	"sync"
 
 	"github.com/grafana/grafana/pkg/infra/log"
 )
@@ -13,6 +14,8 @@ var (
 )
 
 type FeatureManager struct {
+	mu sync.RWMutex
+
 	isDevMod bool
 
 	flags    map[string]*FeatureFlag
@@ -24,6 +27,9 @@ type FeatureManager struct {
 
 // This will merge the flags with the current configuration
 func (fm *FeatureManager) registerFlags(flags ...FeatureFlag) {
+	fm.mu.Lock()
+	defer fm.mu.Unlock()
+
 	for _, add := range flags {
 		if add.Name == "" {
 			continue // skip it with warning?
@@ -99,16 +105,25 @@ func (fm *FeatureManager) update() {
 
 // IsEnabled checks if a feature is enabled
 func (fm *FeatureManager) IsEnabled(ctx context.Context, flag string) bool {
+	fm.mu.RLock()
+	defer fm.mu.RUnlock()
+
 	return fm.enabled[flag]
 }
 
 // IsEnabledGlobally checks if a feature is for all tenants
 func (fm *FeatureManager) IsEnabledGlobally(flag string) bool {
+	fm.mu.RLock()
+	defer fm.mu.RUnlock()
+
 	return fm.enabled[flag]
 }
 
 // GetEnabled returns a map containing only the features that are enabled
 func (fm *FeatureManager) GetEnabled(ctx context.Context) map[string]bool {
+	fm.mu.RLock()
+	defer fm.mu.RUnlock()
+
 	enabled := make(map[string]bool, len(fm.enabled))
 	for key, val := range fm.enabled {
 		if val {
@@ -120,11 +135,29 @@ func (fm *FeatureManager) GetEnabled(ctx context.Context) map[string]bool {
 
 // GetFlags returns all flag definitions
 func (fm *FeatureManager) GetFlags() []FeatureFlag {
+	fm.mu.RLock()
+	defer fm.mu.RUnlock()
+
 	v := make([]FeatureFlag, 0, len(fm.flags))
 	for _, value := range fm.flags {
 		v = append(v, *value)
 	}
 	return v
+}
+
+// SetStartupState updates the in-memory startup state for a flag and reevaluates all flags.
+// Changes are runtime-only and are not persisted to disk.
+func (fm *FeatureManager) SetStartupState(name string, enabled bool) error {
+	fm.mu.Lock()
+	defer fm.mu.Unlock()
+
+	if _, ok := fm.flags[name]; !ok {
+		return fmt.Errorf("%w: %s", ErrFeatureFlagNotFound, name)
+	}
+
+	fm.startup[name] = enabled
+	fm.update()
+	return nil
 }
 
 // ############# Test Functions #############

--- a/pkg/services/featuremgmt/manager.go
+++ b/pkg/services/featuremgmt/manager.go
@@ -133,6 +133,26 @@ func (fm *FeatureManager) GetEnabled(ctx context.Context) map[string]bool {
 	return enabled
 }
 
+// GetSnapshot returns a consistent snapshot of flag definitions and enabled states.
+func (fm *FeatureManager) GetSnapshot() ([]FeatureFlag, map[string]bool) {
+	fm.mu.RLock()
+	defer fm.mu.RUnlock()
+
+	enabled := make(map[string]bool, len(fm.enabled))
+	for key, val := range fm.enabled {
+		if val {
+			enabled[key] = true
+		}
+	}
+
+	flags := make([]FeatureFlag, 0, len(fm.flags))
+	for _, value := range fm.flags {
+		flags = append(flags, *value)
+	}
+
+	return flags, enabled
+}
+
 // GetFlags returns all flag definitions
 func (fm *FeatureManager) GetFlags() []FeatureFlag {
 	fm.mu.RLock()
@@ -190,5 +210,10 @@ func WithManager(spec ...any) *FeatureManager {
 		}
 	}
 
-	return &FeatureManager{enabled: enabled, flags: features, startup: enabled, warnings: map[string]string{}}
+	startup := make(map[string]bool, len(enabled))
+	for key, val := range enabled {
+		startup[key] = val
+	}
+
+	return &FeatureManager{enabled: enabled, flags: features, startup: startup, warnings: map[string]string{}}
 }

--- a/pkg/services/featuremgmt/manager_test.go
+++ b/pkg/services/featuremgmt/manager_test.go
@@ -78,4 +78,38 @@ func TestFeatureManager(t *testing.T) {
 		err := ft.SetStartupState("missing", true)
 		require.ErrorIs(t, err, ErrFeatureFlagNotFound)
 	})
+
+	t.Run("snapshot returns matching flags and enabled states", func(t *testing.T) {
+		ft := &FeatureManager{
+			flags: map[string]*FeatureFlag{
+				"a": {Name: "a", Expression: "true"},
+				"b": {Name: "b"},
+			},
+			startup: map[string]bool{
+				"a": false,
+				"b": true,
+			},
+			warnings: map[string]string{},
+		}
+		ft.update()
+
+		flags, enabled := ft.GetSnapshot()
+		require.Len(t, flags, 2)
+		require.Equal(t, map[string]bool{"b": true}, enabled)
+
+		names := make(map[string]bool, len(flags))
+		for _, flag := range flags {
+			names[flag.Name] = true
+		}
+
+		require.Equal(t, map[string]bool{"a": true, "b": true}, names)
+	})
+
+	t.Run("with manager keeps startup separate from enabled", func(t *testing.T) {
+		ft := WithManager("a", true)
+
+		ft.startup["a"] = false
+
+		require.True(t, ft.enabled["a"])
+	})
 }

--- a/pkg/services/featuremgmt/manager_test.go
+++ b/pkg/services/featuremgmt/manager_test.go
@@ -65,4 +65,17 @@ func TestFeatureManager(t *testing.T) {
 		require.False(t, ft.IsEnabledGlobally("b"))
 		require.False(t, ft.IsEnabledGlobally("c"))
 	})
+
+	t.Run("set startup state updates runtime values", func(t *testing.T) {
+		ft := WithManager("a", true, "b", false)
+
+		require.NoError(t, ft.SetStartupState("b", true))
+		require.True(t, ft.IsEnabledGlobally("b"))
+
+		require.NoError(t, ft.SetStartupState("a", false))
+		require.False(t, ft.IsEnabledGlobally("a"))
+
+		err := ft.SetStartupState("missing", true)
+		require.ErrorIs(t, err, ErrFeatureFlagNotFound)
+	})
 }

--- a/pkg/services/featuremgmt/models.go
+++ b/pkg/services/featuremgmt/models.go
@@ -4,7 +4,10 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 )
+
+var ErrFeatureFlagNotFound = errors.New("feature flag not found")
 
 //go:generate mockery --name FeatureToggles --structname MockFeatureToggles --inpackage --filename feature_toggles_mock.go --with-expecter
 type FeatureToggles interface {

--- a/pkg/services/navtree/navtreeimpl/admin.go
+++ b/pkg/services/navtree/navtreeimpl/admin.go
@@ -39,6 +39,11 @@ func (s *ServiceImpl) getAdminNode(c *contextmodel.ReqContext) (*navtree.NavLink
 			Text: "Settings", SubTitle: "View the settings defined in your Grafana config", Id: "server-settings", Url: s.cfg.AppSubURL + "/admin/settings", Icon: "sliders-v-alt",
 		})
 	}
+	if hasAccess(ac.EvalPermission(ac.ActionFeatureManagementRead)) {
+		generalNodeLinks = append(generalNodeLinks, &navtree.NavLink{
+			Text: "Feature toggles", SubTitle: "View and change runtime feature flags", Id: "feature-toggles", Url: s.cfg.AppSubURL + "/admin/feature-toggles", Icon: "toggle-off",
+		})
+	}
 	if hasGlobalAccess(orgsAccessEvaluator) {
 		generalNodeLinks = append(generalNodeLinks, &navtree.NavLink{
 			Text: "Organizations", SubTitle: "Isolated instances of Grafana running on the same server", Id: "global-orgs", Url: s.cfg.AppSubURL + "/admin/orgs", Icon: "building",

--- a/pkg/services/navtree/navtreeimpl/navtree_test.go
+++ b/pkg/services/navtree/navtreeimpl/navtree_test.go
@@ -9,12 +9,19 @@ import (
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 
+	claims "github.com/grafana/authlib/types"
+	ac "github.com/grafana/grafana/pkg/services/accesscontrol"
+	accesscontrolmock "github.com/grafana/grafana/pkg/services/accesscontrol/mock"
+	authn "github.com/grafana/grafana/pkg/services/authn"
+	"github.com/grafana/grafana/pkg/services/authn/authntest"
 	contextmodel "github.com/grafana/grafana/pkg/services/contexthandler/model"
 	"github.com/grafana/grafana/pkg/services/dashboards"
+	"github.com/grafana/grafana/pkg/services/featuremgmt"
 	"github.com/grafana/grafana/pkg/services/search/model"
 	"github.com/grafana/grafana/pkg/services/star"
 	"github.com/grafana/grafana/pkg/services/star/startest"
 	"github.com/grafana/grafana/pkg/services/user"
+	"github.com/grafana/grafana/pkg/setting"
 	"github.com/grafana/grafana/pkg/web"
 )
 
@@ -157,4 +164,54 @@ func TestBuildStarredItemsNavLinks(t *testing.T) {
 		require.Equal(t, "B Dashboard", navLinks[1].Text)
 		require.Equal(t, "C Dashboard", navLinks[2].Text)
 	})
+}
+
+func TestGetNavTreeIncludesFeatureTogglesLink(t *testing.T) {
+	httpReq, _ := http.NewRequest(http.MethodGet, "", nil)
+	reqCtx := &contextmodel.ReqContext{
+		SignedInUser: &user.SignedInUser{
+			UserID:         1,
+			OrgID:          1,
+			OrgRole:        identity.RoleAdmin,
+			IsGrafanaAdmin: true,
+			Permissions: map[int64]map[string][]string{
+				1: {},
+				0: {ac.ActionFeatureManagementRead: []string{"*"}},
+			},
+		},
+		Context: &web.Context{Req: httpReq},
+	}
+	reqCtx.IsSignedIn = true
+
+	service := ServiceImpl{
+		cfg:      setting.NewCfg(),
+		features: featuremgmt.WithFeatures(),
+		accessControl: accesscontrolmock.New().WithPermissions([]ac.Permission{
+			{Action: ac.ActionFeatureManagementRead, Scope: "*"},
+		}),
+		authnService: &authntest.FakeService{
+			ExpectedIdentity: &authn.Identity{
+				ID:          "user:1",
+				Type:        claims.TypeUser,
+				Permissions: map[int64]map[string][]string{0: {ac.ActionFeatureManagementRead: []string{"*"}}},
+			},
+		},
+	}
+
+	node, err := service.getAdminNode(reqCtx)
+	require.NoError(t, err)
+	require.NotNil(t, node)
+
+	var found bool
+	for _, child := range node.Children {
+		if child.Id != "cfg/general" {
+			continue
+		}
+		for _, subChild := range child.Children {
+			if subChild.Id == "feature-toggles" && subChild.Url == "/admin/feature-toggles" {
+				found = true
+			}
+		}
+	}
+	require.True(t, found)
 }

--- a/pkg/services/navtree/navtreeimpl/navtree_test.go
+++ b/pkg/services/navtree/navtreeimpl/navtree_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	claims "github.com/grafana/authlib/types"
+	"github.com/grafana/grafana/pkg/apimachinery/identity"
 	ac "github.com/grafana/grafana/pkg/services/accesscontrol"
 	accesscontrolmock "github.com/grafana/grafana/pkg/services/accesscontrol/mock"
 	authn "github.com/grafana/grafana/pkg/services/authn"
@@ -17,6 +18,7 @@ import (
 	contextmodel "github.com/grafana/grafana/pkg/services/contexthandler/model"
 	"github.com/grafana/grafana/pkg/services/dashboards"
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
+	"github.com/grafana/grafana/pkg/services/licensing"
 	"github.com/grafana/grafana/pkg/services/search/model"
 	"github.com/grafana/grafana/pkg/services/star"
 	"github.com/grafana/grafana/pkg/services/star/startest"
@@ -186,6 +188,7 @@ func TestGetNavTreeIncludesFeatureTogglesLink(t *testing.T) {
 	service := ServiceImpl{
 		cfg:      setting.NewCfg(),
 		features: featuremgmt.WithFeatures(),
+		license:  &licensing.OSSLicensingService{},
 		accessControl: accesscontrolmock.New().WithPermissions([]ac.Permission{
 			{Action: ac.ActionFeatureManagementRead, Scope: "*"},
 		}),

--- a/public/app/core/utils/navBarItem-translations.ts
+++ b/public/app/core/utils/navBarItem-translations.ts
@@ -129,6 +129,8 @@ export function getNavTitle(navId: string | undefined) {
       return t('nav.global-orgs.title', 'Organizations');
     case 'server-settings':
       return t('nav.server-settings.title', 'Settings');
+    case 'feature-toggles':
+      return t('nav.feature-toggles.title', 'Feature toggles');
     case 'storage':
       return t('nav.storage.title', 'Storage');
     case 'migrate-to-cloud':
@@ -279,6 +281,8 @@ export function getNavSubTitle(navId: string | undefined) {
       return t('nav.global-orgs.subtitle', 'Isolated instances of Grafana running on the same server');
     case 'server-settings':
       return t('nav.server-settings.subtitle', 'View the settings defined in your Grafana config');
+    case 'feature-toggles':
+      return t('nav.feature-toggles.subtitle', 'View and change runtime feature flags');
     case 'storage':
       return t('nav.storage.subtitle', 'Manage file storage');
     case 'migrate-to-cloud':

--- a/public/app/features/admin/FeatureTogglesPage.test.tsx
+++ b/public/app/features/admin/FeatureTogglesPage.test.tsx
@@ -1,0 +1,108 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import { AppEvents } from '@grafana/data';
+import { getAppEvents, getBackendSrv } from '@grafana/runtime';
+
+import { TestProvider } from '../../../test/helpers/TestProvider';
+import { contextSrv } from '../../core/services/context_srv';
+
+import FeatureTogglesPage from './FeatureTogglesPage';
+
+const mockGet = jest.fn();
+const mockPut = jest.fn();
+const mockPublish = jest.fn();
+
+jest.mock('@grafana/runtime', () => ({
+  ...jest.requireActual('@grafana/runtime'),
+  getBackendSrv: jest.fn(() => ({ get: mockGet, put: mockPut })),
+  getAppEvents: jest.fn(() => ({ publish: mockPublish })),
+}));
+
+const renderPage = () => {
+  render(
+    <TestProvider>
+      <FeatureTogglesPage />
+    </TestProvider>
+  );
+};
+
+describe('FeatureTogglesPage', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGet.mockResolvedValue([
+      {
+        name: 'alphaFlag',
+        description: 'An alpha toggle',
+        stage: 'experimental',
+        requiresDevMode: false,
+        requiresRestart: false,
+        enabled: false,
+      },
+      {
+        name: 'betaFlag',
+        description: 'A beta toggle',
+        stage: 'preview',
+        requiresDevMode: true,
+        requiresRestart: true,
+        enabled: true,
+      },
+    ]);
+    mockPut.mockResolvedValue({});
+  });
+
+  it('loads and renders toggles', async () => {
+    jest.spyOn(contextSrv, 'hasPermission').mockImplementation((action: string) => {
+      return action === 'featuremgmt.write';
+    });
+
+    renderPage();
+
+    expect(await screen.findByText('alphaFlag')).toBeInTheDocument();
+    expect(screen.getByText('betaFlag')).toBeInTheDocument();
+    expect(mockGet).toHaveBeenCalledWith('/api/feature-toggles');
+  });
+
+  it('filters toggles by search text', async () => {
+    jest.spyOn(contextSrv, 'hasPermission').mockReturnValue(true);
+    renderPage();
+
+    await screen.findByText('alphaFlag');
+    await userEvent.type(screen.getByLabelText('Search feature toggles'), 'beta');
+
+    expect(screen.queryByText('alphaFlag')).not.toBeInTheDocument();
+    expect(screen.getByText('betaFlag')).toBeInTheDocument();
+  });
+
+  it('updates a toggle when user has write permission', async () => {
+    jest.spyOn(contextSrv, 'hasPermission').mockImplementation((action: string) => {
+      return action === 'featuremgmt.write';
+    });
+
+    renderPage();
+    await screen.findByText('alphaFlag');
+
+    const alphaSwitch = screen.getByRole('switch', { name: 'Toggle alphaFlag' });
+    await userEvent.click(alphaSwitch);
+
+    await waitFor(() => {
+      expect(mockPut).toHaveBeenCalledWith('/api/feature-toggles/alphaFlag', { enabled: true });
+    });
+
+    expect(mockPublish).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: AppEvents.alertSuccess.name,
+      })
+    );
+  });
+
+  it('shows read-only state without write permission', async () => {
+    jest.spyOn(contextSrv, 'hasPermission').mockReturnValue(false);
+
+    renderPage();
+    await screen.findByText('alphaFlag');
+
+    expect(screen.getByText('Read only')).toBeInTheDocument();
+    expect(screen.getByRole('switch', { name: 'Toggle alphaFlag' })).toBeDisabled();
+  });
+});

--- a/public/app/features/admin/FeatureTogglesPage.test.tsx
+++ b/public/app/features/admin/FeatureTogglesPage.test.tsx
@@ -7,19 +7,18 @@ import { getAppEvents, getBackendSrv } from '@grafana/runtime';
 import { TestProvider } from '../../../test/helpers/TestProvider';
 import { contextSrv } from '../../core/services/context_srv';
 
-import FeatureTogglesPage from './FeatureTogglesPage';
-
 const mockGet = jest.fn();
 const mockPut = jest.fn();
 const mockPublish = jest.fn();
 
 jest.mock('@grafana/runtime', () => ({
   ...jest.requireActual('@grafana/runtime'),
-  getBackendSrv: jest.fn(() => ({ get: mockGet, put: mockPut })),
-  getAppEvents: jest.fn(() => ({ publish: mockPublish })),
+  getBackendSrv: jest.fn(),
+  getAppEvents: jest.fn(),
 }));
 
 const renderPage = () => {
+  const { default: FeatureTogglesPage } = require('./FeatureTogglesPage');
   render(
     <TestProvider>
       <FeatureTogglesPage />
@@ -30,6 +29,8 @@ const renderPage = () => {
 describe('FeatureTogglesPage', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    jest.mocked(getBackendSrv).mockReturnValue({ get: mockGet, put: mockPut } as never);
+    jest.mocked(getAppEvents).mockReturnValue({ publish: mockPublish } as never);
     mockGet.mockResolvedValue([
       {
         name: 'alphaFlag',

--- a/public/app/features/admin/FeatureTogglesPage.test.tsx
+++ b/public/app/features/admin/FeatureTogglesPage.test.tsx
@@ -49,7 +49,7 @@ describe('FeatureTogglesPage', () => {
         enabled: true,
       },
     ]);
-    mockPut.mockResolvedValue({});
+    mockPut.mockResolvedValue({ name: 'alphaFlag', enabled: true });
   });
 
   it('loads and renders toggles', async () => {
@@ -90,9 +90,40 @@ describe('FeatureTogglesPage', () => {
       expect(mockPut).toHaveBeenCalledWith('/api/feature-toggles/alphaFlag', { enabled: true });
     });
 
+    await waitFor(() => {
+      expect(alphaSwitch).toBeChecked();
+    });
+
     expect(mockPublish).toHaveBeenCalledWith(
       expect.objectContaining({
         type: AppEvents.alertSuccess.name,
+        payload: ['Enabled alphaFlag'],
+      })
+    );
+  });
+
+  it('reconciles optimistic state with the server response', async () => {
+    jest.spyOn(contextSrv, 'hasPermission').mockReturnValue(true);
+    mockPut.mockResolvedValue({ name: 'alphaFlag', enabled: false });
+
+    renderPage();
+    await screen.findByText('alphaFlag');
+
+    const alphaSwitch = screen.getByRole('switch', { name: 'Toggle alphaFlag' });
+    await userEvent.click(alphaSwitch);
+
+    await waitFor(() => {
+      expect(mockPut).toHaveBeenCalledWith('/api/feature-toggles/alphaFlag', { enabled: true });
+    });
+
+    await waitFor(() => {
+      expect(alphaSwitch).not.toBeChecked();
+    });
+
+    expect(mockPublish).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: AppEvents.alertSuccess.name,
+        payload: ['Disabled alphaFlag'],
       })
     );
   });

--- a/public/app/features/admin/FeatureTogglesPage.tsx
+++ b/public/app/features/admin/FeatureTogglesPage.tsx
@@ -1,0 +1,211 @@
+import { css } from '@emotion/css';
+import { useCallback, useEffect, useMemo, useState } from 'react';
+
+import { AppEvents, GrafanaTheme2 } from '@grafana/data';
+import { t } from '@grafana/i18n';
+import { getAppEvents, getBackendSrv } from '@grafana/runtime';
+import { Alert, Input, Spinner, Stack, Switch, Text, useStyles2 } from '@grafana/ui';
+import { Page } from 'app/core/components/Page/Page';
+import { contextSrv } from 'app/core/services/context_srv';
+import { AccessControlAction } from 'app/types/accessControl';
+
+type FeatureToggleDTO = {
+  name: string;
+  description: string;
+  stage: string;
+  requiresDevMode: boolean;
+  requiresRestart: boolean;
+  enabled: boolean;
+};
+
+const appEvents = getAppEvents();
+
+export default function FeatureTogglesPage() {
+  const styles = useStyles2(getStyles);
+  const [isLoading, setIsLoading] = useState(true);
+  const [isError, setIsError] = useState(false);
+  const [query, setQuery] = useState('');
+  const [featureToggles, setFeatureToggles] = useState<FeatureToggleDTO[]>([]);
+  const [pendingToggles, setPendingToggles] = useState<Record<string, boolean>>({});
+
+  const canWrite = contextSrv.hasPermission(AccessControlAction.FeatureManagementWrite);
+
+  const loadToggles = useCallback(async () => {
+    setIsLoading(true);
+    setIsError(false);
+    try {
+      const values = await getBackendSrv().get<FeatureToggleDTO[]>('/api/feature-toggles');
+      setFeatureToggles(values);
+    } catch (error) {
+      setIsError(true);
+      appEvents.publish({
+        type: AppEvents.alertError.name,
+        payload: [t('admin.feature-toggles.load-error', 'Failed to load feature toggles'), error as Error],
+      });
+    } finally {
+      setIsLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    loadToggles();
+  }, [loadToggles]);
+
+  const onToggle = useCallback(
+    async (name: string, enabled: boolean) => {
+      setPendingToggles((current) => ({ ...current, [name]: true }));
+      setFeatureToggles((current) =>
+        current.map((item) => (item.name === name ? { ...item, enabled } : item))
+      );
+
+      try {
+        await getBackendSrv().put(`/api/feature-toggles/${encodeURIComponent(name)}`, { enabled });
+        appEvents.publish({
+          type: AppEvents.alertSuccess.name,
+          payload: [
+            enabled
+              ? t('admin.feature-toggles.enabled', 'Enabled {{name}}', { name })
+              : t('admin.feature-toggles.disabled', 'Disabled {{name}}', { name }),
+          ],
+        });
+      } catch (error) {
+        // Revert optimistic update on failure.
+        setFeatureToggles((current) =>
+          current.map((item) => (item.name === name ? { ...item, enabled: !enabled } : item))
+        );
+        appEvents.publish({
+          type: AppEvents.alertError.name,
+          payload: [t('admin.feature-toggles.update-error', 'Failed to update feature toggle'), error as Error],
+        });
+      } finally {
+        setPendingToggles((current) => {
+          const next = { ...current };
+          delete next[name];
+          return next;
+        });
+      }
+    },
+    [setFeatureToggles]
+  );
+
+  const visibleToggles = useMemo(() => {
+    const search = query.trim().toLowerCase();
+    if (!search) {
+      return featureToggles;
+    }
+
+    return featureToggles.filter((item) => {
+      return (
+        item.name.toLowerCase().includes(search) ||
+        item.description.toLowerCase().includes(search) ||
+        item.stage.toLowerCase().includes(search)
+      );
+    });
+  }, [featureToggles, query]);
+
+  return (
+    <Page navId="feature-toggles">
+      <Page.Contents isLoading={isLoading}>
+        <Stack direction="column" gap={2}>
+          <Alert title={t('admin.feature-toggles.runtime-note-title', 'Runtime-only changes')}>
+            {t(
+              'admin.feature-toggles.runtime-note-body',
+              'Changes here affect in-memory state and are not persisted across Grafana restarts.'
+            )}
+          </Alert>
+          {!canWrite && (
+            <Alert title={t('admin.feature-toggles.read-only-title', 'Read only')} severity="info">
+              {t(
+                'admin.feature-toggles.read-only-body',
+                'You have permission to view toggles but not to change them.'
+              )}
+            </Alert>
+          )}
+
+          <Input
+            aria-label={t('admin.feature-toggles.search-label', 'Search feature toggles')}
+            placeholder={t('admin.feature-toggles.search-placeholder', 'Search by name, stage, or description')}
+            value={query}
+            onChange={(event) => setQuery(event.currentTarget.value)}
+          />
+
+          {!isLoading && !isError && visibleToggles.length === 0 && (
+            <Text color="secondary">
+              {t('admin.feature-toggles.empty', 'No feature toggles match your search.')}
+            </Text>
+          )}
+
+          {!isLoading && isError && (
+            <Text color="warning">{t('admin.feature-toggles.load-error-inline', 'Unable to load feature toggles.')}</Text>
+          )}
+
+          <div className={styles.list} data-testid="feature-toggles-list">
+            {visibleToggles.map((item) => {
+              const isPending = Boolean(pendingToggles[item.name]);
+              return (
+                <div className={styles.row} key={item.name}>
+                  <div className={styles.meta}>
+                    <Text element="h5">{item.name}</Text>
+                    {item.description && (
+                      <Text color="secondary" variant="bodySmall">
+                        {item.description}
+                      </Text>
+                    )}
+                    <Text color="secondary" variant="bodySmall">
+                      {t('admin.feature-toggles.stage', 'Stage: {{stage}}', { stage: item.stage })}
+                      {item.requiresDevMode
+                        ? ` · ${t('admin.feature-toggles.requires-dev-mode', 'Requires dev mode')}`
+                        : ''}
+                      {item.requiresRestart
+                        ? ` · ${t('admin.feature-toggles.requires-restart', 'Requires restart')}`
+                        : ''}
+                    </Text>
+                  </div>
+                  <div className={styles.toggleWrap}>
+                    {isPending && <Spinner inline size={14} />}
+                    <Switch
+                      value={item.enabled}
+                      disabled={!canWrite || isPending}
+                      onChange={(event) => onToggle(item.name, event.currentTarget.checked)}
+                      aria-label={t('admin.feature-toggles.switch-label', 'Toggle {{name}}', { name: item.name })}
+                    />
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        </Stack>
+      </Page.Contents>
+    </Page>
+  );
+}
+
+const getStyles = (theme: GrafanaTheme2) => {
+  return {
+    list: css({
+      border: `1px solid ${theme.colors.border.weak}`,
+      borderRadius: theme.shape.radius.default,
+      overflow: 'hidden',
+    }),
+    row: css({
+      display: 'flex',
+      alignItems: 'center',
+      justifyContent: 'space-between',
+      gap: theme.spacing(2),
+      padding: theme.spacing(2),
+      borderBottom: `1px solid ${theme.colors.border.weak}`,
+      '&:last-child': {
+        borderBottom: 'none',
+      },
+    }),
+    meta: css({
+      minWidth: 0,
+      flexGrow: 1,
+    }),
+    toggleWrap: css({
+      display: 'flex',
+      alignItems: 'center',
+      gap: theme.spacing(1),
+    }),
+  };
+};

--- a/public/app/features/admin/FeatureTogglesPage.tsx
+++ b/public/app/features/admin/FeatureTogglesPage.tsx
@@ -18,6 +18,11 @@ type FeatureToggleDTO = {
   enabled: boolean;
 };
 
+type UpdateFeatureToggleResponse = {
+  name: string;
+  enabled: boolean;
+};
+
 const appEvents = getAppEvents();
 
 export default function FeatureTogglesPage() {
@@ -59,11 +64,17 @@ export default function FeatureTogglesPage() {
       );
 
       try {
-        await getBackendSrv().put(`/api/feature-toggles/${encodeURIComponent(name)}`, { enabled });
+        const result = await getBackendSrv().put<UpdateFeatureToggleResponse>(
+          `/api/feature-toggles/${encodeURIComponent(name)}`,
+          { enabled }
+        );
+        setFeatureToggles((current) =>
+          current.map((item) => (item.name === name ? { ...item, enabled: result.enabled } : item))
+        );
         appEvents.publish({
           type: AppEvents.alertSuccess.name,
           payload: [
-            enabled
+            result.enabled
               ? t('admin.feature-toggles.enabled', 'Enabled {{name}}', { name })
               : t('admin.feature-toggles.disabled', 'Disabled {{name}}', { name }),
           ],

--- a/public/app/features/admin/FeatureTogglesPage.tsx
+++ b/public/app/features/admin/FeatureTogglesPage.tsx
@@ -54,9 +54,7 @@ export default function FeatureTogglesPage() {
   const onToggle = useCallback(
     async (name: string, enabled: boolean) => {
       setPendingToggles((current) => ({ ...current, [name]: true }));
-      setFeatureToggles((current) =>
-        current.map((item) => (item.name === name ? { ...item, enabled } : item))
-      );
+      setFeatureToggles((current) => current.map((item) => (item.name === name ? { ...item, enabled } : item)));
 
       try {
         await getBackendSrv().put(`/api/feature-toggles/${encodeURIComponent(name)}`, { enabled });
@@ -115,10 +113,7 @@ export default function FeatureTogglesPage() {
           </Alert>
           {!canWrite && (
             <Alert title={t('admin.feature-toggles.read-only-title', 'Read only')} severity="info">
-              {t(
-                'admin.feature-toggles.read-only-body',
-                'You have permission to view toggles but not to change them.'
-              )}
+              {t('admin.feature-toggles.read-only-body', 'You have permission to view toggles but not to change them.')}
             </Alert>
           )}
 
@@ -130,13 +125,13 @@ export default function FeatureTogglesPage() {
           />
 
           {!isLoading && !isError && visibleToggles.length === 0 && (
-            <Text color="secondary">
-              {t('admin.feature-toggles.empty', 'No feature toggles match your search.')}
-            </Text>
+            <Text color="secondary">{t('admin.feature-toggles.empty', 'No feature toggles match your search.')}</Text>
           )}
 
           {!isLoading && isError && (
-            <Text color="warning">{t('admin.feature-toggles.load-error-inline', 'Unable to load feature toggles.')}</Text>
+            <Text color="warning">
+              {t('admin.feature-toggles.load-error-inline', 'Unable to load feature toggles.')}
+            </Text>
           )}
 
           <div className={styles.list} data-testid="feature-toggles-list">

--- a/public/app/routes/routes.tsx
+++ b/public/app/routes/routes.tsx
@@ -348,6 +348,17 @@ export function getAppRoutes(): RouteDescriptor[] {
       ),
     },
     {
+      path: '/admin/feature-toggles',
+      roles: () =>
+        contextSrv.evaluatePermission([
+          AccessControlAction.FeatureManagementRead,
+          AccessControlAction.FeatureManagementWrite,
+        ]),
+      component: SafeDynamicImport(
+        () => import(/* webpackChunkName: "FeatureTogglesAdmin" */ 'app/features/admin/FeatureTogglesPage')
+      ),
+    },
+    {
       path: '/admin/upgrading',
       component: SafeDynamicImport(() => import('app/features/admin/UpgradePage')),
     },

--- a/public/app/types/accessControl.ts
+++ b/public/app/types/accessControl.ts
@@ -169,6 +169,8 @@ export enum AccessControlAction {
   // Settings
   SettingsRead = 'settings:read',
   SettingsWrite = 'settings:write',
+  FeatureManagementRead = 'featuremgmt.read',
+  FeatureManagementWrite = 'featuremgmt.write',
 
   // GroupSync
   GroupSyncMappingsRead = 'groupsync.mappings:read',


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
**What is this feature?**

This change adds a new Administration page at `/admin/feature-toggles` that lists all feature flags and allows authorized users to toggle them on or off at runtime.

**Why do we need this feature?**

Users currently have no built-in UI to inspect all flags in one place or quickly test behavior by toggling flags. This page provides a direct, discoverable workflow in Grafana’s admin area.

**Who is this feature for?**

Grafana administrators and operators who need to inspect and adjust runtime feature flags for validation and troubleshooting.

**Which issue(s) does this PR fix?**:

Fixes #

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.

Implementation notes:
- Added backend endpoints:
  - `GET /api/feature-toggles` (requires `featuremgmt.read`)
  - `PUT /api/feature-toggles/:name` (requires `featuremgmt.write`)
- Added thread-safe runtime mutation support to `FeatureManager` via `SetStartupState`.
- Added admin route + left nav item (`Feature toggles`) under Administration > General.
- Added frontend page `FeatureTogglesPage` with search, inline switch controls, optimistic updates, and toast notifications.
- Added targeted backend/frontend tests for API behavior, nav wiring, and page interaction.

Follow-up fixes included in current branch history:
- Prettier formatting fix for `public/app/features/admin/FeatureTogglesPage.tsx`.
- API response reconciliation fix: `PUT /api/feature-toggles/:name` returns actual enabled state after update.
- Frontend uses response `enabled` value to avoid stale optimistic state.
- Additional tests for response-state behavior and UI handling.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-67b57519-ea26-4359-9ac9-22f3479f8b7b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-67b57519-ea26-4359-9ac9-22f3479f8b7b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

