### PR TITLE
Frontend: Add VS Code dark blue and Solarized theme options

### DIFF
--- a/packages/grafana-data/src/themes/registry.ts
+++ b/packages/grafana-data/src/themes/registry.ts
@@ -11,11 +11,14 @@ import gloom from './themeDefinitions/gloom.json';
 import mars from './themeDefinitions/mars.json';
 import matrix from './themeDefinitions/matrix.json';
 import sapphiredusk from './themeDefinitions/sapphiredusk.json';
+import solarized_dark from './themeDefinitions/solarized_dark.json';
+import solarized_light from './themeDefinitions/solarized_light.json';
 import synthwave from './themeDefinitions/synthwave.json';
 import tritanopia_dark from './themeDefinitions/tritanopia_dark.json';
 import tritanopia_light from './themeDefinitions/tritanopia_light.json';
 import tron from './themeDefinitions/tron.json';
 import victorian from './themeDefinitions/victorian.json';
+import vscode_dark_blue from './themeDefinitions/vscode_dark_blue.json';
 import zen from './themeDefinitions/zen.json';
 import { GrafanaTheme2 } from './types';
 
@@ -35,11 +38,14 @@ const extraThemes: { [key: string]: unknown } = {
   mars,
   matrix,
   sapphiredusk,
+  solarized_dark,
+  solarized_light,
   synthwave,
   tritanopia_dark,
   tritanopia_light,
   tron,
   victorian,
+  vscode_dark_blue,
   zen,
 };
 

--- a/packages/grafana-data/src/themes/themeDefinitions/solarized_dark.json
+++ b/packages/grafana-data/src/themes/themeDefinitions/solarized_dark.json
@@ -1,0 +1,67 @@
+{
+  "name": "Solarized dark",
+  "id": "solarized_dark",
+  "colors": {
+    "mode": "dark",
+    "border": {
+      "weak": "rgba(147, 161, 161, 0.18)",
+      "medium": "rgba(147, 161, 161, 0.28)",
+      "strong": "rgba(147, 161, 161, 0.4)"
+    },
+    "text": {
+      "primary": "#93A1A1",
+      "secondary": "#839496",
+      "disabled": "#657B83",
+      "link": "#268BD2",
+      "maxContrast": "#FDF6E3"
+    },
+    "primary": {
+      "main": "#268BD2",
+      "text": "#2AA198",
+      "border": "#268BD2"
+    },
+    "secondary": {
+      "main": "#073642",
+      "shade": "#0E4D5A",
+      "transparent": "rgba(131, 148, 150, 0.12)",
+      "text": "#93A1A1",
+      "contrastText": "#FDF6E3",
+      "border": "rgba(131, 148, 150, 0.2)"
+    },
+    "info": {
+      "main": "#2AA198"
+    },
+    "error": {
+      "main": "#DC322F"
+    },
+    "success": {
+      "main": "#859900"
+    },
+    "warning": {
+      "main": "#B58900"
+    },
+    "background": {
+      "canvas": "#002B36",
+      "primary": "#073642",
+      "secondary": "#0B3B47",
+      "elevated": "#0B3B47"
+    },
+    "action": {
+      "hover": "rgba(131, 148, 150, 0.12)",
+      "selected": "rgba(38, 139, 210, 0.2)",
+      "selectedBorder": "#268BD2",
+      "focus": "rgba(38, 139, 210, 0.24)",
+      "hoverOpacity": 0.08,
+      "disabledText": "#657B83",
+      "disabledBackground": "rgba(131, 148, 150, 0.08)",
+      "disabledOpacity": 0.38
+    },
+    "gradients": {
+      "brandHorizontal": "linear-gradient(270deg, #2AA198 0%, #268BD2 100%)",
+      "brandVertical": "linear-gradient(0deg, #2AA198 0%, #268BD2 100%)"
+    },
+    "contrastThreshold": 3,
+    "hoverFactor": 0.03,
+    "tonalOffset": 0.15
+  }
+}

--- a/packages/grafana-data/src/themes/themeDefinitions/solarized_light.json
+++ b/packages/grafana-data/src/themes/themeDefinitions/solarized_light.json
@@ -1,0 +1,67 @@
+{
+  "name": "Solarized light",
+  "id": "solarized_light",
+  "colors": {
+    "mode": "light",
+    "border": {
+      "weak": "rgba(101, 123, 131, 0.24)",
+      "medium": "rgba(88, 110, 117, 0.35)",
+      "strong": "rgba(73, 94, 101, 0.45)"
+    },
+    "text": {
+      "primary": "#073642",
+      "secondary": "#586E75",
+      "disabled": "#93A1A1",
+      "link": "#268BD2",
+      "maxContrast": "#000000"
+    },
+    "primary": {
+      "main": "#268BD2",
+      "text": "#0068A8",
+      "border": "#0068A8"
+    },
+    "secondary": {
+      "main": "#F7F3E8",
+      "shade": "#EEE8D5",
+      "transparent": "rgba(101, 123, 131, 0.12)",
+      "text": "#586E75",
+      "contrastText": "#073642",
+      "border": "rgba(88, 110, 117, 0.3)"
+    },
+    "info": {
+      "main": "#2AA198"
+    },
+    "error": {
+      "main": "#DC322F"
+    },
+    "success": {
+      "main": "#859900"
+    },
+    "warning": {
+      "main": "#B58900"
+    },
+    "background": {
+      "canvas": "#FDF6E3",
+      "primary": "#FDF6E3",
+      "secondary": "#EEE8D5",
+      "elevated": "#FFFBF0"
+    },
+    "action": {
+      "hover": "rgba(131, 148, 150, 0.2)",
+      "selected": "rgba(38, 139, 210, 0.2)",
+      "selectedBorder": "#268BD2",
+      "focus": "rgba(38, 139, 210, 0.28)",
+      "hoverOpacity": 0.08,
+      "disabledText": "#93A1A1",
+      "disabledBackground": "rgba(147, 161, 161, 0.15)",
+      "disabledOpacity": 0.38
+    },
+    "gradients": {
+      "brandHorizontal": "linear-gradient(90deg, #268BD2 0%, #2AA198 100%)",
+      "brandVertical": "linear-gradient(0deg, #268BD2 0%, #2AA198 100%)"
+    },
+    "contrastThreshold": 3,
+    "hoverFactor": 0.03,
+    "tonalOffset": 0.2
+  }
+}

--- a/packages/grafana-data/src/themes/themeDefinitions/vscode_dark_blue.json
+++ b/packages/grafana-data/src/themes/themeDefinitions/vscode_dark_blue.json
@@ -1,0 +1,67 @@
+{
+  "name": "VS Code dark blue",
+  "id": "vscode_dark_blue",
+  "colors": {
+    "mode": "dark",
+    "border": {
+      "weak": "rgba(199, 210, 254, 0.14)",
+      "medium": "rgba(199, 210, 254, 0.24)",
+      "strong": "rgba(199, 210, 254, 0.34)"
+    },
+    "text": {
+      "primary": "#E5E7EB",
+      "secondary": "#94A3B8",
+      "disabled": "#64748B",
+      "link": "#60A5FA",
+      "maxContrast": "#FFFFFF"
+    },
+    "primary": {
+      "main": "#3B82F6",
+      "text": "#93C5FD",
+      "border": "#3B82F6"
+    },
+    "secondary": {
+      "main": "#1E293B",
+      "shade": "#334155",
+      "transparent": "rgba(148, 163, 184, 0.10)",
+      "text": "#CBD5E1",
+      "contrastText": "#FFFFFF",
+      "border": "rgba(148, 163, 184, 0.16)"
+    },
+    "info": {
+      "main": "#38BDF8"
+    },
+    "error": {
+      "main": "#EF4444"
+    },
+    "success": {
+      "main": "#22C55E"
+    },
+    "warning": {
+      "main": "#F59E0B"
+    },
+    "background": {
+      "canvas": "#0F172A",
+      "primary": "#111827",
+      "secondary": "#1E293B",
+      "elevated": "#1E293B"
+    },
+    "action": {
+      "hover": "rgba(148, 163, 184, 0.14)",
+      "selected": "rgba(59, 130, 246, 0.22)",
+      "selectedBorder": "#3B82F6",
+      "focus": "rgba(59, 130, 246, 0.24)",
+      "hoverOpacity": 0.08,
+      "disabledText": "#64748B",
+      "disabledBackground": "rgba(148, 163, 184, 0.08)",
+      "disabledOpacity": 0.38
+    },
+    "gradients": {
+      "brandHorizontal": "linear-gradient(270deg, #1D4ED8 0%, #3B82F6 100%)",
+      "brandVertical": "linear-gradient(0deg, #1D4ED8 0%, #3B82F6 100%)"
+    },
+    "contrastThreshold": 3,
+    "hoverFactor": 0.03,
+    "tonalOffset": 0.15
+  }
+}

--- a/pkg/services/preference/themes_generated.go
+++ b/pkg/services/preference/themes_generated.go
@@ -16,10 +16,13 @@ var themes = []ThemeDTO{
 	{ID: "mars", Type: "dark", IsExtra: true},
 	{ID: "matrix", Type: "dark", IsExtra: true},
 	{ID: "sapphiredusk", Type: "dark", IsExtra: true},
+	{ID: "solarized_dark", Type: "dark", IsExtra: true},
+	{ID: "solarized_light", Type: "light", IsExtra: true},
 	{ID: "synthwave", Type: "dark", IsExtra: true},
 	{ID: "tritanopia_dark", Type: "dark", IsExtra: true},
 	{ID: "tritanopia_light", Type: "light", IsExtra: true},
 	{ID: "tron", Type: "dark", IsExtra: true},
 	{ID: "victorian", Type: "dark", IsExtra: true},
+	{ID: "vscode_dark_blue", Type: "dark", IsExtra: true},
 	{ID: "zen", Type: "light", IsExtra: true},
 }

--- a/public/app/core/components/ThemeSelector/getSelectableThemes.test.ts
+++ b/public/app/core/components/ThemeSelector/getSelectableThemes.test.ts
@@ -1,0 +1,44 @@
+import { config } from '@grafana/runtime';
+
+import { getSelectableThemes } from './getSelectableThemes';
+
+describe('getSelectableThemes', () => {
+  const featureTogglesBackup = { ...config.featureToggles };
+
+  afterEach(() => {
+    config.featureToggles = { ...featureTogglesBackup };
+  });
+
+  it('includes new custom themes by default', () => {
+    config.featureToggles = {
+      ...featureTogglesBackup,
+      colorblindThemes: false,
+      grafanaconThemes: false,
+    };
+
+    const themes = getSelectableThemes();
+    const themeIds = themes.map((theme) => theme.id);
+
+    expect(themeIds).toEqual(expect.arrayContaining(['vscode_dark_blue', 'solarized_dark', 'solarized_light']));
+  });
+
+  it('still includes colorblind themes behind feature toggle', () => {
+    config.featureToggles = {
+      ...featureTogglesBackup,
+      colorblindThemes: true,
+      grafanaconThemes: false,
+    };
+
+    const themes = getSelectableThemes();
+    const themeIds = themes.map((theme) => theme.id);
+
+    expect(themeIds).toEqual(
+      expect.arrayContaining([
+        'deuteranopia_protanopia_dark',
+        'deuteranopia_protanopia_light',
+        'tritanopia_dark',
+        'tritanopia_light',
+      ])
+    );
+  });
+});

--- a/public/app/core/components/ThemeSelector/getSelectableThemes.ts
+++ b/public/app/core/components/ThemeSelector/getSelectableThemes.ts
@@ -4,6 +4,10 @@ import { config } from '@grafana/runtime';
 export function getSelectableThemes() {
   const allowedExtraThemes = [];
 
+  allowedExtraThemes.push('vscode_dark_blue');
+  allowedExtraThemes.push('solarized_dark');
+  allowedExtraThemes.push('solarized_light');
+
   if (config.featureToggles.colorblindThemes) {
     allowedExtraThemes.push('deuteranopia_protanopia_dark');
     allowedExtraThemes.push('deuteranopia_protanopia_light');


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
**What is this feature?**

Adds three new selectable frontend themes in Grafana's theme selector:
- VS Code dark blue
- Solarized dark
- Solarized light

**Why do we need this feature?**

Users asked for additional high-contrast and familiar editor-inspired theme options beyond the existing built-ins.

**Who is this feature for?**

Grafana users who want more visual personalization and prefer VS Code/Solarized-inspired palettes.

**Which issue(s) does this PR fix?**:

Fixes #

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a notable improvement, it's added to our What's New doc.

Implementation notes:
- Added JSON theme definitions in `packages/grafana-data/src/themes/themeDefinitions/`.
- Registered all three themes in `packages/grafana-data/src/themes/registry.ts`.
- Updated `public/app/core/components/ThemeSelector/getSelectableThemes.ts` so these three themes are selectable by default in the theme picker.
- Added a focused test: `public/app/core/components/ThemeSelector/getSelectableThemes.test.ts`.
- Regenerated backend preference theme allowlist in `pkg/services/preference/themes_generated.go` so the new theme IDs are accepted when persisting user preferences.

Walkthrough artifacts:
- <a href="https://cursor.com/agents/bc-2bd5e28d-40dd-4c2a-af65-bc00b2219915/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ftheme_switching_vscode_solarized_explicit_clicks.mp4"><img src="https://cursor.com/artifacts/c/art-7a5045ae-9820-4385-b959-0275b02a52be" alt="theme_switching_vscode_solarized_explicit_clicks.mp4" /></a>
- ![VS Code dark blue selected](https://cursor.com/artifacts/c/art-6dec2286-c837-4a9d-b32e-04941d002ead)
- ![Solarized dark selected](https://cursor.com/artifacts/c/art-c642bd20-2642-4dc9-90e4-bed75f660962)
- ![Solarized light selected](https://cursor.com/artifacts/c/art-95b04f2e-05b5-4f81-8e4f-515cd13d4ed5)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2bd5e28d-40dd-4c2a-af65-bc00b2219915"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2bd5e28d-40dd-4c2a-af65-bc00b2219915"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

