### PR TITLE
Navigation: normalize bookmark URL matching

### DIFF
--- a/public/app/core/components/AppChrome/MegaMenu/utils.test.ts
+++ b/public/app/core/components/AppChrome/MegaMenu/utils.test.ts
@@ -187,6 +187,22 @@ describe('findByUrl', () => {
     });
   });
 
+  it('matches trailing slash differences', () => {
+    expect(findByUrl(mockNavTree, '/item/')).toEqual({
+      text: 'Item',
+      url: '/item',
+      id: 'item',
+    });
+  });
+
+  it('matches absolute and relative URLs', () => {
+    expect(findByUrl(mockNavTree, 'http://localhost:3000/item')).toEqual({
+      text: 'Item',
+      url: '/item',
+      id: 'item',
+    });
+  });
+
   it('returns null if no item found', () => {
     expect(findByUrl(mockNavTree, '/no-item')).toBeNull();
   });

--- a/public/app/core/components/AppChrome/MegaMenu/utils.ts
+++ b/public/app/core/components/AppChrome/MegaMenu/utils.ts
@@ -159,8 +159,10 @@ export function getEditionAndUpdateLinks(): NavModelItem[] {
 }
 
 export function findByUrl(nodes: NavModelItem[], url: string): NavModelItem | null {
+  const normalizedUrl = normalizeNavItemUrl(url);
+
   for (const item of nodes) {
-    if (item.url === url) {
+    if (item.url && normalizeNavItemUrl(item.url) === normalizedUrl) {
       return item;
     } else if (item.children?.length) {
       const found = findByUrl(item.children, url);
@@ -170,6 +172,17 @@ export function findByUrl(nodes: NavModelItem[], url: string): NavModelItem | nu
     }
   }
   return null;
+}
+
+function normalizeNavItemUrl(url: string): string {
+  if (!url) {
+    return url;
+  }
+
+  const [pathWithOrigin, search = ''] = url.split('?');
+  const path = pathWithOrigin.replace(/^https?:\/\/[^/]+/i, '').replace(/\/+$/, '') || '/';
+
+  return search ? `${path}?${search}` : path;
 }
 
 /**


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
**What is this feature?**

Normalizes bookmark URL matching so saved bookmarks continue to resolve in the navigation and `/bookmarks` page when the stored URL format differs slightly from the nav tree entry.

**Why do we need this feature?**

GRF-9 reports that the bookmarks page is not rendering correctly. The current matcher relies on exact string equality, which is brittle when bookmark URLs include an origin or trailing slash while nav items use normalized relative paths.

**Who is this feature for?**

Signed-in Grafana users who pin navigation items and view them from the Bookmarks section or `/bookmarks` page.

**Which issue(s) does this PR fix?**:

Fixes https://fe-anysphere-demo.atlassian.net/browse/GRF-9

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a notable improvement, it's added to our What's New doc.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-53ffd482-2320-4ce8-b8f6-ce21ce733552"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-53ffd482-2320-4ce8-b8f6-ce21ce733552"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

