### PR TITLE
Frontend: refresh login landing page styling

### DIFF
--- a/public/app/core/components/Login/LoginLayout.tsx
+++ b/public/app/core/components/Login/LoginLayout.tsx
@@ -110,7 +110,6 @@ export const getLoginStyles = (theme: GrafanaTheme2) => {
       flexDirection: 'column',
       alignItems: 'center',
       justifyContent: 'center',
-      overflow: 'hidden',
     }),
     loginAnim: css({
       ['&:before']: {

--- a/public/app/core/components/Login/LoginLayout.tsx
+++ b/public/app/core/components/Login/LoginLayout.tsx
@@ -1,5 +1,5 @@
 import { cx, css, keyframes } from '@emotion/css';
-import { useEffect, useState } from 'react';
+import { ReactNode, useEffect, useState } from 'react';
 import * as React from 'react';
 
 import { GrafanaTheme2 } from '@grafana/data';
@@ -22,9 +22,15 @@ export interface LoginLayoutProps {
   /** Custom branding settings that can be used e.g. for previewing the Login page changes */
   branding?: BrandingSettings;
   isChangingPassword?: boolean;
+  sideContent?: ReactNode;
 }
 
-export const LoginLayout = ({ children, branding, isChangingPassword }: React.PropsWithChildren<LoginLayoutProps>) => {
+export const LoginLayout = ({
+  children,
+  branding,
+  isChangingPassword,
+  sideContent,
+}: React.PropsWithChildren<LoginLayoutProps>) => {
   const loginStyles = useStyles2(getLoginStyles);
   const [startAnim, setStartAnim] = useState(false);
   const subTitle = branding?.loginSubtitle ?? Branding.GetLoginSubTitle();
@@ -40,23 +46,26 @@ export const LoginLayout = ({ children, branding, isChangingPassword }: React.Pr
       className={cx(loginStyles.container, startAnim && loginStyles.loginAnim, branding?.loginBackground)}
     >
       <div className={loginStyles.loginMain}>
-        <div className={cx(loginStyles.loginContent, loginBoxBackground, 'login-content-box')}>
-          <div className={loginStyles.loginLogoWrapper}>
-            <Branding.LoginLogo className={loginStyles.loginLogo} logo={loginLogo} />
-            <div className={loginStyles.titleWrapper}>
-              {isChangingPassword ? (
-                <h1 className={loginStyles.mainTitle}>
-                  <Trans i18nKey="login.layout.update-password">Update your password</Trans>
-                </h1>
-              ) : (
-                <>
-                  <h1 className={loginStyles.mainTitle}>{loginTitle}</h1>
-                  {subTitle && <h3 className={loginStyles.subTitle}>{subTitle}</h3>}
-                </>
-              )}
+        <div className={loginStyles.loginSurface}>
+          {sideContent && !isChangingPassword && <div className={loginStyles.sideContent}>{sideContent}</div>}
+          <div className={cx(loginStyles.loginContent, loginBoxBackground, 'login-content-box')}>
+            <div className={loginStyles.loginLogoWrapper}>
+              <Branding.LoginLogo className={loginStyles.loginLogo} logo={loginLogo} />
+              <div className={loginStyles.titleWrapper}>
+                {isChangingPassword ? (
+                  <h1 className={loginStyles.mainTitle}>
+                    <Trans i18nKey="login.layout.update-password">Update your password</Trans>
+                  </h1>
+                ) : (
+                  <>
+                    <h1 className={loginStyles.mainTitle}>{loginTitle}</h1>
+                    {subTitle && <h3 className={loginStyles.subTitle}>{subTitle}</h3>}
+                  </>
+                )}
+              </div>
             </div>
+            <div className={loginStyles.loginOuterBox}>{children}</div>
           </div>
-          <div className={loginStyles.loginOuterBox}>{children}</div>
         </div>
       </div>
       {branding?.hideFooter ? <></> : <Footer hideEdition={hideEdition} customLinks={branding?.footerLinks} />}
@@ -84,6 +93,10 @@ export const getLoginStyles = (theme: GrafanaTheme2) => {
       alignItems: 'center',
       justifyContent: 'center',
       minWidth: '100%',
+      padding: theme.spacing(3, 2),
+      [theme.breakpoints.up('md')]: {
+        padding: theme.spacing(5, 3),
+      },
     }),
     container: css({
       minHeight: '100%',
@@ -96,6 +109,7 @@ export const getLoginStyles = (theme: GrafanaTheme2) => {
       flexDirection: 'column',
       alignItems: 'center',
       justifyContent: 'center',
+      overflow: 'hidden',
     }),
     loginAnim: css({
       ['&:before']: {
@@ -104,6 +118,17 @@ export const getLoginStyles = (theme: GrafanaTheme2) => {
 
       ['.login-content-box']: {
         opacity: 1,
+      },
+    }),
+    loginSurface: css({
+      width: '100%',
+      maxWidth: 1180,
+      display: 'grid',
+      gap: theme.spacing(3),
+      alignItems: 'stretch',
+      [theme.breakpoints.up('lg')]: {
+        gridTemplateColumns: 'minmax(0, 1.1fr) minmax(420px, 0.9fr)',
+        gap: theme.spacing(4),
       },
     }),
     submitButton: css({
@@ -124,13 +149,15 @@ export const getLoginStyles = (theme: GrafanaTheme2) => {
       alignItems: 'center',
       justifyContent: 'center',
       flexDirection: 'column',
-      padding: theme.spacing(3),
+      padding: theme.spacing(4, 4, 3),
     }),
     titleWrapper: css({
       textAlign: 'center',
     }),
     mainTitle: css({
       fontSize: 22,
+      margin: 0,
+      lineHeight: 1.15,
 
       [theme.breakpoints.up('sm')]: {
         fontSize: 32,
@@ -139,10 +166,10 @@ export const getLoginStyles = (theme: GrafanaTheme2) => {
     subTitle: css({
       fontSize: theme.typography.size.md,
       color: theme.colors.text.secondary,
+      margin: theme.spacing(1, 0, 0),
     }),
     loginContent: css({
-      maxWidth: 478,
-      width: `calc(100% - 2rem)`,
+      width: '100%',
       display: 'flex',
       alignItems: 'stretch',
       flexDirection: 'column',
@@ -150,9 +177,12 @@ export const getLoginStyles = (theme: GrafanaTheme2) => {
       justifyContent: 'flex-start',
       zIndex: 1,
       minHeight: 320,
-      borderRadius: theme.shape.radius.lg,
+      borderRadius: theme.shape.radius.xl,
       padding: theme.spacing(2, 0),
       opacity: 0,
+      border: `1px solid ${theme.colors.border.weak}`,
+      boxShadow: theme.shadows.z3,
+      backdropFilter: 'blur(22px)',
       [theme.transitions.handleMotion('no-preference')]: {
         transition: 'opacity 0.5s ease-in-out',
       },
@@ -165,6 +195,15 @@ export const getLoginStyles = (theme: GrafanaTheme2) => {
         justifyContent: 'center',
       },
     }),
+    sideContent: css({
+      display: 'none',
+      [theme.breakpoints.up('lg')]: {
+        display: 'flex',
+        flexDirection: 'column',
+        justifyContent: 'center',
+        minWidth: 0,
+      },
+    }),
     loginOuterBox: css({
       display: 'flex',
       overflowY: 'hidden',
@@ -172,7 +211,7 @@ export const getLoginStyles = (theme: GrafanaTheme2) => {
       justifyContent: 'center',
     }),
     loginInnerBox: css({
-      padding: theme.spacing(0, 2, 2, 2),
+      padding: theme.spacing(0, 4, 4),
       display: 'flex',
       flexDirection: 'column',
       alignItems: 'center',

--- a/public/app/core/components/Login/LoginLayout.tsx
+++ b/public/app/core/components/Login/LoginLayout.tsx
@@ -33,6 +33,7 @@ export const LoginLayout = ({
 }: React.PropsWithChildren<LoginLayoutProps>) => {
   const loginStyles = useStyles2(getLoginStyles);
   const [startAnim, setStartAnim] = useState(false);
+  const hasSideContent = Boolean(sideContent) && !isChangingPassword;
   const subTitle = branding?.loginSubtitle ?? Branding.GetLoginSubTitle();
   const loginTitle = branding?.loginTitle ?? Branding.LoginTitle;
   const loginBoxBackground = branding?.loginBoxBackground || Branding.LoginBoxBackground();
@@ -46,8 +47,8 @@ export const LoginLayout = ({
       className={cx(loginStyles.container, startAnim && loginStyles.loginAnim, branding?.loginBackground)}
     >
       <div className={loginStyles.loginMain}>
-        <div className={loginStyles.loginSurface}>
-          {sideContent && !isChangingPassword && <div className={loginStyles.sideContent}>{sideContent}</div>}
+        <div className={cx(loginStyles.loginSurface, hasSideContent && loginStyles.loginSurfaceWithSideContent)}>
+          {hasSideContent && <div className={loginStyles.sideContent}>{sideContent}</div>}
           <div className={cx(loginStyles.loginContent, loginBoxBackground, 'login-content-box')}>
             <div className={loginStyles.loginLogoWrapper}>
               <Branding.LoginLogo className={loginStyles.loginLogo} logo={loginLogo} />
@@ -123,12 +124,15 @@ export const getLoginStyles = (theme: GrafanaTheme2) => {
     loginSurface: css({
       width: '100%',
       maxWidth: 1180,
-      display: 'grid',
-      gap: theme.spacing(3),
-      alignItems: 'stretch',
+      display: 'flex',
+      justifyContent: 'center',
+    }),
+    loginSurfaceWithSideContent: css({
       [theme.breakpoints.up('lg')]: {
+        display: 'grid',
         gridTemplateColumns: 'minmax(0, 1.1fr) minmax(420px, 0.9fr)',
         gap: theme.spacing(4),
+        alignItems: 'stretch',
       },
     }),
     submitButton: css({
@@ -170,6 +174,7 @@ export const getLoginStyles = (theme: GrafanaTheme2) => {
     }),
     loginContent: css({
       width: '100%',
+      maxWidth: 520,
       display: 'flex',
       alignItems: 'stretch',
       flexDirection: 'column',

--- a/public/app/core/components/Login/LoginLayout.tsx
+++ b/public/app/core/components/Login/LoginLayout.tsx
@@ -184,9 +184,6 @@ export const getLoginStyles = (theme: GrafanaTheme2) => {
       borderRadius: theme.shape.radius.xl,
       padding: theme.spacing(2, 0),
       opacity: 0,
-      border: `1px solid ${theme.colors.border.weak}`,
-      boxShadow: theme.shadows.z3,
-      backdropFilter: 'blur(22px)',
       [theme.transitions.handleMotion('no-preference')]: {
         transition: 'opacity 0.5s ease-in-out',
       },
@@ -215,7 +212,7 @@ export const getLoginStyles = (theme: GrafanaTheme2) => {
       justifyContent: 'center',
     }),
     loginInnerBox: css({
-      padding: theme.spacing(0, 4, 4),
+      padding: theme.spacing(0, 2, 2, 2),
       display: 'flex',
       flexDirection: 'column',
       alignItems: 'center',

--- a/public/app/core/components/Login/LoginLayout.tsx
+++ b/public/app/core/components/Login/LoginLayout.tsx
@@ -181,7 +181,7 @@ export const getLoginStyles = (theme: GrafanaTheme2) => {
       justifyContent: 'flex-start',
       zIndex: 1,
       minHeight: 320,
-      borderRadius: theme.shape.radius.xl,
+      borderRadius: theme.shape.radius.default,
       padding: theme.spacing(2, 0),
       opacity: 0,
       [theme.transitions.handleMotion('no-preference')]: {

--- a/public/app/core/components/Login/LoginPage.test.tsx
+++ b/public/app/core/components/Login/LoginPage.test.tsx
@@ -42,7 +42,7 @@ describe('Login Page', () => {
   it('renders correctly', () => {
     render(<LoginPage />);
 
-    expect(screen.getByRole('heading', { name: 'Observe your stack with Grafana' })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'Welcome to Grafana' })).toBeInTheDocument();
     expect(screen.getByRole('textbox', { name: 'Email or username' })).toBeInTheDocument();
     expect(screen.getByLabelText('Password')).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Log in' })).toBeInTheDocument();

--- a/public/app/core/components/Login/LoginPage.test.tsx
+++ b/public/app/core/components/Login/LoginPage.test.tsx
@@ -42,7 +42,7 @@ describe('Login Page', () => {
   it('renders correctly', () => {
     render(<LoginPage />);
 
-    expect(screen.getByRole('heading', { name: 'Welcome to Grafana' })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'Observe your stack with Grafana' })).toBeInTheDocument();
     expect(screen.getByRole('textbox', { name: 'Email or username' })).toBeInTheDocument();
     expect(screen.getByLabelText('Password')).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Log in' })).toBeInTheDocument();

--- a/public/app/core/components/Login/LoginPage.test.tsx
+++ b/public/app/core/components/Login/LoginPage.test.tsx
@@ -3,6 +3,7 @@ import userEvent from '@testing-library/user-event';
 import { render } from 'test/test-utils';
 
 import * as runtimeMock from '@grafana/runtime';
+import { Branding } from 'app/core/components/Branding/Branding';
 
 import LoginPage from './LoginPage';
 
@@ -42,7 +43,7 @@ describe('Login Page', () => {
   it('renders correctly', () => {
     render(<LoginPage />);
 
-    expect(screen.getByRole('heading', { name: 'Welcome to Grafana' })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: Branding.LoginTitle })).toBeInTheDocument();
     expect(screen.getByRole('textbox', { name: 'Email or username' })).toBeInTheDocument();
     expect(screen.getByLabelText('Password')).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Log in' })).toBeInTheDocument();

--- a/public/app/core/components/Login/LoginPage.tsx
+++ b/public/app/core/components/Login/LoginPage.tsx
@@ -1,7 +1,5 @@
-// Libraries
 import { css } from '@emotion/css';
 
-// Components
 import { GrafanaTheme2, PageLayoutType } from '@grafana/data';
 import { Trans, t } from '@grafana/i18n';
 import { config } from '@grafana/runtime';
@@ -17,8 +15,26 @@ import { LoginLayout, InnerBox } from './LoginLayout';
 import { LoginServiceButtons } from './LoginServiceButtons';
 import { UserSignup } from './UserSignup';
 
+const heroPoints = [
+  'See signal across metrics, logs, traces, and frontend performance in one place.',
+  'Move from incident detection to root cause analysis without switching tools.',
+  'Roll out observability with opinionated dashboards and fast setup.',
+];
+
+const heroStats = [
+  { label: 'Coverage', value: 'Full-stack' },
+  { label: 'Setup', value: 'Minutes' },
+  { label: 'Teams', value: 'One workspace' },
+];
+
 const LoginPage = () => {
   const styles = useStyles2(getStyles);
+  const loginBranding = {
+    loginTitle: 'Observe your stack with Grafana',
+    loginSubtitle: 'Bring dashboards, logs, metrics, traces, and app performance into one focused workspace.',
+    loginBackground: styles.pageBackground,
+    loginBoxBackground: styles.loginCardBackground,
+  };
 
   document.title = Branding.AppTitle;
 
@@ -38,7 +54,11 @@ const LoginPage = () => {
           showDefaultPasswordWarning,
           loginErrorMessage,
         }) => (
-          <LoginLayout isChangingPassword={isChangingPassword}>
+          <LoginLayout
+            isChangingPassword={isChangingPassword}
+            branding={loginBranding}
+            sideContent={<LoginHero />}
+          >
             {!isChangingPassword && (
               <InnerBox>
                 {loginErrorMessage && (
@@ -90,6 +110,39 @@ const LoginPage = () => {
 
 export default LoginPage;
 
+const LoginHero = () => {
+  const styles = useStyles2(getStyles);
+
+  return (
+    <div className={styles.heroPanel}>
+      <div className={styles.heroEyebrow}>Observability platform</div>
+      <h2 className={styles.heroTitle}>Understand production health before issues reach users.</h2>
+      <p className={styles.heroDescription}>
+        A sharper landing experience inspired by modern observability products, adapted for Grafana&apos;s voice and
+        product surface.
+      </p>
+
+      <div className={styles.heroStats}>
+        {heroStats.map((stat) => (
+          <div key={stat.label} className={styles.statCard}>
+            <div className={styles.statValue}>{stat.value}</div>
+            <div className={styles.statLabel}>{stat.label}</div>
+          </div>
+        ))}
+      </div>
+
+      <div className={styles.heroList}>
+        {heroPoints.map((point) => (
+          <div key={point} className={styles.heroListItem}>
+            <span className={styles.heroListMarker} />
+            <span>{point}</span>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+};
+
 const getStyles = (theme: GrafanaTheme2) => {
   return {
     forgottenPassword: css({
@@ -99,6 +152,119 @@ const getStyles = (theme: GrafanaTheme2) => {
 
     alert: css({
       width: '100%',
+    }),
+
+    heroPanel: css({
+      position: 'relative',
+      padding: theme.spacing(4),
+      borderRadius: theme.shape.radius.xl,
+      color: theme.colors.text.primary,
+      background: theme.isDark
+        ? 'linear-gradient(145deg, rgba(20,18,11,0.9) 0%, rgba(34,26,23,0.86) 50%, rgba(52,27,18,0.92) 100%)'
+        : 'linear-gradient(145deg, rgba(255,248,242,0.92) 0%, rgba(248,241,236,0.96) 45%, rgba(244,233,225,0.98) 100%)',
+      border: `1px solid ${theme.colors.border.weak}`,
+      boxShadow: theme.shadows.z2,
+      overflow: 'hidden',
+      '&::after': {
+        content: '""',
+        position: 'absolute',
+        inset: 'auto -15% -30% auto',
+        width: 280,
+        height: 280,
+        borderRadius: '50%',
+        background: 'radial-gradient(circle, rgba(245,78,0,0.26) 0%, rgba(245,78,0,0) 72%)',
+        pointerEvents: 'none',
+      },
+    }),
+
+    pageBackground: css({
+      background:
+        theme.isDark
+          ? 'radial-gradient(circle at top left, rgba(245,78,0,0.16), rgba(245,78,0,0) 26%), linear-gradient(180deg, rgba(20,18,11,0.98) 0%, rgba(26,22,18,0.98) 42%, rgba(14,13,11,1) 100%)'
+          : 'radial-gradient(circle at top left, rgba(245,78,0,0.12), rgba(245,78,0,0) 28%), linear-gradient(180deg, rgba(247,247,244,1) 0%, rgba(242,241,237,1) 46%, rgba(235,234,229,1) 100%)',
+    }),
+
+    loginCardBackground: css({
+      background:
+        theme.isDark
+          ? 'linear-gradient(180deg, rgba(27,25,19,0.92) 0%, rgba(22,20,16,0.94) 100%)'
+          : 'linear-gradient(180deg, rgba(255,255,255,0.9) 0%, rgba(247,247,244,0.94) 100%)',
+    }),
+
+    heroEyebrow: css({
+      fontSize: theme.typography.size.sm,
+      textTransform: 'uppercase',
+      letterSpacing: '0.08em',
+      color: theme.colors.warning.text,
+      marginBottom: theme.spacing(2),
+    }),
+
+    heroTitle: css({
+      fontSize: theme.typography.h1.fontSize,
+      lineHeight: 1.05,
+      margin: 0,
+      maxWidth: 560,
+    }),
+
+    heroDescription: css({
+      margin: theme.spacing(2, 0, 3),
+      fontSize: theme.typography.size.lg,
+      lineHeight: 1.5,
+      color: theme.colors.text.secondary,
+      maxWidth: 620,
+    }),
+
+    heroStats: css({
+      display: 'grid',
+      gridTemplateColumns: 'minmax(0, 1fr)',
+      gap: theme.spacing(1.5),
+      marginBottom: theme.spacing(3),
+      [theme.breakpoints.up('sm')]: {
+        gridTemplateColumns: 'repeat(3, minmax(0, 1fr))',
+      },
+    }),
+
+    statCard: css({
+      padding: theme.spacing(2),
+      borderRadius: theme.shape.radius.lg,
+      background: theme.isDark ? 'rgba(255,255,255,0.04)' : 'rgba(255,255,255,0.62)',
+      border: `1px solid ${theme.colors.border.weak}`,
+      minHeight: 92,
+    }),
+
+    statValue: css({
+      fontSize: theme.typography.h4.fontSize,
+      fontWeight: theme.typography.fontWeightBold,
+      marginBottom: theme.spacing(0.75),
+    }),
+
+    statLabel: css({
+      color: theme.colors.text.secondary,
+      fontSize: theme.typography.size.sm,
+    }),
+
+    heroList: css({
+      display: 'grid',
+      gap: theme.spacing(1.5),
+      maxWidth: 620,
+    }),
+
+    heroListItem: css({
+      display: 'flex',
+      gap: theme.spacing(1.5),
+      alignItems: 'flex-start',
+      color: theme.colors.text.secondary,
+      lineHeight: 1.5,
+    }),
+
+    heroListMarker: css({
+      width: 10,
+      height: 10,
+      borderRadius: '50%',
+      background: theme.colors.warning.main,
+      boxShadow: `0 0 0 6px ${theme.isDark ? 'rgba(245,78,0,0.14)' : 'rgba(245,78,0,0.12)'}`,
+      marginTop: theme.spacing(0.75),
+      flexShrink: 0,
     }),
   };
 };

--- a/public/app/core/components/Login/LoginPage.tsx
+++ b/public/app/core/components/Login/LoginPage.tsx
@@ -54,11 +54,7 @@ const LoginPage = () => {
           showDefaultPasswordWarning,
           loginErrorMessage,
         }) => (
-          <LoginLayout
-            isChangingPassword={isChangingPassword}
-            branding={loginBranding}
-            sideContent={<LoginHero />}
-          >
+          <LoginLayout isChangingPassword={isChangingPassword} branding={loginBranding} sideContent={<LoginHero />}>
             {!isChangingPassword && (
               <InnerBox>
                 {loginErrorMessage && (
@@ -178,17 +174,15 @@ const getStyles = (theme: GrafanaTheme2) => {
     }),
 
     pageBackground: css({
-      background:
-        theme.isDark
-          ? 'radial-gradient(circle at top left, rgba(245,78,0,0.16), rgba(245,78,0,0) 26%), linear-gradient(180deg, rgba(20,18,11,0.98) 0%, rgba(26,22,18,0.98) 42%, rgba(14,13,11,1) 100%)'
-          : 'radial-gradient(circle at top left, rgba(245,78,0,0.12), rgba(245,78,0,0) 28%), linear-gradient(180deg, rgba(247,247,244,1) 0%, rgba(242,241,237,1) 46%, rgba(235,234,229,1) 100%)',
+      background: theme.isDark
+        ? 'radial-gradient(circle at top left, rgba(245,78,0,0.16), rgba(245,78,0,0) 26%), linear-gradient(180deg, rgba(20,18,11,0.98) 0%, rgba(26,22,18,0.98) 42%, rgba(14,13,11,1) 100%)'
+        : 'radial-gradient(circle at top left, rgba(245,78,0,0.12), rgba(245,78,0,0) 28%), linear-gradient(180deg, rgba(247,247,244,1) 0%, rgba(242,241,237,1) 46%, rgba(235,234,229,1) 100%)',
     }),
 
     loginCardBackground: css({
-      background:
-        theme.isDark
-          ? 'linear-gradient(180deg, rgba(27,25,19,0.92) 0%, rgba(22,20,16,0.94) 100%)'
-          : 'linear-gradient(180deg, rgba(255,255,255,0.9) 0%, rgba(247,247,244,0.94) 100%)',
+      background: theme.isDark
+        ? 'linear-gradient(180deg, rgba(27,25,19,0.92) 0%, rgba(22,20,16,0.94) 100%)'
+        : 'linear-gradient(180deg, rgba(255,255,255,0.9) 0%, rgba(247,247,244,0.94) 100%)',
     }),
 
     heroEyebrow: css({

--- a/public/app/core/components/Login/LoginPage.tsx
+++ b/public/app/core/components/Login/LoginPage.tsx
@@ -155,7 +155,7 @@ const getStyles = (theme: GrafanaTheme2) => {
     heroPanel: css({
       position: 'relative',
       padding: theme.spacing(4),
-      borderRadius: theme.shape.radius.xl,
+      borderRadius: theme.shape.radius.default,
       color: theme.colors.text.primary,
       background: theme.isDark
         ? 'linear-gradient(145deg, rgba(20,18,11,0.9) 0%, rgba(34,26,23,0.86) 50%, rgba(52,27,18,0.92) 100%)'

--- a/public/app/core/components/Login/LoginPage.tsx
+++ b/public/app/core/components/Login/LoginPage.tsx
@@ -15,23 +15,9 @@ import { LoginLayout, InnerBox } from './LoginLayout';
 import { LoginServiceButtons } from './LoginServiceButtons';
 import { UserSignup } from './UserSignup';
 
-const heroPoints = [
-  'See signal across metrics, logs, traces, and frontend performance in one place.',
-  'Move from incident detection to root cause analysis without switching tools.',
-  'Roll out observability with opinionated dashboards and fast setup.',
-];
-
-const heroStats = [
-  { label: 'Coverage', value: 'Full-stack' },
-  { label: 'Setup', value: 'Minutes' },
-  { label: 'Teams', value: 'One workspace' },
-];
-
 const LoginPage = () => {
   const styles = useStyles2(getStyles);
   const loginBranding = {
-    loginTitle: 'Observe your stack with Grafana',
-    loginSubtitle: 'Bring dashboards, logs, metrics, traces, and app performance into one focused workspace.',
     loginBackground: styles.pageBackground,
     loginBoxBackground: styles.loginCardBackground,
   };
@@ -108,14 +94,30 @@ export default LoginPage;
 
 const LoginHero = () => {
   const styles = useStyles2(getStyles);
+  const heroStats = [
+    { label: t('login.hero.stat.coverage', 'Coverage'), value: t('login.hero.value.coverage', 'Full-stack') },
+    { label: t('login.hero.stat.setup', 'Setup'), value: t('login.hero.value.setup', 'Minutes') },
+    { label: t('login.hero.stat.teams', 'Teams'), value: t('login.hero.value.teams', 'One workspace') },
+  ];
+  const heroPoints = [
+    t('login.hero.point.unify', 'See signal across metrics, logs, traces, and frontend performance in one place.'),
+    t('login.hero.point.root-cause', 'Move from incident detection to root cause analysis without switching tools.'),
+    t('login.hero.point.setup', 'Roll out observability with opinionated dashboards and fast setup.'),
+  ];
 
   return (
     <div className={styles.heroPanel}>
-      <div className={styles.heroEyebrow}>Observability platform</div>
-      <h2 className={styles.heroTitle}>Understand production health before issues reach users.</h2>
+      <div className={styles.heroEyebrow}>
+        <Trans i18nKey="login.hero.eyebrow">Observability platform</Trans>
+      </div>
+      <h2 className={styles.heroTitle}>
+        <Trans i18nKey="login.hero.title">Understand production health before issues reach users.</Trans>
+      </h2>
       <p className={styles.heroDescription}>
-        A sharper landing experience inspired by modern observability products, adapted for Grafana&apos;s voice and
-        product surface.
+        <Trans i18nKey="login.hero.description">
+          Unify dashboards, telemetry, and troubleshooting workflows so teams can detect issues earlier and resolve them
+          faster.
+        </Trans>
       </p>
 
       <div className={styles.heroStats}>
@@ -167,7 +169,7 @@ const getStyles = (theme: GrafanaTheme2) => {
         inset: 'auto -15% -30% auto',
         width: 280,
         height: 280,
-        borderRadius: '50%',
+        borderRadius: theme.shape.radius.circle,
         background: 'radial-gradient(circle, rgba(245,78,0,0.26) 0%, rgba(245,78,0,0) 72%)',
         pointerEvents: 'none',
       },
@@ -254,7 +256,7 @@ const getStyles = (theme: GrafanaTheme2) => {
     heroListMarker: css({
       width: 10,
       height: 10,
-      borderRadius: '50%',
+      borderRadius: theme.shape.radius.circle,
       background: theme.colors.warning.main,
       boxShadow: `0 0 0 6px ${theme.isDark ? 'rgba(245,78,0,0.14)' : 'rgba(245,78,0,0.12)'}`,
       marginTop: theme.spacing(0.75),


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
**What is this feature?**

Refreshes Grafana's logged-out landing experience on `/login` with a more polished, product-marketing style layout inspired by modern observability landing pages. The update introduces a split hero plus auth card layout, stronger background treatment, and supporting copy/stats while preserving the existing login flow.

**Why do we need this feature?**

The default logged-out experience feels utilitarian. This change gives the homepage/login entry point a more intentional first impression without expanding the scope into signed-in navigation or backend behavior.

**Who is this feature for?**

Users arriving at Grafana before authentication, especially during product evaluation or first-time setup.

**Which issue(s) does this PR fix?**:

Fixes #

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective in component-level auth flows.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a notable improvement, it's added to our What's New doc.

Target repo: fieldsphere/grafana

Latest CI fix:
- Replaced unsupported `theme.shape.radius.xl` usages with supported radius tokens to satisfy TypeScript on this branch.

Tested with:
- `yarn typecheck`
- `yarn prettier --check public/app/core/components/Login/LoginLayout.tsx public/app/core/components/Login/LoginPage.tsx public/app/core/components/Login/LoginPage.test.tsx`
- `yarn jest --no-watch public/app/core/components/Login/LoginPage.test.tsx`

Browser walkthrough artifacts:
- `/opt/cursor/artifacts/grafana_login_playwright_demo.webm`
- `/opt/cursor/artifacts/grafana_login_playwright_full.png`
- `/opt/cursor/artifacts/grafana_login_playwright_interaction.png`
- `/opt/cursor/artifacts/grafana_login_browser_walkthrough_final.webp`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3b7d79a4-e74f-47b1-905b-cd7154316d1d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3b7d79a4-e74f-47b1-905b-cd7154316d1d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

