### PR TITLE
Core: Introduce structured logging normalization across frontend and backend

### DIFF
--- a/pkg/components/dashdiffs/formatter_json.go
+++ b/pkg/components/dashdiffs/formatter_json.go
@@ -156,7 +156,6 @@ func (f *JSONFormatter) Format(diff diff.Diff) (result string, err error) {
 	b := &bytes.Buffer{}
 	err = f.tpl.ExecuteTemplate(b, "JSONDiffWrapper", f.Lines)
 	if err != nil {
-		fmt.Printf("%v\n", err)
 		return "", err
 	}
 

--- a/pkg/expr/sql/frame_table.go
+++ b/pkg/expr/sql/frame_table.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"log/slog"
 	"math"
 	"strings"
 
@@ -185,7 +186,7 @@ func convertDataType(fieldType data.FieldType) mysql.Type {
 	case data.FieldTypeJSON, data.FieldTypeNullableJSON: //nolint:staticcheck
 		return types.JSON
 	default:
-		fmt.Printf("------- Unsupported field type: %v", fieldType)
+		slog.Warn("Unsupported field type", "field_type", fieldType)
 		return types.JSON
 	}
 }

--- a/pkg/infra/log/log.go
+++ b/pkg/infra/log/log.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	stdlog "log"
 	"log/slog"
 	"os"
 	"path/filepath"
@@ -54,6 +55,7 @@ func init() {
 	}
 	logger := level.NewFilter(format(os.Stderr), level.AllowInfo())
 	root = newManager(logger)
+	configureStdlibBridge()
 	// Use default Info level during package initialization before config is loaded
 	initAppSDKLogger(logger, slog.LevelInfo)
 
@@ -64,6 +66,23 @@ func init() {
 		}
 		return nil, false
 	})
+}
+
+type stdlibLogWriter struct{}
+
+func (w *stdlibLogWriter) Write(p []byte) (int, error) {
+	msg := strings.TrimSpace(string(p))
+	if msg == "" {
+		return len(p), nil
+	}
+	root.Warn("stdlib log emitted", "message", msg)
+	return len(p), nil
+}
+
+func configureStdlibBridge() {
+	stdlog.SetFlags(0)
+	stdlog.SetPrefix("")
+	stdlog.SetOutput(&stdlibLogWriter{})
 }
 
 // logManager manage loggers

--- a/pkg/infra/log/syslog.go
+++ b/pkg/infra/log/syslog.go
@@ -56,14 +56,14 @@ func NewSyslog(sec *ini.Section, format Formatedlogger) *SysLogHandler {
 	handler.Tag = sec.Key("tag").MustString("")
 
 	if err := handler.Init(); err != nil {
-		fmt.Printf("Failed to init syslog handler. Error: %v\n", err)
+		fmt.Fprintln(os.Stderr, "Failed to init syslog handler.", "error", err)
 		root.Error("Failed to init syslog log handler", "error", err)
 		os.Exit(1)
 	}
 	handler.logger = gokitsyslog.NewSyslogLogger(handler.syslog, format, gokitsyslog.PrioritySelectorOption(selector))
 
 	if err := handler.Log("msg", "syslog logger initialized"); err != nil {
-		fmt.Printf("Failed to log to syslog handler. Error: %v\n", err)
+		fmt.Fprintln(os.Stderr, "Failed to log to syslog handler.", "error", err)
 		root.Error("Failed to log to syslog log handler", "error", err)
 		os.Exit(1)
 	}

--- a/pkg/operators/provisioning/connection_operator.go
+++ b/pkg/operators/provisioning/connection_operator.go
@@ -37,7 +37,7 @@ func RunConnectionController(deps server.OperatorDependencies) error {
 	signal.Notify(sigChan, syscall.SIGINT, syscall.SIGTERM)
 	go func() {
 		<-sigChan
-		fmt.Println("Received shutdown signal, stopping controllers")
+		logger.Info("Received shutdown signal, stopping controllers")
 		cancel()
 	}()
 

--- a/pkg/operators/provisioning/jobs_operator.go
+++ b/pkg/operators/provisioning/jobs_operator.go
@@ -66,7 +66,7 @@ func RunJobController(deps server.OperatorDependencies) error {
 	signal.Notify(sigChan, syscall.SIGINT, syscall.SIGTERM)
 	go func() {
 		<-sigChan
-		fmt.Println("Received shutdown signal, stopping controllers")
+		logger.Info("Received shutdown signal, stopping controllers")
 		cancel()
 	}()
 

--- a/pkg/operators/provisioning/repo_operator.go
+++ b/pkg/operators/provisioning/repo_operator.go
@@ -40,7 +40,7 @@ func RunRepoController(deps server.OperatorDependencies) error {
 	signal.Notify(sigChan, syscall.SIGINT, syscall.SIGTERM)
 	go func() {
 		<-sigChan
-		fmt.Println("Received shutdown signal, stopping controllers")
+		logger.Info("Received shutdown signal, stopping controllers")
 		cancel()
 	}()
 

--- a/pkg/registry/apps/annotation/tags_handler.go
+++ b/pkg/registry/apps/annotation/tags_handler.go
@@ -3,7 +3,7 @@ package annotation
 import (
 	"context"
 	"encoding/json"
-	"fmt"
+	"log/slog"
 
 	"github.com/grafana/grafana-app-sdk/app"
 )
@@ -19,7 +19,7 @@ type tagItem struct {
 
 func newTagsHandler(tagProvider TagProvider) func(ctx context.Context, writer app.CustomRouteResponseWriter, request *app.CustomRouteRequest) error {
 	return func(ctx context.Context, writer app.CustomRouteResponseWriter, request *app.CustomRouteRequest) error {
-		fmt.Println("Handling /tags request")
+		slog.Debug("Handling /tags request")
 		namespace := request.ResourceIdentifier.Namespace
 		if namespace == "" {
 			namespace = "default"

--- a/pkg/services/ldap/settings.go
+++ b/pkg/services/ldap/settings.go
@@ -223,7 +223,7 @@ func assertNotEmptyCfg(val any, propName string) error {
 			return fmt.Errorf("LDAP config file is missing option: %q", propName)
 		}
 	default:
-		fmt.Println("unknown")
+		logger.Warn("Unknown LDAP config value type", "type", fmt.Sprintf("%T", val), "propName", propName)
 	}
 	return nil
 }

--- a/pkg/services/sqlstore/sqlstore.go
+++ b/pkg/services/sqlstore/sqlstore.go
@@ -416,6 +416,7 @@ var testSQLStoreSetup = false
 var testSQLStore *SQLStore
 var testSQLStoreMutex sync.Mutex
 var testSQLStoreCleanup []func()
+var testSQLLogger = log.New("sqlstore.testdb")
 
 // InitTestDBOpt contains options for InitTestDB.
 type InitTestDBOpt struct {
@@ -453,7 +454,7 @@ func SetupTestDB() {
 	testSQLStoreMutex.Lock()
 	defer testSQLStoreMutex.Unlock()
 	if testSQLStoreSetup {
-		fmt.Printf("ERROR: Test DB already set up, SetupTestDB called twice\n")
+		testSQLLogger.Error("Test DB already set up, SetupTestDB called twice")
 		os.Exit(1)
 	}
 	testSQLStoreSetup = true
@@ -463,12 +464,12 @@ func CleanupTestDB() {
 	testSQLStoreMutex.Lock()
 	defer testSQLStoreMutex.Unlock()
 	if !testSQLStoreSetup {
-		fmt.Printf("ERROR: Test DB not set up, SetupTestDB not called\n")
+		testSQLLogger.Error("Test DB not set up, SetupTestDB not called")
 		os.Exit(1)
 	}
 	if testSQLStore != nil {
 		if err := testSQLStore.GetEngine().Close(); err != nil {
-			fmt.Printf("Failed to close testSQLStore engine: %s\n", err)
+			testSQLLogger.Error("Failed to close test SQL store engine", "err", err)
 		}
 
 		for _, cleanup := range testSQLStoreCleanup {

--- a/pkg/services/sqlstore/sqlutil/sqlutil.go
+++ b/pkg/services/sqlstore/sqlutil/sqlutil.go
@@ -6,7 +6,11 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
+
+	"github.com/grafana/grafana/pkg/infra/log"
 )
+
+var logger = log.New("sqlstore.sqlutil")
 
 // ITestDB is an interface of arguments for testing db
 type ITestDB interface {
@@ -99,17 +103,17 @@ func sqLite3TestDB() (*TestDB, error) {
 			// remove db file if it exists
 			err := os.Remove(sqliteDb)
 			if err != nil && !errors.Is(err, fs.ErrNotExist) {
-				fmt.Printf("Error removing sqlite db file %s: %v\n", sqliteDb, err)
+				logger.Warn("Error removing sqlite test db file", "file", sqliteDb, "err", err)
 			}
 
 			// remove wal & shm files if they exist
 			err = os.Remove(sqliteDb + "-wal")
 			if err != nil && !errors.Is(err, fs.ErrNotExist) {
-				fmt.Printf("Error removing sqlite wal file %s: %v\n", sqliteDb+"-wal", err)
+				logger.Warn("Error removing sqlite test wal file", "file", sqliteDb+"-wal", "err", err)
 			}
 			err = os.Remove(sqliteDb + "-shm")
 			if err != nil && !errors.Is(err, fs.ErrNotExist) {
-				fmt.Printf("Error removing sqlite shm file %s: %v\n", sqliteDb+"-shm", err)
+				logger.Warn("Error removing sqlite test shm file", "file", sqliteDb+"-shm", "err", err)
 			}
 		}
 	}

--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -1145,14 +1145,18 @@ func (cfg *Cfg) loadConfiguration(args CommandLineArgs) (*ini.File, error) {
 
 	// check if config file exists
 	if _, err := os.Stat(defaultConfigFile); os.IsNotExist(err) {
-		fmt.Println("Grafana-server Init Failed: Could not find config defaults, make sure homepath command line parameter is set or working directory is homepath")
+		cfg.Logger.Error(
+			"Grafana-server init failed: could not find config defaults",
+			"default_config_file", defaultConfigFile,
+			"hint", "make sure homepath command line parameter is set or working directory is homepath",
+		)
 		os.Exit(1)
 	}
 
 	// load defaults
 	parsedFile, err := ini.Load(defaultConfigFile)
 	if err != nil {
-		fmt.Printf("Failed to parse defaults.ini, %v\n", err)
+		cfg.Logger.Error("Failed to parse defaults.ini", "default_config_file", defaultConfigFile, "err", err)
 		os.Exit(1)
 		return nil, err
 	}
@@ -1197,7 +1201,7 @@ func (cfg *Cfg) loadConfiguration(args CommandLineArgs) (*ini.File, error) {
 		return nil, err
 	}
 
-	cfg.Logger.Info(fmt.Sprintf("Starting %s", ApplicationName), "version", BuildVersion, "commit", BuildCommit, "branch", BuildBranch, "compiled", time.Unix(BuildStamp, 0))
+	cfg.Logger.Info("Starting Grafana", "application", ApplicationName, "version", BuildVersion, "commit", BuildCommit, "branch", BuildBranch, "compiled", time.Unix(BuildStamp, 0))
 
 	return parsedFile, err
 }
@@ -1679,27 +1683,27 @@ func (cfg *Cfg) handleAWSConfig() {
 	// Also set environment variables that can be used by core plugins
 	err := os.Setenv(awsds.AssumeRoleEnabledEnvVarKeyName, strconv.FormatBool(cfg.AWSAssumeRoleEnabled))
 	if err != nil {
-		cfg.Logger.Error(fmt.Sprintf("could not set environment variable '%s'", awsds.AssumeRoleEnabledEnvVarKeyName), err)
+		cfg.Logger.Error("Could not set environment variable", "var", awsds.AssumeRoleEnabledEnvVarKeyName, "err", err)
 	}
 
 	err = os.Setenv(awsds.AllowedAuthProvidersEnvVarKeyName, allowedAuthProviders)
 	if err != nil {
-		cfg.Logger.Error(fmt.Sprintf("could not set environment variable '%s'", awsds.AllowedAuthProvidersEnvVarKeyName), err)
+		cfg.Logger.Error("Could not set environment variable", "var", awsds.AllowedAuthProvidersEnvVarKeyName, "err", err)
 	}
 
 	err = os.Setenv(awsds.ListMetricsPageLimitKeyName, strconv.Itoa(cfg.AWSListMetricsPageLimit))
 	if err != nil {
-		cfg.Logger.Error(fmt.Sprintf("could not set environment variable '%s'", awsds.ListMetricsPageLimitKeyName), err)
+		cfg.Logger.Error("Could not set environment variable", "var", awsds.ListMetricsPageLimitKeyName, "err", err)
 	}
 
 	err = os.Setenv(awsds.GrafanaAssumeRoleExternalIdKeyName, cfg.AWSExternalId)
 	if err != nil {
-		cfg.Logger.Error(fmt.Sprintf("could not set environment variable '%s'", awsds.GrafanaAssumeRoleExternalIdKeyName), err)
+		cfg.Logger.Error("Could not set environment variable", "var", awsds.GrafanaAssumeRoleExternalIdKeyName, "err", err)
 	}
 
 	err = os.Setenv(awsds.SessionDurationEnvVarKeyName, cfg.AWSSessionDuration)
 	if err != nil {
-		cfg.Logger.Error(fmt.Sprintf("could not set environment variable '%s'", awsds.SessionDurationEnvVarKeyName), err)
+		cfg.Logger.Error("Could not set environment variable", "var", awsds.SessionDurationEnvVarKeyName, "err", err)
 	}
 }
 

--- a/pkg/tsdb/influxdb/fsql/arrow.go
+++ b/pkg/tsdb/influxdb/fsql/arrow.go
@@ -175,7 +175,7 @@ func newDataField[T any](f arrow.Field) *data.Field {
 func copyData(field *data.Field, col arrow.Array) error {
 	defer func() {
 		if r := recover(); r != nil {
-			fmt.Println(fmt.Errorf("panic: %s %s", r, string(debug.Stack())))
+			slog.Error("panic while copying arrow data", "panic", r, "stack", string(debug.Stack()))
 		}
 	}()
 

--- a/pkg/tsdb/influxdb/influxql/converter/converter.go
+++ b/pkg/tsdb/influxdb/influxql/converter/converter.go
@@ -60,8 +60,7 @@ l1Fields:
 			break l1Fields
 		default:
 			v, err := iter.Read()
-			// TODO: log this properly
-			fmt.Printf("[ROOT] unsupported key: %s / %v\n\n", l1Field, v)
+			slog.Debug("InfluxQL result contains unsupported root key", "key", l1Field, "value", v)
 			if err != nil {
 				if rsp != nil {
 					rsp.Error = err
@@ -161,7 +160,7 @@ func readSeries(iter *sdkjsoniter.Iterator, query *models.Query) *backend.DataRe
 				if err != nil {
 					return rspErr(err)
 				}
-				fmt.Printf("[Series] unsupported key: %s / %v\n", l1Field, v)
+				slog.Debug("InfluxQL result series contains unsupported key", "key", l1Field, "value", v)
 			}
 		}
 

--- a/pkg/tsdb/influxdb/influxql/querydata/stream_parser.go
+++ b/pkg/tsdb/influxdb/influxql/querydata/stream_parser.go
@@ -8,15 +8,18 @@ import (
 	"github.com/grafana/grafana-plugin-sdk-go/data"
 	jsoniter "github.com/json-iterator/go"
 
+	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/tsdb/influxdb/influxql/converter"
 	"github.com/grafana/grafana/pkg/tsdb/influxdb/influxql/util"
 	"github.com/grafana/grafana/pkg/tsdb/influxdb/models"
 )
 
+var logger = log.New("tsdb.influxdb.influxql.querydata")
+
 func ResponseParse(buf io.ReadCloser, statusCode int, query *models.Query) *backend.DataResponse {
 	defer func() {
 		if err := buf.Close(); err != nil {
-			fmt.Println("Failed to close response body", "err", err)
+			logger.Warn("Failed to close response body", "err", err)
 		}
 	}()
 

--- a/public/app/core/utils/structuredConsole.test.ts
+++ b/public/app/core/utils/structuredConsole.test.ts
@@ -1,0 +1,77 @@
+import { enableStructuredConsoleLogging } from './structuredConsole';
+
+type ConsoleLevel = 'log' | 'info' | 'debug' | 'warn' | 'error';
+
+type MockConsoleMethod = jest.Mock<void, [unknown]>;
+
+interface MockConsole {
+  log: MockConsoleMethod;
+  info: MockConsoleMethod;
+  debug: MockConsoleMethod;
+  warn: MockConsoleMethod;
+  error: MockConsoleMethod;
+}
+
+function createMockConsole(): MockConsole {
+  return {
+    log: jest.fn(),
+    info: jest.fn(),
+    debug: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+  };
+}
+
+function readEntry(mockConsole: MockConsole, level: ConsoleLevel): Record<string, unknown> {
+  const call = mockConsole[level].mock.calls[0];
+  return call[0] as Record<string, unknown>;
+}
+
+describe('enableStructuredConsoleLogging', () => {
+  it('emits structured payloads for every console level', () => {
+    const mockConsole = createMockConsole() as unknown as Console;
+
+    enableStructuredConsoleLogging(mockConsole);
+
+    mockConsole.log('hello', { id: 1 });
+    mockConsole.info('info-message');
+    mockConsole.debug('debug-message');
+    mockConsole.warn('warn-message');
+    mockConsole.error('error-message');
+
+    for (const level of ['log', 'info', 'debug', 'warn', 'error'] as const) {
+      const entry = readEntry(mockConsole as unknown as MockConsole, level);
+      expect(entry.logger).toBe('grafana.frontend.console');
+      expect(entry.level).toBe(level);
+      expect(typeof entry.timestamp).toBe('string');
+      expect(Array.isArray(entry.args)).toBe(true);
+    }
+
+    const logEntry = readEntry(mockConsole as unknown as MockConsole, 'log');
+    expect(logEntry.message).toBe('hello');
+    expect(logEntry.args).toEqual(['hello', { id: 1 }]);
+  });
+
+  it('serializes errors in args and avoids repatching', () => {
+    const mockConsole = createMockConsole() as unknown as Console;
+
+    enableStructuredConsoleLogging(mockConsole);
+    enableStructuredConsoleLogging(mockConsole);
+
+    const err = new Error('boom');
+    mockConsole.error(err);
+
+    const entry = readEntry(mockConsole as unknown as MockConsole, 'error');
+    expect(entry.message).toBe('boom');
+    expect(entry.args).toEqual([
+      {
+        type: 'error',
+        name: 'Error',
+        message: 'boom',
+        stack: expect.any(String),
+      },
+    ]);
+
+    expect((mockConsole as unknown as MockConsole).error).toHaveBeenCalledTimes(1);
+  });
+});

--- a/public/app/core/utils/structuredConsole.test.ts
+++ b/public/app/core/utils/structuredConsole.test.ts
@@ -2,34 +2,59 @@ import { enableStructuredConsoleLogging } from './structuredConsole';
 
 type ConsoleLevel = 'log' | 'info' | 'debug' | 'warn' | 'error';
 
-type MockConsoleMethod = jest.Mock<void, [unknown]>;
+function createMockConsole() {
+  const sink: Record<ConsoleLevel, unknown[]> = {
+    log: [],
+    info: [],
+    debug: [],
+    warn: [],
+    error: [],
+  };
+  const callCounts: Record<ConsoleLevel, number> = {
+    log: 0,
+    info: 0,
+    debug: 0,
+    warn: 0,
+    error: 0,
+  };
 
-interface MockConsole {
-  log: MockConsoleMethod;
-  info: MockConsoleMethod;
-  debug: MockConsoleMethod;
-  warn: MockConsoleMethod;
-  error: MockConsoleMethod;
-}
+  const mockConsole: Console = {
+    log: (entry: unknown) => {
+      callCounts.log++;
+      sink.log.push(entry);
+    },
+    info: (entry: unknown) => {
+      callCounts.info++;
+      sink.info.push(entry);
+    },
+    debug: (entry: unknown) => {
+      callCounts.debug++;
+      sink.debug.push(entry);
+    },
+    warn: (entry: unknown) => {
+      callCounts.warn++;
+      sink.warn.push(entry);
+    },
+    error: (entry: unknown) => {
+      callCounts.error++;
+      sink.error.push(entry);
+    },
+  };
 
-function createMockConsole(): MockConsole {
   return {
-    log: jest.fn(),
-    info: jest.fn(),
-    debug: jest.fn(),
-    warn: jest.fn(),
-    error: jest.fn(),
+    mockConsole,
+    sink,
+    callCounts,
   };
 }
 
-function readEntry(mockConsole: MockConsole, level: ConsoleLevel): Record<string, unknown> {
-  const call = mockConsole[level].mock.calls[0];
-  return call[0] as Record<string, unknown>;
+function readEntry(sink: Record<ConsoleLevel, unknown[]>, level: ConsoleLevel): Record<string, unknown> {
+  return sink[level][0] as Record<string, unknown>;
 }
 
 describe('enableStructuredConsoleLogging', () => {
   it('emits structured payloads for every console level', () => {
-    const mockConsole = createMockConsole() as unknown as Console;
+    const { mockConsole, sink } = createMockConsole();
 
     enableStructuredConsoleLogging(mockConsole);
 
@@ -40,20 +65,22 @@ describe('enableStructuredConsoleLogging', () => {
     mockConsole.error('error-message');
 
     for (const level of ['log', 'info', 'debug', 'warn', 'error'] as const) {
-      const entry = readEntry(mockConsole as unknown as MockConsole, level);
+      const entry = readEntry(sink, level);
       expect(entry.logger).toBe('grafana.frontend.console');
       expect(entry.level).toBe(level);
       expect(typeof entry.timestamp).toBe('string');
       expect(Array.isArray(entry.args)).toBe(true);
     }
 
-    const logEntry = readEntry(mockConsole as unknown as MockConsole, 'log');
+    const logEntry = readEntry(sink, 'log');
     expect(logEntry.message).toBe('hello');
     expect(logEntry.args).toEqual(['hello', { id: 1 }]);
+    expect(logEntry.payload).toEqual(['hello', { id: 1 }]);
+    expect(logEntry.original_args_count).toBe(2);
   });
 
   it('serializes errors in args and avoids repatching', () => {
-    const mockConsole = createMockConsole() as unknown as Console;
+    const { mockConsole, sink, callCounts } = createMockConsole();
 
     enableStructuredConsoleLogging(mockConsole);
     enableStructuredConsoleLogging(mockConsole);
@@ -61,7 +88,7 @@ describe('enableStructuredConsoleLogging', () => {
     const err = new Error('boom');
     mockConsole.error(err);
 
-    const entry = readEntry(mockConsole as unknown as MockConsole, 'error');
+    const entry = readEntry(sink, 'error');
     expect(entry.message).toBe('boom');
     expect(entry.args).toEqual([
       {
@@ -71,7 +98,14 @@ describe('enableStructuredConsoleLogging', () => {
         stack: expect.any(String),
       },
     ]);
+    expect(entry.payload).toEqual({
+      type: 'error',
+      name: 'Error',
+      message: 'boom',
+      stack: expect.any(String),
+    });
+    expect(entry.original_args_count).toBe(1);
 
-    expect((mockConsole as unknown as MockConsole).error).toHaveBeenCalledTimes(1);
+    expect(callCounts.error).toBe(1);
   });
 });

--- a/public/app/core/utils/structuredConsole.test.ts
+++ b/public/app/core/utils/structuredConsole.test.ts
@@ -18,26 +18,26 @@ function createMockConsole() {
     error: 0,
   };
 
-  const mockConsole: Console = {
-    log: (entry: unknown) => {
+  const mockConsole = {
+    log: (...entries: unknown[]) => {
       callCounts.log++;
-      sink.log.push(entry);
+      sink.log.push(...entries);
     },
-    info: (entry: unknown) => {
+    info: (...entries: unknown[]) => {
       callCounts.info++;
-      sink.info.push(entry);
+      sink.info.push(...entries);
     },
-    debug: (entry: unknown) => {
+    debug: (...entries: unknown[]) => {
       callCounts.debug++;
-      sink.debug.push(entry);
+      sink.debug.push(...entries);
     },
-    warn: (entry: unknown) => {
+    warn: (...entries: unknown[]) => {
       callCounts.warn++;
-      sink.warn.push(entry);
+      sink.warn.push(...entries);
     },
-    error: (entry: unknown) => {
+    error: (...entries: unknown[]) => {
       callCounts.error++;
-      sink.error.push(entry);
+      sink.error.push(...entries);
     },
   };
 

--- a/public/app/core/utils/structuredConsole.ts
+++ b/public/app/core/utils/structuredConsole.ts
@@ -1,7 +1,8 @@
 type ConsoleLevel = 'log' | 'info' | 'debug' | 'warn' | 'error';
+type ConsoleLike = Record<ConsoleLevel, (...args: unknown[]) => void>;
 
 const LOGGER_NAME = 'grafana.frontend.console';
-const patchedConsoles = new WeakSet<Console>();
+const patchedConsoles = new WeakSet<ConsoleLike>();
 
 interface StructuredConsoleEntry {
   logger: string;
@@ -59,7 +60,7 @@ function buildStructuredEntry(level: ConsoleLevel, args: unknown[]): StructuredC
   };
 }
 
-export function enableStructuredConsoleLogging(targetConsole: Console = console): void {
+export function enableStructuredConsoleLogging(targetConsole: ConsoleLike = console): void {
   if (patchedConsoles.has(targetConsole)) {
     return;
   }

--- a/public/app/core/utils/structuredConsole.ts
+++ b/public/app/core/utils/structuredConsole.ts
@@ -1,11 +1,7 @@
 type ConsoleLevel = 'log' | 'info' | 'debug' | 'warn' | 'error';
 
-const PATCH_MARKER = Symbol.for('grafana.structured_console_patched');
 const LOGGER_NAME = 'grafana.frontend.console';
-
-type ConsoleWithMarker = Console & {
-  [PATCH_MARKER]?: boolean;
-};
+const patchedConsoles = new WeakSet<Console>();
 
 interface StructuredConsoleEntry {
   logger: string;
@@ -32,7 +28,7 @@ function normalizeConsoleArg(arg: unknown): unknown {
     case 'symbol':
       return arg.toString();
     case 'function':
-      return `[Function ${(arg as Function).name || 'anonymous'}]`;
+      return `[Function ${arg.name || 'anonymous'}]`;
     default:
       return arg;
   }
@@ -64,8 +60,7 @@ function buildStructuredEntry(level: ConsoleLevel, args: unknown[]): StructuredC
 }
 
 export function enableStructuredConsoleLogging(targetConsole: Console = console): void {
-  const consoleWithMarker = targetConsole as ConsoleWithMarker;
-  if (consoleWithMarker[PATCH_MARKER]) {
+  if (patchedConsoles.has(targetConsole)) {
     return;
   }
 
@@ -82,5 +77,5 @@ export function enableStructuredConsoleLogging(targetConsole: Console = console)
     };
   }
 
-  consoleWithMarker[PATCH_MARKER] = true;
+  patchedConsoles.add(targetConsole);
 }

--- a/public/app/core/utils/structuredConsole.ts
+++ b/public/app/core/utils/structuredConsole.ts
@@ -1,0 +1,86 @@
+type ConsoleLevel = 'log' | 'info' | 'debug' | 'warn' | 'error';
+
+const PATCH_MARKER = Symbol.for('grafana.structured_console_patched');
+const LOGGER_NAME = 'grafana.frontend.console';
+
+type ConsoleWithMarker = Console & {
+  [PATCH_MARKER]?: boolean;
+};
+
+interface StructuredConsoleEntry {
+  logger: string;
+  level: ConsoleLevel;
+  message: string;
+  timestamp: string;
+  args: unknown[];
+  original_args_count: number;
+  payload: unknown;
+}
+
+function normalizeConsoleArg(arg: unknown): unknown {
+  if (arg instanceof Error) {
+    return {
+      type: 'error',
+      name: arg.name,
+      message: arg.message,
+      stack: arg.stack,
+    };
+  }
+
+  switch (typeof arg) {
+    case 'bigint':
+    case 'symbol':
+      return arg.toString();
+    case 'function':
+      return `[Function ${(arg as Function).name || 'anonymous'}]`;
+    default:
+      return arg;
+  }
+}
+
+function inferMessage(level: ConsoleLevel, args: unknown[]): string {
+  if (typeof args[0] === 'string') {
+    return args[0];
+  }
+
+  if (args[0] instanceof Error) {
+    return args[0].message;
+  }
+
+  return `console.${level}`;
+}
+
+function buildStructuredEntry(level: ConsoleLevel, args: unknown[]): StructuredConsoleEntry {
+  const normalizedArgs = args.map(normalizeConsoleArg);
+  return {
+    logger: LOGGER_NAME,
+    level,
+    message: inferMessage(level, args),
+    timestamp: new Date().toISOString(),
+    args: normalizedArgs,
+    original_args_count: args.length,
+    payload: normalizedArgs.length === 1 ? normalizedArgs[0] : normalizedArgs,
+  };
+}
+
+export function enableStructuredConsoleLogging(targetConsole: Console = console): void {
+  const consoleWithMarker = targetConsole as ConsoleWithMarker;
+  if (consoleWithMarker[PATCH_MARKER]) {
+    return;
+  }
+
+  const levels: ConsoleLevel[] = ['log', 'info', 'debug', 'warn', 'error'];
+  for (const level of levels) {
+    const original = targetConsole[level];
+    if (typeof original !== 'function') {
+      continue;
+    }
+
+    const originalBound = original.bind(targetConsole);
+    targetConsole[level] = (...args: unknown[]) => {
+      originalBound(buildStructuredEntry(level, args));
+    };
+  }
+
+  consoleWithMarker[PATCH_MARKER] = true;
+}

--- a/public/app/index.ts
+++ b/public/app/index.ts
@@ -1,3 +1,5 @@
+import { enableStructuredConsoleLogging } from './core/utils/structuredConsole';
+
 // The new index.html fetches window.grafanaBootData asynchronously.
 // Since much of Grafana depends on it in includes side effects at import time,
 // we delay loading the rest of the app using import() until the boot data is ready.
@@ -17,6 +19,7 @@ if (window.nonce) {
 
 // This is an indication to the window.onLoad failure check that the app bundle has loaded.
 window.__grafana_app_bundle_loaded = true;
+enableStructuredConsoleLogging();
 
 async function bootstrapWindowData() {
   // Wait for window.grafanaBootData is ready. The new index.html loads it from


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
**What is this feature?**

This change introduces centralized structured logging normalization in both frontend and backend runtime paths.

- Frontend: all existing `console.log/info/debug/warn/error` calls are normalized into structured payloads via a single bootstrap-time console patch.
- Backend: stdlib `log` output is bridged into Grafana's structured logger, and several runtime `fmt.Print*` logging paths were migrated to structured log fields.

**Why do we need this feature?**

Logging currently mixes structured and unstructured patterns, making machine parsing and downstream analysis inconsistent. Centralized normalization ensures existing call sites emit structured entries without requiring risky bulk rewrites of hundreds of files.

**Who is this feature for?**

Grafana operators and engineers who rely on consistent, parseable logs for debugging, monitoring, and analytics.

**Which issue(s) does this PR fix?**:

Fixes #

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a notable improvement, it's added to What's New.

Implementation notes:
- Added `public/app/core/utils/structuredConsole.ts` and tests.
- Enabled structured console normalization in `public/app/index.ts` before app bootstrap.
- Added stdlib logger bridge in `pkg/infra/log/log.go`.
- Migrated selected runtime print statements to structured logs in `pkg/setting`, `pkg/services/sqlstore`, provisioning operators, Influx parsers, and related runtime helpers.
- Kept user-facing CLI output behavior intact in command binaries.
- Follow-up CI fixes:
  - removed TypeScript type assertions from `structuredConsole.ts` to satisfy lint rules.
  - changed structured console typing to a `ConsoleLike` interface and updated tests to avoid `Console`-shape typecheck failures.

Validation:
- `yarn eslint public/app/core/utils/structuredConsole.ts public/app/core/utils/structuredConsole.test.ts`
- `yarn jest --no-watch public/app/core/utils/structuredConsole.test.ts`
- `yarn typecheck`
- `go test ./pkg/infra/log ./pkg/setting ./pkg/services/sqlstore ./pkg/operators/provisioning ./pkg/registry/apps/annotation ./pkg/tsdb/influxdb/influxql/querydata ./pkg/tsdb/influxdb/influxql/converter ./pkg/tsdb/influxdb/fsql ./pkg/expr/sql ./pkg/components/dashdiffs`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-63b40677-590b-470d-89b7-f8e5d303b44c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-63b40677-590b-470d-89b7-f8e5d303b44c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

