### PR TITLE
Preferences: Add aubergine theme option

### DIFF
--- a/public/app/core/components/ThemeSelector/getSelectableThemes.test.ts
+++ b/public/app/core/components/ThemeSelector/getSelectableThemes.test.ts
@@ -1,0 +1,23 @@
+import { config } from '@grafana/runtime';
+
+import { getSelectableThemes } from './getSelectableThemes';
+
+describe('getSelectableThemes', () => {
+  const originalFeatureToggles = config.featureToggles;
+
+  afterEach(() => {
+    config.featureToggles = originalFeatureToggles;
+  });
+
+  it('does not include extra themes when grafanacon themes are disabled', () => {
+    config.featureToggles = { ...originalFeatureToggles, grafanaconThemes: false };
+
+    expect(getSelectableThemes().map((theme) => theme.id)).toEqual(['dark', 'light', 'system']);
+  });
+
+  it('includes the aubergine theme when grafanacon themes are enabled', () => {
+    config.featureToggles = { ...originalFeatureToggles, grafanaconThemes: true };
+
+    expect(getSelectableThemes().map((theme) => theme.id)).toContain('aubergine');
+  });
+});

--- a/public/app/core/components/ThemeSelector/getSelectableThemes.ts
+++ b/public/app/core/components/ThemeSelector/getSelectableThemes.ts
@@ -5,6 +5,7 @@ export function getSelectableThemes() {
   const allowedExtraThemes = [];
 
   if (config.featureToggles.grafanaconThemes) {
+    allowedExtraThemes.push('aubergine');
     allowedExtraThemes.push('desertbloom');
     allowedExtraThemes.push('gildedgrove');
     allowedExtraThemes.push('sapphiredusk');


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
**What is this feature?**

Adds the built-in `aubergine` extra theme to the selectable interface theme options when the `grafanaconThemes` feature toggle is enabled.

**Why do we need this feature?**

The repo already contains a purple-toned built-in theme definition, but it was omitted from the allowlist used by the Shared Preferences theme selector, so users could not choose it.

**Who is this feature for?**

Grafana users trying experimental interface themes behind `grafanaconThemes`.

**Which issue(s) does this PR fix?**:

Fixes #

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a notable improvement, it's added to our What's New doc.

### Walkthrough
<a href="https://cursor.com/agents/bc-38851403-7c87-420f-90bb-a460851ac907/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Faubergine_theme_walkthrough.mp4"><img src="https://cursor.com/artifacts/c/art-e992daeb-8a22-4e24-9e9b-95e814521a46" alt="aubergine_theme_walkthrough.mp4" /></a>
![Aubergine theme option](https://cursor.com/artifacts/c/art-4a0587ff-be09-4337-879c-a115a34009a0)
![Aubergine theme applied](https://cursor.com/artifacts/c/art-757d3b98-591a-4322-86b4-b2c187712c4f)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-38851403-7c87-420f-90bb-a460851ac907"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-38851403-7c87-420f-90bb-a460851ac907"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

