### PR TITLE
Admin: Labs page for feature flag catalog

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -118,6 +118,7 @@ func (hs *HTTPServer) registerRoutes() {
 	r.Get("/admin/orgs", authorizeInOrg(ac.UseGlobalOrg, ac.OrgsAccessEvaluator), hs.Index)
 	r.Get("/admin/orgs/edit/:id", authorizeInOrg(ac.UseGlobalOrg, ac.OrgsAccessEvaluator), hs.Index)
 	r.Get("/admin/stats", authorize(ac.EvalPermission(ac.ActionServerStatsRead)), hs.Index)
+	r.Get("/admin/labs", authorize(ac.EvalPermission(ac.ActionFeatureManagementRead)), hs.Index)
 	r.Get("/admin/provisioning", reqOrgAdmin, hs.Index)
 	r.Get("/admin/provisioning/*", middleware.ProvisioningAuth(reqOrgAdmin), hs.Index)
 
@@ -309,6 +310,8 @@ func (hs *HTTPServer) registerRoutes() {
 			userRoute.Get("/auth-tokens", requestmeta.SetOwner(requestmeta.TeamAuth), routing.Wrap(hs.GetUserAuthTokens))
 			userRoute.Post("/revoke-auth-token", requestmeta.SetOwner(requestmeta.TeamAuth), routing.Wrap(hs.RevokeUserAuthToken))
 		}, reqSignedInNoAnonymous)
+
+		apiRoute.Get("/featuremgmt/toggles", authorize(ac.EvalPermission(ac.ActionFeatureManagementRead)), routing.Wrap(hs.GetFeatureFlagCatalog))
 
 		apiRoute.Group("/users", func(usersRoute routing.RouteRegister) {
 			userIDScope := ac.Scope("global.users", "id", ac.Parameter(":id"))

--- a/pkg/api/featuremgmt_catalog.go
+++ b/pkg/api/featuremgmt_catalog.go
@@ -1,0 +1,67 @@
+package api
+
+import (
+	"context"
+	"net/http"
+	"sort"
+
+	"github.com/grafana/grafana/pkg/api/response"
+	contextmodel "github.com/grafana/grafana/pkg/services/contexthandler/model"
+	"github.com/grafana/grafana/pkg/services/featuremgmt"
+)
+
+// FeatureFlagCatalogItem is a feature flag definition with current enabled state for the Labs UI.
+type FeatureFlagCatalogItem struct {
+	Name            string `json:"name"`
+	Description     string `json:"description"`
+	Stage           string `json:"stage"`
+	Enabled         bool   `json:"enabled"`
+	Expression      string `json:"expression"`
+	RequiresDevMode bool   `json:"requiresDevMode"`
+	FrontendOnly    bool   `json:"frontend"`
+	RequiresRestart bool   `json:"requiresRestart"`
+}
+
+type featureFlagCatalogResponse struct {
+	FeatureFlags []FeatureFlagCatalogItem `json:"featureFlags"`
+}
+
+// GET /api/featuremgmt/toggles
+func (hs *HTTPServer) GetFeatureFlagCatalog(c *contextmodel.ReqContext) response.Response {
+	ctx := c.Req.Context()
+	defs := hs.Features.GetFlags()
+	if defs == nil {
+		defs = []featuremgmt.FeatureFlag{}
+	}
+
+	enabled := hs.Features.GetEnabled(ctx)
+	items := make([]FeatureFlagCatalogItem, 0, len(defs))
+	for _, def := range defs {
+		if def.HideFromDocs {
+			continue
+		}
+		items = append(items, FeatureFlagCatalogItem{
+			Name:            def.Name,
+			Description:     def.Description,
+			Stage:           def.Stage.String(),
+			Enabled:         isFlagEnabled(ctx, hs.Features, enabled, def.Name),
+			Expression:      def.Expression,
+			RequiresDevMode: def.RequiresDevMode,
+			FrontendOnly:    def.FrontendOnly,
+			RequiresRestart: def.RequiresRestart,
+		})
+	}
+
+	sort.Slice(items, func(i, j int) bool { return items[i].Name < items[j].Name })
+
+	return response.JSON(http.StatusOK, featureFlagCatalogResponse{FeatureFlags: items})
+}
+
+func isFlagEnabled(ctx context.Context, ft featuremgmt.FeatureToggles, enabledMap map[string]bool, name string) bool {
+	if enabledMap != nil {
+		if v, ok := enabledMap[name]; ok {
+			return v
+		}
+	}
+	return ft.IsEnabled(ctx, name)
+}

--- a/pkg/api/featuremgmt_catalog_test.go
+++ b/pkg/api/featuremgmt_catalog_test.go
@@ -1,0 +1,61 @@
+package api
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/grafana/pkg/services/accesscontrol"
+	"github.com/grafana/grafana/pkg/services/featuremgmt"
+	"github.com/grafana/grafana/pkg/setting"
+	"github.com/grafana/grafana/pkg/web/webtest"
+)
+
+func TestAPI_GetFeatureFlagCatalog(t *testing.T) {
+	server := SetupAPITestServer(t, func(hs *HTTPServer) {
+		hs.Cfg = setting.NewCfg()
+		hs.Features = featuremgmt.WithFeatures([]any{"catalogTestFlag", true, "catalogOffFlag", false}...)
+	})
+
+	url := "/api/featuremgmt/toggles"
+
+	t.Run("forbidden without permission", func(t *testing.T) {
+		req := webtest.RequestWithSignedInUser(server.NewGetRequest(url), userWithPermissions(1, []accesscontrol.Permission{{Action: "orgs:invalid"}}))
+		res, err := server.Send(req)
+		require.NoError(t, err)
+		assert.Equal(t, http.StatusForbidden, res.StatusCode)
+		require.NoError(t, res.Body.Close())
+	})
+
+	t.Run("ok with featuremgmt read", func(t *testing.T) {
+		req := webtest.RequestWithSignedInUser(
+			server.NewGetRequest(url),
+			userWithPermissions(1, []accesscontrol.Permission{{Action: accesscontrol.ActionFeatureManagementRead}}),
+		)
+		res, err := server.Send(req)
+		require.NoError(t, err)
+		assert.Equal(t, http.StatusOK, res.StatusCode)
+		b, readErr := io.ReadAll(res.Body)
+		require.NoError(t, readErr)
+		require.NoError(t, res.Body.Close())
+
+		var payload struct {
+			FeatureFlags []struct {
+				Name    string `json:"name"`
+				Enabled bool   `json:"enabled"`
+			} `json:"featureFlags"`
+		}
+		require.NoError(t, json.Unmarshal(b, &payload))
+
+		byName := make(map[string]bool, len(payload.FeatureFlags))
+		for _, f := range payload.FeatureFlags {
+			byName[f.Name] = f.Enabled
+		}
+		assert.True(t, byName["catalogTestFlag"])
+		assert.False(t, byName["catalogOffFlag"])
+	})
+}

--- a/pkg/registry/apis/dashboard/register_test.go
+++ b/pkg/registry/apis/dashboard/register_test.go
@@ -320,3 +320,7 @@ func (m *mockFeatureToggles) GetEnabled(ctx context.Context) map[string]bool {
 
 	return res
 }
+
+func (m *mockFeatureToggles) GetFlags() []featuremgmt.FeatureFlag {
+	return nil
+}

--- a/pkg/services/featuremgmt/feature_toggles_mock.go
+++ b/pkg/services/featuremgmt/feature_toggles_mock.go
@@ -162,6 +162,53 @@ func (_c *MockFeatureToggles_IsEnabledGlobally_Call) RunAndReturn(run func(strin
 	return _c
 }
 
+// GetFlags provides a mock function with no fields
+func (_m *MockFeatureToggles) GetFlags() []FeatureFlag {
+	ret := _m.Called()
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetFlags")
+	}
+
+	var r0 []FeatureFlag
+	if rf, ok := ret.Get(0).(func() []FeatureFlag); ok {
+		r0 = rf()
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]FeatureFlag)
+		}
+	}
+
+	return r0
+}
+
+// MockFeatureToggles_GetFlags_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetFlags'
+type MockFeatureToggles_GetFlags_Call struct {
+	*mock.Call
+}
+
+// GetFlags is a helper method to define mock.On call
+func (_e *MockFeatureToggles_Expecter) GetFlags() *MockFeatureToggles_GetFlags_Call {
+	return &MockFeatureToggles_GetFlags_Call{Call: _e.mock.On("GetFlags")}
+}
+
+func (_c *MockFeatureToggles_GetFlags_Call) Run(run func()) *MockFeatureToggles_GetFlags_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run()
+	})
+	return _c
+}
+
+func (_c *MockFeatureToggles_GetFlags_Call) Return(_a0 []FeatureFlag) *MockFeatureToggles_GetFlags_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *MockFeatureToggles_GetFlags_Call) RunAndReturn(run func() []FeatureFlag) *MockFeatureToggles_GetFlags_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // NewMockFeatureToggles creates a new instance of MockFeatureToggles. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
 // The first argument is typically a *testing.T value.
 func NewMockFeatureToggles(t interface {

--- a/pkg/services/featuremgmt/models.go
+++ b/pkg/services/featuremgmt/models.go
@@ -29,6 +29,10 @@ type FeatureToggles interface {
 	// Get the enabled flags -- this *may* also include disabled flags (with value false)
 	// but it is guaranteed to have the enabled ones listed
 	GetEnabled(ctx context.Context) map[string]bool
+
+	// GetFlags returns registered feature flag definitions (metadata). Implementations used only
+	// for runtime enablement checks may return nil or empty.
+	GetFlags() []FeatureFlag
 }
 
 func AnyEnabled(f FeatureToggles, flags ...string) bool {

--- a/pkg/services/navtree/models.go
+++ b/pkg/services/navtree/models.go
@@ -38,6 +38,9 @@ const (
 	WeightHelp
 )
 
+// WeightLabs places Labs immediately below Administration (WeightConfig) in the sorted nav.
+const WeightLabs = WeightConfig + 10
+
 const (
 	NavIDRoot                 = "root"
 	NavIDDashboards           = "dashboards/browse"
@@ -56,6 +59,7 @@ const (
 	NavIDCfgPlugins           = "cfg/plugins"
 	NavIDCfgAccess            = "cfg/access"
 	NavIDBookmarks            = "bookmarks"
+	NavIDLabs                 = "labs"
 )
 
 type NavLink struct {

--- a/pkg/services/navtree/navtreeimpl/navtree.go
+++ b/pkg/services/navtree/navtreeimpl/navtree.go
@@ -170,6 +170,19 @@ func (s *ServiceImpl) GetNavTree(c *contextmodel.ReqContext, prefs *pref.Prefere
 		return nil, err
 	}
 
+	if hasAccess(ac.EvalPermission(ac.ActionFeatureManagementRead)) {
+		treeRoot.AddSection(&navtree.NavLink{
+			Text:       "Labs",
+			Id:         navtree.NavIDLabs,
+			SubTitle:   "Browse available feature flags for this Grafana instance",
+			Icon:       "rocket",
+			Url:        s.cfg.AppSubURL + "/admin/labs",
+			SortWeight: navtree.WeightLabs,
+			IsNew:      true,
+			Keywords:   []string{"labs", "feature flags", "feature toggles"},
+		})
+	}
+
 	s.addHelpLinks(treeRoot, c)
 
 	if err := s.addAppLinks(treeRoot, c); err != nil {

--- a/pkg/services/secrets/kvstore/test_helpers.go
+++ b/pkg/services/secrets/kvstore/test_helpers.go
@@ -127,3 +127,7 @@ func (f fakeFeatureToggles) IsEnabled(ctx context.Context, feature string) bool 
 func (f fakeFeatureToggles) GetEnabled(ctx context.Context) map[string]bool {
 	return map[string]bool{}
 }
+
+func (f fakeFeatureToggles) GetFlags() []featuremgmt.FeatureFlag {
+	return nil
+}

--- a/pkg/storage/unified/sql/db/dbimpl/dbimpl_test.go
+++ b/pkg/storage/unified/sql/db/dbimpl/dbimpl_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/grafana/grafana/pkg/bus"
 	infraDB "github.com/grafana/grafana/pkg/infra/db"
 	"github.com/grafana/grafana/pkg/infra/tracing"
+	"github.com/grafana/grafana/pkg/services/featuremgmt"
 	"github.com/grafana/grafana/pkg/services/sqlstore"
 	"github.com/grafana/grafana/pkg/setting"
 )
@@ -166,6 +167,8 @@ func (featureTogglesNop) IsEnabledGlobally(string) bool {
 func (featureTogglesNop) GetEnabled(context.Context) map[string]bool {
 	return map[string]bool{}
 }
+
+func (featureTogglesNop) GetFlags() []featuremgmt.FeatureFlag { return nil }
 
 func (nopBus) Publish(context.Context, bus.Msg) error { return nil }
 func (nopBus) AddEventListener(bus.HandlerFunc)       {}

--- a/public/app/core/utils/navBarItem-translations.ts
+++ b/public/app/core/utils/navBarItem-translations.ts
@@ -91,6 +91,8 @@ export function getNavTitle(navId: string | undefined) {
       return t('nav.alerting-admin.title', 'Settings');
     case 'alerts/recently-deleted':
       return t('nav.alerts-recently-deleted.title', 'Recently deleted');
+    case 'labs':
+      return t('nav.labs.title', 'Labs');
     case 'cfg':
       return t('nav.config.title', 'Administration');
     case 'cfg/general':

--- a/public/app/features/admin/LabsPage.tsx
+++ b/public/app/features/admin/LabsPage.tsx
@@ -1,0 +1,142 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+
+import { GrafanaTheme2 } from '@grafana/data';
+import { t, Trans } from '@grafana/i18n';
+import { getBackendSrv } from '@grafana/runtime';
+import {
+  Alert,
+  Badge,
+  CellProps,
+  Column,
+  InteractiveTable,
+  LoadingBar,
+  Stack,
+  Text,
+  useStyles2,
+} from '@grafana/ui';
+import { Page } from 'app/core/components/Page/Page';
+import { contextSrv } from 'app/core/services/context_srv';
+import { AccessControlAction } from 'app/types/accessControl';
+
+export interface FeatureFlagCatalogItem {
+  name: string;
+  description: string;
+  stage: string;
+  enabled: boolean;
+  expression: string;
+  requiresDevMode: boolean;
+  frontend: boolean;
+  requiresRestart: boolean;
+}
+
+interface CatalogResponse {
+  featureFlags: FeatureFlagCatalogItem[];
+}
+
+export default function LabsPage() {
+  const styles = useStyles2(getStyles);
+  const [items, setItems] = useState<FeatureFlagCatalogItem[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const canRead = contextSrv.hasPermission(AccessControlAction.FeatureManagementRead);
+
+  const load = useCallback(async () => {
+    if (!canRead) {
+      setLoading(false);
+      return;
+    }
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await getBackendSrv().get<CatalogResponse>('/api/featuremgmt/toggles');
+      setItems(res.featureFlags ?? []);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setLoading(false);
+    }
+  }, [canRead]);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  const columns = useMemo(
+    (): Array<Column<FeatureFlagCatalogItem>> => [
+      {
+        id: 'name',
+        header: t('labs.table.column-name', 'Name'),
+        cell: ({ row: { original } }: CellProps<FeatureFlagCatalogItem, string>) => (
+          <span className={styles.mono}>{original.name}</span>
+        ),
+      },
+      {
+        id: 'description',
+        header: t('labs.table.column-description', 'Description'),
+      },
+      {
+        id: 'stage',
+        header: t('labs.table.column-stage', 'Stage'),
+      },
+      {
+        id: 'enabled',
+        header: t('labs.table.column-enabled', 'Enabled'),
+        cell: ({ row: { original } }: CellProps<FeatureFlagCatalogItem, boolean>) =>
+          original.enabled ? (
+            <Badge text={t('labs.badge.enabled', 'On')} color="green" />
+          ) : (
+            <Badge text={t('labs.badge.disabled', 'Off')} color="blue" />
+          ),
+      },
+    ],
+    [styles.mono]
+  );
+
+  if (!canRead) {
+    return (
+      <Page navId="labs">
+        <Page.Contents>
+          <Alert title={t('labs.alert.no-permission.title', 'Permission required')} severity="warning">
+            <Trans i18nKey="labs.alert.no-permission.body">
+              You need the feature management read permission to view feature flags.
+            </Trans>
+          </Alert>
+        </Page.Contents>
+      </Page>
+    );
+  }
+
+  return (
+    <Page navId="labs">
+      <Page.Contents>
+        <Stack direction="column" gap={2}>
+          <Text element="p" color="secondary">
+            <Trans i18nKey="labs.description">
+              Feature flags available on this Grafana instance. Values reflect server configuration; many flags require
+              a restart to change.
+            </Trans>
+          </Text>
+          {error && (
+            <Alert title={t('labs.alert.load-error.title', 'Could not load feature flags')} severity="error">
+              {error}
+            </Alert>
+          )}
+          {loading && <LoadingBar />}
+          {!loading && !error && (
+            <InteractiveTable columns={columns} data={items} getRowId={(row) => row.name} pageSize={50} />
+          )}
+        </Stack>
+      </Page.Contents>
+    </Page>
+  );
+}
+
+function getStyles(theme: GrafanaTheme2) {
+  return {
+    mono: {
+      fontFamily: theme.typography.fontFamilyMonospace,
+      fontSize: theme.typography.size.sm,
+    },
+  };
+}

--- a/public/app/routes/routes.tsx
+++ b/public/app/routes/routes.tsx
@@ -234,6 +234,13 @@ export function getAppRoutes(): RouteDescriptor[] {
       component: () => <NavLandingPage navId="cfg/plugins" />,
     },
     {
+      path: '/admin/labs',
+      roles: () => contextSrv.evaluatePermission([AccessControlAction.FeatureManagementRead]),
+      component: SafeDynamicImport(
+        () => import(/* webpackChunkName: "LabsPage" */ 'app/features/admin/LabsPage')
+      ),
+    },
+    {
       path: '/admin/extensions',
       roles: () =>
         contextSrv.evaluatePermission([AccessControlAction.PluginsInstall, AccessControlAction.PluginsWrite]),

--- a/public/app/types/accessControl.ts
+++ b/public/app/types/accessControl.ts
@@ -177,6 +177,8 @@ export enum AccessControlAction {
   // Migration Assistant
   MigrationAssistantMigrate = 'migrationassistant:migrate',
 
+  FeatureManagementRead = 'featuremgmt:read',
+
   // Saved Queries
   QueriesRead = 'queries:read',
   QueriesWrite = 'queries:write',


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
**What is this feature?**

Adds a **Labs** top-level navigation item (with the standard **New** badge) next to **Administration**, an `/admin/labs` page, and `GET /api/featuremgmt/toggles` that returns registered feature flag metadata plus current enabled state. Flags with `HideFromDocs` are omitted from the catalog.

**Why do we need this feature?**

Gives Grafana admins a single place to see which feature flags exist on the instance and whether they are on, without digging through config or code.

**Who is this feature for?**

Organization admins with `featuremgmt:read` (same fixed role as other feature management permissions).

**Which issue(s) does this PR fix?**

Fixes #

**Special notes for your reviewer:**

- `FeatureToggles` now includes `GetFlags()`; fakes and mock updated.
- Route and API are gated on `ActionFeatureManagementRead`.

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a notable improvement, it's added to What's New.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-df247c6b-e9a9-4d2b-97fe-807c96d47afb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-df247c6b-e9a9-4d2b-97fe-807c96d47afb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

