### PR TITLE
feat: structured logging replaces console.log across repo

### DIFF
--- a/.github/actions/changelog/index.js
+++ b/.github/actions/changelog/index.js
@@ -8,7 +8,15 @@ import {findPreviousVersion, semverParse} from "./semver.js";
 // newlines and percent signs
 //
 const escapeData = (s) => s.replace(/%/g, '%25').replace(/\r/g, '%0D').replace(/\n/g, '%0A');
-const LOG = (msg) => console.log(`::notice::${escapeData(msg)}`);
+const LOG = (msg) => {
+  const payload = JSON.stringify({
+    level: 'NOTICE',
+    source: 'github-actions.changelog',
+    message: msg,
+    timestamp: Date.now(),
+  });
+  process.stdout.write(`::notice::${escapeData(payload)}\n`);
+};
 
 
 // Using `git tag -l` output find the tag (version) that goes semantically
@@ -198,7 +206,16 @@ const getChangeLogItems = async (name, owner, from, to) => {
 // ======================================================
 
 LOG(`Changelog action started`);
-console.log(process.argv);
+// eslint-disable-next-line no-console
+console.info(
+  JSON.stringify({
+    level: 'INFO',
+    source: 'github-actions.changelog',
+    message: 'process.argv',
+    argv: process.argv,
+    timestamp: Date.now(),
+  })
+);
 const ghtoken = process.env.GITHUB_TOKEN || process.env.INPUT_GITHUB_TOKEN;
 if (!ghtoken) {
   throw 'GITHUB_TOKEN is not set and "github_token" input is empty';

--- a/.github/actions/changelog/semver.js
+++ b/.github/actions/changelog/semver.js
@@ -82,7 +82,19 @@ function test(version, expected) {
 
   const failureMessage = `FAIILED. Expected ${expected}, but was ${prev[5]}`;
 
-  console.log(`Test ${version}, ${prev[5] === expected ? 'PASSED' : failureMessage}`);
+  // eslint-disable-next-line no-console
+  console.info(
+    JSON.stringify({
+      level: 'INFO',
+      source: 'github-actions.changelog.semver-test',
+      version,
+      expected,
+      actual: prev[5],
+      passed: prev[5] === expected,
+      message: prev[5] === expected ? 'PASSED' : failureMessage,
+      timestamp: Date.now(),
+    })
+  );
 }
 
 test("v11.5.4+security-01", "v11.5.4");

--- a/.github/actions/report-go-cache-sizes/index.js
+++ b/.github/actions/report-go-cache-sizes/index.js
@@ -11,8 +11,25 @@ function size(dir) {
 try {
   const gomodcache = execSync("go env GOMODCACHE").toString().trim();
   const gocache = execSync("go env GOCACHE").toString().trim();
-  console.log(`GOMODCACHE: ${size(gomodcache)} (${gomodcache})`);
-  console.log(`GOCACHE:    ${size(gocache)} (${gocache})`);
+  // eslint-disable-next-line no-console
+  console.info(
+    JSON.stringify({
+      level: 'INFO',
+      source: 'github-actions.report-go-cache-sizes',
+      gomodcache: { path: gomodcache, size: size(gomodcache) },
+      gocache: { path: gocache, size: size(gocache) },
+      timestamp: Date.now(),
+    })
+  );
 } catch (e) {
-  console.log("Could not determine Go cache sizes:", e.message);
+  // eslint-disable-next-line no-console
+  console.warn(
+    JSON.stringify({
+      level: 'WARN',
+      source: 'github-actions.report-go-cache-sizes',
+      message: 'Could not determine Go cache sizes',
+      error: e.message,
+      timestamp: Date.now(),
+    })
+  );
 }

--- a/.github/workflows/scripts/crowdin/create-tasks.ts
+++ b/.github/workflows/scripts/crowdin/create-tasks.ts
@@ -38,7 +38,15 @@ async function getLanguages(projectId: number) {
   try {
     const project = await projectsGroupsApi.getProject(projectId);
     const languages = project.data.targetLanguages;
-    console.log('Fetched languages successfully!');
+    // eslint-disable-next-line no-console
+    console.info(
+      JSON.stringify({
+        level: 'INFO',
+        source: 'crowdin.create-tasks',
+        message: 'Fetched languages successfully',
+        timestamp: Date.now(),
+      })
+    );
     return languages;
   } catch (error) {
     console.error('Failed to fetch languages: ', error.message);
@@ -54,7 +62,15 @@ async function getFileIds(projectId: number) {
     const response = await sourceFilesApi.listProjectFiles(projectId);
     const files = response.data;
     const fileIds = files.map(file => file.data.id);
-    console.log('Fetched file ids successfully!');
+    // eslint-disable-next-line no-console
+    console.info(
+      JSON.stringify({
+        level: 'INFO',
+        source: 'crowdin.create-tasks',
+        message: 'Fetched file ids successfully',
+        timestamp: Date.now(),
+      })
+    );
     return fileIds;
   } catch (error) {
     console.error('Failed to fetch file IDs: ', error.message);
@@ -73,7 +89,15 @@ async function getWorkflowStepId(projectId: number) {
     if (!workflowStepId) {
       throw new Error(`Workflow step with type "${TRANSLATE_BY_VENDOR_WORKFLOW_TYPE}" not found`);
     }
-    console.log('Fetched workflow step ID successfully!');
+    // eslint-disable-next-line no-console
+    console.info(
+      JSON.stringify({
+        level: 'INFO',
+        source: 'crowdin.create-tasks',
+        message: 'Fetched workflow step ID successfully',
+        timestamp: Date.now(),
+      })
+    );
     return workflowStepId;
   } catch (error) {
     console.error('Failed to fetch workflow step ID: ', error.message);
@@ -95,10 +119,29 @@ async function createTask(projectId: number, title: string, languageId: string, 
       fileIds,
     };
 
-    console.log(`Creating Crowdin task: "${title}" for language ${languageId}`);
+    // eslint-disable-next-line no-console
+    console.info(
+      JSON.stringify({
+        level: 'INFO',
+        source: 'crowdin.create-tasks',
+        message: 'Creating Crowdin task',
+        title,
+        languageId,
+        timestamp: Date.now(),
+      })
+    );
 
     const response = await tasksApi.addTask(projectId, taskParams);
-    console.log(`Task created successfully! Task ID: ${response.data.id}`);
+    // eslint-disable-next-line no-console
+    console.info(
+      JSON.stringify({
+        level: 'INFO',
+        source: 'crowdin.create-tasks',
+        message: 'Task created successfully',
+        taskId: response.data.id,
+        timestamp: Date.now(),
+      })
+    );
     return response.data;
   } catch (error) {
     console.error('Failed to create Crowdin task: ', error.message);

--- a/cypress.config.js
+++ b/cypress.config.js
@@ -22,7 +22,16 @@ module.exports = defineConfig({
       on('file:preprocessor', typescriptPreprocessor);
       on('task', {
         log({ message, optional }) {
-          optional ? console.log(message, optional) : console.log(message);
+          // eslint-disable-next-line no-console
+          console.info(
+            JSON.stringify({
+              level: 'INFO',
+              source: 'cypress.config.task.log',
+              message,
+              optional,
+              timestamp: Date.now(),
+            })
+          );
           return null;
         },
       });
@@ -55,14 +64,34 @@ module.exports = defineConfig({
       });
 
       on('before:browser:launch', (browser = {}, launchOptions) => {
-        console.log('launching browser %s is headless? %s', browser.name, browser.isHeadless);
+        // eslint-disable-next-line no-console
+        console.info(
+          JSON.stringify({
+            level: 'INFO',
+            source: 'cypress.config.beforeBrowserLaunch',
+            message: 'Launching browser',
+            browserName: browser.name,
+            isHeadless: browser.isHeadless,
+            timestamp: Date.now(),
+          })
+        );
 
         // the browser width and height we want to get
         // our screenshots and videos will be of that resolution
         const width = 1920;
         const height = 1080;
 
-        console.log('setting the browser window size to %d x %d', width, height);
+        // eslint-disable-next-line no-console
+        console.info(
+          JSON.stringify({
+            level: 'INFO',
+            source: 'cypress.config.beforeBrowserLaunch',
+            message: 'Setting browser window size',
+            width,
+            height,
+            timestamp: Date.now(),
+          })
+        );
 
         if (browser.name === 'chrome' && browser.isHeadless) {
           launchOptions.args.push(`--window-size=${width},${height}`);

--- a/devenv/docker/blocks/elastic/data/data.js
+++ b/devenv/docker/blocks/elastic/data/data.js
@@ -176,7 +176,16 @@ async function main() {
 
 // when running in docker, we catch the needed stop-signal, to shutdown fast
 process.on('SIGTERM', () => {
-  console.log('shutdown requested');
+  // eslint-disable-next-line no-console
+  console.info(
+    JSON.stringify({
+      level: 'INFO',
+      source: 'devenv.elastic.fake-data',
+      message: 'shutdown requested',
+      signal: 'SIGTERM',
+      timestamp: Date.now(),
+    })
+  );
   process.exit(0);
 });
 

--- a/devenv/docker/blocks/loki/data/data.js
+++ b/devenv/docker/blocks/loki/data/data.js
@@ -213,7 +213,16 @@ async function main() {
 
 // when running in docker, we catch the needed stop-signal, to shutdown fast
 process.on('SIGTERM', () => {
-  console.log('shutdown requested');
+  // eslint-disable-next-line no-console
+  console.info(
+    JSON.stringify({
+      level: 'INFO',
+      source: 'devenv.loki.fake-data',
+      message: 'shutdown requested',
+      signal: 'SIGTERM',
+      timestamp: Date.now(),
+    })
+  );
   process.exit(0);
 });
 

--- a/e2e-playwright/plugin-e2e/plugin-e2e-api-tests/as-admin-user/openFeature.spec.ts
+++ b/e2e-playwright/plugin-e2e/plugin-e2e-api-tests/as-admin-user/openFeature.spec.ts
@@ -46,7 +46,15 @@ test(
         expect(testFlagFalse.variant).toBe('playwright-override');
       }
     } catch {
-      console.log('OFREP endpoint not called - OpenFeature may not be enabled');
+      // eslint-disable-next-line no-console
+      console.info(
+        JSON.stringify({
+          level: 'INFO',
+          source: 'e2e.openFeature',
+          message: 'OFREP endpoint not called; OpenFeature may not be enabled',
+          timestamp: Date.now(),
+        })
+      );
     }
   }
 );
@@ -92,7 +100,15 @@ test(
       expect(testFlagFalse?.value).toBe(false);
       expect(testFlagFalse?.variant).toBe('playwright-override');
     } catch {
-      console.log('OFREP endpoint not called - OpenFeature may not be enabled');
+      // eslint-disable-next-line no-console
+      console.info(
+        JSON.stringify({
+          level: 'INFO',
+          source: 'e2e.openFeature',
+          message: 'OFREP endpoint not called; OpenFeature may not be enabled',
+          timestamp: Date.now(),
+        })
+      );
     }
   }
 );

--- a/e2e-playwright/test-plugins/frontend-sandbox-panel-test/module.js
+++ b/e2e-playwright/test-plugins/frontend-sandbox-panel-test/module.js
@@ -127,20 +127,47 @@ define(['react', '@grafana/data'], function (React, grafanaData) {
     const globalTests = [
       function () {
         try {
-          console.log(window.Prism.languages);
+          // eslint-disable-next-line no-console
+          console.info(
+            JSON.stringify({
+              level: 'INFO',
+              source: 'e2e.frontend-sandbox-panel-test',
+              message: 'Prism globals probe',
+              languages: window.Prism?.languages,
+              timestamp: Date.now(),
+            })
+          );
           return 'Prism';
         } catch (e) {}
       },
       function () {
         try {
-          console.log(window.jQuery.fn.jquery);
-          console.log(window.$.fn.jquery);
+          // eslint-disable-next-line no-console
+          console.info(
+            JSON.stringify({
+              level: 'INFO',
+              source: 'e2e.frontend-sandbox-panel-test',
+              message: 'jQuery version probe',
+              jquery: window.jQuery?.fn?.jquery,
+              dollar: window.$?.fn?.jquery,
+              timestamp: Date.now(),
+            })
+          );
           return 'jQuery';
         } catch (e) {}
       },
       function () {
         try {
-          console.log(window.locationSandbox);
+          // eslint-disable-next-line no-console
+          console.info(
+            JSON.stringify({
+              level: 'INFO',
+              source: 'e2e.frontend-sandbox-panel-test',
+              message: 'locationSandbox probe',
+              locationSandbox: window.locationSandbox,
+              timestamp: Date.now(),
+            })
+          );
           return 'location';
         } catch (e) {}
       },

--- a/e2e-playwright/test-plugins/frontend-sandbox-panel-test/module.js
+++ b/e2e-playwright/test-plugins/frontend-sandbox-panel-test/module.js
@@ -127,13 +127,14 @@ define(['react', '@grafana/data'], function (React, grafanaData) {
     const globalTests = [
       function () {
         try {
+          // Intentionally no optional chaining: sandbox must throw when globals are blocked.
           // eslint-disable-next-line no-console
           console.info(
             JSON.stringify({
               level: 'INFO',
               source: 'e2e.frontend-sandbox-panel-test',
               message: 'Prism globals probe',
-              languages: window.Prism?.languages,
+              languages: window.Prism.languages,
               timestamp: Date.now(),
             })
           );
@@ -148,8 +149,8 @@ define(['react', '@grafana/data'], function (React, grafanaData) {
               level: 'INFO',
               source: 'e2e.frontend-sandbox-panel-test',
               message: 'jQuery version probe',
-              jquery: window.jQuery?.fn?.jquery,
-              dollar: window.$?.fn?.jquery,
+              jquery: window.jQuery.fn.jquery,
+              dollar: window.$.fn.jquery,
               timestamp: Date.now(),
             })
           );

--- a/e2e-playwright/utils/RequestsRecorder.ts
+++ b/e2e-playwright/utils/RequestsRecorder.ts
@@ -60,7 +60,16 @@ export class RequestsRecorder {
         return Promise.resolve();
       }
 
-      console.log('waiting for', this.#requestsInFlight, 'requests to finish');
+      // eslint-disable-next-line no-console
+      console.info(
+        JSON.stringify({
+          level: 'INFO',
+          source: 'e2e.RequestsRecorder',
+          message: 'Waiting for in-flight requests',
+          requestsInFlight: this.#requestsInFlight,
+          timestamp: Date.now(),
+        })
+      );
 
       return new Promise<void>((resolve) => {
         this.#resolve = resolve;

--- a/e2e-playwright/various-suite/keybinds.spec.ts
+++ b/e2e-playwright/various-suite/keybinds.spec.ts
@@ -105,7 +105,15 @@ test.describe(
       const modKey = process.platform === 'darwin' ? 'Meta' : 'Control';
 
       // Test that mod+o works in the main dashboard (should not trigger file dialog)
-      console.log('Testing mod+o in main dashboard view...');
+      // eslint-disable-next-line no-console
+      console.info(
+        JSON.stringify({
+          level: 'INFO',
+          source: 'e2e.keybinds',
+          message: 'Testing mod+o in main dashboard view',
+          timestamp: Date.now(),
+        })
+      );
       await page.keyboard.press(`${modKey}+o`);
       expect(page.url()).toBe(currentUrl); // Should not navigate away
 

--- a/e2e-playwright/various-suite/perf-test.spec.ts
+++ b/e2e-playwright/various-suite/perf-test.spec.ts
@@ -50,7 +50,7 @@ test('payload-size', { tag: '@performance' }, async ({ page }) => {
   const instance = new URL(process.env.GRAFANA_URL || 'http://undefined').host;
   promRegistry.setDefaultLabels({ instance });
   const metricsText = await promRegistry.metrics();
-  console.log(metricsText);
+  process.stdout.write(metricsText.endsWith('\n') ? metricsText : `${metricsText}\n`);
   fs.writeFileSync(process.env.METRICS_OUTPUT_PATH || '/tmp/asset-metrics.txt', metricsText);
 
   await stopListening();

--- a/e2e/cypress/plugins/benchmark/index.js
+++ b/e2e/cypress/plugins/benchmark/index.js
@@ -54,7 +54,16 @@ const initialize = (on, config) => {
 
   if (!fs.existsSync(resultsFolder)) {
     fs.mkdirSync(resultsFolder, { recursive: true });
-    console.log(`Created folder for benchmark results ${resultsFolder}`);
+    // eslint-disable-next-line no-console
+    console.info(
+      JSON.stringify({
+        level: 'INFO',
+        source: 'cypress.benchmark',
+        message: 'Created folder for benchmark results',
+        resultsFolder,
+        timestamp: Date.now(),
+      })
+    );
   }
 
   on('before:browser:launch', async (browser, options) => {
@@ -69,10 +78,16 @@ const initialize = (on, config) => {
 
     args.push('--start-fullscreen');
 
-    console.log(
-      `initialized benchmarking plugin with ${collectors.length} collectors: ${collectors
-        .map((col) => col.getName())
-        .join(', ')}`
+    // eslint-disable-next-line no-console
+    console.info(
+      JSON.stringify({
+        level: 'INFO',
+        source: 'cypress.benchmark',
+        message: 'Initialized benchmarking plugin',
+        collectorCount: collectors.length,
+        collectors: collectors.map((col) => col.getName()),
+        timestamp: Date.now(),
+      })
     );
 
     return options;

--- a/e2e/cypress/plugins/index.js
+++ b/e2e/cypress/plugins/index.js
@@ -19,7 +19,16 @@ module.exports = (on, config) => {
   on('file:preprocessor', typescriptPreprocessor);
   on('task', {
     log({ message, optional }) {
-      optional ? console.log(message, optional) : console.log(message);
+      // eslint-disable-next-line no-console
+      console.info(
+        JSON.stringify({
+          level: 'INFO',
+          source: 'cypress.plugins.task.log',
+          message,
+          optional,
+          timestamp: Date.now(),
+        })
+      );
       return null;
     },
   });
@@ -39,14 +48,34 @@ module.exports = (on, config) => {
   // Make recordings higher resolution
   // https://www.cypress.io/blog/2021/03/01/generate-high-resolution-videos-and-screenshots/
   on('before:browser:launch', (browser = {}, launchOptions) => {
-    console.log('launching browser %s is headless? %s', browser.name, browser.isHeadless);
+    // eslint-disable-next-line no-console
+    console.info(
+      JSON.stringify({
+        level: 'INFO',
+        source: 'cypress.beforeBrowserLaunch',
+        message: 'Launching browser',
+        browserName: browser.name,
+        isHeadless: browser.isHeadless,
+        timestamp: Date.now(),
+      })
+    );
 
     // the browser width and height we want to get
     // our screenshots and videos will be of that resolution
     const width = 1920;
     const height = 1080;
 
-    console.log('setting the browser window size to %d x %d', width, height);
+    // eslint-disable-next-line no-console
+    console.info(
+      JSON.stringify({
+        level: 'INFO',
+        source: 'cypress.beforeBrowserLaunch',
+        message: 'Setting browser window size',
+        width,
+        height,
+        timestamp: Date.now(),
+      })
+    );
 
     if (browser.name === 'chrome' && browser.isHeadless) {
       launchOptions.args.push(`--window-size=${width},${height}`);

--- a/e2e/cypress/plugins/smtpTester.js
+++ b/e2e/cypress/plugins/smtpTester.js
@@ -8,7 +8,16 @@ const PORT = 7777;
 const initialize = (on, config) => {
   // starts the SMTP server at localhost:7777
   const mailServer = ms.init(PORT);
-  console.log('mail server at port %d', PORT);
+  // eslint-disable-next-line no-console
+  console.info(
+    JSON.stringify({
+      level: 'INFO',
+      source: 'cypress.smtpTester',
+      message: 'SMTP test server listening',
+      port: PORT,
+      timestamp: Date.now(),
+    })
+  );
 
   let lastEmail = {};
 
@@ -20,10 +29,27 @@ const initialize = (on, config) => {
   on('task', {
     resetEmails(recipient) {
       if (recipient) {
-        console.log('reset all emails for recipient %s', recipient);
+        // eslint-disable-next-line no-console
+        console.info(
+          JSON.stringify({
+            level: 'INFO',
+            source: 'cypress.smtpTester',
+            message: 'Reset emails for recipient',
+            recipient,
+            timestamp: Date.now(),
+          })
+        );
         delete lastEmail[recipient];
       } else {
-        console.log('reset all emails');
+        // eslint-disable-next-line no-console
+        console.info(
+          JSON.stringify({
+            level: 'INFO',
+            source: 'cypress.smtpTester',
+            message: 'Reset all emails',
+            timestamp: Date.now(),
+          })
+        );
         lastEmail = {};
       }
     },
@@ -92,14 +118,32 @@ const initialize = (on, config) => {
       removePDFGeneratedOnDate(expectedDoc);
 
       if (inputDoc.numpages !== expectedDoc.numpages) {
-        console.log('PDFs do not contain the same number of pages');
+        // eslint-disable-next-line no-console
+        console.warn(
+          JSON.stringify({
+            level: 'WARN',
+            source: 'cypress.smtpTester.comparePDFs',
+            message: 'PDF page count mismatch',
+            expectedPages: expectedDoc.numpages,
+            inputPages: inputDoc.numpages,
+            timestamp: Date.now(),
+          })
+        );
         return false;
       }
 
       if (inputDoc.text !== expectedDoc.text) {
-        console.log('PDFs do not contain the same text');
-        console.log('PDF expected text: ', expectedDoc.text);
-        console.log('PDF input text: ', inputDoc.text);
+        // eslint-disable-next-line no-console
+        console.warn(
+          JSON.stringify({
+            level: 'WARN',
+            source: 'cypress.smtpTester.comparePDFs',
+            message: 'PDF text mismatch',
+            expectedTextSample: String(expectedDoc.text).slice(0, 200),
+            inputTextSample: String(inputDoc.text).slice(0, 200),
+            timestamp: Date.now(),
+          })
+        );
         return false;
       }
 

--- a/e2e/log-reporter.js
+++ b/e2e/log-reporter.js
@@ -38,19 +38,14 @@ class LogReporter extends Mocha.reporters.Spec {
       end: this.stats.end.getTime(),
     };
 
-    // Example
-    // CypressStats suites=1 tests=2 testPasses=1 pending=0 failures=1
-    // start=1668783563731 end=1668783645198 duration=81467
-    console.log(`CypressStats ${objToLogAttributes(stats)}`);
+    // eslint-disable-next-line no-console
+    console.info(JSON.stringify({ event: 'CypressStats', ...stats, timestamp: Date.now() }));
   }
 
   reportResults() {
     this._testsResults.map(cleanTest).map((test) => {
-      // Example
-      // CypressTestResult title="Login scenario, create test data source, dashboard, panel, and export scenario"
-      // suite="Smoke tests" file=../../e2e/smoke-tests-suite/1-smoketests.spec.ts duration=68694
-      // currentRetry=0 speed=undefined err=false
-      console.log(`CypressTestResult ${objToLogAttributes(test)}`);
+      // eslint-disable-next-line no-console
+      console.info(JSON.stringify({ event: 'CypressTestResult', ...test, timestamp: Date.now() }));
     });
   }
 
@@ -60,43 +55,12 @@ class LogReporter extends Mocha.reporters.Spec {
       const test = failure.title;
       const error = failure.err;
 
-      // Example
-      // CypressError suite="Smoke tests" test="Login scenario, create test data source, dashboard,
-      // panel, and export scenario" error=false
-      console.error(`CypressError ${objToLogAttributes({ suite, test, error })}`);
+      // eslint-disable-next-line no-console
+      console.error(
+        JSON.stringify({ event: 'CypressError', suite, test, error, timestamp: Date.now(), level: 'ERROR' })
+      );
     });
   }
-}
-
-/**
- * Stringify object to be log friendly
- * @param {Object} obj
- * @returns {String}
- */
-function objToLogAttributes(obj) {
-  return Object.entries(obj)
-    .map(([key, value]) => `${key}=${formatValue(value)}`)
-    .join(' ');
-}
-
-/**
- * Escape double quotes
- * @param {String} str
- * @returns
- */
-function escapeQuotes(str) {
-  return String(str).replaceAll('"', '\\"');
-}
-
-/**
- * Wrap the value within double quote if needed
- * @param {*} value
- * @returns
- */
-function formatValue(value) {
-  const hasWhiteSpaces = /\s/g.test(value);
-
-  return hasWhiteSpaces ? `"${escapeQuotes(value)}"` : value;
 }
 
 /**

--- a/eslint-suppressions.json
+++ b/eslint-suppressions.json
@@ -3859,9 +3859,6 @@
     }
   },
   "public/app/plugins/panel/live/LivePanel.tsx": {
-    "@typescript-eslint/consistent-type-assertions": {
-      "count": 1
-    },
     "react-prefer-function-component/react-prefer-function-component": {
       "count": 1
     }

--- a/jest.config.codeowner.js
+++ b/jest.config.codeowner.js
@@ -64,12 +64,31 @@ const testFiles = teamFiles.filter((file) => {
 });
 
 if (testFiles.length === 0) {
-  console.log(`No test files found for team ${codeownerName}`);
+  // eslint-disable-next-line no-console
+  console.info(
+    JSON.stringify({
+      level: 'INFO',
+      source: 'jest.config.codeowner',
+      message: 'No test files found for team',
+      codeownerName,
+      timestamp: Date.now(),
+    })
+  );
   process.exit(0);
 }
 
-console.log(
-  `🧪 Collecting coverage for ${sourceFiles.length} testable files and running ${testFiles.length} test files of ${teamFiles.length} files owned by ${codeownerName}.`
+// eslint-disable-next-line no-console
+console.info(
+  JSON.stringify({
+    level: 'INFO',
+    source: 'jest.config.codeowner',
+    message: 'Starting codeowner coverage run',
+    codeownerName,
+    testableFileCount: sourceFiles.length,
+    testFileCount: testFiles.length,
+    teamFileCount: teamFiles.length,
+    timestamp: Date.now(),
+  })
 );
 
 module.exports = {
@@ -100,7 +119,16 @@ module.exports = {
         cleanCache: true,
         onEnd: (coverageResults) => {
           const reportURL = `file://${path.resolve(outputDir)}/index.html`;
-          console.log(`📄 Coverage report saved to ${reportURL}`);
+          // eslint-disable-next-line no-console
+          console.info(
+            JSON.stringify({
+              level: 'INFO',
+              source: 'jest.config.codeowner',
+              message: 'Coverage report saved',
+              reportURL,
+              timestamp: Date.now(),
+            })
+          );
 
           if (process.env.SHOULD_OPEN_COVERAGE_REPORT === 'true') {
             openCoverageReport(reportURL);
@@ -160,7 +188,16 @@ function writeCoverageSummaryArtifact(coverageResults) {
 
   try {
     fs.writeFileSync(COVERAGE_SUMMARY_OUTPUT_PATH, JSON.stringify(summary, null, 2));
-    console.log(`📊 Coverage summary written to ${COVERAGE_SUMMARY_OUTPUT_PATH}`);
+    // eslint-disable-next-line no-console
+    console.info(
+      JSON.stringify({
+        level: 'INFO',
+        source: 'jest.config.codeowner',
+        message: 'Coverage summary written',
+        path: COVERAGE_SUMMARY_OUTPUT_PATH,
+        timestamp: Date.now(),
+      })
+    );
   } catch (err) {
     console.error(`Failed to write coverage summary: ${err}`);
   }

--- a/packages/grafana-alerting/src/grafana/rules/components/labels/AlertLabel.story.tsx
+++ b/packages/grafana-alerting/src/grafana/rules/components/labels/AlertLabel.story.tsx
@@ -7,7 +7,9 @@ import { AlertLabel } from './AlertLabel';
 
 function storyLog(message: string, context?: Record<string, unknown>) {
   // eslint-disable-next-line no-console
-  console.info(JSON.stringify({ level: 'INFO', source: 'storybook.AlertLabel', message, timestamp: Date.now(), ...context }));
+  console.info(
+    JSON.stringify({ level: 'INFO', source: 'storybook.AlertLabel', message, timestamp: Date.now(), ...context })
+  );
 }
 
 const meta: Meta<typeof AlertLabel> = {

--- a/packages/grafana-alerting/src/grafana/rules/components/labels/AlertLabel.story.tsx
+++ b/packages/grafana-alerting/src/grafana/rules/components/labels/AlertLabel.story.tsx
@@ -5,6 +5,11 @@ import { Stack, Text } from '@grafana/ui';
 
 import { AlertLabel } from './AlertLabel';
 
+function storyLog(message: string, context?: Record<string, unknown>) {
+  // eslint-disable-next-line no-console
+  console.info(JSON.stringify({ level: 'INFO', source: 'storybook.AlertLabel', message, timestamp: Date.now(), ...context }));
+}
+
 const meta: Meta<typeof AlertLabel> = {
   component: AlertLabel,
   title: 'Rules/AlertLabel',
@@ -42,7 +47,7 @@ export const Clickable: StoryObj<typeof AlertLabel> = {
       {...args}
       labelKey="region"
       value="eu-central-1"
-      onClick={([value, key]) => console.log('clicked', key, value)}
+      onClick={([value, key]) => storyLog('label clicked', { key, value })}
     />
   ),
 };

--- a/packages/grafana-api-clients/src/generator/helpers.ts
+++ b/packages/grafana-api-clients/src/generator/helpers.ts
@@ -71,7 +71,16 @@ export const runGenerateApis =
         command = 'yarn workspace @grafana/api-clients generate-apis';
       }
 
-      console.log(`⏳ Running ${command} to generate endpoints...`);
+      // eslint-disable-next-line no-console
+      console.info(
+        JSON.stringify({
+          level: 'INFO',
+          source: 'api-clients.generator',
+          message: 'Running API generation command',
+          command,
+          timestamp: Date.now(),
+        })
+      );
       execSync(command, { stdio: 'inherit', cwd: basePath });
       return '✅ API endpoints generated successfully!';
     } catch (error) {
@@ -94,7 +103,15 @@ export const formatFiles =
     try {
       const filesList = filesToFormat.map((file: string) => `"${file}"`).join(' ');
 
-      console.log('🧹 Running ESLint on generated/modified files...');
+      // eslint-disable-next-line no-console
+      console.info(
+        JSON.stringify({
+          level: 'INFO',
+          source: 'api-clients.generator',
+          message: 'Running ESLint on generated files',
+          timestamp: Date.now(),
+        })
+      );
       try {
         execSync(`yarn eslint --fix ${filesList}`, { cwd: basePath });
       } catch (error) {
@@ -102,7 +119,15 @@ export const formatFiles =
         console.warn(`⚠️ Warning: ESLint encountered issues: ${errorMessage}`);
       }
 
-      console.log('🧹 Running Prettier on generated/modified files...');
+      // eslint-disable-next-line no-console
+      console.info(
+        JSON.stringify({
+          level: 'INFO',
+          source: 'api-clients.generator',
+          message: 'Running Prettier on generated files',
+          timestamp: Date.now(),
+        })
+      );
       try {
         // '--ignore-path' is necessary so the gitignored files ('local/' folder) can still be formatted
         execSync(`yarn prettier --write ${filesList} --ignore-path=./.prettierignore`, { cwd: basePath });

--- a/packages/grafana-data/scripts/generateSchema.ts
+++ b/packages/grafana-data/scripts/generateSchema.ts
@@ -19,4 +19,13 @@ fs.writeFileSync(
   )
 );
 
-console.log('Successfully generated theme schema');
+// eslint-disable-next-line no-console
+console.info(
+  JSON.stringify({
+    level: 'INFO',
+    source: 'grafana-data.generateSchema',
+    message: 'Successfully generated theme schema',
+    outPath: jsonOut,
+    timestamp: Date.now(),
+  })
+);

--- a/packages/grafana-data/src/utils/LocalStorageValueProvider.tsx
+++ b/packages/grafana-data/src/utils/LocalStorageValueProvider.tsx
@@ -3,6 +3,22 @@ import * as React from 'react';
 
 import { store } from './store';
 
+function logStorageFailure(operation: string, error: unknown) {
+  const err = error instanceof Error ? error : new Error(String(error));
+  // eslint-disable-next-line no-console
+  console.error(
+    JSON.stringify({
+      level: 'ERROR',
+      source: 'LocalStorageValueProvider',
+      operation,
+      message: err.message,
+      name: err.name,
+      stack: err.stack,
+      timestamp: Date.now(),
+    })
+  );
+}
+
 export interface Props<T> {
   storageKey: string;
   defaultValue: T;
@@ -32,7 +48,7 @@ export const LocalStorageValueProvider = <T,>(props: Props<T>) => {
     try {
       store.setObject(storageKey, value);
     } catch (error) {
-      console.error(error);
+      logStorageFailure('save', error);
     }
     setState({ value });
   };
@@ -41,7 +57,7 @@ export const LocalStorageValueProvider = <T,>(props: Props<T>) => {
     try {
       store.delete(storageKey);
     } catch (error) {
-      console.log(error);
+      logStorageFailure('delete', error);
     }
     setState({ value: defaultValue });
   };

--- a/packages/grafana-openapi/src/scripts/process-specs.ts
+++ b/packages/grafana-openapi/src/scripts/process-specs.ts
@@ -155,7 +155,15 @@ function processDirectory(sourceDir: string, outputDir: string) {
     const outputPath = path.join(outputDir, file);
 
     // eslint-disable-next-line no-console
-    console.info(JSON.stringify({ level: 'INFO', source: 'openapi.process-specs', message: 'Processing file', file, timestamp: Date.now() }));
+    console.info(
+      JSON.stringify({
+        level: 'INFO',
+        source: 'openapi.process-specs',
+        message: 'Processing file',
+        file,
+        timestamp: Date.now(),
+      })
+    );
 
     const fileContent = fs.readFileSync(inputPath, 'utf-8');
 
@@ -170,7 +178,15 @@ function processDirectory(sourceDir: string, outputDir: string) {
     const outputSpec = processOpenAPISpec(inputSpec);
     fs.writeFileSync(outputPath, JSON.stringify(outputSpec, null, 2), 'utf-8');
     // eslint-disable-next-line no-console
-    console.info(JSON.stringify({ level: 'INFO', source: 'openapi.process-specs', message: 'Processing completed', file, timestamp: Date.now() }));
+    console.info(
+      JSON.stringify({
+        level: 'INFO',
+        source: 'openapi.process-specs',
+        message: 'Processing completed',
+        file,
+        timestamp: Date.now(),
+      })
+    );
   }
 }
 

--- a/packages/grafana-openapi/src/scripts/process-specs.ts
+++ b/packages/grafana-openapi/src/scripts/process-specs.ts
@@ -154,7 +154,8 @@ function processDirectory(sourceDir: string, outputDir: string) {
     const inputPath = path.join(sourceDir, file);
     const outputPath = path.join(outputDir, file);
 
-    console.log(`Processing file "${file}"...`);
+    // eslint-disable-next-line no-console
+    console.info(JSON.stringify({ level: 'INFO', source: 'openapi.process-specs', message: 'Processing file', file, timestamp: Date.now() }));
 
     const fileContent = fs.readFileSync(inputPath, 'utf-8');
 
@@ -168,7 +169,8 @@ function processDirectory(sourceDir: string, outputDir: string) {
 
     const outputSpec = processOpenAPISpec(inputSpec);
     fs.writeFileSync(outputPath, JSON.stringify(outputSpec, null, 2), 'utf-8');
-    console.log(`Processing completed for file "${file}".`);
+    // eslint-disable-next-line no-console
+    console.info(JSON.stringify({ level: 'INFO', source: 'openapi.process-specs', message: 'Processing completed', file, timestamp: Date.now() }));
   }
 }
 

--- a/packages/grafana-prometheus/src/components/monaco-query-field/getOverrideServices.ts
+++ b/packages/grafana-prometheus/src/components/monaco-query-field/getOverrideServices.ts
@@ -1,5 +1,8 @@
 // Core Grafana history https://github.com/grafana/grafana/blob/v11.0.0-preview/public/app/plugins/datasource/prometheus/components/monaco-query-field/getOverrideServices.ts
+import { createMonitoringLogger } from '@grafana/runtime';
 import { monacoTypes } from '@grafana/ui';
+
+const monacoStorageLogger = createMonitoringLogger('plugins.prometheus.monacoStorage');
 
 // this thing here is a workaround in a way.
 // what we want to achieve, is that when the autocomplete-window
@@ -82,7 +85,7 @@ function makeStorageService() {
     },
 
     logStorage: (): void => {
-      console.log('logStorage: not implemented');
+      monacoStorageLogger.logDebug('Monaco logStorage not implemented');
     },
 
     migrate: (): Promise<void> => {

--- a/packages/grafana-prometheus/src/datasource.ts
+++ b/packages/grafana-prometheus/src/datasource.ts
@@ -31,6 +31,7 @@ import {
 import {
   BackendSrvRequest,
   config,
+  createMonitoringLogger,
   DataSourceWithBackend,
   FetchResponse,
   getBackendSrv,
@@ -38,6 +39,8 @@ import {
   isFetchError,
   TemplateSrv,
 } from '@grafana/runtime';
+
+const prometheusDatasourceLogger = createMonitoringLogger('plugins.prometheus.datasource');
 
 import { addLabelToQuery } from './add_label_to_query';
 import { PrometheusAnnotationSupport } from './annotations';
@@ -172,8 +175,10 @@ export class PrometheusDatasource
         this.ruleMappings = extractRuleMappingFromGroups(ruleGroups);
       }
     } catch (err) {
-      console.log('Rules API is experimental. Ignore next error.');
-      console.error(err);
+      prometheusDatasourceLogger.logWarning('Prometheus rules API is experimental; ignoring error');
+      prometheusDatasourceLogger.logError(err instanceof Error ? err : new Error(String(err)), {
+        phase: 'loadRules',
+      });
     }
   }
 

--- a/packages/grafana-runtime/src/config.ts
+++ b/packages/grafana-runtime/src/config.ts
@@ -313,7 +313,17 @@ function overrideFeatureTogglesFromLocalStorage(config: GrafanaBootConfig) {
       const toggleState = featureValue === 'true' || featureValue === '1';
       // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
       featureToggles[featureName as keyof FeatureToggles] = toggleState;
-      console.log(`Setting feature toggle ${featureName} = ${toggleState} via localstorage`);
+      // eslint-disable-next-line no-console
+      console.info(
+        JSON.stringify({
+          level: 'INFO',
+          source: 'config.featureToggles',
+          message: 'Feature toggle set from localStorage',
+          featureName,
+          toggleState,
+          timestamp: Date.now(),
+        })
+      );
     }
   }
 }
@@ -339,9 +349,28 @@ function overrideFeatureTogglesFromUrl(config: GrafanaBootConfig) {
       if (toggleState !== featureToggles[key]) {
         if (isDevelopment || safeRuntimeFeatureFlags.has(featureName)) {
           featureToggles[featureName] = toggleState;
-          console.log(`Setting feature toggle ${featureName} = ${toggleState} via url`);
+          // eslint-disable-next-line no-console
+          console.info(
+            JSON.stringify({
+              level: 'INFO',
+              source: 'config.featureToggles',
+              message: 'Feature toggle set from URL',
+              featureName,
+              toggleState,
+              timestamp: Date.now(),
+            })
+          );
         } else {
-          console.log(`Unable to change feature toggle ${featureName} via url in production.`);
+          // eslint-disable-next-line no-console
+          console.warn(
+            JSON.stringify({
+              level: 'WARN',
+              source: 'config.featureToggles',
+              message: 'Feature toggle URL override ignored in production',
+              featureName,
+              timestamp: Date.now(),
+            })
+          );
         }
       }
     }
@@ -352,7 +381,15 @@ let bootData = window.grafanaBootData;
 
 if (!bootData) {
   if (process.env.NODE_ENV !== 'test') {
-    console.error('window.grafanaBootData was not set by the time config was initialized');
+    // eslint-disable-next-line no-console
+    console.error(
+      JSON.stringify({
+        level: 'ERROR',
+        source: 'config.boot',
+        message: 'window.grafanaBootData was not set by the time config was initialized',
+        timestamp: Date.now(),
+      })
+    );
   }
 
   bootData = {

--- a/packages/grafana-runtime/src/index.ts
+++ b/packages/grafana-runtime/src/index.ts
@@ -17,6 +17,7 @@ export {
   createMonitoringLogger,
   logMeasurement,
   type MonitoringLogger,
+  type MonitoringLogFields,
 } from './utils/logging';
 export {
   DataSourceWithBackend,

--- a/packages/grafana-runtime/src/utils/logging.ts
+++ b/packages/grafana-runtime/src/utils/logging.ts
@@ -4,16 +4,99 @@ import { config } from '../config';
 
 export { LogLevel };
 
+/** Arbitrary fields attached to a log line (normalized to string values for Faro). */
+export type MonitoringLogFields = Record<string, unknown>;
+
+function isDevelopmentEnv(): boolean {
+  return config.buildInfo.env === 'development';
+}
+
+function normalizeLogContext(fields?: MonitoringLogFields): LogContext | undefined {
+  if (!fields) {
+    return undefined;
+  }
+  const out: LogContext = {};
+  for (const [key, value] of Object.entries(fields)) {
+    if (value === undefined || value === null) {
+      continue;
+    }
+    if (typeof value === 'string') {
+      out[key] = value;
+    } else if (typeof value === 'number' || typeof value === 'boolean') {
+      out[key] = String(value);
+    } else {
+      try {
+        out[key] = JSON.stringify(value);
+      } catch {
+        out[key] = String(value);
+      }
+    }
+  }
+  return Object.keys(out).length > 0 ? out : undefined;
+}
+
+function emitStructuredConsoleLine(level: string, message: string, fields?: MonitoringLogFields): void {
+  if (!isDevelopmentEnv()) {
+    return;
+  }
+  let line: string;
+  try {
+    line = JSON.stringify({
+      level,
+      message,
+      timestamp: Date.now(),
+      ...fields,
+    });
+  } catch {
+    line = JSON.stringify({
+      level,
+      message,
+      timestamp: Date.now(),
+      contextNote: 'Could not serialize log fields',
+    });
+  }
+  switch (level) {
+    case 'DEBUG':
+      // eslint-disable-next-line no-console
+      console.debug(line);
+      break;
+    case 'INFO':
+      // eslint-disable-next-line no-console
+      console.info(line);
+      break;
+    case 'WARN':
+      // eslint-disable-next-line no-console
+      console.warn(line);
+      break;
+    case 'ERROR':
+      // eslint-disable-next-line no-console
+      console.error(line);
+      break;
+    default:
+      // eslint-disable-next-line no-console
+      console.info(line);
+  }
+}
+
+function pushLogToFaro(level: LogLevel, message: string, contexts?: LogContext): void {
+  if (!config.grafanaJavascriptAgent.enabled || typeof faro.api?.pushLog !== 'function') {
+    return;
+  }
+  faro.api.pushLog([message], {
+    level,
+    context: contexts,
+  });
+}
+
 /**
  * Log a message at INFO level
  * @public
  */
-export function logInfo(message: string, contexts?: LogContext) {
-  if (config.grafanaJavascriptAgent.enabled) {
-    faro.api.pushLog([message], {
-      level: LogLevel.INFO,
-      context: contexts,
-    });
+export function logInfo(message: string, fields?: MonitoringLogFields) {
+  const contexts = normalizeLogContext(fields);
+  pushLogToFaro(LogLevel.INFO, message, contexts);
+  if (!config.grafanaJavascriptAgent.enabled) {
+    emitStructuredConsoleLine('INFO', message, fields);
   }
 }
 
@@ -22,12 +105,11 @@ export function logInfo(message: string, contexts?: LogContext) {
  *
  * @public
  */
-export function logWarning(message: string, contexts?: LogContext) {
-  if (config.grafanaJavascriptAgent.enabled) {
-    faro.api.pushLog([message], {
-      level: LogLevel.WARN,
-      context: contexts,
-    });
+export function logWarning(message: string, fields?: MonitoringLogFields) {
+  const contexts = normalizeLogContext(fields);
+  pushLogToFaro(LogLevel.WARN, message, contexts);
+  if (!config.grafanaJavascriptAgent.enabled) {
+    emitStructuredConsoleLine('WARN', message, fields);
   }
 }
 
@@ -36,12 +118,11 @@ export function logWarning(message: string, contexts?: LogContext) {
  *
  * @public
  */
-export function logDebug(message: string, contexts?: LogContext) {
-  if (config.grafanaJavascriptAgent.enabled) {
-    faro.api.pushLog([message], {
-      level: LogLevel.DEBUG,
-      context: contexts,
-    });
+export function logDebug(message: string, fields?: MonitoringLogFields) {
+  const contexts = normalizeLogContext(fields);
+  pushLogToFaro(LogLevel.DEBUG, message, contexts);
+  if (!config.grafanaJavascriptAgent.enabled) {
+    emitStructuredConsoleLine('DEBUG', message, fields);
   }
 }
 
@@ -50,10 +131,21 @@ export function logDebug(message: string, contexts?: LogContext) {
  *
  * @public
  */
-export function logError(err: Error, contexts?: LogContext) {
-  if (config.grafanaJavascriptAgent.enabled) {
+export function logError(err: Error, fields?: MonitoringLogFields) {
+  const contexts = normalizeLogContext({
+    ...fields,
+    name: err.name,
+    stack: err.stack ?? '',
+  });
+  if (config.grafanaJavascriptAgent.enabled && typeof faro.api?.pushError === 'function') {
     faro.api.pushError(err, {
       context: contexts,
+    });
+  } else if (isDevelopmentEnv()) {
+    emitStructuredConsoleLine('ERROR', err.message, {
+      ...fields,
+      name: err.name,
+      stack: err.stack,
     });
   }
 }
@@ -64,82 +156,87 @@ export function logError(err: Error, contexts?: LogContext) {
  * @public
  */
 export type MeasurementValues = Record<string, number>;
-export function logMeasurement(type: string, values: MeasurementValues, context?: LogContext) {
-  if (config.grafanaJavascriptAgent.enabled) {
-    faro.api.pushMeasurement(
-      {
-        type,
-        values,
-      },
-      { context: context }
-    );
+export function logMeasurement(type: string, values: MeasurementValues, fields?: MonitoringLogFields) {
+  const faroContext = normalizeLogContext(fields);
+  if (!config.grafanaJavascriptAgent.enabled || typeof faro.api?.pushMeasurement !== 'function') {
+    if (isDevelopmentEnv()) {
+      emitStructuredConsoleLine('INFO', `measurement:${type}`, { ...fields, type, values });
+    }
+    return;
   }
+  faro.api.pushMeasurement(
+    {
+      type,
+      values,
+    },
+    { context: faroContext }
+  );
 }
 
 export interface MonitoringLogger {
-  logDebug: (message: string, contexts?: LogContext) => void;
-  logInfo: (message: string, contexts?: LogContext) => void;
-  logWarning: (message: string, contexts?: LogContext) => void;
-  logError: (error: Error, contexts?: LogContext) => void;
-  logMeasurement: (type: string, measurement: MeasurementValues, contexts?: LogContext) => void;
+  logDebug: (message: string, fields?: MonitoringLogFields) => void;
+  logInfo: (message: string, fields?: MonitoringLogFields) => void;
+  logWarning: (message: string, fields?: MonitoringLogFields) => void;
+  logError: (error: Error, fields?: MonitoringLogFields) => void;
+  logMeasurement: (type: string, measurement: MeasurementValues, fields?: MonitoringLogFields) => void;
 }
 /**
  * Creates a monitoring logger with five levels of logging methods: `logDebug`, `logInfo`, `logWarning`, `logError`, and `logMeasurement`.
  * These methods use `faro.api.pushX` web SDK methods to report these logs or errors to the Faro collector.
  *
  * @param {string} source - Identifier for the source of the log messages.
- * @param {LogContext} [defaultContext] - Context to be included in every log message.
+ * @param {MonitoringLogFields} [defaultContext] - Context to be included in every log message.
  *
  * @returns {MonitoringLogger} Logger object with five methods:
- * - `logDebug(message: string, contexts?: LogContext)`: Logs a debug message.
- * - `logInfo(message: string, contexts?: LogContext)`: Logs an informational message.
- * - `logWarning(message: string, contexts?: LogContext)`: Logs a warning message.
- * - `logError(error: Error, contexts?: LogContext)`: Logs an error message.
- * - `logMeasurement(measurement: Omit<MeasurementEvent, 'timestamp'>, contexts?: LogContext)`: Logs a measurement.
- * Each method combines the `defaultContext` (if provided), the `source`, and an optional `LogContext` parameter into a full context that is included with the log message.
+ * - `logDebug(message: string, fields?: MonitoringLogFields)`: Logs a debug message.
+ * - `logInfo(message: string, fields?: MonitoringLogFields)`: Logs an informational message.
+ * - `logWarning(message: string, fields?: MonitoringLogFields)`: Logs a warning message.
+ * - `logError(error: Error, fields?: MonitoringLogFields)`: Logs an error message.
+ * - `logMeasurement(measurement: Omit<MeasurementEvent, 'timestamp'>, fields?: MonitoringLogFields)`: Logs a measurement.
+ * Each method combines the `defaultContext` (if provided), the `source`, and an optional `MonitoringLogFields` parameter into a full context that is included with the log message.
  */
-export function createMonitoringLogger(source: string, defaultContext?: LogContext): MonitoringLogger {
-  const createFullContext = (contexts?: LogContext) => ({
+export function createMonitoringLogger(source: string, defaultContext?: MonitoringLogFields): MonitoringLogger {
+  const createFullContext = (fields?: MonitoringLogFields) => ({
     source: source,
     ...defaultContext,
-    ...contexts,
+    ...fields,
   });
 
   return {
     /**
      * Logs a debug message with optional additional context.
      * @param {string} message - The debug message to be logged.
-     * @param {LogContext} [contexts] - Optional additional context to be included.
+     * @param {MonitoringLogFields} [fields] - Optional additional context to be included.
      */
-    logDebug: (message: string, contexts?: LogContext) => logDebug(message, createFullContext(contexts)),
+    logDebug: (message: string, fields?: MonitoringLogFields) => logDebug(message, createFullContext(fields)),
 
     /**
      * Logs an informational message with optional additional context.
      * @param {string} message - The informational message to be logged.
      * @param {LogContext} [contexts] - Optional additional context to be included.
      */
-    logInfo: (message: string, contexts?: LogContext) => logInfo(message, createFullContext(contexts)),
+    logInfo: (message: string, fields?: MonitoringLogFields) => logInfo(message, createFullContext(fields)),
 
     /**
      * Logs a warning message with optional additional context.
      * @param {string} message - The warning message to be logged.
      * @param {LogContext} [contexts] - Optional additional context to be included.
      */
-    logWarning: (message: string, contexts?: LogContext) => logWarning(message, createFullContext(contexts)),
+    logWarning: (message: string, fields?: MonitoringLogFields) => logWarning(message, createFullContext(fields)),
 
     /**
      * Logs an error with optional additional context.
      * @param {Error} error - The error object to be logged.
      * @param {LogContext} [contexts] - Optional additional context to be included.
      */
-    logError: (error: Error, contexts?: LogContext) => logError(error, createFullContext(contexts)),
+    logError: (error: Error, fields?: MonitoringLogFields) => logError(error, createFullContext(fields)),
 
     /**
      * Logs an measurement with optional additional context.
      * @param {MeasurementEvent} measurement - The measurement object to be recorded.
      * @param {LogContext} [contexts] - Optional additional context to be included.
      */
-    logMeasurement: (type: string, measurement: MeasurementValues, contexts?: LogContext) =>
-      logMeasurement(type, measurement, createFullContext(contexts)),
+    logMeasurement: (type: string, measurement: MeasurementValues, fields?: MonitoringLogFields) =>
+      logMeasurement(type, measurement, createFullContext(fields)),
   };
 }

--- a/packages/grafana-ui/src/components/Card/Card.story.tsx
+++ b/packages/grafana-ui/src/components/Card/Card.story.tsx
@@ -1,5 +1,6 @@
 import { Meta, StoryFn } from '@storybook/react';
 
+import { storyStructuredInfo } from '../../utils/storybookStructuredLog';
 import { Button } from '../Button/Button';
 import { IconButton } from '../IconButton/IconButton';
 import { TextLink } from '../Link/TextLink';
@@ -93,7 +94,10 @@ export const Tags: StoryFn<typeof Card> = (args) => {
       <Card.Heading>Test dashboard</Card.Heading>
       <Card.Description>Card with a list of tags</Card.Description>
       <Card.Tags>
-        <TagList tags={['tag1', 'tag2', 'tag3']} onClick={(tag) => console.log(tag)} />
+        <TagList
+          tags={['tag1', 'tag2', 'tag3']}
+          onClick={(tag) => storyStructuredInfo('storybook.Card', 'tag click', { tag })}
+        />
       </Card.Tags>
     </Card>
   );

--- a/packages/grafana-ui/src/components/Cascader/Cascader.story.tsx
+++ b/packages/grafana-ui/src/components/Cascader/Cascader.story.tsx
@@ -1,12 +1,13 @@
 import { StoryFn, Meta } from '@storybook/react';
 import { useId, useState } from 'react';
 
+import { storyStructuredInfo } from '../../utils/storybookStructuredLog';
 import { Field } from '../Forms/Field';
 
 import { Cascader, CascaderOption } from './Cascader';
 import mdx from './Cascader.mdx';
 
-const onSelect = (val: string) => console.log(val);
+const onSelect = (val: string) => storyStructuredInfo('storybook.Cascader', 'onSelect', { value: val });
 const options = [
   {
     label: 'First',

--- a/packages/grafana-ui/src/components/Combobox/storyUtils.ts
+++ b/packages/grafana-ui/src/components/Combobox/storyUtils.ts
@@ -1,3 +1,5 @@
+import { storyStructuredInfo } from '../../utils/storybookStructuredLog';
+
 import { ComboboxOption } from './types';
 
 let fakeApiOptions: Array<ComboboxOption<string>>;
@@ -13,7 +15,9 @@ export async function fakeSearchAPI(urlString: string): Promise<Array<ComboboxOp
 
   if (!fakeApiOptions) {
     fakeApiOptions = await generateOptions(1000);
-    console.log('fakeApiOptions', fakeApiOptions);
+    storyStructuredInfo('storybook.Combobox.fakeSearchAPI', 'Generated fake API options', {
+      optionCount: fakeApiOptions.length,
+    });
   }
 
   if (!searchQuery || searchQuery.length === 0) {

--- a/packages/grafana-ui/src/components/FileUpload/FileUpload.story.tsx
+++ b/packages/grafana-ui/src/components/FileUpload/FileUpload.story.tsx
@@ -1,5 +1,6 @@
 import { Meta, StoryFn } from '@storybook/react';
 
+import { storyStructuredInfo } from '../../utils/storybookStructuredLog';
 import { FileUpload } from './FileUpload';
 import mdx from './FileUpload.mdx';
 
@@ -28,7 +29,11 @@ export const Basic: StoryFn<typeof FileUpload> = (args) => {
   return (
     <FileUpload
       size={args.size}
-      onFileUpload={({ currentTarget }) => console.log('file', currentTarget?.files && currentTarget.files[0])}
+      onFileUpload={({ currentTarget }) =>
+        storyStructuredInfo('storybook.FileUpload', 'onFileUpload', {
+          fileName: currentTarget?.files?.[0]?.name,
+        })
+      }
     />
   );
 };

--- a/packages/grafana-ui/src/components/FileUpload/FileUpload.story.tsx
+++ b/packages/grafana-ui/src/components/FileUpload/FileUpload.story.tsx
@@ -1,6 +1,7 @@
 import { Meta, StoryFn } from '@storybook/react';
 
 import { storyStructuredInfo } from '../../utils/storybookStructuredLog';
+
 import { FileUpload } from './FileUpload';
 import mdx from './FileUpload.mdx';
 

--- a/packages/grafana-ui/src/components/Forms/FieldArray.story.tsx
+++ b/packages/grafana-ui/src/components/Forms/FieldArray.story.tsx
@@ -1,8 +1,8 @@
 import { Meta, StoryFn } from '@storybook/react';
 import { FieldValues } from 'react-hook-form';
 
-import { storyStructuredInfo } from '../../utils/storybookStructuredLog';
 import { withStoryContainer } from '../../utils/storybook/withStoryContainer';
+import { storyStructuredInfo } from '../../utils/storybookStructuredLog';
 import { Button } from '../Button/Button';
 import { Input } from '../Input/Input';
 import { Stack } from '../Layout/Stack/Stack';
@@ -37,7 +37,10 @@ export const Simple: StoryFn = (args) => {
     people: [{ firstName: 'Janis', lastName: 'Joplin' }],
   };
   return (
-    <Form onSubmit={(values) => storyStructuredInfo('storybook.FieldArray', 'onSubmit', { values })} defaultValues={defaultValues}>
+    <Form
+      onSubmit={(values) => storyStructuredInfo('storybook.FieldArray', 'onSubmit', { values })}
+      defaultValues={defaultValues}
+    >
       {({ control, register }) => (
         <div>
           <FieldArray control={control} name="people">

--- a/packages/grafana-ui/src/components/Forms/FieldArray.story.tsx
+++ b/packages/grafana-ui/src/components/Forms/FieldArray.story.tsx
@@ -1,6 +1,7 @@
 import { Meta, StoryFn } from '@storybook/react';
 import { FieldValues } from 'react-hook-form';
 
+import { storyStructuredInfo } from '../../utils/storybookStructuredLog';
 import { withStoryContainer } from '../../utils/storybook/withStoryContainer';
 import { Button } from '../Button/Button';
 import { Input } from '../Input/Input';
@@ -36,7 +37,7 @@ export const Simple: StoryFn = (args) => {
     people: [{ firstName: 'Janis', lastName: 'Joplin' }],
   };
   return (
-    <Form onSubmit={(values) => console.log(values)} defaultValues={defaultValues}>
+    <Form onSubmit={(values) => storyStructuredInfo('storybook.FieldArray', 'onSubmit', { values })} defaultValues={defaultValues}>
       {({ control, register }) => (
         <div>
           <FieldArray control={control} name="people">

--- a/packages/grafana-ui/src/components/Forms/FieldSet.story.tsx
+++ b/packages/grafana-ui/src/components/Forms/FieldSet.story.tsx
@@ -1,6 +1,7 @@
 import { Meta, StoryFn } from '@storybook/react';
 import { useId } from 'react';
 
+import { storyStructuredInfo } from '../../utils/storybookStructuredLog';
 import { Button } from '../Button/Button';
 import { Input } from '../Input/Input';
 
@@ -34,7 +35,7 @@ export const Basic: StoryFn<typeof FieldSet> = (args: Props) => {
   const colorId = useId();
   const fontSizeId = useId();
   return (
-    <Form onSubmit={() => console.log('Submit')}>
+    <Form onSubmit={() => storyStructuredInfo('storybook.FieldSet', 'Form submit')}>
       {() => (
         <>
           <FieldSet {...args}>

--- a/packages/grafana-ui/src/components/Forms/Form.story.tsx
+++ b/packages/grafana-ui/src/components/Forms/Form.story.tsx
@@ -2,6 +2,7 @@ import { StoryFn } from '@storybook/react';
 import { useId } from 'react';
 import { ValidateResult } from 'react-hook-form';
 
+import { storyStructuredInfo } from '../../utils/storybookStructuredLog';
 import { withStoryContainer } from '../../utils/storybook/withStoryContainer';
 import { Button } from '../Button/Button';
 import { Input } from '../Input/Input';
@@ -70,11 +71,11 @@ const renderForm = (defaultValues?: FormDTO) => {
     <Form
       defaultValues={defaultValues}
       onSubmit={(data: FormDTO) => {
-        console.log(data);
+        storyStructuredInfo('storybook.Form', 'onSubmit', { data });
       }}
     >
       {({ register, control, errors }) => {
-        console.log(errors);
+        storyStructuredInfo('storybook.Form', 'form errors snapshot', { errors });
         return (
           <>
             <Legend>Edit user</Legend>
@@ -162,7 +163,7 @@ export const AsyncValidation: StoryFn = ({ passAsyncValidation }) => {
         }}
       >
         {({ register, control, errors, formState }) => {
-          console.log(errors);
+          storyStructuredInfo('storybook.Form', 'async validation errors', { errors });
           return (
             <>
               <Legend>Edit user</Legend>
@@ -201,7 +202,9 @@ const validateAsync = (shouldPass: boolean) => async () => {
     });
     return true;
   } catch (e) {
-    console.log(e);
+    storyStructuredInfo('storybook.Form', 'async validateAsync error', {
+      error: e instanceof Error ? e.message : String(e),
+    });
     return false;
   }
 };

--- a/packages/grafana-ui/src/components/Forms/Form.story.tsx
+++ b/packages/grafana-ui/src/components/Forms/Form.story.tsx
@@ -2,8 +2,8 @@ import { StoryFn } from '@storybook/react';
 import { useId } from 'react';
 import { ValidateResult } from 'react-hook-form';
 
-import { storyStructuredInfo } from '../../utils/storybookStructuredLog';
 import { withStoryContainer } from '../../utils/storybook/withStoryContainer';
+import { storyStructuredInfo } from '../../utils/storybookStructuredLog';
 import { Button } from '../Button/Button';
 import { Input } from '../Input/Input';
 import { InputControl } from '../InputControl';

--- a/packages/grafana-ui/src/components/ThemeDemos/EmotionPerfTest.tsx
+++ b/packages/grafana-ui/src/components/ThemeDemos/EmotionPerfTest.tsx
@@ -7,11 +7,12 @@ import React, { Profiler, ProfilerOnRenderCallback, useState, FC } from 'react';
 import { GrafanaTheme2 } from '@grafana/data';
 
 import { useStyles2, useTheme2 } from '../../themes/ThemeContext';
+import { storyStructuredInfo } from '../../utils/storybookStructuredLog';
 import { Button } from '../Button/Button';
 import { Stack } from '../Layout/Stack/Stack';
 
 export function EmotionPerfTest() {
-  console.log('process.env.NODE_ENV', process.env.NODE_ENV);
+  storyStructuredInfo('storybook.EmotionPerfTest', 'NODE_ENV', { nodeEnv: process.env.NODE_ENV });
 
   return (
     <Stack direction="column">
@@ -126,7 +127,7 @@ function NoStyles({ index }: TestComponentProps) {
 
 function MeasureRender({ children, id }: { children: React.ReactNode; id: string }) {
   const onRender: ProfilerOnRenderCallback = (id, phase, actualDuration, baseDuration, startTime, commitTime) => {
-    console.log('Profile ' + id, actualDuration);
+    storyStructuredInfo('storybook.EmotionPerfTest', 'Profiler render', { id, actualDuration, phase });
   };
 
   return (

--- a/packages/grafana-ui/src/components/ValuePicker/ValuePicker.story.tsx
+++ b/packages/grafana-ui/src/components/ValuePicker/ValuePicker.story.tsx
@@ -1,7 +1,7 @@
 import { Meta, StoryFn } from '@storybook/react';
 
-import { storyStructuredInfo } from '../../utils/storybookStructuredLog';
 import { getAvailableIcons } from '../../types/icon';
+import { storyStructuredInfo } from '../../utils/storybookStructuredLog';
 import { generateOptions } from '../Select/mockOptions';
 
 import { ValuePicker } from './ValuePicker';
@@ -44,7 +44,11 @@ const options = generateOptions();
 export const Simple: StoryFn<typeof ValuePicker> = (args) => {
   return (
     <div style={{ width: '200px' }}>
-      <ValuePicker {...args} options={options} onChange={(v) => storyStructuredInfo('storybook.ValuePicker', 'onChange', { value: v })} />
+      <ValuePicker
+        {...args}
+        options={options}
+        onChange={(v) => storyStructuredInfo('storybook.ValuePicker', 'onChange', { value: v })}
+      />
     </div>
   );
 };

--- a/packages/grafana-ui/src/components/ValuePicker/ValuePicker.story.tsx
+++ b/packages/grafana-ui/src/components/ValuePicker/ValuePicker.story.tsx
@@ -1,5 +1,6 @@
 import { Meta, StoryFn } from '@storybook/react';
 
+import { storyStructuredInfo } from '../../utils/storybookStructuredLog';
 import { getAvailableIcons } from '../../types/icon';
 import { generateOptions } from '../Select/mockOptions';
 
@@ -43,7 +44,7 @@ const options = generateOptions();
 export const Simple: StoryFn<typeof ValuePicker> = (args) => {
   return (
     <div style={{ width: '200px' }}>
-      <ValuePicker {...args} options={options} onChange={(v) => console.log(v)} />
+      <ValuePicker {...args} options={options} onChange={(v) => storyStructuredInfo('storybook.ValuePicker', 'onChange', { value: v })} />
     </div>
   );
 };

--- a/packages/grafana-ui/src/utils/logger.ts
+++ b/packages/grafana-ui/src/utils/logger.ts
@@ -1,5 +1,6 @@
-import { faro, LogLevel } from '@grafana/faro-web-sdk';
 import { throttle } from 'lodash';
+
+import { faro, LogLevel } from '@grafana/faro-web-sdk';
 
 type Args = Parameters<typeof console.log>;
 

--- a/packages/grafana-ui/src/utils/logger.ts
+++ b/packages/grafana-ui/src/utils/logger.ts
@@ -1,12 +1,35 @@
+import { faro, LogLevel } from '@grafana/faro-web-sdk';
 import { throttle } from 'lodash';
 
 type Args = Parameters<typeof console.log>;
 
+function pushDebugLog(name: string, id: string, args: Args) {
+  const message = `[${name}: ${id}]`;
+  const context =
+    args.length > 0
+      ? {
+          details: (() => {
+            try {
+              return JSON.stringify(args);
+            } catch {
+              return String(args);
+            }
+          })(),
+        }
+      : undefined;
+  if (typeof faro.api?.pushLog === 'function') {
+    faro.api.pushLog([message], {
+      level: LogLevel.DEBUG,
+      context,
+    });
+  }
+}
+
 /**
  * @internal
- * */
-const throttledLog = throttle((...t: Args) => {
-  console.log(...t);
+ */
+const throttledPush = throttle((name: string, id: string, args: Args) => {
+  pushDebugLog(name, id, args);
 }, 500);
 
 /**
@@ -32,8 +55,11 @@ export const createLogger = (name: string): Logger => {
       if (process.env.NODE_ENV === 'production' || process.env.NODE_ENV === 'test' || !loggingEnabled) {
         return;
       }
-      const fn = throttle ? throttledLog : console.log;
-      fn(`[${name}: ${id}]:`, ...t);
+      if (throttle) {
+        throttledPush(name, id, t);
+      } else {
+        pushDebugLog(name, id, t);
+      }
     },
     enable: () => (loggingEnabled = true),
     disable: () => (loggingEnabled = false),

--- a/packages/grafana-ui/src/utils/logger.ts
+++ b/packages/grafana-ui/src/utils/logger.ts
@@ -4,6 +4,28 @@ import { faro, LogLevel } from '@grafana/faro-web-sdk';
 
 type Args = Parameters<typeof console.log>;
 
+function emitFallbackDebugLine(name: string, id: string, args: Args) {
+  const line = JSON.stringify({
+    level: 'DEBUG',
+    source: `grafana-ui.createLogger.${name}`,
+    id,
+    timestamp: Date.now(),
+    ...(args.length > 0
+      ? {
+          details: (() => {
+            try {
+              return JSON.stringify(args);
+            } catch {
+              return String(args);
+            }
+          })(),
+        }
+      : {}),
+  });
+  // eslint-disable-next-line no-console
+  console.debug(line);
+}
+
 function pushDebugLog(name: string, id: string, args: Args) {
   const message = `[${name}: ${id}]`;
   const context =
@@ -23,6 +45,8 @@ function pushDebugLog(name: string, id: string, args: Args) {
       level: LogLevel.DEBUG,
       context,
     });
+  } else {
+    emitFallbackDebugLine(name, id, args);
   }
 }
 

--- a/packages/grafana-ui/src/utils/storybookStructuredLog.ts
+++ b/packages/grafana-ui/src/utils/storybookStructuredLog.ts
@@ -1,0 +1,15 @@
+/**
+ * Structured one-line logs for Storybook demos (avoid raw console.log).
+ */
+export function storyStructuredInfo(source: string, message: string, context?: Record<string, unknown>): void {
+  // eslint-disable-next-line no-console
+  console.info(
+    JSON.stringify({
+      level: 'INFO',
+      source,
+      message,
+      timestamp: Date.now(),
+      ...context,
+    })
+  );
+}

--- a/public/app/core/services/FetchQueue.ts
+++ b/public/app/core/services/FetchQueue.ts
@@ -1,6 +1,8 @@
 import { Observable, Subject } from 'rxjs';
 
-import { BackendSrvRequest } from '@grafana/runtime';
+import { BackendSrvRequest, createMonitoringLogger } from '@grafana/runtime';
+
+const fetchQueueLogger = createMonitoringLogger('core.FetchQueue');
 
 export interface QueueState extends Record<string, { state: FetchStatus; options: BackendSrvRequest }> {}
 
@@ -90,8 +92,10 @@ export class FetchQueue {
       []
     );
 
-    console.log('FetchQueue noOfStarted', update.noOfInProgress);
-    console.log('FetchQueue noOfNotStarted', update.noOfPending);
-    console.log('FetchQueue state', entriesWithoutOptions);
+    fetchQueueLogger.logDebug('FetchQueue update', {
+      noOfStarted: update.noOfInProgress,
+      noOfNotStarted: update.noOfPending,
+      state: entriesWithoutOptions,
+    });
   };
 }

--- a/public/app/core/services/backend_srv.ts
+++ b/public/app/core/services/backend_srv.ts
@@ -27,7 +27,14 @@ import {
 import { v4 as uuidv4 } from 'uuid';
 
 import { AppEvents, DataQueryErrorType, deprecationWarning } from '@grafana/data';
-import { BackendSrv as BackendService, BackendSrvRequest, config, FetchError, FetchResponse } from '@grafana/runtime';
+import {
+  BackendSrv as BackendService,
+  BackendSrvRequest,
+  config,
+  createMonitoringLogger,
+  FetchError,
+  FetchResponse,
+} from '@grafana/runtime';
 import { appEvents } from 'app/core/app_events';
 import { getConfig } from 'app/core/config';
 import { getSessionExpiry, hasSessionExpiry } from 'app/core/utils/auth';
@@ -61,6 +68,7 @@ export interface FolderRequestOptions {
 }
 
 const GRAFANA_TRACEID_HEADER = 'grafana-trace-id';
+const backendSrvStreamLogger = createMonitoringLogger('core.backendSrv');
 
 export interface InspectorStream {
   response: FetchResponse | FetchError;
@@ -235,7 +243,10 @@ export class BackendSrv implements BackendService {
             observer.complete();
           }) // runs in background
           .catch((e) => {
-            console.log(requestId, 'catch', e);
+            backendSrvStreamLogger.logError(e instanceof Error ? e : new Error(String(e)), {
+              requestId,
+              phase: 'streamRead',
+            });
             observer.error(e);
           }); // from abort
       },

--- a/public/app/core/services/echo/backends/analytics/BrowseConsoleBackend.ts
+++ b/public/app/core/services/echo/backends/analytics/BrowseConsoleBackend.ts
@@ -1,5 +1,5 @@
-/* eslint-disable no-console */
 import {
+  createMonitoringLogger,
   EchoBackend,
   EchoEventType,
   isExperimentViewEvent,
@@ -7,6 +7,8 @@ import {
   isPageviewEvent,
   PageviewEchoEvent,
 } from '@grafana/runtime';
+
+const browseConsoleLogger = createMonitoringLogger('EchoSrv.BrowseConsole');
 
 export class BrowserConsoleBackend implements EchoBackend<PageviewEchoEvent, unknown> {
   options = {};
@@ -16,12 +18,15 @@ export class BrowserConsoleBackend implements EchoBackend<PageviewEchoEvent, unk
 
   addEvent = (e: PageviewEchoEvent) => {
     if (isPageviewEvent(e)) {
-      console.log('[EchoSrv:pageview]', e.payload.page);
+      browseConsoleLogger.logInfo('Echo pageview', { page: e.payload.page });
     }
 
     if (isInteractionEvent(e)) {
       const eventName = e.payload.interactionName;
-      console.log('[EchoSrv:event]', eventName, e.payload.properties);
+      browseConsoleLogger.logInfo('Echo interaction', {
+        eventName,
+        properties: e.payload.properties,
+      });
 
       // Warn for non-scalar property values. We're not yet making this a hard a
       const invalidTypeProperties = Object.entries(e.payload.properties ?? {}).filter(([_, value]) => {
@@ -32,17 +37,18 @@ export class BrowserConsoleBackend implements EchoBackend<PageviewEchoEvent, unk
       });
 
       if (invalidTypeProperties.length > 0) {
-        console.warn(
-          'Event',
-          eventName,
-          'has invalid property types. Event properties should only be string, number or boolean. Invalid properties:',
-          Object.fromEntries(invalidTypeProperties)
+        browseConsoleLogger.logWarning(
+          'Event has invalid property types; properties should be string, number, boolean, or undefined',
+          {
+            eventName,
+            invalidProperties: Object.fromEntries(invalidTypeProperties),
+          }
         );
       }
     }
 
     if (isExperimentViewEvent(e)) {
-      console.log('[EchoSrv:experiment]', e.payload);
+      browseConsoleLogger.logInfo('Echo experiment view', { payload: e.payload });
     }
   };
 

--- a/public/app/core/utils/dag.ts
+++ b/public/app/core/utils/dag.ts
@@ -268,7 +268,17 @@ export const printGraph = (g: Graph) => {
     if (!inputEdges) {
       inputEdges = '<none>';
     }
-    console.log(`${n.name}:\n - links to:   ${outputEdges}\n - links from: ${inputEdges}`);
+    // eslint-disable-next-line no-console
+    console.info(
+      JSON.stringify({
+        level: 'INFO',
+        source: 'core.dag.printGraph',
+        node: n.name,
+        linksTo: outputEdges,
+        linksFrom: inputEdges,
+        timestamp: Date.now(),
+      })
+    );
   });
 };
 

--- a/public/app/core/utils/debugLog.ts
+++ b/public/app/core/utils/debugLog.ts
@@ -1,4 +1,5 @@
 import { store } from '@grafana/data';
+import { logDebug } from '@grafana/runtime';
 
 /**
  * Creates a debug logger gated by a localStorage key.
@@ -11,7 +12,7 @@ export function createDebugLog(key: string, prefix: string) {
 
   return function debugLog(message: string, ...args: unknown[]) {
     if (store.get(storageKey) === 'true') {
-      console.log(`[${prefix}] ${message}`, ...args);
+      logDebug(message, { source: `debug.${prefix}`, key, details: args });
     }
   };
 }

--- a/public/app/features/auth-config/FieldRenderer.tsx
+++ b/public/app/features/auth-config/FieldRenderer.tsx
@@ -3,7 +3,10 @@ import { useEffect, useState } from 'react';
 import { UseFormReturn, Controller } from 'react-hook-form';
 
 import { SelectableValue } from '@grafana/data';
+import { createMonitoringLogger } from '@grafana/runtime';
 import { Checkbox, Field, Input, SecretInput, Select, Switch, useTheme2 } from '@grafana/ui';
+
+const authConfigFieldLogger = createMonitoringLogger('features.auth-config.fieldRenderer');
 
 import { fieldMap } from './fields';
 import { SSOProviderDTO, SSOSettingsField } from './types';
@@ -78,7 +81,7 @@ export const FieldRenderer = ({
   }, [isDisabled, disabledWhen?.disabledValue, name, setValue]);
 
   if (!field) {
-    console.log('missing field:', name);
+    authConfigFieldLogger.logWarning('Missing SSO field definition', { name, provider });
     return null;
   }
 

--- a/public/app/features/auth-config/state/actions.ts
+++ b/public/app/features/auth-config/state/actions.ts
@@ -1,6 +1,8 @@
 import { lastValueFrom } from 'rxjs';
 
-import { getBackendSrv, isFetchError } from '@grafana/runtime';
+import { createMonitoringLogger, getBackendSrv, isFetchError } from '@grafana/runtime';
+
+const authConfigActionsLogger = createMonitoringLogger('features.auth-config.actions');
 import { contextSrv } from 'app/core/services/context_srv';
 import { AccessControlAction } from 'app/types/accessControl';
 import { Settings, UpdateSettingsQuery } from 'app/types/settings';
@@ -78,7 +80,10 @@ export function saveSettings(data: UpdateSettingsQuery): ThunkResult<Promise<boo
         dispatch(resetError());
         return true;
       } catch (error) {
-        console.log(error);
+        authConfigActionsLogger.logError(
+          error instanceof Error ? error : new Error('Failed to save admin settings'),
+          { phase: 'saveSettings' }
+        );
         if (isFetchError(error)) {
           error.isHandled = true;
           const updateErr: SettingsError = {

--- a/public/app/features/auth-config/state/actions.ts
+++ b/public/app/features/auth-config/state/actions.ts
@@ -1,8 +1,6 @@
 import { lastValueFrom } from 'rxjs';
 
 import { createMonitoringLogger, getBackendSrv, isFetchError } from '@grafana/runtime';
-
-const authConfigActionsLogger = createMonitoringLogger('features.auth-config.actions');
 import { contextSrv } from 'app/core/services/context_srv';
 import { AccessControlAction } from 'app/types/accessControl';
 import { Settings, UpdateSettingsQuery } from 'app/types/settings';
@@ -20,6 +18,8 @@ import {
   setError,
   settingsUpdated,
 } from './reducers';
+
+const authConfigActionsLogger = createMonitoringLogger('features.auth-config.actions');
 
 export function loadSettings(showSpinner = true): ThunkResult<Promise<Settings>> {
   return async (dispatch) => {
@@ -80,10 +80,9 @@ export function saveSettings(data: UpdateSettingsQuery): ThunkResult<Promise<boo
         dispatch(resetError());
         return true;
       } catch (error) {
-        authConfigActionsLogger.logError(
-          error instanceof Error ? error : new Error('Failed to save admin settings'),
-          { phase: 'saveSettings' }
-        );
+        authConfigActionsLogger.logError(error instanceof Error ? error : new Error('Failed to save admin settings'), {
+          phase: 'saveSettings',
+        });
         if (isFetchError(error)) {
           error.isHandled = true;
           const updateErr: SettingsError = {

--- a/public/app/features/canvas/runtime/frame.tsx
+++ b/public/app/features/canvas/runtime/frame.tsx
@@ -1,6 +1,9 @@
 import { cloneDeep } from 'lodash';
 
+import { createMonitoringLogger } from '@grafana/runtime';
 import { notFoundItem } from 'app/features/canvas/elements/notFound';
+
+const canvasFrameLogger = createMonitoringLogger('features.canvas.frame');
 import { DimensionContext } from 'app/features/dimensions/context';
 import { HorizontalConstraint, Placement, VerticalConstraint } from 'app/plugins/panel/canvas/panelcfg.gen';
 import { LayerActionID } from 'app/plugins/panel/canvas/types';
@@ -129,7 +132,7 @@ export class FrameState extends ElementState {
         break;
       case LayerActionID.Duplicate:
         if (element.item.id === 'frame') {
-          console.log('Can not duplicate frames (yet)', action, element);
+          canvasFrameLogger.logDebug('Cannot duplicate frames yet', { action, elementName: element.options.name });
           return;
         }
         const opts = cloneDeep(element.options);
@@ -239,7 +242,7 @@ export class FrameState extends ElementState {
         break;
 
       default:
-        console.log('DO action', action, element);
+        canvasFrameLogger.logDebug('Unhandled canvas layer action', { action, elementName: element.options.name });
         return;
     }
   };

--- a/public/app/features/canvas/runtime/frame.tsx
+++ b/public/app/features/canvas/runtime/frame.tsx
@@ -2,8 +2,6 @@ import { cloneDeep } from 'lodash';
 
 import { createMonitoringLogger } from '@grafana/runtime';
 import { notFoundItem } from 'app/features/canvas/elements/notFound';
-
-const canvasFrameLogger = createMonitoringLogger('features.canvas.frame');
 import { DimensionContext } from 'app/features/dimensions/context';
 import { HorizontalConstraint, Placement, VerticalConstraint } from 'app/plugins/panel/canvas/panelcfg.gen';
 import { LayerActionID } from 'app/plugins/panel/canvas/types';
@@ -17,6 +15,8 @@ import { ElementState } from './element';
 import { RootElement } from './root';
 import { Scene } from './scene';
 import { initMoveable } from './sceneAbleManagement';
+
+const canvasFrameLogger = createMonitoringLogger('features.canvas.frame');
 
 const DEFAULT_OFFSET = 10;
 const HORIZONTAL_OFFSET = 50;

--- a/public/app/features/dashboard-scene/inspect/HelpWizard/SupportSnapshotService.ts
+++ b/public/app/features/dashboard-scene/inspect/HelpWizard/SupportSnapshotService.ts
@@ -2,6 +2,7 @@ import saveAs from 'file-saver';
 
 import { dateTimeFormat, formattedValueToString, getValueFormat, SelectableValue } from '@grafana/data';
 import { t } from '@grafana/i18n';
+import { createMonitoringLogger } from '@grafana/runtime';
 import { sceneGraph, SceneObject, VizPanel } from '@grafana/scenes';
 import { StateManagerBase } from 'app/core/services/StateManagerBase';
 
@@ -9,6 +10,8 @@ import { transformSaveModelToScene } from '../../serialization/transformSaveMode
 
 import { Randomize } from './randomizer';
 import { getDebugDashboard, getGithubMarkdown } from './utils';
+
+const supportSnapshotSceneLogger = createMonitoringLogger('features.dashboard-scene.supportSnapshot');
 
 interface SupportSnapshotState {
   currentTab: SnapshotTab;
@@ -84,7 +87,10 @@ export class SupportSnapshotService extends StateManagerBase<SupportSnapshotStat
         const dash = transformSaveModelToScene({ dashboard: snapshot, meta: { isEmbedded: true } });
         scene = dash.state.body; // skip the wrappers
       } catch (ex) {
-        console.log('Error creating scene:', ex);
+        supportSnapshotSceneLogger.logError(
+          ex instanceof Error ? ex : new Error('Error creating scene from support snapshot'),
+          { phase: 'buildDebugDashboard' }
+        );
       }
     }
 

--- a/public/app/features/dashboard-scene/pages/DashboardScenePage.tsx
+++ b/public/app/features/dashboard-scene/pages/DashboardScenePage.tsx
@@ -3,7 +3,9 @@ import { Params, useParams } from 'react-router-dom-v5-compat';
 import { usePrevious } from 'react-use';
 
 import { PageLayoutType } from '@grafana/data';
-import { locationService } from '@grafana/runtime';
+import { createMonitoringLogger, locationService } from '@grafana/runtime';
+
+const dashboardScenePageLogger = createMonitoringLogger('features.dashboard-scene.page');
 import { UrlSyncContextProvider } from '@grafana/scenes';
 import { Box } from '@grafana/ui';
 import { Page } from 'app/core/components/Page/Page';
@@ -112,7 +114,7 @@ export function DashboardScenePage({ route, queryParams, location }: Props) {
   // A bit tricky for transition to or from Home dashboard that does not have a uid in the url (but could have it in the dashboard model)
   // if prevMatch is undefined we are going from normal route to home route or vice versa
   if (type !== 'snapshot' && (!prevMatch || uid !== prevMatch?.params.uid)) {
-    console.log('skipping rendering');
+    dashboardScenePageLogger.logDebug('Skipping render during dashboard transition', { uid, prevUid: prevMatch?.params.uid });
     return null;
   }
 

--- a/public/app/features/dashboard-scene/pages/DashboardScenePage.tsx
+++ b/public/app/features/dashboard-scene/pages/DashboardScenePage.tsx
@@ -4,8 +4,6 @@ import { usePrevious } from 'react-use';
 
 import { PageLayoutType } from '@grafana/data';
 import { createMonitoringLogger, locationService } from '@grafana/runtime';
-
-const dashboardScenePageLogger = createMonitoringLogger('features.dashboard-scene.page');
 import { UrlSyncContextProvider } from '@grafana/scenes';
 import { Box } from '@grafana/ui';
 import { Page } from 'app/core/components/Page/Page';
@@ -28,6 +26,8 @@ import { preserveDashboardSceneStateInLocalStorage } from '../utils/dashboardSes
 
 import { getDashboardScenePageStateManager } from './DashboardScenePageStateManager';
 import { shouldHideDashboardKioskFooter } from './utils';
+
+const dashboardScenePageLogger = createMonitoringLogger('features.dashboard-scene.page');
 
 export interface Props
   extends Omit<GrafanaRouteComponentProps<DashboardPageRouteParams, DashboardPageRouteSearchParams>, 'match'> {}
@@ -114,7 +114,10 @@ export function DashboardScenePage({ route, queryParams, location }: Props) {
   // A bit tricky for transition to or from Home dashboard that does not have a uid in the url (but could have it in the dashboard model)
   // if prevMatch is undefined we are going from normal route to home route or vice versa
   if (type !== 'snapshot' && (!prevMatch || uid !== prevMatch?.params.uid)) {
-    dashboardScenePageLogger.logDebug('Skipping render during dashboard transition', { uid, prevUid: prevMatch?.params.uid });
+    dashboardScenePageLogger.logDebug('Skipping render during dashboard transition', {
+      uid,
+      prevUid: prevMatch?.params.uid,
+    });
     return null;
   }
 

--- a/public/app/features/dashboard-scene/pages/DashboardScenePageStateManager.ts
+++ b/public/app/features/dashboard-scene/pages/DashboardScenePageStateManager.ts
@@ -808,7 +808,10 @@ export class DashboardScenePageStateManager extends DashboardScenePageStateManag
             ...locationService.getLocation(),
             pathname: dashboardUrl,
           });
-          dashboardScenePageStateLogger.logInfo('Correcting dashboard URL to match slug', { dashboardUrl, currentPath });
+          dashboardScenePageStateLogger.logInfo('Correcting dashboard URL to match slug', {
+            dashboardUrl,
+            currentPath,
+          });
         }
       }
 
@@ -1036,7 +1039,10 @@ export class DashboardScenePageStateManagerV2 extends DashboardScenePageStateMan
             ...locationService.getLocation(),
             pathname: dashboardUrl,
           });
-          dashboardScenePageStateLogger.logInfo('Correcting dashboard URL to match slug', { dashboardUrl, currentPath });
+          dashboardScenePageStateLogger.logInfo('Correcting dashboard URL to match slug', {
+            dashboardUrl,
+            currentPath,
+          });
         }
       }
       // Populate nav model in global store according to the folder

--- a/public/app/features/dashboard-scene/pages/DashboardScenePageStateManager.ts
+++ b/public/app/features/dashboard-scene/pages/DashboardScenePageStateManager.ts
@@ -1,6 +1,13 @@
 import { locationUtil, UrlQueryMap } from '@grafana/data';
 import { t } from '@grafana/i18n';
-import { config, getBackendSrv, getDataSourceSrv, isFetchError, locationService } from '@grafana/runtime';
+import {
+  config,
+  createMonitoringLogger,
+  getBackendSrv,
+  getDataSourceSrv,
+  isFetchError,
+  locationService,
+} from '@grafana/runtime';
 import { UserStorage } from '@grafana/runtime/internal';
 import { sceneGraph } from '@grafana/scenes';
 import { Spec as DashboardV2Spec, VariableKind, DashboardLink } from '@grafana/schema/apis/dashboard.grafana.app/v2';
@@ -77,6 +84,7 @@ export interface DashboardScenePageState {
 export const DASHBOARD_CACHE_TTL = 500;
 
 const LOAD_SCENE_MEASUREMENT = 'loadDashboardScene';
+const dashboardScenePageStateLogger = createMonitoringLogger('features.dashboard-scene.state');
 
 /** Only used by cache in loading home in DashboardPageProxy and initDashboard (Old arch), can remove this after old dashboard arch is gone */
 export const HOME_DASHBOARD_CACHE_KEY = '__grafana_home_uid__';
@@ -800,7 +808,7 @@ export class DashboardScenePageStateManager extends DashboardScenePageStateManag
             ...locationService.getLocation(),
             pathname: dashboardUrl,
           });
-          console.log('not correct url correcting', dashboardUrl, currentPath);
+          dashboardScenePageStateLogger.logInfo('Correcting dashboard URL to match slug', { dashboardUrl, currentPath });
         }
       }
 
@@ -1028,7 +1036,7 @@ export class DashboardScenePageStateManagerV2 extends DashboardScenePageStateMan
             ...locationService.getLocation(),
             pathname: dashboardUrl,
           });
-          console.log('not correct url correcting', dashboardUrl, currentPath);
+          dashboardScenePageStateLogger.logInfo('Correcting dashboard URL to match slug', { dashboardUrl, currentPath });
         }
       }
       // Populate nav model in global store according to the folder

--- a/public/app/features/dashboard-scene/settings/VersionsEditView.tsx
+++ b/public/app/features/dashboard-scene/settings/VersionsEditView.tsx
@@ -3,6 +3,7 @@ import * as React from 'react';
 import { useMemo } from 'react';
 
 import { PageLayoutType, dateTimeFormat, dateTimeFormatTimeAgo } from '@grafana/data';
+import { createMonitoringLogger } from '@grafana/runtime';
 import { Trans } from '@grafana/i18n';
 import { SceneComponentProps, SceneObjectBase, sceneGraph } from '@grafana/scenes';
 import { Alert, Spinner, Stack } from '@grafana/ui';
@@ -31,6 +32,8 @@ import { VersionsHistoryButtons } from './version-history/VersionHistoryButtons'
 import { VersionHistoryComparison } from './version-history/VersionHistoryComparison';
 import { VersionHistoryHeader } from './version-history/VersionHistoryHeader';
 import { VersionHistoryTable } from './version-history/VersionHistoryTable';
+
+const versionsEditViewLogger = createMonitoringLogger('features.dashboard-scene.versionsEdit');
 
 export interface VersionsEditViewState extends DashboardEditViewState {
   versions?: DecoratedRevisionModel[];
@@ -118,7 +121,11 @@ export class VersionsEditView extends SceneObjectBase<VersionsEditViewState> imp
         // Update the continueToken for the next request, if available
         this._continueToken = result.metadata.continue ?? '';
       })
-      .catch((err) => console.log(err))
+      .catch((err) =>
+        versionsEditViewLogger.logError(err instanceof Error ? err : new Error(String(err)), {
+          phase: 'listDashboardHistory',
+        })
+      )
       .finally(() => this.setState({ isAppending: false }));
   };
 

--- a/public/app/features/dashboard-scene/settings/VersionsEditView.tsx
+++ b/public/app/features/dashboard-scene/settings/VersionsEditView.tsx
@@ -3,8 +3,8 @@ import * as React from 'react';
 import { useMemo } from 'react';
 
 import { PageLayoutType, dateTimeFormat, dateTimeFormatTimeAgo } from '@grafana/data';
-import { createMonitoringLogger } from '@grafana/runtime';
 import { Trans } from '@grafana/i18n';
+import { createMonitoringLogger } from '@grafana/runtime';
 import { SceneComponentProps, SceneObjectBase, sceneGraph } from '@grafana/scenes';
 import { Alert, Spinner, Stack } from '@grafana/ui';
 import { useGetDisplayMappingQuery } from 'app/api/clients/iam/v0alpha1';

--- a/public/app/features/dashboard/components/DashboardSettings/VersionsSettings.tsx
+++ b/public/app/features/dashboard/components/DashboardSettings/VersionsSettings.tsx
@@ -1,7 +1,10 @@
 import { PureComponent } from 'react';
 import * as React from 'react';
 
+import { createMonitoringLogger } from '@grafana/runtime';
 import { Spinner, Stack } from '@grafana/ui';
+
+const versionsSettingsLogger = createMonitoringLogger('features.dashboard.versionsSettings');
 import { Page } from 'app/core/components/Page/Page';
 import { Resource } from 'app/features/apiserver/types';
 import { getDashboardAPI } from 'app/features/dashboard/api/dashboard_api';
@@ -69,7 +72,11 @@ export class VersionsSettings extends PureComponent<Props, State> {
         // Update the continueToken for the next request, if available
         this.continueToken = result.metadata.continue ?? '';
       })
-      .catch((err) => console.log(err))
+      .catch((err) =>
+        versionsSettingsLogger.logError(err instanceof Error ? err : new Error(String(err)), {
+          phase: 'listDashboardHistory',
+        })
+      )
       .finally(() => this.setState({ isAppending: false }));
   };
 

--- a/public/app/features/dashboard/components/DashboardSettings/VersionsSettings.tsx
+++ b/public/app/features/dashboard/components/DashboardSettings/VersionsSettings.tsx
@@ -3,8 +3,6 @@ import * as React from 'react';
 
 import { createMonitoringLogger } from '@grafana/runtime';
 import { Spinner, Stack } from '@grafana/ui';
-
-const versionsSettingsLogger = createMonitoringLogger('features.dashboard.versionsSettings');
 import { Page } from 'app/core/components/Page/Page';
 import { Resource } from 'app/features/apiserver/types';
 import { getDashboardAPI } from 'app/features/dashboard/api/dashboard_api';
@@ -20,6 +18,8 @@ import { VersionHistoryComparison } from '../VersionHistory/VersionHistoryCompar
 import { VersionHistoryTable } from '../VersionHistory/VersionHistoryTable';
 
 import { SettingsPageProps } from './types';
+
+const versionsSettingsLogger = createMonitoringLogger('features.dashboard.versionsSettings');
 
 interface Props extends SettingsPageProps {}
 

--- a/public/app/features/dashboard/components/HelpWizard/SupportSnapshotService.ts
+++ b/public/app/features/dashboard/components/HelpWizard/SupportSnapshotService.ts
@@ -2,6 +2,7 @@ import saveAs from 'file-saver';
 
 import { dateTimeFormat, formattedValueToString, getValueFormat, SelectableValue } from '@grafana/data';
 import { t } from '@grafana/i18n';
+import { createMonitoringLogger } from '@grafana/runtime';
 import { SceneObject } from '@grafana/scenes';
 import { StateManagerBase } from 'app/core/services/StateManagerBase';
 import { Randomize } from 'app/features/dashboard-scene/inspect/HelpWizard/randomizer';
@@ -12,6 +13,8 @@ import { DashboardModel } from '../../state/DashboardModel';
 import { PanelModel } from '../../state/PanelModel';
 
 import { getDebugDashboard, getGithubMarkdown } from './utils';
+
+const supportSnapshotLogger = createMonitoringLogger('features.dashboard.supportSnapshot');
 
 interface SupportSnapshotState {
   currentTab: SnapshotTab;
@@ -88,7 +91,10 @@ export class SupportSnapshotService extends StateManagerBase<SupportSnapshotStat
       const dash = createDashboardSceneFromDashboardModel(oldModel, snapshot);
       scene = dash.state.body; // skip the wrappers
     } catch (ex) {
-      console.log('Error creating scene:', ex);
+      supportSnapshotLogger.logError(
+        ex instanceof Error ? ex : new Error('Error creating scene from support snapshot'),
+        { phase: 'buildDebugDashboard' }
+      );
     }
 
     this.setState({ snapshot, snapshotText, markdownText, snapshotSize, snapshotUpdate: snapshotUpdate + 1, scene });

--- a/public/app/features/dashboard/dashgrid/DashboardGrid.tsx
+++ b/public/app/features/dashboard/dashgrid/DashboardGrid.tsx
@@ -4,7 +4,9 @@ import * as React from 'react';
 import ReactGridLayout, { ItemCallback } from 'react-grid-layout';
 import { Subscription } from 'rxjs';
 
-import { config } from '@grafana/runtime';
+import { config, createMonitoringLogger } from '@grafana/runtime';
+
+const dashboardGridLogger = createMonitoringLogger('features.dashboard.DashboardGrid');
 import { appEvents } from 'app/core/app_events';
 import { GRID_CELL_HEIGHT, GRID_CELL_VMARGIN, GRID_COLUMN_COUNT } from 'app/core/constants';
 import { contextSrv } from 'app/core/services/context_srv';
@@ -115,7 +117,7 @@ export class DashboardGrid extends PureComponent<Props, State> {
       this.panelMap[panel.key] = panel;
 
       if (!panel.gridPos) {
-        console.log('panel without gridpos');
+        dashboardGridLogger.logWarning('Panel without gridPos skipped', { panelId: panel.id, panelType: panel.type });
         continue;
       }
 

--- a/public/app/features/dashboard/dashgrid/DashboardGrid.tsx
+++ b/public/app/features/dashboard/dashgrid/DashboardGrid.tsx
@@ -5,8 +5,6 @@ import ReactGridLayout, { ItemCallback } from 'react-grid-layout';
 import { Subscription } from 'rxjs';
 
 import { config, createMonitoringLogger } from '@grafana/runtime';
-
-const dashboardGridLogger = createMonitoringLogger('features.dashboard.DashboardGrid');
 import { appEvents } from 'app/core/app_events';
 import { GRID_CELL_HEIGHT, GRID_CELL_VMARGIN, GRID_COLUMN_COUNT } from 'app/core/constants';
 import { contextSrv } from 'app/core/services/context_srv';
@@ -20,6 +18,8 @@ import { GridPos, PanelModel } from '../state/PanelModel';
 
 import DashboardEmpty from './DashboardEmpty/DashboardEmpty';
 import { DashboardPanel } from './DashboardPanel';
+
+const dashboardGridLogger = createMonitoringLogger('features.dashboard.DashboardGrid');
 
 export const PANEL_FILTER_VARIABLE = 'systemPanelFilterVar';
 

--- a/public/app/features/dashboard/dashgrid/PanelStateWrapper.tsx
+++ b/public/app/features/dashboard/dashgrid/PanelStateWrapper.tsx
@@ -23,7 +23,9 @@ import {
   toDataFrameDTO,
   toUtc,
 } from '@grafana/data';
-import { RefreshEvent } from '@grafana/runtime';
+import { createMonitoringLogger, RefreshEvent } from '@grafana/runtime';
+
+const panelStateWrapperLogger = createMonitoringLogger('features.dashboard.PanelStateWrapper');
 import { VizLegendOptions } from '@grafana/schema';
 import {
   ErrorBoundary,
@@ -257,7 +259,7 @@ export class PanelStateWrapper extends PureComponent<Props, State> {
       const delta = liveTime.to.valueOf() - data.timeRange.to.valueOf();
       if (delta < 100) {
         // 10hz
-        console.log('Skip tick render', this.props.panel.title, delta);
+        panelStateWrapperLogger.logDebug('Skip tick render', { panelTitle: this.props.panel.title, delta });
         return;
       }
     }

--- a/public/app/features/dashboard/dashgrid/PanelStateWrapper.tsx
+++ b/public/app/features/dashboard/dashgrid/PanelStateWrapper.tsx
@@ -24,8 +24,6 @@ import {
   toUtc,
 } from '@grafana/data';
 import { createMonitoringLogger, RefreshEvent } from '@grafana/runtime';
-
-const panelStateWrapperLogger = createMonitoringLogger('features.dashboard.PanelStateWrapper');
 import { VizLegendOptions } from '@grafana/schema';
 import {
   ErrorBoundary,
@@ -58,6 +56,8 @@ import { PanelLoadTimeMonitor } from './PanelLoadTimeMonitor';
 import { seriesVisibilityConfigFactory } from './SeriesVisibilityConfigFactory';
 import { liveTimer } from './liveTimer';
 import { PanelOptionsLogger } from './panelOptionsLogger';
+
+const panelStateWrapperLogger = createMonitoringLogger('features.dashboard.PanelStateWrapper');
 
 const DEFAULT_PLUGIN_ERROR = 'Error in plugin';
 

--- a/public/app/features/dashboard/services/performanceUtils.ts
+++ b/public/app/features/dashboard/services/performanceUtils.ts
@@ -1,5 +1,4 @@
 import { store } from '@grafana/data';
-import { logDebug } from '@grafana/runtime';
 import { performanceUtils, writePerformanceLog } from '@grafana/scenes';
 
 /**
@@ -85,7 +84,18 @@ export function writePerformanceGroupStart(logger: string, message: string): voi
  */
 export function writePerformanceGroupLog(logger: string, message: string, data?: unknown): void {
   if (isPerformanceLoggingEnabled()) {
-    logDebug(message, { source: 'sceneProfiling', logger, data });
+    // Keep lines inside console.group* visible in all envs (logDebug is dev-only without Faro).
+    // eslint-disable-next-line no-console
+    console.info(
+      JSON.stringify({
+        level: 'DEBUG',
+        source: 'sceneProfiling',
+        logger,
+        message,
+        data,
+        timestamp: Date.now(),
+      })
+    );
   }
 }
 

--- a/public/app/features/dashboard/services/performanceUtils.ts
+++ b/public/app/features/dashboard/services/performanceUtils.ts
@@ -1,4 +1,5 @@
 import { store } from '@grafana/data';
+import { logDebug } from '@grafana/runtime';
 import { performanceUtils, writePerformanceLog } from '@grafana/scenes';
 
 /**
@@ -84,13 +85,7 @@ export function writePerformanceGroupStart(logger: string, message: string): voi
  */
 export function writePerformanceGroupLog(logger: string, message: string, data?: unknown): void {
   if (isPerformanceLoggingEnabled()) {
-    if (data) {
-      // eslint-disable-next-line no-console
-      console.log(message, data);
-    } else {
-      // eslint-disable-next-line no-console
-      console.log(message);
-    }
+    logDebug(message, { source: 'sceneProfiling', logger, data });
   }
 }
 

--- a/public/app/features/dashboard/state/DashboardModel.ts
+++ b/public/app/features/dashboard/state/DashboardModel.ts
@@ -18,7 +18,7 @@ import {
   UrlQueryValue,
 } from '@grafana/data';
 import { PromQuery } from '@grafana/prometheus';
-import { RefreshEvent, TimeRangeUpdatedEvent } from '@grafana/runtime';
+import { RefreshEvent, TimeRangeUpdatedEvent, createMonitoringLogger } from '@grafana/runtime';
 import { Dashboard, DashboardLink, VariableModel } from '@grafana/schema';
 import { DEFAULT_ANNOTATION_COLOR } from '@grafana/ui';
 import { GRID_CELL_HEIGHT, GRID_CELL_VMARGIN, GRID_COLUMN_COUNT, REPEAT_DIR_VERTICAL } from 'app/core/constants';
@@ -36,6 +36,8 @@ import {
 } from 'app/types/events';
 
 import { appEvents } from '../../../core/app_events';
+
+const dashboardModelLogger = createMonitoringLogger('features.dashboard.DashboardModel');
 import { dispatch } from '../../../store/store';
 import {
   VariablesChanged,
@@ -1119,13 +1121,13 @@ export class DashboardModel implements TimeModel {
 
   /** @deprecated */
   on<T>(event: AppEvent<T>, callback: (payload?: T) => void) {
-    console.log('DashboardModel.on is deprecated use events.subscribe');
+    dashboardModelLogger.logWarning('DashboardModel.on is deprecated; use events.subscribe');
     this.events.on(event, callback);
   }
 
   /** @deprecated */
   off<T>(event: AppEvent<T>, callback: (payload?: T) => void) {
-    console.log('DashboardModel.off is deprecated');
+    dashboardModelLogger.logWarning('DashboardModel.off is deprecated');
     this.events.off(event, callback);
   }
 

--- a/public/app/features/dashboard/state/DashboardModel.ts
+++ b/public/app/features/dashboard/state/DashboardModel.ts
@@ -36,8 +36,6 @@ import {
 } from 'app/types/events';
 
 import { appEvents } from '../../../core/app_events';
-
-const dashboardModelLogger = createMonitoringLogger('features.dashboard.DashboardModel');
 import { dispatch } from '../../../store/store';
 import {
   VariablesChanged,
@@ -53,6 +51,8 @@ import { DashboardMigrator } from './DashboardMigrator';
 import { PanelModel } from './PanelModel';
 import { TimeModel } from './TimeModel';
 import { deleteScopeVars, isOnTheSameGridRow } from './utils';
+
+const dashboardModelLogger = createMonitoringLogger('features.dashboard.DashboardModel');
 
 export interface CloneOptions {
   saveVariables?: boolean;

--- a/public/app/features/dashboard/state/initDashboard.ts
+++ b/public/app/features/dashboard/state/initDashboard.ts
@@ -1,6 +1,6 @@
 import { DataQuery, locationUtil, setWeekStart, DashboardLoadedEvent, store } from '@grafana/data';
 import { t } from '@grafana/i18n';
-import { config, isFetchError, locationService } from '@grafana/runtime';
+import { config, createMonitoringLogger, isFetchError, locationService } from '@grafana/runtime';
 import { appEvents } from 'app/core/app_events';
 import { createErrorNotification } from 'app/core/copy/appNotification';
 import { notifyApp } from 'app/core/reducers/appNotification';
@@ -41,6 +41,7 @@ import { emitDashboardViewEvent } from './analyticsProcessor';
 import { dashboardInitCompleted, dashboardInitFailed, dashboardInitFetching, dashboardInitServices } from './reducers';
 
 const INIT_DASHBOARD_MEASUREMENT = 'initDashboard';
+const initDashboardLogger = createMonitoringLogger('features.dashboard.init');
 
 export interface InitDashboardArgs {
   urlUid?: string;
@@ -109,7 +110,7 @@ async function fetchDashboard(
               ...locationService.getLocation(),
               pathname: dashboardUrl,
             });
-            console.log('not correct url correcting', dashboardUrl, currentPath);
+            initDashboardLogger.logInfo('Correcting dashboard URL to match slug', { dashboardUrl, currentPath });
           }
         }
         return dashDTO;

--- a/public/app/features/explore/TraceView/components/CriticalPath/index.tsx
+++ b/public/app/features/explore/TraceView/components/CriticalPath/index.tsx
@@ -13,15 +13,16 @@
 // limitations under the License.
 
 import memoizeOne from 'memoize-one';
+
 import { createMonitoringLogger } from '@grafana/runtime';
 
 import { TraceSpan, CriticalPathSection, Trace } from '../types/trace';
 
-const criticalPathLogger = createMonitoringLogger('features.explore.traceView.criticalPath');
-
 import findLastFinishingChildSpan from './utils/findLastFinishingChildSpan';
 import getChildOfSpans from './utils/getChildOfSpans';
 import sanitizeOverFlowingChildren from './utils/sanitizeOverFlowingChildren';
+
+const criticalPathLogger = createMonitoringLogger('features.explore.traceView.criticalPath');
 
 /**
  * Computes the critical path sections of a Jaeger trace.

--- a/public/app/features/explore/TraceView/components/CriticalPath/index.tsx
+++ b/public/app/features/explore/TraceView/components/CriticalPath/index.tsx
@@ -13,8 +13,11 @@
 // limitations under the License.
 
 import memoizeOne from 'memoize-one';
+import { createMonitoringLogger } from '@grafana/runtime';
 
 import { TraceSpan, CriticalPathSection, Trace } from '../types/trace';
+
+const criticalPathLogger = createMonitoringLogger('features.explore.traceView.criticalPath');
 
 import findLastFinishingChildSpan from './utils/findLastFinishingChildSpan';
 import getChildOfSpans from './utils/getChildOfSpans';
@@ -103,8 +106,9 @@ function criticalPathForTrace(trace: Trace) {
       const sanitizedSpanMap = sanitizeOverFlowingChildren(refinedSpanMap);
       criticalPath = computeCriticalPath(sanitizedSpanMap, rootSpanId, criticalPath);
     } catch (error) {
-      /* eslint-disable no-console */
-      console.log('error while computing critical path for a trace', error);
+      criticalPathLogger.logError(
+        error instanceof Error ? error : new Error('error while computing critical path for a trace')
+      );
     }
   }
   return criticalPath;

--- a/public/app/features/explore/state/query.ts
+++ b/public/app/features/explore/state/query.ts
@@ -21,8 +21,6 @@ import {
 } from '@grafana/data';
 import { combinePanelData } from '@grafana/o11y-ds-frontend';
 import { config, createMonitoringLogger, getDataSourceSrv } from '@grafana/runtime';
-
-const exploreQueryLogger = createMonitoringLogger('features.explore.query');
 import { DataQuery } from '@grafana/schema';
 import { notifyApp } from 'app/core/reducers/appNotification';
 import {
@@ -66,6 +64,8 @@ import { addHistoryItem, loadRichHistory } from './history';
 import { changeCorrelationEditorDetails } from './main';
 import { updateTime } from './time';
 import { createCacheKey, filterLogRowsByIndex, getCorrelationsData, getResultsFromCache } from './utils';
+
+const exploreQueryLogger = createMonitoringLogger('features.explore.query');
 
 /**
  * Derives from explore state if a given Explore pane is waiting for more data to be received

--- a/public/app/features/explore/state/query.ts
+++ b/public/app/features/explore/state/query.ts
@@ -20,7 +20,9 @@ import {
   SupplementaryQueryType,
 } from '@grafana/data';
 import { combinePanelData } from '@grafana/o11y-ds-frontend';
-import { config, getDataSourceSrv } from '@grafana/runtime';
+import { config, createMonitoringLogger, getDataSourceSrv } from '@grafana/runtime';
+
+const exploreQueryLogger = createMonitoringLogger('features.explore.query');
 import { DataQuery } from '@grafana/schema';
 import { notifyApp } from 'app/core/reducers/appNotification';
 import {
@@ -657,7 +659,10 @@ export const runQueries = createAsyncThunk<void, RunQueriesOptions>(
 
           // Keep scanning for results if this was the last scanning transaction
           if (exploreState!.scanning) {
-            console.log(data.series);
+            exploreQueryLogger.logDebug('Explore scan query result', {
+              seriesCount: data.series.length,
+              state: data.state,
+            });
             if (data.state === LoadingState.Done && data.series.length === 0) {
               const range = getShiftedTimeRange(-1, exploreState!.range);
               dispatch(updateTime({ exploreId, absoluteRange: range }));

--- a/public/app/features/live/centrifuge/LiveDataStream.ts
+++ b/public/app/features/live/centrifuge/LiveDataStream.ts
@@ -13,9 +13,17 @@ import {
   StreamingDataFrame,
 } from '@grafana/data';
 import { getStreamingFrameOptions } from '@grafana/data/internal';
-import { LiveDataStreamOptions, StreamingFrameAction, StreamingFrameOptions, toDataQueryError } from '@grafana/runtime';
+import {
+  createMonitoringLogger,
+  LiveDataStreamOptions,
+  StreamingFrameAction,
+  StreamingFrameOptions,
+  toDataQueryError,
+} from '@grafana/runtime';
 
 import { StreamingResponseDataType } from '../data/utils';
+
+const liveDataStreamLogger = createMonitoringLogger('features.live.LiveDataStream');
 
 import { DataStreamSubscriptionKey, StreamingDataQueryResponse } from './service';
 
@@ -149,7 +157,10 @@ export class LiveDataStream<T = unknown> {
   };
 
   private onError = (err: unknown) => {
-    console.log('LiveQuery [error]', { err }, this.deps.channelId);
+    liveDataStreamLogger.logError(err instanceof Error ? err : new Error(String(err)), {
+      phase: 'LiveQuery',
+      channelId: this.deps.channelId,
+    });
     this.stream.next({
       type: InternalStreamMessageType.Error,
       error: toDataQueryError(err),
@@ -158,7 +169,7 @@ export class LiveDataStream<T = unknown> {
   };
 
   private onComplete = () => {
-    console.log('LiveQuery [complete]', this.deps.channelId);
+    liveDataStreamLogger.logDebug('LiveQuery complete', { channelId: this.deps.channelId });
     this.shutdown();
   };
 

--- a/public/app/features/live/centrifuge/channel.ts
+++ b/public/app/features/live/centrifuge/channel.ts
@@ -19,6 +19,9 @@ import {
   DataFrameJSON,
   isValidLiveChannelAddress,
 } from '@grafana/data';
+import { createMonitoringLogger } from '@grafana/runtime';
+
+const centrifugeChannelLogger = createMonitoringLogger('features.live.centrifuge.channel');
 
 /**
  * Internal class that maps Centrifuge support to GrafanaLive
@@ -81,7 +84,10 @@ export class CentrifugeLiveChannel<T = any> {
           this.sendStatus();
         }
       } catch (err) {
-        console.log('publish error', this.addr, err);
+        centrifugeChannelLogger.logError(err instanceof Error ? err : new Error(String(err)), {
+          phase: 'publication',
+          addr: this.addr,
+        });
         this.currentStatus.error = err;
         this.currentStatus.timestamp = Date.now();
         this.sendStatus();

--- a/public/app/features/live/centrifuge/service.ts
+++ b/public/app/features/live/centrifuge/service.ts
@@ -27,9 +27,12 @@ import {
   StreamingFrameOptions,
   BackendDataSourceResponse,
   getBackendSrv,
+  createMonitoringLogger,
 } from '@grafana/runtime';
 
 import { StreamingResponseData } from '../data/utils';
+
+const centrifugeServiceLogger = createMonitoringLogger('features.live.centrifuge.service');
 
 import { LiveDataStream } from './LiveDataStream';
 import { CentrifugeLiveChannel } from './channel';
@@ -125,7 +128,10 @@ export class CentrifugeService implements CentrifugeSrv {
   };
 
   private onServerSideMessage = (context: ServerPublicationContext) => {
-    console.log('Publication from server-side channel', context);
+    centrifugeServiceLogger.logDebug('Publication from server-side channel', {
+      channel: context.channel,
+      offset: context.offset,
+    });
   };
 
   private onError = (context: ErrorContext) => {

--- a/public/app/features/live/dashboard/dashboardWatcher.ts
+++ b/public/app/features/live/dashboard/dashboardWatcher.ts
@@ -11,8 +11,6 @@ import {
   LiveChannelScope,
 } from '@grafana/data';
 import { createMonitoringLogger, getGrafanaLiveSrv, locationService } from '@grafana/runtime';
-
-const dashboardWatcherLogger = createMonitoringLogger('features.live.dashboardWatcher');
 import { appEvents } from 'app/core/app_events';
 import { contextSrv } from 'app/core/services/context_srv';
 
@@ -21,6 +19,8 @@ import { getDashboardSrv } from '../../dashboard/services/DashboardSrv';
 
 import { DashboardChangedModal } from './DashboardChangedModal';
 import { DashboardEvent, DashboardEventAction } from './types';
+
+const dashboardWatcherLogger = createMonitoringLogger('features.live.dashboardWatcher');
 
 // sessionId is not a security-sensitive value.
 // It is used for filtering out dashboard edit events from the same browsing session

--- a/public/app/features/live/dashboard/dashboardWatcher.ts
+++ b/public/app/features/live/dashboard/dashboardWatcher.ts
@@ -10,7 +10,9 @@ import {
   LiveChannelEvent,
   LiveChannelScope,
 } from '@grafana/data';
-import { getGrafanaLiveSrv, locationService } from '@grafana/runtime';
+import { createMonitoringLogger, getGrafanaLiveSrv, locationService } from '@grafana/runtime';
+
+const dashboardWatcherLogger = createMonitoringLogger('features.live.dashboardWatcher');
 import { appEvents } from 'app/core/app_events';
 import { contextSrv } from 'app/core/services/context_srv';
 
@@ -127,7 +129,10 @@ class DashboardWatcher {
 
             const dash = getDashboardSrv().getCurrent();
             if (dash?.uid !== event.message.uid) {
-              console.log('dashboard event for different dashboard?', event, dash);
+              dashboardWatcherLogger.logDebug('Ignoring dashboard live event for non-current dashboard', {
+                eventUid: event.message.uid,
+                currentUid: dash?.uid,
+              });
               return;
             }
 

--- a/public/app/features/panel/panellinks/linkSuppliers.ts
+++ b/public/app/features/panel/panellinks/linkSuppliers.ts
@@ -13,13 +13,13 @@ import {
 } from '@grafana/data';
 import { t } from '@grafana/i18n';
 import { createMonitoringLogger } from '@grafana/runtime';
-
-const linkSuppliersLogger = createMonitoringLogger('features.panel.linkSuppliers');
 import { VizPanel } from '@grafana/scenes';
 import { PanelModel } from 'app/features/dashboard/state/PanelModel';
 import { dashboardSceneGraph } from 'app/features/dashboard-scene/utils/dashboardSceneGraph';
 
 import { getLinkSrv } from './link_srv';
+
+const linkSuppliersLogger = createMonitoringLogger('features.panel.linkSuppliers');
 
 interface SeriesVars {
   name?: string;

--- a/public/app/features/panel/panellinks/linkSuppliers.ts
+++ b/public/app/features/panel/panellinks/linkSuppliers.ts
@@ -12,6 +12,9 @@ import {
   ScopedVars,
 } from '@grafana/data';
 import { t } from '@grafana/i18n';
+import { createMonitoringLogger } from '@grafana/runtime';
+
+const linkSuppliersLogger = createMonitoringLogger('features.panel.linkSuppliers');
 import { VizPanel } from '@grafana/scenes';
 import { PanelModel } from 'app/features/dashboard/state/PanelModel';
 import { dashboardSceneGraph } from 'app/features/dashboard-scene/utils/dashboardSceneGraph';
@@ -124,7 +127,10 @@ export const getFieldLinksSupplier = (value: FieldDisplay): LinkModelSupplier<Fi
           };
         }
       } else {
-        console.log('VALUE', value);
+        linkSuppliersLogger.logDebug('Field link supplier missing view context', {
+          hasColIndex: value.colIndex !== undefined,
+          fieldName: value.name,
+        });
       }
 
       const replace: InterpolateFunction = (value: string, vars: ScopedVars | undefined, fmt?: string | Function) => {

--- a/public/app/features/panel/state/actions.ts
+++ b/public/app/features/panel/state/actions.ts
@@ -1,7 +1,5 @@
 import { DataTransformerConfig, FieldConfigSource, getPanelOptionsWithDefaults } from '@grafana/data';
 import { createMonitoringLogger } from '@grafana/runtime';
-
-const panelStateLogger = createMonitoringLogger('features.panel.state');
 import { PanelModel } from 'app/features/dashboard/state/PanelModel';
 import { getLibraryPanel } from 'app/features/library-panels/state/api';
 import { LibraryElementDTO } from 'app/features/library-panels/types';
@@ -11,6 +9,8 @@ import { DashboardPanelsChangedEvent, PanelOptionsChangedEvent, PanelQueriesChan
 import { ThunkResult } from 'app/types/store';
 
 import { changePanelKey, panelModelAndPluginReady, removePanel } from './reducers';
+
+const panelStateLogger = createMonitoringLogger('features.panel.state');
 
 export function initPanelState(panel: PanelModel): ThunkResult<Promise<void>> {
   return async (dispatch, getStore) => {

--- a/public/app/features/panel/state/actions.ts
+++ b/public/app/features/panel/state/actions.ts
@@ -1,4 +1,7 @@
 import { DataTransformerConfig, FieldConfigSource, getPanelOptionsWithDefaults } from '@grafana/data';
+import { createMonitoringLogger } from '@grafana/runtime';
+
+const panelStateLogger = createMonitoringLogger('features.panel.state');
 import { PanelModel } from 'app/features/dashboard/state/PanelModel';
 import { getLibraryPanel } from 'app/features/library-panels/state/api';
 import { LibraryElementDTO } from 'app/features/library-panels/types';
@@ -165,7 +168,7 @@ export function loadLibraryPanelAndUpdate(panel: PanelModel): ThunkResult<void> 
 
       await dispatch(initPanelState(panel));
     } catch (ex) {
-      console.log('ERROR: ', ex);
+      panelStateLogger.logError(ex instanceof Error ? ex : new Error('Failed to load library panel'), { uid });
       dispatch(
         panelModelAndPluginReady({
           key: panel.key,

--- a/public/app/features/plugins/admin/state/actions.ts
+++ b/public/app/features/plugins/admin/state/actions.ts
@@ -3,8 +3,6 @@ import { from, forkJoin, timeout, lastValueFrom, catchError, of } from 'rxjs';
 
 import { PanelPlugin, PluginError } from '@grafana/data';
 import { config, createMonitoringLogger, getBackendSrv, isFetchError } from '@grafana/runtime';
-
-const pluginAdminActionsLogger = createMonitoringLogger('features.plugins.admin.actions');
 import { refetchPanelPluginMetas } from '@grafana/runtime/internal';
 import { importPanelPlugin } from 'app/features/plugins/importPanelPlugin';
 import { StoreState, ThunkResult } from 'app/types/store';
@@ -24,6 +22,8 @@ import {
 import { STATE_PREFIX } from '../constants';
 import { mapLocalToCatalog, mergeLocalsAndRemotes } from '../helpers';
 import { CatalogPlugin, RemotePlugin, LocalPlugin, InstancePlugin, ProvisionedPlugin, PluginStatus } from '../types';
+
+const pluginAdminActionsLogger = createMonitoringLogger('features.plugins.admin.actions');
 
 // Fetches
 export const fetchAll = createAsyncThunk(`${STATE_PREFIX}/fetchAll`, async (_, thunkApi) => {
@@ -116,10 +116,9 @@ export const fetchAll = createAsyncThunk(`${STATE_PREFIX}/fetchAll`, async (_, t
           }
         },
         (error) => {
-          pluginAdminActionsLogger.logError(
-            error instanceof Error ? error : new Error('Plugin catalog fetch failed'),
-            { phase: 'fetchAll' }
-          );
+          pluginAdminActionsLogger.logError(error instanceof Error ? error : new Error('Plugin catalog fetch failed'), {
+            phase: 'fetchAll',
+          });
           thunkApi.dispatch({ type: `${STATE_PREFIX}/fetchLocal/rejected` });
           thunkApi.dispatch({ type: `${STATE_PREFIX}/fetchRemote/rejected` });
           return thunkApi.rejectWithValue('Unknown error.');

--- a/public/app/features/plugins/admin/state/actions.ts
+++ b/public/app/features/plugins/admin/state/actions.ts
@@ -2,7 +2,9 @@ import { createAction, createAsyncThunk, Update } from '@reduxjs/toolkit';
 import { from, forkJoin, timeout, lastValueFrom, catchError, of } from 'rxjs';
 
 import { PanelPlugin, PluginError } from '@grafana/data';
-import { config, getBackendSrv, isFetchError } from '@grafana/runtime';
+import { config, createMonitoringLogger, getBackendSrv, isFetchError } from '@grafana/runtime';
+
+const pluginAdminActionsLogger = createMonitoringLogger('features.plugins.admin.actions');
 import { refetchPanelPluginMetas } from '@grafana/runtime/internal';
 import { importPanelPlugin } from 'app/features/plugins/importPanelPlugin';
 import { StoreState, ThunkResult } from 'app/types/store';
@@ -114,7 +116,10 @@ export const fetchAll = createAsyncThunk(`${STATE_PREFIX}/fetchAll`, async (_, t
           }
         },
         (error) => {
-          console.log(error);
+          pluginAdminActionsLogger.logError(
+            error instanceof Error ? error : new Error('Plugin catalog fetch failed'),
+            { phase: 'fetchAll' }
+          );
           thunkApi.dispatch({ type: `${STATE_PREFIX}/fetchLocal/rejected` });
           thunkApi.dispatch({ type: `${STATE_PREFIX}/fetchRemote/rejected` });
           return thunkApi.rejectWithValue('Unknown error.');

--- a/public/app/features/plugins/loader/pluginLoader.mock.ts
+++ b/public/app/features/plugins/loader/pluginLoader.mock.ts
@@ -17,7 +17,6 @@ export const mockSystemModule = `System.register(['./dependencyA'], function (_e
 
 export const mockAmdModule = `define([], function() {
   return function() {
-    console.log('AMD module loaded');
     var pluginPath = "/public/plugins/";
   }
 });`;

--- a/public/app/features/plugins/loader/utils.ts
+++ b/public/app/features/plugins/loader/utils.ts
@@ -1,4 +1,6 @@
-import { config } from '@grafana/runtime';
+import { config, createMonitoringLogger } from '@grafana/runtime';
+
+const pluginLoaderUtilsLogger = createMonitoringLogger('features.plugins.loader.utils');
 
 import { sandboxPluginDependencies } from '../sandbox/pluginDependencies';
 
@@ -29,7 +31,7 @@ function addPreload(id: string, preload: (() => Promise<System.Module>) | System
   try {
     resolvedId = SystemJS.resolve(id);
   } catch (e) {
-    console.log(e);
+    pluginLoaderUtilsLogger.logError(e instanceof Error ? e : new Error(String(e)), { phase: 'SystemJS.resolve', id });
   }
 
   if (resolvedId && SystemJS.has(resolvedId)) {

--- a/public/app/features/plugins/sandbox/distortions.ts
+++ b/public/app/features/plugins/sandbox/distortions.ts
@@ -2,6 +2,7 @@ import { ProxyTarget } from '@locker/near-membrane-shared';
 import DOMPurify from 'dompurify';
 import { cloneDeep, isFunction } from 'lodash';
 
+import { createMonitoringLogger } from '@grafana/runtime';
 import { Monaco } from '@grafana/ui';
 
 import { loadScriptIntoSandbox } from './codeLoader';
@@ -68,6 +69,7 @@ type DistortionMap = Map<
 const generalDistortionMap: DistortionMap = new Map();
 
 const SANDBOX_LIVE_API_PATCHED = Symbol.for('@SANDBOX_LIVE_API_PATCHED');
+const sandboxPluginConsoleLogger = createMonitoringLogger('sandbox.pluginConsole');
 
 export function getGeneralSandboxDistortionMap() {
   if (generalDistortionMap.size === 0) {
@@ -140,7 +142,7 @@ function distortConsole(distortions: DistortionMap) {
       const pluginId = meta.id;
 
       function sandboxLog(...args: unknown[]) {
-        console.log(`[plugin ${pluginId}]`, ...args);
+        sandboxPluginConsoleLogger.logDebug('Sandboxed plugin console output', { pluginId, args });
       }
       return {
         log: sandboxLog,
@@ -170,7 +172,7 @@ function distortAlert(distortions: DistortionMap) {
     });
 
     return function (...args: unknown[]) {
-      console.log(`[plugin ${pluginId}]`, ...args);
+      sandboxPluginConsoleLogger.logDebug('Sandboxed plugin alert output', { pluginId, args });
     };
   }
   const descriptor = Object.getOwnPropertyDescriptor(window, 'alert');

--- a/public/app/features/search/service/unified.ts
+++ b/public/app/features/search/service/unified.ts
@@ -8,7 +8,9 @@ import {
 } from '@grafana/api-clients/rtkq/dashboard/v0alpha1';
 import { arrayToDataFrame, DataFrame, DataFrameView, getDisplayProcessor, SelectableValue } from '@grafana/data';
 import { t } from '@grafana/i18n';
-import { config, getBackendSrv } from '@grafana/runtime';
+import { config, createMonitoringLogger, getBackendSrv } from '@grafana/runtime';
+
+const unifiedSearchLogger = createMonitoringLogger('features.search.unified');
 import { generatedAPI, ListStarsApiResponse } from 'app/api/clients/collections/v1alpha1';
 import { getAPIBaseURL } from 'app/api/utils';
 import { TermCount } from 'app/core/components/TagFilter/TagFilter';
@@ -203,7 +205,7 @@ export class UnifiedSearcher implements GrafanaSearcher {
         const resp = await this.fetchResponse(nextPageUrl);
         const frame = toDashboardResults(resp, query.sort ?? '');
         if (!frame) {
-          console.log('no results', frame);
+          unifiedSearchLogger.logDebug('Search pagination returned no frame', { offset, nextPageUrl });
           return;
         }
 

--- a/public/app/features/search/service/unified.ts
+++ b/public/app/features/search/service/unified.ts
@@ -9,8 +9,6 @@ import {
 import { arrayToDataFrame, DataFrame, DataFrameView, getDisplayProcessor, SelectableValue } from '@grafana/data';
 import { t } from '@grafana/i18n';
 import { config, createMonitoringLogger, getBackendSrv } from '@grafana/runtime';
-
-const unifiedSearchLogger = createMonitoringLogger('features.search.unified');
 import { generatedAPI, ListStarsApiResponse } from 'app/api/clients/collections/v1alpha1';
 import { getAPIBaseURL } from 'app/api/utils';
 import { TermCount } from 'app/core/components/TagFilter/TagFilter';
@@ -32,6 +30,8 @@ import { appendFrame, filterSearchResults, replaceCurrentFolderQuery } from './u
 // The backend returns an empty frame with a special name to indicate that the indexing engine is being rebuilt,
 // and that it can not serve any search requests. We are temporarily using the old SQL Search API as a fallback when that happens.
 const loadingFrameName = 'Loading';
+
+const unifiedSearchLogger = createMonitoringLogger('features.search.unified');
 
 const searchURI = `${v0alphaBaseURL}/search`;
 

--- a/public/app/features/templating/LegacyVariableWrapper.ts
+++ b/public/app/features/templating/LegacyVariableWrapper.ts
@@ -1,10 +1,10 @@
 import { createMonitoringLogger } from '@grafana/runtime';
 import { VariableValue, FormatVariable } from '@grafana/scenes';
-
-const legacyVariableLogger = createMonitoringLogger('features.templating.legacyVariable');
 import { VariableModel, VariableType } from '@grafana/schema';
 
 import { ALL_VARIABLE_TEXT, ALL_VARIABLE_VALUE } from '../variables/constants';
+
+const legacyVariableLogger = createMonitoringLogger('features.templating.legacyVariable');
 
 export class LegacyVariableWrapper implements FormatVariable {
   state: { name: string; value: VariableValue; text: VariableValue; type: VariableType };

--- a/public/app/features/templating/LegacyVariableWrapper.ts
+++ b/public/app/features/templating/LegacyVariableWrapper.ts
@@ -1,4 +1,7 @@
+import { createMonitoringLogger } from '@grafana/runtime';
 import { VariableValue, FormatVariable } from '@grafana/scenes';
+
+const legacyVariableLogger = createMonitoringLogger('features.templating.legacyVariable');
 import { VariableModel, VariableType } from '@grafana/schema';
 
 import { ALL_VARIABLE_TEXT, ALL_VARIABLE_VALUE } from '../variables/constants';
@@ -31,7 +34,7 @@ export class LegacyVariableWrapper implements FormatVariable {
       return text.join(' + ');
     }
 
-    console.log('value', text);
+    legacyVariableLogger.logDebug('Legacy variable text has unexpected shape', { text, typeofText: typeof text });
     return String(text);
   }
 }

--- a/public/app/features/transformers/spatial/SpatialTransformerEditor.tsx
+++ b/public/app/features/transformers/spatial/SpatialTransformerEditor.tsx
@@ -12,6 +12,7 @@ import {
   TransformerCategory,
 } from '@grafana/data';
 import { t } from '@grafana/i18n';
+import { createMonitoringLogger } from '@grafana/runtime';
 import { FrameGeometrySourceMode } from '@grafana/schema';
 import { useTheme2 } from '@grafana/ui';
 import { addLocationFields } from 'app/features/geo/editor/locationEditor';
@@ -23,6 +24,8 @@ import lightImage from '../images/light/spatial.svg';
 import { SpatialCalculation, SpatialOperation, SpatialAction, SpatialTransformOptions } from './models.gen';
 import { getDefaultOptions, getTransformerOptionPane } from './optionsHelper';
 import { isLineBuilderOption, getSpatialTransformer } from './spatialTransformer';
+
+const spatialTransformerEditorLogger = createMonitoringLogger('features.transformers.spatial');
 
 // Nothing defined in state
 const supplier = (
@@ -138,7 +141,7 @@ export const SetGeometryTransformerEditor = (props: Props) => {
     if (!props.options.source?.mode) {
       const opts = getDefaultOptions(supplier);
       props.onChange({ ...opts, ...props.options });
-      console.log('geometry useEffect', opts);
+      spatialTransformerEditorLogger.logDebug('Initialized default spatial geometry options', { opts });
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);

--- a/public/app/plugins/datasource/elasticsearch/components/QueryEditor/index.tsx
+++ b/public/app/plugins/datasource/elasticsearch/components/QueryEditor/index.tsx
@@ -3,7 +3,9 @@ import { useCallback, useEffect, useId, useRef, useState } from 'react';
 import { SemVer } from 'semver';
 
 import { getDefaultTimeRange, GrafanaTheme2, QueryEditorProps } from '@grafana/data';
-import { config } from '@grafana/runtime';
+import { config, createMonitoringLogger } from '@grafana/runtime';
+
+const elasticQueryEditorLogger = createMonitoringLogger('plugins.datasource.elasticsearch.queryEditor');
 import { Alert, ConfirmModal, InlineField, InlineLabel, Input, QueryField, useStyles2 } from '@grafana/ui';
 
 import { ElasticsearchDataQuery, QueryType } from '../../dataquery.gen';
@@ -41,8 +43,9 @@ function useElasticVersion(datasource: ElasticDatasourceLike): SemVer | null {
         }
       },
       (error) => {
-        // we do nothing
-        console.log(error);
+        elasticQueryEditorLogger.logWarning('Could not load Elasticsearch database version', {
+          message: error instanceof Error ? error.message : String(error),
+        });
       }
     );
 

--- a/public/app/plugins/datasource/elasticsearch/components/QueryEditor/index.tsx
+++ b/public/app/plugins/datasource/elasticsearch/components/QueryEditor/index.tsx
@@ -4,8 +4,6 @@ import { SemVer } from 'semver';
 
 import { getDefaultTimeRange, GrafanaTheme2, QueryEditorProps } from '@grafana/data';
 import { config, createMonitoringLogger } from '@grafana/runtime';
-
-const elasticQueryEditorLogger = createMonitoringLogger('plugins.datasource.elasticsearch.queryEditor');
 import { Alert, ConfirmModal, InlineField, InlineLabel, Input, QueryField, useStyles2 } from '@grafana/ui';
 
 import { ElasticsearchDataQuery, QueryType } from '../../dataquery.gen';
@@ -23,6 +21,8 @@ import { MetricAggregationsEditor } from './MetricAggregationsEditor';
 import { metricAggregationConfig } from './MetricAggregationsEditor/utils';
 import { QueryTypeSelector } from './QueryTypeSelector';
 import { changeAliasPattern, changeEditorTypeAndResetQuery, changeQuery } from './state';
+
+const elasticQueryEditorLogger = createMonitoringLogger('plugins.datasource.elasticsearch.queryEditor');
 
 export type ElasticQueryEditorProps = QueryEditorProps<
   ElasticDatasourceLike,

--- a/public/app/plugins/datasource/elasticsearch/components/reducerTester.ts
+++ b/public/app/plugins/datasource/elasticsearch/components/reducerTester.ts
@@ -82,7 +82,20 @@ export const reducerTester = <State>(): Given<State> => {
 
   const thenStateShouldEqual = (state: State): When<State> => {
     if (showDebugOutput) {
-      console.log(JSON.stringify(resultingState, null, 2));
+      // eslint-disable-next-line no-console
+      console.info(
+        JSON.stringify(
+          {
+            level: 'DEBUG',
+            source: 'test.elasticsearch.reducerTester',
+            message: 'resultingState',
+            state: resultingState,
+            timestamp: Date.now(),
+          },
+          null,
+          2
+        )
+      );
     }
     expect(resultingState).toEqual(state);
 
@@ -91,7 +104,20 @@ export const reducerTester = <State>(): Given<State> => {
 
   const thenStatePredicateShouldEqual = (predicate: (resultingState: State) => boolean): When<State> => {
     if (showDebugOutput) {
-      console.log(JSON.stringify(resultingState, null, 2));
+      // eslint-disable-next-line no-console
+      console.info(
+        JSON.stringify(
+          {
+            level: 'DEBUG',
+            source: 'test.elasticsearch.reducerTester',
+            message: 'resultingState',
+            state: resultingState,
+            timestamp: Date.now(),
+          },
+          null,
+          2
+        )
+      );
     }
     expect(predicate(resultingState)).toBe(true);
 

--- a/public/app/plugins/datasource/grafana-testdata-datasource/components/RawFrameEditor.tsx
+++ b/public/app/plugins/datasource/grafana-testdata-datasource/components/RawFrameEditor.tsx
@@ -2,7 +2,9 @@ import { isArray } from 'lodash';
 import { useState } from 'react';
 
 import { dataFrameToJSON, toDataFrame, toDataFrameDTO } from '@grafana/data';
-import { toDataQueryResponse } from '@grafana/runtime';
+import { createMonitoringLogger, toDataQueryResponse } from '@grafana/runtime';
+
+const rawFrameEditorLogger = createMonitoringLogger('plugins.datasource.testdata.rawFrameEditor');
 import { Alert, CodeEditor } from '@grafana/ui';
 
 import { EditorProps } from '../QueryEditor';
@@ -35,8 +37,7 @@ export const RawFrameEditor = ({ onChange, query }: EditorProps) => {
       }
 
       if (data) {
-        console.log('Original', json);
-        console.log('Save', data);
+        rawFrameEditorLogger.logDebug('Converted raw frame JSON', { originalKeys: Object.keys(json as object), frameCount: data.length });
         setError(undefined);
         setWarning('Converted to direct frame result');
         onChange({ ...query, rawFrameContent: JSON.stringify(data, null, 2) });
@@ -45,7 +46,7 @@ export const RawFrameEditor = ({ onChange, query }: EditorProps) => {
 
       setError('Unable to read dataframes in text');
     } catch (e) {
-      console.log('Error parsing json', e);
+      rawFrameEditorLogger.logError(e instanceof Error ? e : new Error('Error parsing raw frame JSON'));
       setError('Enter JSON array of data frames (or raw query results body)');
       setWarning(undefined);
     }

--- a/public/app/plugins/datasource/grafana-testdata-datasource/components/RawFrameEditor.tsx
+++ b/public/app/plugins/datasource/grafana-testdata-datasource/components/RawFrameEditor.tsx
@@ -3,11 +3,11 @@ import { useState } from 'react';
 
 import { dataFrameToJSON, toDataFrame, toDataFrameDTO } from '@grafana/data';
 import { createMonitoringLogger, toDataQueryResponse } from '@grafana/runtime';
-
-const rawFrameEditorLogger = createMonitoringLogger('plugins.datasource.testdata.rawFrameEditor');
 import { Alert, CodeEditor } from '@grafana/ui';
 
 import { EditorProps } from '../QueryEditor';
+
+const rawFrameEditorLogger = createMonitoringLogger('plugins.datasource.testdata.rawFrameEditor');
 
 export const RawFrameEditor = ({ onChange, query }: EditorProps) => {
   const [error, setError] = useState<string>();
@@ -37,7 +37,10 @@ export const RawFrameEditor = ({ onChange, query }: EditorProps) => {
       }
 
       if (data) {
-        rawFrameEditorLogger.logDebug('Converted raw frame JSON', { originalKeys: Object.keys(json as object), frameCount: data.length });
+        rawFrameEditorLogger.logDebug('Converted raw frame JSON', {
+          originalKeys: json !== null && typeof json === 'object' && !Array.isArray(json) ? Object.keys(json) : [],
+          frameCount: data.length,
+        });
         setError(undefined);
         setWarning('Converted to direct frame result');
         onChange({ ...query, rawFrameContent: JSON.stringify(data, null, 2) });

--- a/public/app/plugins/datasource/grafana-testdata-datasource/runStreams.ts
+++ b/public/app/plugins/datasource/grafana-testdata-datasource/runStreams.ts
@@ -18,10 +18,12 @@ import {
   getDisplayProcessor,
   createTheme,
 } from '@grafana/data';
-import { getBackendSrv } from '@grafana/runtime';
+import { createMonitoringLogger, getBackendSrv } from '@grafana/runtime';
 
 import { getRandomLine } from './LogIpsum';
 import { TestDataDataQuery, StreamingQuery } from './dataquery';
+
+const testdataStreamLogger = createMonitoringLogger('plugins.datasource.testdata.runStreams');
 
 export const defaultStreamQuery: StreamingQuery = {
   type: 'signal',
@@ -125,7 +127,7 @@ export function runSignalStream(
     setTimeout(pushNextEvent, 5);
 
     return () => {
-      console.log('unsubscribing to stream ' + streamId);
+      testdataStreamLogger.logDebug('Unsubscribing from testdata stream', { streamId });
       clearTimeout(timeoutId);
     };
   });
@@ -171,7 +173,7 @@ export function runLogsStream(
     setTimeout(pushNextEvent, 5);
 
     return () => {
-      console.log('unsubscribing to stream ' + streamId);
+      testdataStreamLogger.logDebug('Unsubscribing from testdata stream', { streamId });
       clearTimeout(timeoutId);
     };
   });
@@ -254,7 +256,7 @@ export function runWatchStream(
       });
 
     return () => {
-      console.log('unsubscribing to stream', streamId);
+      testdataStreamLogger.logDebug('Unsubscribing from testdata stream', { streamId });
       sub.unsubscribe();
     };
   });
@@ -314,7 +316,7 @@ export function runFetchStream(
       });
 
       if (value.done) {
-        console.log('Finished stream');
+        testdataStreamLogger.logDebug('Finished testdata stream');
         subscriber.complete(); // necessary?
         return;
       }
@@ -335,7 +337,7 @@ export function runFetchStream(
 
     return () => {
       // Cancel fetch?
-      console.log('unsubscribing to stream ' + streamId);
+      testdataStreamLogger.logDebug('Unsubscribing from testdata stream', { streamId });
     };
   });
 }
@@ -368,7 +370,7 @@ export function runTracesStream(
     setTimeout(pushNextEvent, 5);
 
     return () => {
-      console.log('unsubscribing to stream ' + streamId);
+      testdataStreamLogger.logDebug('Unsubscribing from testdata stream', { streamId });
       clearTimeout(timeoutId);
     };
   });

--- a/public/app/plugins/datasource/loki/components/monaco-query-field/getOverrideServices.ts
+++ b/public/app/plugins/datasource/loki/components/monaco-query-field/getOverrideServices.ts
@@ -1,4 +1,7 @@
+import { createMonitoringLogger } from '@grafana/runtime';
 import { monacoTypes } from '@grafana/ui';
+
+const lokiMonacoStorageLogger = createMonitoringLogger('plugins.loki.monacoStorage');
 
 // this thing here is a workaround in a way.
 // what we want to achieve, is that when the autocomplete-window
@@ -81,7 +84,7 @@ function makeStorageService() {
     },
 
     logStorage: (): void => {
-      console.log('logStorage: not implemented');
+      lokiMonacoStorageLogger.logDebug('Monaco logStorage not implemented');
     },
 
     migrate: (): Promise<void> => {

--- a/public/app/plugins/datasource/loki/metricTimeSplitting.test.ts
+++ b/public/app/plugins/datasource/loki/metricTimeSplitting.test.ts
@@ -81,7 +81,17 @@ describe('logs splitTimeRangeAligned', () => {
     const timeRange = makeTimeRange(toUtc('2022-02-01T08:10:03.234Z'), toUtc('2022-02-01T20:10:03.234Z'));
     const result = splitTimeRangeAligned(timeRange, 200);
 
-    console.log(toUtc(result[0][0]).toISOString(), toUtc(result[0][1]).toISOString());
+    // eslint-disable-next-line no-console
+    console.info(
+      JSON.stringify({
+        level: 'DEBUG',
+        source: 'test.loki.metricTimeSplitting',
+        message: 'splitTimeRangeAligned first window',
+        from: toUtc(result[0][0]).toISOString(),
+        to: toUtc(result[0][1]).toISOString(),
+        timestamp: Date.now(),
+      })
+    );
 
     expect(result).toStrictEqual([[Date.parse('2022-02-01T08:10:03.234Z'), Date.parse('2022-02-01T20:10:03.234Z')]]);
   });

--- a/public/app/plugins/datasource/loki/shardQuerySplitting.ts
+++ b/public/app/plugins/datasource/loki/shardQuerySplitting.ts
@@ -3,7 +3,7 @@ import { Observable, Subscriber, Subscription } from 'rxjs';
 import { v4 as uuidv4 } from 'uuid';
 
 import { DataQueryRequest, DataQueryResponse, LoadingState, QueryResultMetaStat } from '@grafana/data';
-import { config } from '@grafana/runtime';
+import { config, createMonitoringLogger } from '@grafana/runtime';
 
 import { LokiDatasource } from './datasource';
 import { combineResponses, replaceResponses } from './mergeResponses';
@@ -371,9 +371,10 @@ function getInitialGroupSize(shards: number[]) {
 
 // Enable to output debugging logs
 const DEBUG_ENABLED = Boolean(localStorage.getItem(`loki.sharding_debug_enabled`));
+const lokiShardingDebugLogger = createMonitoringLogger('plugins.datasource.loki.shardQuerySplitting');
 function debug(message: string) {
   if (!DEBUG_ENABLED) {
     return;
   }
-  console.log(message);
+  lokiShardingDebugLogger.logDebug(message);
 }

--- a/public/app/plugins/panel/canvas/components/connections/Connections.tsx
+++ b/public/app/plugins/panel/canvas/components/connections/Connections.tsx
@@ -1,7 +1,9 @@
 import * as React from 'react';
 import { BehaviorSubject } from 'rxjs';
 
-import { config } from '@grafana/runtime';
+import { config, createMonitoringLogger } from '@grafana/runtime';
+
+const canvasConnectionsLogger = createMonitoringLogger('plugins.panel.canvas.connections');
 import { CanvasConnection, ConnectionCoordinates, ConnectionPath } from 'app/features/canvas/element';
 import { ElementState } from 'app/features/canvas/runtime/element';
 import { Scene } from 'app/features/canvas/runtime/scene';
@@ -131,7 +133,7 @@ export class Connections {
     let element: ElementState | undefined = this.findElementTarget(event.target);
 
     if (!element) {
-      console.log('no element');
+      canvasConnectionsLogger.logDebug('Canvas connection hover: no element under cursor');
       return;
     }
 
@@ -140,7 +142,7 @@ export class Connections {
     } else {
       this.connectionSource = element;
       if (!this.connectionSource) {
-        console.log('no connection source');
+        canvasConnectionsLogger.logDebug('Canvas connection hover: no connection source');
         return;
       }
     }

--- a/public/app/plugins/panel/canvas/components/connections/Connections.tsx
+++ b/public/app/plugins/panel/canvas/components/connections/Connections.tsx
@@ -2,8 +2,6 @@ import * as React from 'react';
 import { BehaviorSubject } from 'rxjs';
 
 import { config, createMonitoringLogger } from '@grafana/runtime';
-
-const canvasConnectionsLogger = createMonitoringLogger('plugins.panel.canvas.connections');
 import { CanvasConnection, ConnectionCoordinates, ConnectionPath } from 'app/features/canvas/element';
 import { ElementState } from 'app/features/canvas/runtime/element';
 import { Scene } from 'app/features/canvas/runtime/scene';
@@ -33,6 +31,8 @@ export const CONNECTION_VERTEX_ID = 'vertex';
 export const CONNECTION_VERTEX_ADD_ID = 'vertexAdd';
 const CONNECTION_VERTEX_ORTHO_TOLERANCE = 0.05; // Cartesian ratio against vertical or horizontal tolerance
 const CONNECTION_VERTEX_SNAP_TOLERANCE = (5 / 180) * Math.PI; // Multi-segment snapping angle in radians to trigger vertex removal
+
+const canvasConnectionsLogger = createMonitoringLogger('plugins.panel.canvas.connections');
 
 export class Connections {
   scene: Scene;

--- a/public/app/plugins/panel/canvas/components/connections/Connections2.tsx
+++ b/public/app/plugins/panel/canvas/components/connections/Connections2.tsx
@@ -2,8 +2,6 @@ import * as React from 'react';
 import { BehaviorSubject } from 'rxjs';
 
 import { config, createMonitoringLogger } from '@grafana/runtime';
-
-const canvasConnections2Logger = createMonitoringLogger('plugins.panel.canvas.connections2');
 import { CanvasConnection, ConnectionCoordinates, ConnectionPath } from 'app/features/canvas/element';
 import { ElementState } from 'app/features/canvas/runtime/element';
 import { Scene } from 'app/features/canvas/runtime/scene';
@@ -35,6 +33,8 @@ export const CONNECTION_VERTEX_ID = 'vertex';
 export const CONNECTION_VERTEX_ADD_ID = 'vertexAdd';
 const CONNECTION_VERTEX_ORTHO_TOLERANCE = 0.05; // Cartesian ratio against vertical or horizontal tolerance
 const CONNECTION_VERTEX_SNAP_TOLERANCE = (5 / 180) * Math.PI; // Multi-segment snapping angle in radians to trigger vertex removal
+
+const canvasConnections2Logger = createMonitoringLogger('plugins.panel.canvas.connections2');
 
 export class Connections2 {
   scene: Scene;

--- a/public/app/plugins/panel/canvas/components/connections/Connections2.tsx
+++ b/public/app/plugins/panel/canvas/components/connections/Connections2.tsx
@@ -1,7 +1,9 @@
 import * as React from 'react';
 import { BehaviorSubject } from 'rxjs';
 
-import { config } from '@grafana/runtime';
+import { config, createMonitoringLogger } from '@grafana/runtime';
+
+const canvasConnections2Logger = createMonitoringLogger('plugins.panel.canvas.connections2');
 import { CanvasConnection, ConnectionCoordinates, ConnectionPath } from 'app/features/canvas/element';
 import { ElementState } from 'app/features/canvas/runtime/element';
 import { Scene } from 'app/features/canvas/runtime/scene';
@@ -126,7 +128,7 @@ export class Connections2 {
     let element: ElementState | undefined = this.findElementTarget(event.target);
 
     if (!element) {
-      console.log('no element');
+      canvasConnections2Logger.logDebug('Canvas connection hover: no element under cursor');
       return;
     }
 
@@ -135,7 +137,7 @@ export class Connections2 {
     } else {
       this.connectionSource = element;
       if (!this.connectionSource) {
-        console.log('no connection source');
+        canvasConnections2Logger.logDebug('Canvas connection hover: no connection source');
         return;
       }
     }

--- a/public/app/plugins/panel/live/LivePanel.tsx
+++ b/public/app/plugins/panel/live/LivePanel.tsx
@@ -176,8 +176,10 @@ export class LivePanel extends PureComponent<Props, State> {
             },
           }),
           state: LoadingState.Streaming,
+          timeRange: this.props.timeRange,
         };
-        const props = {
+        // TablePanel expects PanelProps<table Options>; use untyped PanelProps so spread stays valid.
+        const props: PanelProps = {
           ...this.props,
           options: { frameIndex: 0, showHeader: true },
         };

--- a/public/app/plugins/panel/live/LivePanel.tsx
+++ b/public/app/plugins/panel/live/LivePanel.tsx
@@ -19,7 +19,9 @@ import {
   StreamingDataFrame,
 } from '@grafana/data';
 import { Trans, t } from '@grafana/i18n';
-import { config, getGrafanaLiveSrv } from '@grafana/runtime';
+import { config, createMonitoringLogger, getGrafanaLiveSrv } from '@grafana/runtime';
+
+const livePanelLogger = createMonitoringLogger('plugins.panel.live');
 import { Alert, stylesFactory, JSONFormatter, CustomScrollbar } from '@grafana/ui';
 
 import { TablePanel } from '../table/TablePanel';
@@ -72,7 +74,7 @@ export class LivePanel extends PureComponent<Props, State> {
       } else if (isLiveChannelMessageEvent(event)) {
         this.setState({ message: event.message, changed: Date.now() });
       } else {
-        console.log('ignore', event);
+        livePanelLogger.logDebug('Ignoring unknown live channel event', { eventType: (event as { type?: string }).type });
       }
     },
   };
@@ -87,7 +89,7 @@ export class LivePanel extends PureComponent<Props, State> {
   async loadChannel() {
     const addr = this.props.options?.channel;
     if (!isValidLiveChannelAddress(addr)) {
-      console.log('INVALID', addr);
+      livePanelLogger.logWarning('Invalid live channel address', { addr });
       this.unsubscribe();
       this.setState({
         addr: undefined,
@@ -96,13 +98,13 @@ export class LivePanel extends PureComponent<Props, State> {
     }
 
     if (isEqual(addr, this.state.addr)) {
-      console.log('Same channel', this.state.addr);
+      livePanelLogger.logDebug('Live channel unchanged; skip reload', { addr });
       return;
     }
 
     const live = getGrafanaLiveSrv();
     if (!live) {
-      console.log('INVALID', addr);
+      livePanelLogger.logWarning('Grafana Live not available', { addr });
       this.unsubscribe();
       this.setState({
         addr: undefined,
@@ -111,7 +113,7 @@ export class LivePanel extends PureComponent<Props, State> {
     }
     this.unsubscribe();
 
-    console.log('LOAD', addr);
+    livePanelLogger.logDebug('Subscribing to live channel', { addr });
 
     // Subscribe to new events
     try {

--- a/public/app/plugins/panel/live/LivePanel.tsx
+++ b/public/app/plugins/panel/live/LivePanel.tsx
@@ -20,14 +20,14 @@ import {
 } from '@grafana/data';
 import { Trans, t } from '@grafana/i18n';
 import { config, createMonitoringLogger, getGrafanaLiveSrv } from '@grafana/runtime';
-
-const livePanelLogger = createMonitoringLogger('plugins.panel.live');
 import { Alert, stylesFactory, JSONFormatter, CustomScrollbar } from '@grafana/ui';
 
 import { TablePanel } from '../table/TablePanel';
 
 import { LivePublish } from './LivePublish';
 import { LivePanelOptions, MessageDisplayMode, MessagePublishMode } from './types';
+
+const livePanelLogger = createMonitoringLogger('plugins.panel.live');
 
 interface Props extends PanelProps<LivePanelOptions> {}
 
@@ -74,7 +74,11 @@ export class LivePanel extends PureComponent<Props, State> {
       } else if (isLiveChannelMessageEvent(event)) {
         this.setState({ message: event.message, changed: Date.now() });
       } else {
-        livePanelLogger.logDebug('Ignoring unknown live channel event', { eventType: (event as { type?: string }).type });
+        const eventType =
+          typeof event === 'object' && event !== null && 'type' in event
+            ? String(Object.getOwnPropertyDescriptor(event, 'type')?.value)
+            : undefined;
+        livePanelLogger.logDebug('Ignoring unknown live channel event', { eventType });
       }
     },
   };
@@ -172,8 +176,8 @@ export class LivePanel extends PureComponent<Props, State> {
             },
           }),
           state: LoadingState.Streaming,
-        } as PanelData;
-        const props: PanelProps = {
+        };
+        const props = {
           ...this.props,
           options: { frameIndex: 0, showHeader: true },
         };

--- a/public/app/plugins/panel/live/LivePublish.tsx
+++ b/public/app/plugins/panel/live/LivePublish.tsx
@@ -3,11 +3,11 @@ import { useMemo } from 'react';
 import { LiveChannelAddress, isValidLiveChannelAddress } from '@grafana/data';
 import { Trans } from '@grafana/i18n';
 import { createMonitoringLogger, getBackendSrv, getGrafanaLiveSrv } from '@grafana/runtime';
-
-const livePublishLogger = createMonitoringLogger('plugins.panel.live.publish');
 import { CodeEditor, Button } from '@grafana/ui';
 
 import { MessagePublishMode } from './types';
+
+const livePublishLogger = createMonitoringLogger('plugins.panel.live.publish');
 
 interface Props {
   height: number;

--- a/public/app/plugins/panel/live/LivePublish.tsx
+++ b/public/app/plugins/panel/live/LivePublish.tsx
@@ -2,7 +2,9 @@ import { useMemo } from 'react';
 
 import { LiveChannelAddress, isValidLiveChannelAddress } from '@grafana/data';
 import { Trans } from '@grafana/i18n';
-import { getBackendSrv, getGrafanaLiveSrv } from '@grafana/runtime';
+import { createMonitoringLogger, getBackendSrv, getGrafanaLiveSrv } from '@grafana/runtime';
+
+const livePublishLogger = createMonitoringLogger('plugins.panel.live.publish');
 import { CodeEditor, Button } from '@grafana/ui';
 
 import { MessagePublishMode } from './types';
@@ -46,7 +48,7 @@ export function LivePublish({ height, mode, body, addr, onSave }: Props) {
     }
 
     const rsp = await getGrafanaLiveSrv().publish(addr, body);
-    console.log('onPublishClicked (response from publish)', rsp);
+    livePublishLogger.logDebug('Live publish response', { response: rsp });
   };
 
   return (

--- a/public/app/plugins/panel/table/migrations.ts
+++ b/public/app/plugins/panel/table/migrations.ts
@@ -12,8 +12,11 @@ import {
   ByNamesMatcherMode,
 } from '@grafana/data';
 import { ReduceTransformerOptions } from '@grafana/data/internal';
+import { createMonitoringLogger } from '@grafana/runtime';
 
 import { Options } from './panelcfg.gen';
+
+const tableMigrationLogger = createMonitoringLogger('plugins.panel.table.migrations');
 
 /**
  * At 7.0, the `table` panel was swapped from an angular implementation to a react one.
@@ -23,7 +26,7 @@ import { Options } from './panelcfg.gen';
 export const tableMigrationHandler = (panel: PanelModel<Options>): Partial<Options> => {
   // Table was saved as an angular table, lets just swap to the 'table-old' panel
   if (!panel.pluginVersion && 'columns' in panel) {
-    console.log('Was angular table', panel);
+    tableMigrationLogger.logDebug('Angular table panel detected for migration', { panelId: panel.id, title: panel.title });
   }
 
   // ensure overrides array exists before applying rest of overrides

--- a/public/app/plugins/panel/table/migrations.ts
+++ b/public/app/plugins/panel/table/migrations.ts
@@ -26,7 +26,10 @@ const tableMigrationLogger = createMonitoringLogger('plugins.panel.table.migrati
 export const tableMigrationHandler = (panel: PanelModel<Options>): Partial<Options> => {
   // Table was saved as an angular table, lets just swap to the 'table-old' panel
   if (!panel.pluginVersion && 'columns' in panel) {
-    tableMigrationLogger.logDebug('Angular table panel detected for migration', { panelId: panel.id, title: panel.title });
+    tableMigrationLogger.logDebug('Angular table panel detected for migration', {
+      panelId: panel.id,
+      title: panel.title,
+    });
   }
 
   // ensure overrides array exists before applying rest of overrides

--- a/public/app/plugins/panel/timeseries/migrations.ts
+++ b/public/app/plugins/panel/timeseries/migrations.ts
@@ -16,6 +16,7 @@ import {
   Threshold,
   ThresholdsMode,
 } from '@grafana/data';
+import { createMonitoringLogger } from '@grafana/runtime';
 import {
   LegendDisplayMode,
   TooltipDisplayMode,
@@ -44,6 +45,8 @@ import { GrafanaQuery, GrafanaQueryType } from 'app/plugins/datasource/grafana/t
 
 import { defaultGraphConfig } from './config';
 import { Options } from './panelcfg.gen';
+
+const timeseriesMigrationLogger = createMonitoringLogger('plugins.panel.timeseries.migrations');
 
 let dashboardRefreshDebouncer: ReturnType<typeof setTimeout> | null = null;
 
@@ -283,7 +286,11 @@ export function graphToTimeseriesOptions(angular: any): {
             });
             break;
           default:
-            console.log('Ignore override migration:', seriesOverride.alias, p, v);
+            timeseriesMigrationLogger.logDebug('Ignoring unknown override migration key', {
+              alias: seriesOverride.alias,
+              property: p,
+              value: v,
+            });
         }
       }
       if (dashOverride) {

--- a/public/swagger/K8sNameLookup.tsx
+++ b/public/swagger/K8sNameLookup.tsx
@@ -1,7 +1,10 @@
 import { useEffect, useState } from 'react';
 
 import { SelectableValue } from '@grafana/data';
+import { createMonitoringLogger } from '@grafana/runtime';
 import { Select } from '@grafana/ui';
+
+const k8sNameLookupLogger = createMonitoringLogger('swagger.k8sNameLookup');
 
 import { NamespaceContext, ResourceContext } from './plugins';
 
@@ -46,7 +49,10 @@ export function K8sNameLookup(props: Props) {
           return;
         }
         const table = await response.json();
-        console.log('LIST', url, table);
+        k8sNameLookupLogger.logDebug('K8s name list loaded', {
+          url,
+          rowCount: Array.isArray(table.rows) ? table.rows.length : 0,
+        });
         const options: Array<SelectableValue<string>> = [];
         if (table.rows?.length) {
           for (const row of table.rows) {

--- a/public/swagger/plugins.tsx
+++ b/public/swagger/plugins.tsx
@@ -1,6 +1,9 @@
 import { createContext } from 'react';
 
+import { createMonitoringLogger } from '@grafana/runtime';
 import { CodeEditor, Monaco } from '@grafana/ui';
+
+const swaggerUiLogger = createMonitoringLogger('swagger.ui');
 
 import { K8sNameLookup } from './K8sNameLookup';
 
@@ -63,7 +66,7 @@ export const WrappedPlugins = function () {
           if (mime) {
             v = mime.get('schema').toJS();
           }
-          console.log('RequestBody', v, mime, props);
+          swaggerUiLogger.logDebug('Swagger RequestBody', { schema: v, mimePresent: Boolean(mime) });
         }
         // console.log('RequestBody PROPS', props);
         return (
@@ -75,7 +78,7 @@ export const WrappedPlugins = function () {
 
       modelExample: (Original: React.ElementType) => (props: UntypedProps) => {
         if (props.isExecute && props.schema) {
-          console.log('modelExample PROPS', props);
+          swaggerUiLogger.logDebug('Swagger modelExample', { isExecute: props.isExecute });
           return (
             <SchemaContext.Provider value={props.schema.toJS()}>
               <Original {...props} />
@@ -128,7 +131,7 @@ export const WrappedPlugins = function () {
                     },
                   });
                 };
-                console.log('CodeEditor', schema);
+                swaggerUiLogger.logDebug('Swagger CodeEditor schema', { schema });
 
                 return (
                   <CodeEditor

--- a/public/test/core/redux/reducerTester.ts
+++ b/public/test/core/redux/reducerTester.ts
@@ -85,7 +85,13 @@ export const reducerTester = <State>(): Given<State> => {
       // eslint-disable-next-line no-console
       console.info(
         JSON.stringify(
-          { level: 'DEBUG', source: 'test.reducerTester', message: 'resultingState', state: resultingState, timestamp: Date.now() },
+          {
+            level: 'DEBUG',
+            source: 'test.reducerTester',
+            message: 'resultingState',
+            state: resultingState,
+            timestamp: Date.now(),
+          },
           null,
           2
         )
@@ -101,7 +107,13 @@ export const reducerTester = <State>(): Given<State> => {
       // eslint-disable-next-line no-console
       console.info(
         JSON.stringify(
-          { level: 'DEBUG', source: 'test.reducerTester', message: 'resultingState', state: resultingState, timestamp: Date.now() },
+          {
+            level: 'DEBUG',
+            source: 'test.reducerTester',
+            message: 'resultingState',
+            state: resultingState,
+            timestamp: Date.now(),
+          },
           null,
           2
         )

--- a/public/test/core/redux/reducerTester.ts
+++ b/public/test/core/redux/reducerTester.ts
@@ -82,7 +82,14 @@ export const reducerTester = <State>(): Given<State> => {
 
   const thenStateShouldEqual = (state: State): When<State> => {
     if (showDebugOutput) {
-      console.log(JSON.stringify(resultingState, null, 2));
+      // eslint-disable-next-line no-console
+      console.info(
+        JSON.stringify(
+          { level: 'DEBUG', source: 'test.reducerTester', message: 'resultingState', state: resultingState, timestamp: Date.now() },
+          null,
+          2
+        )
+      );
     }
     expect(resultingState).toEqual(state);
 
@@ -91,7 +98,14 @@ export const reducerTester = <State>(): Given<State> => {
 
   const thenStatePredicateShouldEqual = (predicate: (resultingState: State) => boolean): When<State> => {
     if (showDebugOutput) {
-      console.log(JSON.stringify(resultingState, null, 2));
+      // eslint-disable-next-line no-console
+      console.info(
+        JSON.stringify(
+          { level: 'DEBUG', source: 'test.reducerTester', message: 'resultingState', state: resultingState, timestamp: Date.now() },
+          null,
+          2
+        )
+      );
     }
     expect(predicate(resultingState)).toBe(true);
 

--- a/public/test/core/redux/reduxTester.ts
+++ b/public/test/core/redux/reduxTester.ts
@@ -118,7 +118,20 @@ export const reduxTester = <State>(args?: ReduxTesterArguments<State>): ReduxTes
 
   const thenDispatchedActionsShouldEqual = (...actions: AnyAction[]): ReduxTesterWhen<State> => {
     if (debug) {
-      console.log('Dispatched Actions', JSON.stringify(dispatchedActions, null, 2));
+      // eslint-disable-next-line no-console
+      console.info(
+        JSON.stringify(
+          {
+            level: 'DEBUG',
+            source: 'test.reduxTester',
+            message: 'Dispatched actions',
+            actions: dispatchedActions,
+            timestamp: Date.now(),
+          },
+          null,
+          2
+        )
+      );
     }
 
     if (!actions.length) {
@@ -133,7 +146,20 @@ export const reduxTester = <State>(args?: ReduxTesterArguments<State>): ReduxTes
     predicate: (dispatchedActions: AnyAction[]) => boolean
   ): ReduxTesterWhen<State> => {
     if (debug) {
-      console.log('Dispatched Actions', JSON.stringify(dispatchedActions, null, 2));
+      // eslint-disable-next-line no-console
+      console.info(
+        JSON.stringify(
+          {
+            level: 'DEBUG',
+            source: 'test.reduxTester',
+            message: 'Dispatched actions',
+            actions: dispatchedActions,
+            timestamp: Date.now(),
+          },
+          null,
+          2
+        )
+      );
     }
 
     expect(predicate(dispatchedActions)).toBe(true);
@@ -142,7 +168,20 @@ export const reduxTester = <State>(args?: ReduxTesterArguments<State>): ReduxTes
 
   const thenNoActionsWhereDispatched = (): ReduxTesterWhen<State> => {
     if (debug) {
-      console.log('Dispatched Actions', JSON.stringify(dispatchedActions, null, 2));
+      // eslint-disable-next-line no-console
+      console.info(
+        JSON.stringify(
+          {
+            level: 'DEBUG',
+            source: 'test.reduxTester',
+            message: 'Dispatched actions',
+            actions: dispatchedActions,
+            timestamp: Date.now(),
+          },
+          null,
+          2
+        )
+      );
     }
 
     expect(dispatchedActions.length).toBe(0);

--- a/public/test/core/thunk/thunkTester.ts
+++ b/public/test/core/thunk/thunkTester.ts
@@ -28,7 +28,20 @@ export const thunkTester = (initialState: unknown, debug?: boolean): ThunkGiven 
 
     dispatchedActions = store.getActions();
     if (debug) {
-      console.log('resultingActions:', JSON.stringify(dispatchedActions, null, 2));
+      // eslint-disable-next-line no-console
+      console.info(
+        JSON.stringify(
+          {
+            level: 'DEBUG',
+            source: 'test.thunkTester',
+            message: 'Resulting actions',
+            actions: dispatchedActions,
+            timestamp: Date.now(),
+          },
+          null,
+          2
+        )
+      );
     }
 
     return dispatchedActions;

--- a/public/test/log-reporter.js
+++ b/public/test/log-reporter.js
@@ -27,8 +27,9 @@ class LogReporter {
       failures: results.numFailedTests,
       duration: Date.now() - results.startTime,
     };
-    // JestStats suites=1 tests=94 passes=93 pending=0 failures=1 duration=3973
-    console.log(`JestStats ${objToLogAttributes(stats)}`);
+    // Structured line for CI (previously: JestStats key=value ...)
+    // eslint-disable-next-line no-console
+    console.info(JSON.stringify({ event: 'JestStats', ...stats, timestamp: Date.now() }));
   }
 }
 
@@ -43,41 +44,9 @@ function printTestFailures(result) {
       duration: result.perfStats.end - result.perfStats.start,
       errorMessage: result.failureMessage,
     };
-    // JestFailure file=<...>/public/app/features/dashboard/state/DashboardMigrator.test.ts
-    // failures=1 duration=3251 errorMessage="formatted error message"
-    console.log(`JestFailure ${objToLogAttributes(testInfo)}`);
+    // eslint-disable-next-line no-console
+    console.info(JSON.stringify({ event: 'JestFailure', ...testInfo, timestamp: Date.now() }));
   }
-}
-
-/**
- * Stringify object to be log friendly
- * @param {Object} obj
- * @returns {String}
- */
-function objToLogAttributes(obj) {
-  return Object.entries(obj)
-    .map(([key, value]) => `${key}=${formatValue(value)}`)
-    .join(' ');
-}
-
-/**
- * Escape double quotes
- * @param {String} str
- * @returns
- */
-function escapeQuotes(str) {
-  return String(str).replaceAll('"', '\\"');
-}
-
-/**
- * Wrap the value within double quote if needed
- * @param {*} value
- * @returns
- */
-function formatValue(value) {
-  const hasWhiteSpaces = /\s/g.test(value);
-
-  return hasWhiteSpaces ? `"${escapeQuotes(value)}"` : value;
 }
 
 module.exports = LogReporter;

--- a/scripts/check-codeowner-affected.js
+++ b/scripts/check-codeowner-affected.js
@@ -35,7 +35,7 @@ function checkCodeownerAffected(codeowner, changedFiles) {
 
   const filesArray = typeof changedFiles === 'string' ? changedFiles.split(/\s+/).filter(Boolean) : changedFiles;
   const isAffected = isCodeownerAffected(codeowner, filesArray);
-  console.log(isAffected ? 'true' : 'false');
+  process.stdout.write(`${isAffected ? 'true' : 'false'}\n`);
 }
 
 if (require.main === module) {

--- a/scripts/cli/reportI18nStats.mjs
+++ b/scripts/cli/reportI18nStats.mjs
@@ -84,5 +84,5 @@ function eachMessage(value, callback) {
 function logStat(name, value) {
   // Note that this output format must match the parsing in ci-frontend-metrics.sh
   // which expects the two values to be separated by a space
-  console.log(`${name} ${value}`);
+  process.stdout.write(`${name} ${value}\n`);
 }

--- a/scripts/codeowners-manifest/generate.js
+++ b/scripts/codeowners-manifest/generate.js
@@ -79,17 +79,32 @@ async function generateCodeownersManifest(
 if (require.main === module) {
   (async () => {
     try {
-      console.log(`📋 Generating files ↔ teams manifests from ${RAW_AUDIT_JSONL_PATH} ...`);
+      // eslint-disable-next-line no-console
+      console.info(
+        JSON.stringify({
+          level: 'INFO',
+          source: 'codeowners-manifest.generate',
+          message: 'Generating manifests',
+          rawAuditPath: RAW_AUDIT_JSONL_PATH,
+          timestamp: Date.now(),
+        })
+      );
       await generateCodeownersManifest(
         RAW_AUDIT_JSONL_PATH,
         CODEOWNERS_JSON_PATH,
         CODEOWNERS_BY_FILENAME_JSON_PATH,
         FILENAMES_BY_CODEOWNER_JSON_PATH
       );
-      console.log('✅ Manifest files generated:');
-      console.log(`   • ${CODEOWNERS_JSON_PATH}`);
-      console.log(`   • ${CODEOWNERS_BY_FILENAME_JSON_PATH}`);
-      console.log(`   • ${FILENAMES_BY_CODEOWNER_JSON_PATH}`);
+      // eslint-disable-next-line no-console
+      console.info(
+        JSON.stringify({
+          level: 'INFO',
+          source: 'codeowners-manifest.generate',
+          message: 'Manifest files generated',
+          outputs: [CODEOWNERS_JSON_PATH, CODEOWNERS_BY_FILENAME_JSON_PATH, FILENAMES_BY_CODEOWNER_JSON_PATH],
+          timestamp: Date.now(),
+        })
+      );
     } catch (e) {
       console.error(e);
       process.exit(1);

--- a/scripts/codeowners-manifest/metadata.js
+++ b/scripts/codeowners-manifest/metadata.js
@@ -38,7 +38,15 @@ function generateCodeownersMetadata(codeownersFilePath, manifestDir, metadataFil
 if (require.main === module) {
   (async () => {
     try {
-      console.log('⚙️ Generating codeowners-manifest metadata ...');
+      // eslint-disable-next-line no-console
+      console.info(
+        JSON.stringify({
+          level: 'INFO',
+          source: 'codeowners-manifest.metadata',
+          message: 'Generating metadata',
+          timestamp: Date.now(),
+        })
+      );
 
       try {
         await access(CODEOWNERS_MANIFEST_DIR);
@@ -49,8 +57,16 @@ if (require.main === module) {
       const metadata = generateCodeownersMetadata(CODEOWNERS_FILE_PATH, CODEOWNERS_MANIFEST_DIR, METADATA_JSON_PATH);
 
       await writeFile(METADATA_JSON_PATH, JSON.stringify(metadata, null, 2), 'utf8');
-      console.log('✅ Metadata generated:');
-      console.log(`   • ${METADATA_JSON_PATH}`);
+      // eslint-disable-next-line no-console
+      console.info(
+        JSON.stringify({
+          level: 'INFO',
+          source: 'codeowners-manifest.metadata',
+          message: 'Metadata generated',
+          outputPath: METADATA_JSON_PATH,
+          timestamp: Date.now(),
+        })
+      );
     } catch (error) {
       console.error('❌ Error generating codeowners metadata:', error.message);
       process.exit(1);

--- a/scripts/codeowners-manifest/raw.js
+++ b/scripts/codeowners-manifest/raw.js
@@ -70,10 +70,26 @@ if (require.main === module) {
         fs.mkdirSync(CODEOWNERS_MANIFEST_DIR, { recursive: true });
       }
 
-      console.log(`🍣 Getting raw CODEOWNERS data for manifest ...`);
+      // eslint-disable-next-line no-console
+      console.info(
+        JSON.stringify({
+          level: 'INFO',
+          source: 'codeowners-manifest.raw',
+          message: 'Generating raw CODEOWNERS audit',
+          timestamp: Date.now(),
+        })
+      );
       await generateCodeownersRawAudit(CODEOWNERS_FILE_PATH, RAW_AUDIT_JSONL_PATH);
-      console.log('✅ Raw audit generated:');
-      console.log(`   • ${RAW_AUDIT_JSONL_PATH}`);
+      // eslint-disable-next-line no-console
+      console.info(
+        JSON.stringify({
+          level: 'INFO',
+          source: 'codeowners-manifest.raw',
+          message: 'Raw audit generated',
+          outputPath: RAW_AUDIT_JSONL_PATH,
+          timestamp: Date.now(),
+        })
+      );
     } catch (e) {
       console.error('❌ Error generating raw audit:', e.message);
       process.exit(1);

--- a/scripts/compare-coverage-by-codeowner.js
+++ b/scripts/compare-coverage-by-codeowner.js
@@ -163,7 +163,16 @@ function compareCoverageByCodeowner(
 
   try {
     fs.writeFileSync(outputPath, markdown, 'utf8');
-    console.log(`✅ Coverage comparison written to ${outputPath}`);
+    // eslint-disable-next-line no-console
+    console.info(
+      JSON.stringify({
+        level: 'INFO',
+        source: 'compare-coverage-by-codeowner',
+        message: 'Coverage comparison written',
+        outputPath,
+        timestamp: Date.now(),
+      })
+    );
   } catch (err) {
     console.error(`Error writing output file: ${err.message}`);
     process.exit(1);
@@ -178,7 +187,15 @@ if (require.main === module) {
     console.error('❌ Coverage check failed: One or more metrics decreased');
     process.exit(1);
   }
-  console.log('✅ Coverage check passed: All metrics maintained or improved');
+  // eslint-disable-next-line no-console
+  console.info(
+    JSON.stringify({
+      level: 'INFO',
+      source: 'compare-coverage-by-codeowner',
+      message: 'Coverage check passed',
+      timestamp: Date.now(),
+    })
+  );
 }
 
 module.exports = { compareCoverageByCodeowner, generateMarkdown, getOverallStatus };

--- a/scripts/levitate-parse-json-report.js
+++ b/scripts/levitate-parse-json-report.js
@@ -37,4 +37,4 @@ if ((data.removals.length > 0 || data.changes.length > 0) && !isFork) {
   markdown += printAffectedPluginsSection(data);
 }
 
-console.log(markdown);
+process.stdout.write(markdown.endsWith('\n') ? markdown : `${markdown}\n`);

--- a/scripts/test-coverage-by-codeowner.js
+++ b/scripts/test-coverage-by-codeowner.js
@@ -76,7 +76,16 @@ if (require.main === module) {
 
       const noOpen = argv['open'] === false;
 
-      console.log(`🧪 Running test coverage for codeowner: ${codeownerName}`);
+      // eslint-disable-next-line no-console
+      console.info(
+        JSON.stringify({
+          level: 'INFO',
+          source: 'test-coverage-by-codeowner',
+          message: 'Running test coverage for codeowner',
+          codeownerName,
+          timestamp: Date.now(),
+        })
+      );
       await runTestCoverageByCodeowner(codeownerName, noOpen);
     } catch (e) {
       console.error(e.message);

--- a/scripts/webpack/webpack.dev.js
+++ b/scripts/webpack/webpack.dev.js
@@ -36,7 +36,15 @@ function scenesModule() {
   try {
     const status = fs.lstatSync(scenesPath);
     if (status.isSymbolicLink()) {
-      console.log(`scenes is linked to local scenes repo`);
+      // eslint-disable-next-line no-console
+      console.info(
+        JSON.stringify({
+          level: 'INFO',
+          source: 'webpack.dev',
+          message: 'Scenes package is symlinked to local repo',
+          timestamp: Date.now(),
+        })
+      );
       return path.resolve(scenesPath + '/src');
     }
   } catch (error) {

--- a/scripts/webpack/webpack.prod.js
+++ b/scripts/webpack/webpack.prod.js
@@ -113,7 +113,16 @@ module.exports = (env = {}) =>
       function () {
         this.hooks.done.tap('Done', function (stats) {
           if (stats.compilation.errors && stats.compilation.errors.length) {
-            console.log(stats.compilation.errors);
+            // eslint-disable-next-line no-console
+            console.error(
+              JSON.stringify({
+                level: 'ERROR',
+                source: 'webpack.prod',
+                message: 'Compilation failed',
+                errors: stats.compilation.errors.map((e) => (e && e.message ? e.message : String(e))),
+                timestamp: Date.now(),
+              })
+            );
             process.exit(1);
           }
         });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Replaces ad-hoc `console.log` usage with structured logging patterns across the Grafana repo: Faro-backed `createMonitoringLogger` / `log*` from `@grafana/runtime` where appropriate, JSON single-line `console.info`/`console.warn`/`console.error` for Node scripts and CI, and `process.stdout.write` where parsers depend on exact output (e.g. i18n stats, levitate markdown, boolean codeowner check).

## Runtime / Faro

- `logInfo`, `logDebug`, `logWarning`, `logError`, `logMeasurement`, and `createMonitoringLogger` now accept `MonitoringLogFields` (`Record<string, unknown>`), normalize values to Faro’s `LogContext` (`Record<string, string>`), and in development emit one JSON line per event when Grafana JavaScript Agent is disabled.
- `config` feature-toggle messages use structured JSON on the console (avoids importing logging during boot).
- `@grafana/ui` `createLogger` routes gated debug output through `faro.api.pushLog` with serialized args, and **falls back to `console.debug(JSON)` when Faro is not initialized**.

## Also covered

- App, packages (Prometheus, Storybook), swagger UI, test helpers, Jest/Cypress/Playwright reporters and plugins, webpack/scripts, GitHub actions, Crowdin script, devenv fake log generators.

## Notes

- Commented-out `console.log` in source and vendor `.yarn/releases` are unchanged.
- GitHub changelog action `LOG()` still uses `::notice::` but the payload is now JSON for structured parsing.

## CI follow-up

- Fixed `import/order` by moving `createMonitoringLogger(...)` calls below all imports.
- Addressed `@typescript-eslint/consistent-type-assertions` in Live panel / testdata editor.
- **Typecheck:** `LivePanel` TablePanel branch — add `timeRange` to `PanelData` and use default `PanelProps` for the spread.
- **Scene profiling:** `writePerformanceGroupLog` uses structured `console.info` inside groups so logs show in non-dev builds.
- **Sandbox e2e:** restore direct `window.Prism` / `jQuery` access so blocked globals throw (structured `console.info` still).
- Ran `yarn lint:ts --prune-suppressions` and Prettier as needed.

## How to verify

- `yarn run prettier:check && yarn run lint`
- `npx tsc --noEmit -p tsconfig.json` (or full `yarn typecheck`)
- `yarn jest public/app/core/history/RichHistoryLocalStorage.test.ts --no-watch --watchAll=false`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e4d729a8-66ce-4b93-9301-a165b2f73931"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e4d729a8-66ce-4b93-9301-a165b2f73931"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

