### PR TITLE
Login: Refresh landing page with marketing hero layout

### DIFF
--- a/public/app/core/components/Login/LoginLayout.tsx
+++ b/public/app/core/components/Login/LoginLayout.tsx
@@ -64,19 +64,25 @@ export const LoginLayout = ({
               </p>
               <div className={loginStyles.heroStats}>
                 <div className={loginStyles.heroStatCard}>
-                  <span className={loginStyles.heroStatValue}>1</span>
+                  <span className={loginStyles.heroStatValue}>
+                    <Trans i18nKey="login.layout.hero-stat-platform-value">1</Trans>
+                  </span>
                   <span className={loginStyles.heroStatLabel}>
                     <Trans i18nKey="login.layout.hero-stat-platform">Unified platform</Trans>
                   </span>
                 </div>
                 <div className={loginStyles.heroStatCard}>
-                  <span className={loginStyles.heroStatValue}>100%</span>
+                  <span className={loginStyles.heroStatValue}>
+                    <Trans i18nKey="login.layout.hero-stat-visibility-value">100%</Trans>
+                  </span>
                   <span className={loginStyles.heroStatLabel}>
                     <Trans i18nKey="login.layout.hero-stat-visibility">Service visibility</Trans>
                   </span>
                 </div>
                 <div className={loginStyles.heroStatCard}>
-                  <span className={loginStyles.heroStatValue}>24/7</span>
+                  <span className={loginStyles.heroStatValue}>
+                    <Trans i18nKey="login.layout.hero-stat-alerting-value">24/7</Trans>
+                  </span>
                   <span className={loginStyles.heroStatLabel}>
                     <Trans i18nKey="login.layout.hero-stat-alerting">Context-aware alerting</Trans>
                   </span>

--- a/public/app/core/components/Login/LoginLayout.tsx
+++ b/public/app/core/components/Login/LoginLayout.tsx
@@ -287,7 +287,7 @@ export const getLoginStyles = (theme: GrafanaTheme2) => {
       gap: theme.spacing(0.5),
     }),
     heroStatValue: css({
-      fontSize: theme.typography.size.xl,
+      fontSize: theme.typography.h3.fontSize,
       fontWeight: theme.typography.fontWeightBold,
       color: theme.colors.text.primary,
       lineHeight: 1.2,

--- a/public/app/core/components/Login/LoginLayout.tsx
+++ b/public/app/core/components/Login/LoginLayout.tsx
@@ -35,7 +35,7 @@ export const LoginLayout = ({
   const [startAnim, setStartAnim] = useState(false);
   const subTitle = branding?.loginSubtitle ?? Branding.GetLoginSubTitle();
   const loginTitle = branding?.loginTitle ?? Branding.LoginTitle;
-  const loginBoxBackground = branding?.loginBoxBackground;
+  const loginBoxBackground = branding?.loginBoxBackground || Branding.LoginBoxBackground();
   const loginLogo = branding?.loginLogo;
   const hideEdition = branding?.hideEdition ?? Branding.HideEdition;
   const shouldShowHeroPanel = showHeroPanel && !isChangingPassword;
@@ -85,13 +85,20 @@ export const LoginLayout = ({
             </div>
           )}
           <div className={cx(loginStyles.loginOuterBox, !shouldShowHeroPanel && loginStyles.loginOuterBoxFullWidth)}>
-            {isChangingPassword && (
+            {!shouldShowHeroPanel && (
               <div className={loginStyles.loginLogoWrapper}>
                 <Branding.LoginLogo className={loginStyles.loginLogo} logo={loginLogo} />
                 <div className={loginStyles.titleWrapper}>
-                  <h1 className={loginStyles.mainTitle}>
-                    <Trans i18nKey="login.layout.update-password">Update your password</Trans>
-                  </h1>
+                  {isChangingPassword ? (
+                    <h1 className={loginStyles.mainTitle}>
+                      <Trans i18nKey="login.layout.update-password">Update your password</Trans>
+                    </h1>
+                  ) : (
+                    <>
+                      <h1 className={loginStyles.mainTitle}>{loginTitle}</h1>
+                      {subTitle && <h3 className={loginStyles.subTitle}>{subTitle}</h3>}
+                    </>
+                  )}
                 </div>
               </div>
             )}

--- a/public/app/core/components/Login/LoginLayout.tsx
+++ b/public/app/core/components/Login/LoginLayout.tsx
@@ -41,22 +41,55 @@ export const LoginLayout = ({ children, branding, isChangingPassword }: React.Pr
     >
       <div className={loginStyles.loginMain}>
         <div className={cx(loginStyles.loginContent, loginBoxBackground, 'login-content-box')}>
-          <div className={loginStyles.loginLogoWrapper}>
-            <Branding.LoginLogo className={loginStyles.loginLogo} logo={loginLogo} />
-            <div className={loginStyles.titleWrapper}>
-              {isChangingPassword ? (
-                <h1 className={loginStyles.mainTitle}>
-                  <Trans i18nKey="login.layout.update-password">Update your password</Trans>
-                </h1>
-              ) : (
-                <>
+          {!isChangingPassword && (
+            <div className={loginStyles.heroPanel}>
+              <div className={loginStyles.loginLogoWrapper}>
+                <Branding.LoginLogo className={loginStyles.loginLogo} logo={loginLogo} />
+                <div className={loginStyles.titleWrapper}>
                   <h1 className={loginStyles.mainTitle}>{loginTitle}</h1>
                   {subTitle && <h3 className={loginStyles.subTitle}>{subTitle}</h3>}
-                </>
-              )}
+                </div>
+              </div>
+              <p className={loginStyles.heroDescription}>
+                <Trans i18nKey="login.layout.hero-description">
+                  See metrics, logs, traces, and incidents in one place with fast, actionable observability.
+                </Trans>
+              </p>
+              <div className={loginStyles.heroStats}>
+                <div className={loginStyles.heroStatCard}>
+                  <span className={loginStyles.heroStatValue}>1</span>
+                  <span className={loginStyles.heroStatLabel}>
+                    <Trans i18nKey="login.layout.hero-stat-platform">Unified platform</Trans>
+                  </span>
+                </div>
+                <div className={loginStyles.heroStatCard}>
+                  <span className={loginStyles.heroStatValue}>100%</span>
+                  <span className={loginStyles.heroStatLabel}>
+                    <Trans i18nKey="login.layout.hero-stat-visibility">Service visibility</Trans>
+                  </span>
+                </div>
+                <div className={loginStyles.heroStatCard}>
+                  <span className={loginStyles.heroStatValue}>24/7</span>
+                  <span className={loginStyles.heroStatLabel}>
+                    <Trans i18nKey="login.layout.hero-stat-alerting">Context-aware alerting</Trans>
+                  </span>
+                </div>
+              </div>
             </div>
+          )}
+          <div className={cx(loginStyles.loginOuterBox, isChangingPassword && loginStyles.loginOuterBoxFullWidth)}>
+            {isChangingPassword && (
+              <div className={loginStyles.loginLogoWrapper}>
+                <Branding.LoginLogo className={loginStyles.loginLogo} logo={loginLogo} />
+                <div className={loginStyles.titleWrapper}>
+                  <h1 className={loginStyles.mainTitle}>
+                    <Trans i18nKey="login.layout.update-password">Update your password</Trans>
+                  </h1>
+                </div>
+              </div>
+            )}
+            {children}
           </div>
-          <div className={loginStyles.loginOuterBox}>{children}</div>
         </div>
       </div>
       {branding?.hideFooter ? <></> : <Footer hideEdition={hideEdition} customLinks={branding?.footerLinks} />}
@@ -141,7 +174,7 @@ export const getLoginStyles = (theme: GrafanaTheme2) => {
       color: theme.colors.text.secondary,
     }),
     loginContent: css({
-      maxWidth: 478,
+      maxWidth: 1040,
       width: `calc(100% - 2rem)`,
       display: 'flex',
       alignItems: 'stretch',
@@ -149,9 +182,12 @@ export const getLoginStyles = (theme: GrafanaTheme2) => {
       position: 'relative',
       justifyContent: 'flex-start',
       zIndex: 1,
-      minHeight: 320,
+      minHeight: 380,
       borderRadius: theme.shape.radius.lg,
-      padding: theme.spacing(2, 0),
+      padding: theme.spacing(1),
+      background: `linear-gradient(140deg, ${theme.colors.background.primary}, ${theme.colors.background.secondary})`,
+      border: `1px solid ${theme.colors.border.weak}`,
+      boxShadow: theme.shadows.z3,
       opacity: 0,
       [theme.transitions.handleMotion('no-preference')]: {
         transition: 'opacity 0.5s ease-in-out',
@@ -161,18 +197,44 @@ export const getLoginStyles = (theme: GrafanaTheme2) => {
       },
 
       [theme.breakpoints.up('sm')]: {
-        minHeight: theme.spacing(40),
+        minHeight: theme.spacing(52),
         justifyContent: 'center',
+        flexDirection: 'row',
+      },
+    }),
+    heroPanel: css({
+      display: 'flex',
+      flexDirection: 'column',
+      justifyContent: 'space-between',
+      gap: theme.spacing(2),
+      padding: theme.spacing(2),
+      [theme.breakpoints.up('sm')]: {
+        width: '54%',
+        padding: theme.spacing(4),
       },
     }),
     loginOuterBox: css({
       display: 'flex',
+      flexDirection: 'column',
       overflowY: 'hidden',
-      alignItems: 'center',
+      alignItems: 'stretch',
       justifyContent: 'center',
+      borderRadius: theme.shape.radius.md,
+      background: theme.colors.background.secondary,
+      border: `1px solid ${theme.colors.border.weak}`,
+      margin: theme.spacing(1),
+      [theme.breakpoints.up('sm')]: {
+        width: '46%',
+        margin: theme.spacing(2),
+      },
+    }),
+    loginOuterBoxFullWidth: css({
+      [theme.breakpoints.up('sm')]: {
+        width: '100%',
+      },
     }),
     loginInnerBox: css({
-      padding: theme.spacing(0, 2, 2, 2),
+      padding: theme.spacing(2),
       display: 'flex',
       flexDirection: 'column',
       alignItems: 'center',
@@ -189,6 +251,42 @@ export const getLoginStyles = (theme: GrafanaTheme2) => {
       [theme.transitions.handleMotion('no-preference')]: {
         animation: `${flyInAnimation} ease-out 0.2s`,
       },
+    }),
+    heroDescription: css({
+      fontSize: theme.typography.size.lg,
+      lineHeight: theme.typography.body.lineHeight,
+      color: theme.colors.text.secondary,
+      margin: 0,
+      maxWidth: 560,
+    }),
+    heroStats: css({
+      display: 'grid',
+      gridTemplateColumns: '1fr',
+      gap: theme.spacing(1),
+      [theme.breakpoints.up('md')]: {
+        gridTemplateColumns: 'repeat(3, 1fr)',
+      },
+    }),
+    heroStatCard: css({
+      background: theme.isDark
+        ? 'linear-gradient(140deg, rgba(245, 78, 0, 0.22), rgba(245, 78, 0, 0.1))'
+        : 'linear-gradient(140deg, rgba(245, 78, 0, 0.16), rgba(245, 78, 0, 0.05))',
+      border: `1px solid ${theme.colors.border.weak}`,
+      borderRadius: theme.shape.radius.md,
+      padding: theme.spacing(1.25, 1.5),
+      display: 'flex',
+      flexDirection: 'column',
+      gap: theme.spacing(0.5),
+    }),
+    heroStatValue: css({
+      fontSize: theme.typography.size.xl,
+      fontWeight: theme.typography.fontWeightBold,
+      color: theme.colors.text.primary,
+      lineHeight: 1.2,
+    }),
+    heroStatLabel: css({
+      fontSize: theme.typography.size.sm,
+      color: theme.colors.text.secondary,
     }),
   };
 };

--- a/public/app/core/components/Login/LoginLayout.tsx
+++ b/public/app/core/components/Login/LoginLayout.tsx
@@ -22,9 +22,15 @@ export interface LoginLayoutProps {
   /** Custom branding settings that can be used e.g. for previewing the Login page changes */
   branding?: BrandingSettings;
   isChangingPassword?: boolean;
+  showHeroPanel?: boolean;
 }
 
-export const LoginLayout = ({ children, branding, isChangingPassword }: React.PropsWithChildren<LoginLayoutProps>) => {
+export const LoginLayout = ({
+  children,
+  branding,
+  isChangingPassword,
+  showHeroPanel = false,
+}: React.PropsWithChildren<LoginLayoutProps>) => {
   const loginStyles = useStyles2(getLoginStyles);
   const [startAnim, setStartAnim] = useState(false);
   const subTitle = branding?.loginSubtitle ?? Branding.GetLoginSubTitle();
@@ -32,6 +38,7 @@ export const LoginLayout = ({ children, branding, isChangingPassword }: React.Pr
   const loginBoxBackground = branding?.loginBoxBackground;
   const loginLogo = branding?.loginLogo;
   const hideEdition = branding?.hideEdition ?? Branding.HideEdition;
+  const shouldShowHeroPanel = showHeroPanel && !isChangingPassword;
 
   useEffect(() => setStartAnim(true), []);
 
@@ -41,7 +48,7 @@ export const LoginLayout = ({ children, branding, isChangingPassword }: React.Pr
     >
       <div className={loginStyles.loginMain}>
         <div className={cx(loginStyles.loginContent, loginBoxBackground, 'login-content-box')}>
-          {!isChangingPassword && (
+          {shouldShowHeroPanel && (
             <div className={loginStyles.heroPanel}>
               <div className={loginStyles.loginLogoWrapper}>
                 <Branding.LoginLogo className={loginStyles.loginLogo} logo={loginLogo} />
@@ -77,7 +84,7 @@ export const LoginLayout = ({ children, branding, isChangingPassword }: React.Pr
               </div>
             </div>
           )}
-          <div className={cx(loginStyles.loginOuterBox, isChangingPassword && loginStyles.loginOuterBoxFullWidth)}>
+          <div className={cx(loginStyles.loginOuterBox, !shouldShowHeroPanel && loginStyles.loginOuterBoxFullWidth)}>
             {isChangingPassword && (
               <div className={loginStyles.loginLogoWrapper}>
                 <Branding.LoginLogo className={loginStyles.loginLogo} logo={loginLogo} />

--- a/public/app/core/components/Login/LoginLayout.tsx
+++ b/public/app/core/components/Login/LoginLayout.tsx
@@ -29,7 +29,7 @@ export const LoginLayout = ({ children, branding, isChangingPassword }: React.Pr
   const [startAnim, setStartAnim] = useState(false);
   const subTitle = branding?.loginSubtitle ?? Branding.GetLoginSubTitle();
   const loginTitle = branding?.loginTitle ?? Branding.LoginTitle;
-  const loginBoxBackground = branding?.loginBoxBackground || Branding.LoginBoxBackground();
+  const loginBoxBackground = branding?.loginBoxBackground;
   const loginLogo = branding?.loginLogo;
   const hideEdition = branding?.hideEdition ?? Branding.HideEdition;
 
@@ -239,6 +239,7 @@ export const getLoginStyles = (theme: GrafanaTheme2) => {
       flexDirection: 'column',
       alignItems: 'center',
       justifyContent: 'center',
+      alignSelf: 'center',
       flexGrow: 1,
       maxWidth: 415,
       width: '100%',

--- a/public/app/core/components/Login/LoginPage.tsx
+++ b/public/app/core/components/Login/LoginPage.tsx
@@ -38,7 +38,7 @@ const LoginPage = () => {
           showDefaultPasswordWarning,
           loginErrorMessage,
         }) => (
-          <LoginLayout isChangingPassword={isChangingPassword}>
+          <LoginLayout isChangingPassword={isChangingPassword} showHeroPanel>
             {!isChangingPassword && (
               <InnerBox>
                 {loginErrorMessage && (


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
**What is this feature?**

Refreshes the Grafana login landing page layout with a more modern SaaS-style presentation inspired by Datadog’s marketing visual style, while keeping authentication behavior unchanged.

**Why do we need this feature?**

The current login landing page is functionally correct but visually plain. This update improves first-impression clarity and perceived product value by adding a clear hero message, supporting value points, and a stronger visual hierarchy for the login card.

**Who is this feature for?**

Users arriving at the Grafana login landing page, especially first-time or evaluative users.

**Which issue(s) does this PR fix?**:

Fixes #

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a notable improvement, it's added to our What's New doc.

Implementation notes:
- UI-only change in `public/app/core/components/Login/LoginLayout.tsx`.
- Added a left hero section with value proposition text and metric cards.
- Converted login form container to a card-like right panel on larger screens.
- Preserved existing login logic and change-password flow.
- Fixed CI lint failure by wrapping hero stat labels in `<Trans />` for localization compliance.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b45b6ab6-d565-48cc-b27e-726b14ebcaff"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b45b6ab6-d565-48cc-b27e-726b14ebcaff"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

