### PR TITLE
chore(deps): audit legacy frontend ignores — unfreeze Slate for Renovate

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -21,10 +21,6 @@
     "react-router-dom", // we should bump this together with history (see https://github.com/grafana/grafana/issues/76744)
     "monaco-editor", // due to us exposing this via @grafana/ui/CodeEditor's props bumping can break plugins
     "@fingerprintjs/fingerprintjs", // we don't want to bump to v4 due to licensing changes
-    "slate", // we don't want to continue using this on the long run, use Monaco editor instead of Slate
-    "slate-react", // we don't want to continue using this on the long run, use Monaco editor instead of Slate
-    "@types/slate-react", // we don't want to continue using this on the long run, use Monaco editor instead of Slate
-    "@types/slate", // we don't want to continue using this on the long run, use Monaco editor instead of Slate
   ],
   includePaths: ["package.json", "packages/**", "public/app/plugins/**", "devenv/frontend-service/docker-compose.yaml"],
   ignorePaths: ["emails/**", "**/mocks/**"],
@@ -62,8 +58,16 @@
       minimumReleaseAge: "7 days",
     },
     {
+      // Slate is legacy; long-term plan is Monaco. Until migration, allow grouped patch/minor PRs for security fixes.
       groupName: "Slate",
-      matchPackageNames: ["@types/slate", "@types/slate-react", "slate", "slate-react"],
+      matchPackageNames: [
+        "@types/slate",
+        "@types/slate-plain-serializer",
+        "@types/slate-react",
+        "slate",
+        "slate-plain-serializer",
+        "slate-react",
+      ],
       minimumReleaseAge: "7 days",
     },
     {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Renovate’s `ignoreDeps` list was effectively “freezing” several frontend packages by excluding them from automated update PRs. This change fixes an immediate inconsistency: **Slate** packages were both in `ignoreDeps` and in a `packageRules` group named “Slate”, so the group could never produce PRs.

## Audit: what is still ignored (and why)

| Package(s) | Reason |
|------------|--------|
| `react`, `react-dom`, `react-refresh`, `@types/react`, `@types/react-dom`, `eslint-plugin-react-hooks` | Held until React 19 rollout — [grafana/grafana#98813](https://github.com/grafana/grafana/issues/98813) |
| `history`, `react-router`, `react-router-dom`, `@types/history` | Bumped together — [grafana/grafana#76744](https://github.com/grafana/grafana/issues/76744) |
| `monaco-editor` | Public API via `@grafana/ui` CodeEditor; bumps can break plugins |
| `@fingerprintjs/fingerprintjs` | v4 licensing change; stay on v3 |
| `cypress` | Deprecated in repo; no further bumps |

**Yarn `resolutions`** in root `package.json` still pin/overrides some transitive deps (e.g. security or patches); that is separate from Renovate ignores.

## What changed

- Removed `slate`, `slate-react`, `@types/slate`, `@types/slate-react` from `ignoreDeps` so the existing **Slate** group can open grouped update PRs (patch/minor per Renovate defaults, with 7-day minimum release age).
- Extended the Slate group to include `slate-plain-serializer` and `@types/slate-plain-serializer` so they move with the rest.

Long-term, Slate remains a migration target (Monaco); this only restores the ability to receive **automated** maintenance updates until that work lands.

**Target repo:** fieldsphere/grafana
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2d29bc3b-b5c0-49b3-b4ae-e745f242a72f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2d29bc3b-b5c0-49b3-b4ae-e745f242a72f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

