### PR TITLE
Admin: add labs feature flags page

### DIFF
--- a/pkg/api/admin.go
+++ b/pkg/api/admin.go
@@ -3,12 +3,15 @@ package api
 import (
 	"context"
 	"net/http"
+	"sort"
 	"time"
 
 	"github.com/grafana/grafana/pkg/api/response"
 	"github.com/grafana/grafana/pkg/apimachinery/identity"
 	ac "github.com/grafana/grafana/pkg/services/accesscontrol"
 	contextmodel "github.com/grafana/grafana/pkg/services/contexthandler/model"
+	"github.com/grafana/grafana/pkg/services/featuremgmt"
+	featuretoggleapi "github.com/grafana/grafana/pkg/services/featuremgmt/feature_toggle_api"
 	"github.com/grafana/grafana/pkg/services/stats"
 	"github.com/grafana/grafana/pkg/setting"
 )
@@ -45,6 +48,34 @@ func (hs *HTTPServer) AdminGetVerboseSettings(c *contextmodel.ReqContext) respon
 		return response.Error(http.StatusForbidden, "Failed to authorize settings", err)
 	}
 	return response.JSON(http.StatusOK, verboseSettings)
+}
+
+func (hs *HTTPServer) AdminGetFeatureToggles(c *contextmodel.ReqContext) response.Response {
+	featureList, err := featuremgmt.GetEmbeddedFeatureList()
+	if err != nil {
+		return response.Error(http.StatusInternalServerError, "Failed to load feature toggle definitions", err)
+	}
+
+	enabled := hs.Features.GetEnabled(c.Req.Context())
+	toggles := make([]featuretoggleapi.ToggleStatus, 0, len(featureList.Items))
+
+	for _, item := range featureList.Items {
+		toggles = append(toggles, featuretoggleapi.ToggleStatus{
+			Name:        item.Name,
+			Description: item.Spec.Description,
+			Stage:       item.Spec.Stage,
+			Enabled:     enabled[item.Name],
+		})
+	}
+
+	sort.Slice(toggles, func(i, j int) bool {
+		return toggles[i].Name < toggles[j].Name
+	})
+
+	return response.JSON(http.StatusOK, featuretoggleapi.ResolvedToggleState{
+		Enabled: enabled,
+		Toggles: toggles,
+	})
 }
 
 // swagger:route GET /admin/stats admin adminGetStats

--- a/pkg/api/admin_test.go
+++ b/pkg/api/admin_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/grafana/grafana/pkg/infra/db/dbtest"
 	"github.com/grafana/grafana/pkg/services/accesscontrol"
+	"github.com/grafana/grafana/pkg/services/featuremgmt"
 	"github.com/grafana/grafana/pkg/services/anonymous/anontest"
 	"github.com/grafana/grafana/pkg/services/stats"
 	"github.com/grafana/grafana/pkg/services/stats/statstest"
@@ -148,6 +149,22 @@ func TestAdmin_AccessControl(t *testing.T) {
 				},
 			},
 		},
+		{
+			expectedCode: http.StatusOK,
+			desc:         "AdminGetFeatureToggles should return 200 for grafana admin",
+			url:          "/api/admin/feature-toggles",
+			permissions:  nil,
+		},
+		{
+			expectedCode: http.StatusForbidden,
+			desc:         "AdminGetFeatureToggles should return 403 for non grafana admin",
+			url:          "/api/admin/feature-toggles",
+			permissions: []accesscontrol.Permission{
+				{
+					Action: accesscontrol.ActionSettingsRead,
+				},
+			},
+		},
 	}
 
 	for _, tt := range tests {
@@ -162,9 +179,15 @@ func TestAdmin_AccessControl(t *testing.T) {
 				hs.SettingsProvider = &setting.OSSImpl{Cfg: hs.Cfg}
 				hs.statsService = fakeStatsService
 				hs.anonService = fakeAnonService
+				hs.Features = featuremgmt.WithFeatures("testFeature", true)
 			})
 
-			res, err := server.Send(webtest.RequestWithSignedInUser(server.NewGetRequest(tt.url), userWithPermissions(1, tt.permissions)))
+			user := userWithPermissions(1, tt.permissions)
+			if tt.url == "/api/admin/feature-toggles" && tt.expectedCode == http.StatusOK {
+				user.IsGrafanaAdmin = true
+			}
+
+			res, err := server.Send(webtest.RequestWithSignedInUser(server.NewGetRequest(tt.url), user))
 			require.NoError(t, err)
 			assert.Equal(t, tt.expectedCode, res.StatusCode)
 			require.NoError(t, res.Body.Close())

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -112,6 +112,7 @@ func (hs *HTTPServer) registerRoutes() {
 	r.Get("/configuration", reqGrafanaAdmin, hs.Index)
 	r.Get("/admin", reqOrgAdmin, hs.Index)
 	r.Get("/admin/settings", authorize(ac.EvalPermission(ac.ActionSettingsRead, ac.ScopeSettingsAll)), hs.Index)
+	r.Get("/labs", reqGrafanaAdmin, hs.Index)
 	r.Get("/admin/users", authorize(ac.EvalAny(ac.EvalPermission(ac.ActionOrgUsersRead), ac.EvalPermission(ac.ActionUsersRead, ac.ScopeGlobalUsersAll))), hs.Index)
 	r.Get("/admin/users/create", authorize(ac.EvalPermission(ac.ActionUsersCreate)), hs.Index)
 	r.Get("/admin/users/edit/:id", authorize(ac.EvalPermission(ac.ActionUsersRead)), hs.Index)
@@ -560,6 +561,7 @@ func (hs *HTTPServer) registerRoutes() {
 		// There is additional filter which will ensure that user sees only settings that they are allowed to see, so we don't need provide additional scope here for ActionSettingsRead.
 		adminRoute.Get("/settings", authorize(ac.EvalPermission(ac.ActionSettingsRead)), routing.Wrap(hs.AdminGetSettings))
 		adminRoute.Get("/settings-verbose", authorize(ac.EvalPermission(ac.ActionSettingsRead)), routing.Wrap(hs.AdminGetVerboseSettings))
+		adminRoute.Get("/feature-toggles", reqGrafanaAdmin, routing.Wrap(hs.AdminGetFeatureToggles))
 		adminRoute.Get("/stats", authorize(ac.EvalPermission(ac.ActionServerStatsRead)), routing.Wrap(hs.AdminGetStats))
 
 		adminRoute.Post("/encryption/rotate-data-keys", reqGrafanaAdmin, routing.Wrap(hs.AdminRotateDataEncryptionKeys))

--- a/pkg/services/navtree/models.go
+++ b/pkg/services/navtree/models.go
@@ -30,6 +30,7 @@ const (
 	WeightApplication
 	WeightAsserts
 	WeightDataConnections
+	WeightLabs
 	WeightApps
 	WeightPlugin
 	WeightConfig
@@ -51,6 +52,7 @@ const (
 	NavIDInfrastructure       = "infrastructure"
 	NavIDReporting            = "reports"
 	NavIDApps                 = "apps"
+	NavIDLabs                 = "labs"
 	NavIDCfgGeneral           = "cfg/general"
 	NavIDCfgPlugins           = "cfg/plugins"
 	NavIDCfgAccess            = "cfg/access"

--- a/pkg/services/navtree/navtreeimpl/navtree.go
+++ b/pkg/services/navtree/navtreeimpl/navtree.go
@@ -145,6 +145,17 @@ func (s *ServiceImpl) GetNavTree(c *contextmodel.ReqContext, prefs *pref.Prefere
 		})
 	}
 
+	if c.GetIsGrafanaAdmin() {
+		treeRoot.AddSection(&navtree.NavLink{
+			Text:       "Labs",
+			Id:         navtree.NavIDLabs,
+			SubTitle:   "Browse feature flags and their current enabled state",
+			Icon:       "flask",
+			SortWeight: navtree.WeightLabs,
+			Url:        s.cfg.AppSubURL + "/labs",
+		})
+	}
+
 	if s.cfg.ProfileEnabled && c.IsSignedIn {
 		treeRoot.AddSection(s.getProfileNode(c))
 	}

--- a/pkg/services/navtree/navtreeimpl/navtree_test.go
+++ b/pkg/services/navtree/navtreeimpl/navtree_test.go
@@ -9,13 +9,23 @@ import (
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 
+	ac "github.com/grafana/grafana/pkg/services/accesscontrol"
+	accesscontrolmock "github.com/grafana/grafana/pkg/services/accesscontrol/mock"
+	"github.com/grafana/grafana/pkg/services/authn"
+	"github.com/grafana/grafana/pkg/services/authn/authntest"
 	contextmodel "github.com/grafana/grafana/pkg/services/contexthandler/model"
 	"github.com/grafana/grafana/pkg/services/dashboards"
+	"github.com/grafana/grafana/pkg/services/featuremgmt"
+	"github.com/grafana/grafana/pkg/services/licensing"
 	"github.com/grafana/grafana/pkg/services/navtree"
+	"github.com/grafana/grafana/pkg/services/pluginsintegration/pluginsettings"
+	"github.com/grafana/grafana/pkg/services/pluginsintegration/pluginstore"
+	pref "github.com/grafana/grafana/pkg/services/preference"
 	"github.com/grafana/grafana/pkg/services/search/model"
 	"github.com/grafana/grafana/pkg/services/star"
 	"github.com/grafana/grafana/pkg/services/star/startest"
 	"github.com/grafana/grafana/pkg/services/user"
+	"github.com/grafana/grafana/pkg/setting"
 	"github.com/grafana/grafana/pkg/web"
 )
 
@@ -161,17 +171,36 @@ func TestBuildStarredItemsNavLinks(t *testing.T) {
 }
 
 func TestLabsNavLinkUsesExpectedMetadata(t *testing.T) {
-	link := &navtree.NavLink{
-		Text:       "Labs",
-		Id:         navtree.NavIDLabs,
-		SubTitle:   "Browse feature flags and their current enabled state",
-		Icon:       "flask",
-		SortWeight: navtree.WeightLabs,
-		Url:        "/labs",
+	httpReq, _ := http.NewRequest(http.MethodGet, "", nil)
+	reqCtx := &contextmodel.ReqContext{
+		SignedInUser: &user.SignedInUser{
+			UserID:         1,
+			OrgID:          1,
+			IsGrafanaAdmin: true,
+		},
+		Context:    &web.Context{Req: httpReq},
+		IsSignedIn: false,
 	}
 
-	require.Equal(t, navtree.NavIDLabs, link.Id)
-	require.Equal(t, "Labs", link.Text)
-	require.Equal(t, "/labs", link.Url)
-	require.EqualValues(t, navtree.WeightLabs, link.SortWeight)
+	service := ServiceImpl{
+		cfg:            setting.NewCfg(),
+		accessControl:  accesscontrolmock.New().WithPermissions([]ac.Permission{}),
+		authnService:   &authntest.FakeService{ExpectedIdentity: &authn.Identity{}},
+		pluginStore:    &pluginstore.FakePluginStore{},
+		pluginSettings: &pluginsettings.FakePluginSettings{Plugins: map[string]*pluginsettings.DTO{}},
+		features:       featuremgmt.WithFeatures(),
+		license:        &licensing.OSSLicensingService{},
+	}
+
+	tree, err := service.GetNavTree(reqCtx, &pref.Preference{})
+	require.NoError(t, err)
+
+	labsLink := tree.FindById(navtree.NavIDLabs)
+	require.NotNil(t, labsLink)
+	require.Equal(t, navtree.NavIDLabs, labsLink.Id)
+	require.Equal(t, "Labs", labsLink.Text)
+	require.Equal(t, "Browse feature flags and their current enabled state", labsLink.SubTitle)
+	require.Equal(t, "flask", labsLink.Icon)
+	require.Equal(t, "/labs", labsLink.Url)
+	require.EqualValues(t, navtree.WeightLabs, labsLink.SortWeight)
 }

--- a/pkg/services/navtree/navtreeimpl/navtree_test.go
+++ b/pkg/services/navtree/navtreeimpl/navtree_test.go
@@ -11,6 +11,7 @@ import (
 
 	contextmodel "github.com/grafana/grafana/pkg/services/contexthandler/model"
 	"github.com/grafana/grafana/pkg/services/dashboards"
+	"github.com/grafana/grafana/pkg/services/navtree"
 	"github.com/grafana/grafana/pkg/services/search/model"
 	"github.com/grafana/grafana/pkg/services/star"
 	"github.com/grafana/grafana/pkg/services/star/startest"
@@ -157,4 +158,20 @@ func TestBuildStarredItemsNavLinks(t *testing.T) {
 		require.Equal(t, "B Dashboard", navLinks[1].Text)
 		require.Equal(t, "C Dashboard", navLinks[2].Text)
 	})
+}
+
+func TestLabsNavLinkUsesExpectedMetadata(t *testing.T) {
+	link := &navtree.NavLink{
+		Text:       "Labs",
+		Id:         navtree.NavIDLabs,
+		SubTitle:   "Browse feature flags and their current enabled state",
+		Icon:       "flask",
+		SortWeight: navtree.WeightLabs,
+		Url:        "/labs",
+	}
+
+	require.Equal(t, navtree.NavIDLabs, link.Id)
+	require.Equal(t, "Labs", link.Text)
+	require.Equal(t, "/labs", link.Url)
+	require.EqualValues(t, navtree.WeightLabs, link.SortWeight)
 }

--- a/public/app/features/admin/LabsPage.test.tsx
+++ b/public/app/features/admin/LabsPage.test.tsx
@@ -1,0 +1,47 @@
+import { render, screen } from '@testing-library/react';
+
+import { TestProvider } from 'test/helpers/TestProvider';
+
+import LabsPage from './LabsPage';
+import { getFeatureToggles } from './labsApi';
+
+jest.mock('./labsApi', () => ({
+  getFeatureToggles: jest.fn(),
+}));
+
+const mockGetFeatureToggles = jest.mocked(getFeatureToggles);
+
+describe('LabsPage', () => {
+  it('renders enabled and disabled feature flags', async () => {
+    mockGetFeatureToggles.mockResolvedValue({
+      enabled: { dashboardScene: true },
+      toggles: [
+        {
+          name: 'dashboardScene',
+          description: 'Enables dashboard rendering using scenes for all roles',
+          stage: 'GA',
+          enabled: true,
+        },
+        {
+          name: 'panelTitleSearch',
+          description: 'Search for dashboards using panel title',
+          stage: 'preview',
+          enabled: false,
+        },
+      ],
+    });
+
+    render(
+      <TestProvider>
+        <LabsPage />
+      </TestProvider>
+    );
+
+    expect(await screen.findByText('Labs feature flags')).toBeInTheDocument();
+    expect(screen.getByText('dashboardScene')).toBeInTheDocument();
+    expect(screen.getByText('panelTitleSearch')).toBeInTheDocument();
+    expect(screen.getByText('Showing 2 of 2 flags')).toBeInTheDocument();
+    expect(screen.getByText('Review all Grafana feature flags and whether they are currently enabled.')).toBeInTheDocument();
+    expect(screen.getByPlaceholderText('Filter feature flags')).toBeInTheDocument();
+  });
+});

--- a/public/app/features/admin/LabsPage.test.tsx
+++ b/public/app/features/admin/LabsPage.test.tsx
@@ -38,8 +38,9 @@ describe('LabsPage', () => {
     );
 
     expect(await screen.findByText('Labs feature flags')).toBeInTheDocument();
-    expect(screen.getByText('dashboardScene')).toBeInTheDocument();
-    expect(screen.getByText('panelTitleSearch')).toBeInTheDocument();
+    expect(screen.getByText('Feature flag')).toBeInTheDocument();
+    expect(screen.getByText('Stage')).toBeInTheDocument();
+    expect(screen.getByText('Description')).toBeInTheDocument();
     expect(screen.getByText('Showing 2 of 2 flags')).toBeInTheDocument();
     expect(screen.getByText('Review all Grafana feature flags and whether they are currently enabled.')).toBeInTheDocument();
     expect(screen.getByPlaceholderText('Filter feature flags')).toBeInTheDocument();

--- a/public/app/features/admin/LabsPage.tsx
+++ b/public/app/features/admin/LabsPage.tsx
@@ -1,0 +1,151 @@
+import { useMemo, useState } from 'react';
+import { useAsync } from 'react-use';
+
+import { Alert, Badge, FilterInput, HorizontalGroup, ScrollContainer, Stack, Text } from '@grafana/ui';
+import { Page } from 'app/core/components/Page/Page';
+
+import { FeatureToggle, getFeatureToggles } from './labsApi';
+
+export default function LabsPage() {
+  const [query, setQuery] = useState('');
+  const { loading, error, value } = useAsync(() => getFeatureToggles(), []);
+
+  const filteredToggles = useMemo(() => {
+    const toggles = value?.toggles ?? [];
+    const search = query.trim().toLowerCase();
+
+    if (!search) {
+      return toggles;
+    }
+
+    return toggles.filter((toggle) => {
+      return (
+        toggle.name.toLowerCase().includes(search) ||
+        toggle.description.toLowerCase().includes(search) ||
+        toggle.stage.toLowerCase().includes(search)
+      );
+    });
+  }, [query, value]);
+
+  return (
+    <Page navId="labs" subTitle="Review all Grafana feature flags and whether they are currently enabled.">
+      <Page.Contents>
+        <Stack gap={3}>
+          <Alert severity="info" title="Labs feature flags">
+            This page is read-only and reflects the current resolved state of Grafana feature flags for this instance.
+          </Alert>
+
+          <HorizontalGroup justify="space-between" wrap>
+            <FilterInput
+              value={query}
+              onChange={setQuery}
+              escapeRegex={false}
+              width={40}
+              placeholder="Filter feature flags"
+            />
+            {value && (
+              <Text color="secondary">
+                Showing {filteredToggles.length} of {value.toggles.length} flags
+              </Text>
+            )}
+          </HorizontalGroup>
+
+          {error && (
+            <Alert severity="error" title="Unable to load feature flags">
+              {error instanceof Error ? error.message : 'An unknown error occurred while loading Labs data.'}
+            </Alert>
+          )}
+
+          {loading && <LabsTableSkeleton />}
+
+          {value && <LabsTable toggles={filteredToggles} />}
+        </Stack>
+      </Page.Contents>
+    </Page>
+  );
+}
+
+function LabsTable({ toggles }: { toggles: FeatureToggle[] }) {
+  return (
+    <ScrollContainer overflowY="visible" overflowX="auto" width="100%">
+      <table className="filter-table">
+        <thead>
+          <tr>
+            <th align="left">Feature flag</th>
+            <th align="left">Stage</th>
+            <th align="left">Enabled</th>
+            <th align="left">Description</th>
+          </tr>
+        </thead>
+        <tbody>
+          {toggles.map((toggle) => (
+            <tr key={toggle.name}>
+              <td>
+                <Text element="span" weight="medium">
+                  {toggle.name}
+                </Text>
+              </td>
+              <td>
+                <Badge text={formatStage(toggle.stage)} color="blue" />
+              </td>
+              <td>
+                <Badge
+                  text={toggle.enabled ? 'Enabled' : 'Disabled'}
+                  color={toggle.enabled ? 'green' : 'darkgrey'}
+                />
+              </td>
+              <td>{toggle.description}</td>
+            </tr>
+          ))}
+          {toggles.length === 0 && (
+            <tr>
+              <td colSpan={4}>
+                <Text color="secondary">No feature flags match the current filter.</Text>
+              </td>
+            </tr>
+          )}
+        </tbody>
+      </table>
+    </ScrollContainer>
+  );
+}
+
+function LabsTableSkeleton() {
+  return (
+    <ScrollContainer overflowY="visible" overflowX="auto" width="100%">
+      <table className="filter-table">
+        <thead>
+          <tr>
+            <th align="left">Feature flag</th>
+            <th align="left">Stage</th>
+            <th align="left">Enabled</th>
+            <th align="left">Description</th>
+          </tr>
+        </thead>
+        <tbody>
+          {Array.from({ length: 8 }).map((_, index) => (
+            <tr key={index}>
+              <td>Loading...</td>
+              <td>Loading...</td>
+              <td>Loading...</td>
+              <td>Loading...</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </ScrollContainer>
+  );
+}
+
+function formatStage(stage: string) {
+  switch (stage) {
+    case 'privatePreview':
+      return 'Private preview';
+    case 'preview':
+      return 'Preview';
+    case 'GA':
+      return 'GA';
+    default:
+      return stage.charAt(0).toUpperCase() + stage.slice(1);
+  }
+}

--- a/public/app/features/admin/LabsPage.tsx
+++ b/public/app/features/admin/LabsPage.tsx
@@ -21,7 +21,7 @@ export default function LabsPage() {
     return toggles.filter((toggle) => {
       return (
         toggle.name.toLowerCase().includes(search) ||
-        toggle.description.toLowerCase().includes(search) ||
+        (toggle.description ?? '').toLowerCase().includes(search) ||
         toggle.stage.toLowerCase().includes(search)
       );
     });

--- a/public/app/features/admin/LabsPage.tsx
+++ b/public/app/features/admin/LabsPage.tsx
@@ -1,7 +1,7 @@
 import { useMemo, useState } from 'react';
 import { useAsync } from 'react-use';
 
-import { Alert, Badge, FilterInput, HorizontalGroup, ScrollContainer, Stack, Text } from '@grafana/ui';
+import { Alert, Badge, FilterInput, HorizontalGroup, Stack, Text } from '@grafana/ui';
 import { Page } from 'app/core/components/Page/Page';
 
 import { FeatureToggle, getFeatureToggles } from './labsApi';
@@ -67,7 +67,7 @@ export default function LabsPage() {
 
 function LabsTable({ toggles }: { toggles: FeatureToggle[] }) {
   return (
-    <ScrollContainer overflowY="visible" overflowX="auto" width="100%">
+    <div style={{ overflowX: 'auto', width: '100%' }}>
       <table className="filter-table">
         <thead>
           <tr>
@@ -106,13 +106,13 @@ function LabsTable({ toggles }: { toggles: FeatureToggle[] }) {
           )}
         </tbody>
       </table>
-    </ScrollContainer>
+    </div>
   );
 }
 
 function LabsTableSkeleton() {
   return (
-    <ScrollContainer overflowY="visible" overflowX="auto" width="100%">
+    <div style={{ overflowX: 'auto', width: '100%' }}>
       <table className="filter-table">
         <thead>
           <tr>
@@ -133,7 +133,7 @@ function LabsTableSkeleton() {
           ))}
         </tbody>
       </table>
-    </ScrollContainer>
+    </div>
   );
 }
 

--- a/public/app/features/admin/LabsPage.tsx
+++ b/public/app/features/admin/LabsPage.tsx
@@ -1,7 +1,7 @@
 import { useMemo, useState } from 'react';
 import { useAsync } from 'react-use';
 
-import { Alert, Badge, FilterInput, HorizontalGroup, ScrollContainer, Stack, Text } from '@grafana/ui';
+import { Alert, Badge, FilterInput, ScrollContainer, Stack, Text } from '@grafana/ui';
 import { Page } from 'app/core/components/Page/Page';
 
 import { FeatureToggle, getFeatureToggles } from './labsApi';
@@ -35,7 +35,7 @@ export default function LabsPage() {
             This page is read-only and reflects the current resolved state of Grafana feature flags for this instance.
           </Alert>
 
-          <HorizontalGroup justify="space-between" wrap>
+          <Stack direction="row" justifyContent="space-between" alignItems="center" wrap>
             <FilterInput
               value={query}
               onChange={setQuery}
@@ -48,7 +48,7 @@ export default function LabsPage() {
                 Showing {filteredToggles.length} of {value.toggles.length} flags
               </Text>
             )}
-          </HorizontalGroup>
+          </Stack>
 
           {error && (
             <Alert severity="error" title="Unable to load feature flags">

--- a/public/app/features/admin/labsApi.ts
+++ b/public/app/features/admin/labsApi.ts
@@ -1,0 +1,17 @@
+import { getBackendSrv } from '@grafana/runtime';
+
+export interface FeatureToggle {
+  name: string;
+  description?: string;
+  stage: string;
+  enabled: boolean;
+}
+
+export interface FeatureTogglesState {
+  enabled: Record<string, boolean>;
+  toggles: FeatureToggle[];
+}
+
+export const getFeatureToggles = async (): Promise<FeatureTogglesState> => {
+  return getBackendSrv().get('/api/admin/feature-toggles');
+};

--- a/public/app/routes/routes.tsx
+++ b/public/app/routes/routes.tsx
@@ -226,6 +226,11 @@ export function getAppRoutes(): RouteDescriptor[] {
       component: () => <NavLandingPage navId="frontend" />,
     },
     {
+      path: '/labs',
+      roles: () => (contextSrv.isGrafanaAdmin ? [] : ['Reject']),
+      component: SafeDynamicImport(() => import(/* webpackChunkName: "LabsPage" */ 'app/features/admin/LabsPage')),
+    },
+    {
       path: '/admin/general',
       component: () => <NavLandingPage navId="cfg/general" />,
     },


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
**What is this feature?**

Adds a new Labs page that is accessible from the left menu for Grafana admins and lists all feature flags with their current enabled state.

<a href="https://cursor.com/agents/bc-4271998c-6ceb-41fd-b723-e2e04d3d4d74/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Flabs_feature_flags_page_demo.mp4"><img src="https://cursor.com/artifacts/c/art-632fa0ea-a3b4-4911-b2a7-004a2723f4d3" alt="labs_feature_flags_page_demo.mp4" /></a>
![Labs nav entry](https://cursor.com/artifacts/c/art-4e167c9f-d978-4f42-a7af-ee1ae60ab9ea)
![Labs page table](https://cursor.com/artifacts/c/art-316e261d-b143-4789-881f-00d7b7c30a7d)

**Why do we need this feature?**

Grafana already exposes enabled feature toggles in boot config, but there is no dedicated UI page that gives admins a single place to inspect the full feature-flag registry and see which flags are currently on or off.

**Who is this feature for?**

Grafana administrators who need a quick UI view of feature flags on an instance.

**Which issue(s) does this PR fix?**:

Fixes #

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a notable improvement, it's added to our What's New doc.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4271998c-6ceb-41fd-b723-e2e04d3d4d74"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4271998c-6ceb-41fd-b723-e2e04d3d4d74"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

