### PR TITLE
Preferences: add purple theme option

### DIFF
--- a/docs/sources/administration/organization-preferences/index.md
+++ b/docs/sources/administration/organization-preferences/index.md
@@ -25,7 +25,7 @@ Preferences are sometimes confusing because they can be set at four different le
 - **Team -** Affects all users assigned to a team. Set by an Organization Admin or Team Admin. To learn more about these roles, refer to [Teams and permissions](../roles-and-permissions/#teams-and-permissions).
 - **User account -** Affects the individual user. Set by the user on their own account.
 
-The lowest level always takes precedence. For example, if a user sets their theme to **Light**, then their visualization of Grafana displays the light theme. Nothing at any higher level can override that.
+The lowest level always takes precedence. For example, if a user sets their theme to **Purple**, then their visualization of Grafana displays the purple theme. Nothing at any higher level can override that.
 
 If the user is aware of the change and intended it, then that's great! But if the user is a Server Admin who made the change to their user preferences a long time ago, they might have forgotten they did that. Then, if that Server Admin is trying to change the theme at the server level, they'll get frustrated as none of their changes have any effect that they can see. (Also, the users on the server might be confused, because _they_ can see the server-level changes!)
 
@@ -102,6 +102,10 @@ Here is an example of the dark theme.
 Here is an example of the light theme.
 
 ![Light theme example](/static/img/docs/preferences/light-theme-7-4.png)
+
+#### Purple
+
+You can also choose **Purple** as a standard theme option.
 
 #### Experimental
 

--- a/docs/sources/administration/user-management/user-preferences/index.md
+++ b/docs/sources/administration/user-management/user-preferences/index.md
@@ -52,7 +52,7 @@ Your profile includes your name, user name, and email address, which you can upd
 
 You can choose the way you would like data to appear in Grafana, including the user interface theme, home dashboard, timezone, and first day of the week. You can set these preferences for your own account, for a team, for an organization, or Grafana-wide using configuration settings. Your user preferences take precedence over team, organization, and Grafana default preferences. For more information, see [Grafana preferences](../../organization-preferences/).
 
-- **Interface theme** determines whether Grafana appears in light mode or dark mode. You can also choose from several experimental modes. By default, the interface theme is set to dark mode. You can also [quickly view and change themes](#view-and-change-themes) using the **Change theme** option.
+- **Interface theme** determines whether Grafana appears in light mode, dark mode, or the purple theme. You can also choose from several experimental modes. By default, the interface theme is set to dark mode. You can also [quickly view and change themes](#view-and-change-themes) using the **Change theme** option.
 - **Home dashboard** refers to the dashboard you see when you sign in to Grafana. By default, this is set to the Home dashboard.
 - **Timezone** is used by dashboards when you set time ranges, so that you view data in your timezone instead of UTC.
 - **Week start** is the first day of the week you want to use in dashboard time ranges, for example, `This week`.

--- a/docs/sources/setup-grafana/configure-grafana/_index.md
+++ b/docs/sources/setup-grafana/configure-grafana/_index.md
@@ -976,7 +976,7 @@ Text used as placeholder text on login page for password input.
 
 #### `default_theme`
 
-Sets the default UI theme: `dark`, `light`, or `system`. The default theme is `dark`.
+Sets the default UI theme: `dark`, `light`, `purple`, or `system`. The default theme is `dark`.
 
 `system` matches the user's system theme.
 

--- a/packages/grafana-data/src/themes/registry.ts
+++ b/packages/grafana-data/src/themes/registry.ts
@@ -8,6 +8,7 @@ import gildedgrove from './themeDefinitions/gildedgrove.json';
 import gloom from './themeDefinitions/gloom.json';
 import mars from './themeDefinitions/mars.json';
 import matrix from './themeDefinitions/matrix.json';
+import purple from './themeDefinitions/purple.json';
 import sapphiredusk from './themeDefinitions/sapphiredusk.json';
 import synthwave from './themeDefinitions/synthwave.json';
 import tron from './themeDefinitions/tron.json';
@@ -69,10 +70,13 @@ export function getBuiltInThemes(allowedExtras: string[]) {
 }
 
 const themeRegistry = new Registry<ThemeRegistryItem>(() => {
+  const { id: _purpleId, ...purpleTheme } = purple;
+
   return [
     { id: 'system', name: 'System preference', build: getSystemPreferenceTheme },
     { id: 'dark', name: 'Dark', build: () => createTheme({ colors: { mode: 'dark' } }) },
     { id: 'light', name: 'Light', build: () => createTheme({ colors: { mode: 'light' } }) },
+    { id: 'purple', name: purple.name, build: () => createTheme(purpleTheme) },
   ];
 });
 

--- a/packages/grafana-data/src/themes/registry.ts
+++ b/packages/grafana-data/src/themes/registry.ts
@@ -69,8 +69,10 @@ export function getBuiltInThemes(allowedExtras: string[]) {
   return sortedThemes;
 }
 
+const parsedPurpleTheme = NewThemeOptionsSchema.parse(purple);
+
 const themeRegistry = new Registry<ThemeRegistryItem>(() => {
-  const { id: _purpleId, ...purpleTheme } = purple;
+  const { id: _purpleId, ...purpleTheme } = parsedPurpleTheme;
 
   return [
     { id: 'system', name: 'System preference', build: getSystemPreferenceTheme },

--- a/packages/grafana-data/src/themes/themeDefinitions/purple.json
+++ b/packages/grafana-data/src/themes/themeDefinitions/purple.json
@@ -1,0 +1,71 @@
+{
+  "name": "Purple",
+  "id": "purple",
+  "colors": {
+    "mode": "dark",
+    "primary": {
+      "main": "#B57CFF",
+      "text": "#E8D8FF",
+      "border": "#C89BFF"
+    },
+    "secondary": {
+      "main": "rgba(181, 124, 255, 0.18)",
+      "shade": "rgba(181, 124, 255, 0.28)",
+      "transparent": "rgba(181, 124, 255, 0.12)",
+      "text": "#F0E8FF",
+      "contrastText": "#F0E8FF",
+      "border": "rgba(200, 155, 255, 0.25)"
+    },
+    "info": {
+      "main": "#8E7CFF",
+      "text": "#E6E1FF"
+    },
+    "success": {
+      "main": "#4BC987",
+      "text": "#D7FFE8"
+    },
+    "warning": {
+      "main": "#F29F4B",
+      "text": "#FFE7CC"
+    },
+    "error": {
+      "main": "#FF6B9A",
+      "text": "#FFD9E5"
+    },
+    "text": {
+      "primary": "#F3EDFF",
+      "secondary": "#C9BFDD",
+      "disabled": "#988FB0",
+      "link": "#D2A8FF",
+      "maxContrast": "#FFFFFF"
+    },
+    "background": {
+      "canvas": "#17101F",
+      "primary": "#21152D",
+      "secondary": "#2C1D3B",
+      "elevated": "#322145"
+    },
+    "border": {
+      "weak": "rgba(200, 155, 255, 0.14)",
+      "medium": "rgba(200, 155, 255, 0.24)",
+      "strong": "rgba(200, 155, 255, 0.38)"
+    },
+    "action": {
+      "hover": "rgba(181, 124, 255, 0.16)",
+      "selected": "rgba(181, 124, 255, 0.2)",
+      "selectedBorder": "#C89BFF",
+      "focus": "rgba(181, 124, 255, 0.24)",
+      "hoverOpacity": 0.08,
+      "disabledText": "#988FB0",
+      "disabledBackground": "rgba(181, 124, 255, 0.06)",
+      "disabledOpacity": 0.38
+    },
+    "gradients": {
+      "brandHorizontal": "linear-gradient(270deg, #7A5CFA 0%, #C89BFF 100%)",
+      "brandVertical": "linear-gradient(0deg, #7A5CFA 0%, #C89BFF 100%)"
+    },
+    "contrastThreshold": 3,
+    "hoverFactor": 0.03,
+    "tonalOffset": 0.15
+  }
+}

--- a/pkg/services/preference/generate_themes.go
+++ b/pkg/services/preference/generate_themes.go
@@ -19,6 +19,10 @@ type ThemeDefinition struct {
 	Id     string `json:"id"`
 }
 
+var standardThemes = map[string]struct{}{
+	"purple": {},
+}
+
 func main() {
 	themesPath := filepath.Join("..", "..", "..", "packages", "grafana-data", "src", "themes", "themeDefinitions")
 
@@ -65,6 +69,11 @@ var themes = []ThemeDTO{
 		themeType := "dark" // default fallback
 		if themeDef.Colors.Mode != "" {
 			themeType = themeDef.Colors.Mode
+		}
+
+		if _, ok := standardThemes[themeId]; ok {
+			output += fmt.Sprintf("\t{ID: %q, Type: %q},\n", themeId, themeType)
+			return nil
 		}
 
 		output += fmt.Sprintf("\t{ID: %q, Type: %q, IsExtra: true},\n", themeId, themeType)

--- a/pkg/services/preference/themes_generated.go
+++ b/pkg/services/preference/themes_generated.go
@@ -13,6 +13,7 @@ var themes = []ThemeDTO{
 	{ID: "gloom", Type: "dark", IsExtra: true},
 	{ID: "mars", Type: "dark", IsExtra: true},
 	{ID: "matrix", Type: "dark", IsExtra: true},
+	{ID: "purple", Type: "dark"},
 	{ID: "sapphiredusk", Type: "dark", IsExtra: true},
 	{ID: "synthwave", Type: "dark", IsExtra: true},
 	{ID: "tron", Type: "dark", IsExtra: true},

--- a/public/app/core/components/SharedPreferences/SharedPreferences.test.tsx
+++ b/public/app/core/components/SharedPreferences/SharedPreferences.test.tsx
@@ -63,6 +63,15 @@ describe('SharedPreferences', () => {
     await waitFor(() => expect(themeSelect).toHaveValue('Light'));
   });
 
+  it('includes the purple theme option', async () => {
+    const { user } = await setup();
+    const themeSelect = await screen.findByRole('combobox', { name: 'Interface theme' });
+
+    await user.click(themeSelect);
+
+    expect(await screen.findByRole('option', { name: 'Purple' })).toBeInTheDocument();
+  });
+
   it('renders the home dashboard preference', async () => {
     await setup();
     const dashboardSelect = getSelectParent(screen.getByLabelText('Home Dashboard'));

--- a/public/app/core/components/ThemeSelector/getSelectableThemes.ts
+++ b/public/app/core/components/ThemeSelector/getSelectableThemes.ts
@@ -2,7 +2,7 @@ import { getBuiltInThemes } from '@grafana/data';
 import { config } from '@grafana/runtime';
 
 export function getSelectableThemes() {
-  const allowedExtraThemes = [];
+  const allowedExtraThemes: string[] = [];
 
   if (config.featureToggles.grafanaconThemes) {
     allowedExtraThemes.push('desertbloom');

--- a/public/app/features/commandPalette/actions/staticActions.ts
+++ b/public/app/features/commandPalette/actions/staticActions.ts
@@ -106,6 +106,14 @@ function getGlobalActions(): CommandPaletteAction[] {
       parent: 'preferences/theme',
       priority: PREFERENCES_PRIORITY,
     },
+    {
+      id: 'preferences/purple-theme',
+      name: t('command-palette.action.purple-theme', 'Purple'),
+      keywords: 'purple theme',
+      perform: () => changeTheme('purple'),
+      parent: 'preferences/theme',
+      priority: PREFERENCES_PRIORITY,
+    },
   ];
 
   if (process.env.NODE_ENV === 'development') {

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -4687,6 +4687,7 @@
       "dark-theme": "Dark",
       "dashboard-from-template": "Dashboard from template",
       "light-theme": "Light",
+      "purple-theme": "Purple",
       "scopes": "Scopes"
     },
     "empty-state": {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
**What is this feature?**

Adds a standard `Purple` UI theme option that can be selected from user preferences, persisted through backend validation, and quickly switched from the command palette.

**Why do we need this feature?**

Users requested a purple theme option, and the change needs to work end to end instead of only as an experimental extra theme.

**Who is this feature for?**

Grafana users and administrators who want an additional built-in UI theme choice.

**Which issue(s) does this PR fix?**:

Fixes #

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a notable improvement, it's added to our What's New doc.
- [x] Follow-up CI fixes include the extracted `public/locales/en-US/grafana.json` entry for the new `command-palette.action.purple-theme` string.
- [x] Follow-up CI fixes also parse the `purple` theme definition through `NewThemeOptionsSchema` before passing it to `createTheme`, which resolves the package build/typecheck failure in `Verify packed frontend packages`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1b44b9d1-b083-4a99-98ce-bbe37deaed5b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1b44b9d1-b083-4a99-98ce-bbe37deaed5b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

