### PR TITLE
Frontend: move root wrappers to v6 history router

### DIFF
--- a/eslint-suppressions.json
+++ b/eslint-suppressions.json
@@ -458,14 +458,6 @@
       "count": 4
     }
   },
-  "packages/grafana-runtime/src/services/LocationService.tsx": {
-    "@typescript-eslint/consistent-type-assertions": {
-      "count": 1
-    },
-    "@typescript-eslint/no-explicit-any": {
-      "count": 5
-    }
-  },
   "packages/grafana-runtime/src/services/backendSrv.ts": {
     "@typescript-eslint/no-explicit-any": {
       "count": 12

--- a/packages/grafana-runtime/package.json
+++ b/packages/grafana-runtime/package.json
@@ -61,6 +61,7 @@
     "@openfeature/core": "^1.9.0",
     "@openfeature/ofrep-web-provider": "^0.3.3",
     "@openfeature/react-sdk": "^1.2.0",
+    "@remix-run/router": "1.23.2",
     "@types/systemjs": "6.15.3",
     "history": "4.10.1",
     "lodash": "^4.17.23",

--- a/packages/grafana-runtime/src/services/LocationService.test.tsx
+++ b/packages/grafana-runtime/src/services/LocationService.test.tsx
@@ -71,4 +71,16 @@ describe('LocationService', () => {
       expect(hookResult.result.current).toBe(locationServiceLocal);
     });
   });
+
+  describe('router history adapter', () => {
+    it('supports detached push calls from the router', () => {
+      const localService = new HistoryWrapper();
+      const routerHistory = localService.getRouterHistory();
+      const { push } = routerHistory;
+
+      push('/detached-call');
+
+      expect(localService.getLocation().pathname).toBe('/detached-call');
+    });
+  });
 });

--- a/packages/grafana-runtime/src/services/LocationService.tsx
+++ b/packages/grafana-runtime/src/services/LocationService.tsx
@@ -1,4 +1,9 @@
-import type { History as RouterHistory, Location as RouterLocation, Path as RouterPath, To as RouterTo } from '@remix-run/router';
+import type {
+  History as RouterHistory,
+  Location as RouterLocation,
+  Path as RouterPath,
+  To as RouterTo,
+} from '@remix-run/router';
 import * as H from 'history';
 import React, { useContext } from 'react';
 import { BehaviorSubject, Observable } from 'rxjs';

--- a/packages/grafana-runtime/src/services/LocationService.tsx
+++ b/packages/grafana-runtime/src/services/LocationService.tsx
@@ -32,6 +32,66 @@ export interface LocationService {
   update: (update: LocationUpdate) => void;
 }
 
+class V4RouterHistoryAdapter implements RouterHistory {
+  constructor(private readonly history: H.History) {}
+
+  get action(): RouterHistory['action'] {
+    return this.history.action as RouterHistory['action'];
+  }
+
+  get location(): RouterLocation {
+    return toRouterLocation(this.history.location);
+  }
+
+  createHref = (to: RouterTo) => {
+    return this.history.createHref(toHistoryLocationDescriptor(to));
+  };
+
+  createURL = (to: RouterTo) => {
+    const href = this.createHref(to);
+    return new URL(href, typeof window === 'undefined' ? 'http://localhost' : window.location.origin);
+  };
+
+  encodeLocation = (to: RouterTo): RouterPath => {
+    if (typeof to === 'string') {
+      const encoded = new URL(to, 'http://localhost');
+      return {
+        pathname: encoded.pathname,
+        search: encoded.search,
+        hash: encoded.hash,
+      };
+    }
+
+    return {
+      pathname: to.pathname ?? '',
+      search: to.search ?? '',
+      hash: to.hash ?? '',
+    };
+  };
+
+  push = (to: RouterTo, state?: any) => {
+    this.history.push(toHistoryLocationDescriptor(to), state);
+  };
+
+  replace = (to: RouterTo, state?: any) => {
+    this.history.replace(toHistoryLocationDescriptor(to), state);
+  };
+
+  go = (delta: number) => {
+    this.history.go(delta);
+  };
+
+  listen = (listener: Parameters<RouterHistory['listen']>[0]) => {
+    return this.history.listen((location, action) => {
+      listener({
+        action: action as RouterHistory['action'],
+        location: toRouterLocation(location),
+        delta: null,
+      });
+    });
+  };
+}
+
 /** @internal */
 export class HistoryWrapper implements LocationService {
   private readonly history: H.History;
@@ -202,66 +262,6 @@ export const LocationServiceProvider: React.FC<{ service: LocationService; child
 }) => {
   return <LocationServiceContext.Provider value={service}>{children}</LocationServiceContext.Provider>;
 };
-
-class V4RouterHistoryAdapter implements RouterHistory {
-  constructor(private readonly history: H.History) {}
-
-  get action(): RouterHistory['action'] {
-    return this.history.action as RouterHistory['action'];
-  }
-
-  get location(): RouterLocation {
-    return toRouterLocation(this.history.location);
-  }
-
-  createHref(to: RouterTo) {
-    return this.history.createHref(toHistoryLocationDescriptor(to));
-  }
-
-  createURL(to: RouterTo) {
-    const href = this.createHref(to);
-    return new URL(href, typeof window === 'undefined' ? 'http://localhost' : window.location.origin);
-  }
-
-  encodeLocation(to: RouterTo): RouterPath {
-    if (typeof to === 'string') {
-      const encoded = new URL(to, 'http://localhost');
-      return {
-        pathname: encoded.pathname,
-        search: encoded.search,
-        hash: encoded.hash,
-      };
-    }
-
-    return {
-      pathname: to.pathname ?? '',
-      search: to.search ?? '',
-      hash: to.hash ?? '',
-    };
-  }
-
-  push(to: RouterTo, state?: any) {
-    this.history.push(toHistoryLocationDescriptor(to), state);
-  }
-
-  replace(to: RouterTo, state?: any) {
-    this.history.replace(toHistoryLocationDescriptor(to), state);
-  }
-
-  go(delta: number) {
-    this.history.go(delta);
-  }
-
-  listen(listener: Parameters<RouterHistory['listen']>[0]) {
-    return this.history.listen((location, action) => {
-      listener({
-        action: action as RouterHistory['action'],
-        location: toRouterLocation(location),
-        delta: null,
-      });
-    });
-  }
-}
 
 function toRouterLocation(location: H.Location): RouterLocation {
   return {

--- a/packages/grafana-runtime/src/services/LocationService.tsx
+++ b/packages/grafana-runtime/src/services/LocationService.tsx
@@ -1,3 +1,4 @@
+import type { History as RouterHistory, Location as RouterLocation, Path as RouterPath, To as RouterTo } from '@remix-run/router';
 import * as H from 'history';
 import React, { useContext } from 'react';
 import { BehaviorSubject, Observable } from 'rxjs';
@@ -20,6 +21,7 @@ export interface LocationService {
   reload: () => void;
   getLocation: () => H.Location;
   getHistory: () => H.History;
+  getRouterHistory: () => RouterHistory;
   getSearch: () => URLSearchParams;
   getSearchObject: () => UrlQueryMap;
   getLocationObservable: () => Observable<H.Location>;
@@ -33,6 +35,7 @@ export interface LocationService {
 /** @internal */
 export class HistoryWrapper implements LocationService {
   private readonly history: H.History;
+  private readonly routerHistory: RouterHistory;
   private locationObservable: BehaviorSubject<H.Location>;
 
   constructor(history?: H.History) {
@@ -42,6 +45,7 @@ export class HistoryWrapper implements LocationService {
       (process.env.NODE_ENV === 'test'
         ? H.createMemoryHistory({ initialEntries: ['/'] })
         : H.createBrowserHistory({ basename: config.appSubUrl ?? '/' }));
+    this.routerHistory = new V4RouterHistoryAdapter(this.history);
 
     this.locationObservable = new BehaviorSubject(this.history.location);
 
@@ -63,6 +67,10 @@ export class HistoryWrapper implements LocationService {
 
   getHistory() {
     return this.history;
+  }
+
+  getRouterHistory() {
+    return this.routerHistory;
   }
 
   getSearch() {
@@ -194,3 +202,85 @@ export const LocationServiceProvider: React.FC<{ service: LocationService; child
 }) => {
   return <LocationServiceContext.Provider value={service}>{children}</LocationServiceContext.Provider>;
 };
+
+class V4RouterHistoryAdapter implements RouterHistory {
+  constructor(private readonly history: H.History) {}
+
+  get action(): RouterHistory['action'] {
+    return this.history.action as RouterHistory['action'];
+  }
+
+  get location(): RouterLocation {
+    return toRouterLocation(this.history.location);
+  }
+
+  createHref(to: RouterTo) {
+    return this.history.createHref(toHistoryLocationDescriptor(to));
+  }
+
+  createURL(to: RouterTo) {
+    const href = this.createHref(to);
+    return new URL(href, typeof window === 'undefined' ? 'http://localhost' : window.location.origin);
+  }
+
+  encodeLocation(to: RouterTo): RouterPath {
+    if (typeof to === 'string') {
+      const encoded = new URL(to, 'http://localhost');
+      return {
+        pathname: encoded.pathname,
+        search: encoded.search,
+        hash: encoded.hash,
+      };
+    }
+
+    return {
+      pathname: to.pathname ?? '',
+      search: to.search ?? '',
+      hash: to.hash ?? '',
+    };
+  }
+
+  push(to: RouterTo, state?: any) {
+    this.history.push(toHistoryLocationDescriptor(to), state);
+  }
+
+  replace(to: RouterTo, state?: any) {
+    this.history.replace(toHistoryLocationDescriptor(to), state);
+  }
+
+  go(delta: number) {
+    this.history.go(delta);
+  }
+
+  listen(listener: Parameters<RouterHistory['listen']>[0]) {
+    return this.history.listen((location, action) => {
+      listener({
+        action: action as RouterHistory['action'],
+        location: toRouterLocation(location),
+        delta: null,
+      });
+    });
+  }
+}
+
+function toRouterLocation(location: H.Location): RouterLocation {
+  return {
+    pathname: location.pathname,
+    search: location.search,
+    hash: location.hash,
+    state: location.state,
+    key: location.key ?? 'default',
+  };
+}
+
+function toHistoryLocationDescriptor(to: RouterTo): H.LocationDescriptorObject {
+  if (typeof to === 'string') {
+    return to;
+  }
+
+  return {
+    pathname: to.pathname ?? '',
+    search: to.search ?? '',
+    hash: to.hash ?? '',
+  };
+}

--- a/packages/grafana-runtime/src/services/LocationService.tsx
+++ b/packages/grafana-runtime/src/services/LocationService.tsx
@@ -1,4 +1,5 @@
-import type {
+import {
+  Action as RouterAction,
   History as RouterHistory,
   Location as RouterLocation,
   Path as RouterPath,
@@ -8,21 +9,23 @@ import * as H from 'history';
 import React, { useContext } from 'react';
 import { BehaviorSubject, Observable } from 'rxjs';
 
-import { deprecationWarning, UrlQueryMap, urlUtil } from '@grafana/data';
+import { deprecationWarning, UrlQueryMap, UrlQueryValue, urlUtil } from '@grafana/data';
 import { attachDebugger, createLogger } from '@grafana/ui';
 
 import { config } from '../config';
 
 import { LocationUpdate } from './LocationSrv';
 
+type HistoryLocationDescriptor = H.Path | H.LocationDescriptor<unknown>;
+
 /**
  * @public
  * A wrapper to help work with browser location and history
  */
 export interface LocationService {
-  partial: (query: Record<string, any>, replace?: boolean) => void;
-  push: (location: H.Path | H.LocationDescriptor<any>) => void;
-  replace: (location: H.Path | H.LocationDescriptor<any>) => void;
+  partial: (query: Record<string, unknown>, replace?: boolean) => void;
+  push: (location: HistoryLocationDescriptor) => void;
+  replace: (location: HistoryLocationDescriptor) => void;
   reload: () => void;
   getLocation: () => H.Location;
   getHistory: () => H.History;
@@ -41,7 +44,7 @@ class V4RouterHistoryAdapter implements RouterHistory {
   constructor(private readonly history: H.History) {}
 
   get action(): RouterHistory['action'] {
-    return this.history.action as RouterHistory['action'];
+    return toRouterAction(this.history.action);
   }
 
   get location(): RouterLocation {
@@ -49,7 +52,7 @@ class V4RouterHistoryAdapter implements RouterHistory {
   }
 
   createHref = (to: RouterTo) => {
-    return this.history.createHref(toHistoryLocationDescriptor(to));
+    return this.history.createHref(toHistoryPathDescriptor(to));
   };
 
   createURL = (to: RouterTo) => {
@@ -74,11 +77,11 @@ class V4RouterHistoryAdapter implements RouterHistory {
     };
   };
 
-  push = (to: RouterTo, state?: any) => {
+  push = (to: RouterTo, state?: unknown) => {
     this.history.push(toHistoryLocationDescriptor(to), state);
   };
 
-  replace = (to: RouterTo, state?: any) => {
+  replace = (to: RouterTo, state?: unknown) => {
     this.history.replace(toHistoryLocationDescriptor(to), state);
   };
 
@@ -89,7 +92,7 @@ class V4RouterHistoryAdapter implements RouterHistory {
   listen = (listener: Parameters<RouterHistory['listen']>[0]) => {
     return this.history.listen((location, action) => {
       listener({
-        action: action as RouterHistory['action'],
+        action: toRouterAction(action),
         location: toRouterLocation(location),
         delta: null,
       });
@@ -142,7 +145,7 @@ export class HistoryWrapper implements LocationService {
     return new URLSearchParams(this.history.location.search);
   }
 
-  partial(query: Record<string, any>, replace?: boolean) {
+  partial(query: Record<string, unknown>, replace?: boolean) {
     const currentLocation = this.history.location;
     const newQuery = this.getSearchObject();
 
@@ -151,7 +154,7 @@ export class HistoryWrapper implements LocationService {
       if (query[key] === null || query[key] === undefined) {
         delete newQuery[key];
       } else {
-        newQuery[key] = query[key];
+        newQuery[key] = toUrlQueryValue(query[key]);
       }
     }
 
@@ -164,16 +167,16 @@ export class HistoryWrapper implements LocationService {
     }
   }
 
-  push(location: H.Path | H.LocationDescriptor) {
+  push(location: HistoryLocationDescriptor) {
     this.history.push(location);
   }
 
-  replace(location: H.Path | H.LocationDescriptor) {
+  replace(location: HistoryLocationDescriptor) {
     this.history.replace(location);
   }
 
   reload() {
-    const prevState = (this.history.location.state as any)?.routeReloadCounter;
+    const prevState = getRouteReloadCounter(this.history.location.state);
     this.history.replace({
       ...this.history.location,
       state: { routeReloadCounter: prevState ? prevState + 1 : 1 },
@@ -278,9 +281,58 @@ function toRouterLocation(location: H.Location): RouterLocation {
   };
 }
 
-function toHistoryLocationDescriptor(to: RouterTo): H.LocationDescriptorObject {
+function toRouterAction(action: H.Action): RouterHistory['action'] {
+  return ROUTER_ACTIONS.get(action) ?? DEFAULT_ROUTER_ACTION;
+}
+
+const ROUTER_ACTIONS = new Map<H.Action, RouterHistory['action']>([
+  ['PUSH', RouterAction.Push],
+  ['REPLACE', RouterAction.Replace],
+  ['POP', RouterAction.Pop],
+]);
+const DEFAULT_ROUTER_ACTION: RouterHistory['action'] = RouterAction.Pop;
+
+function getRouteReloadCounter(state: unknown): number | undefined {
+  if (typeof state !== 'object' || state === null || !('routeReloadCounter' in state)) {
+    return undefined;
+  }
+
+  const counter = state.routeReloadCounter;
+  return typeof counter === 'number' ? counter : undefined;
+}
+
+function toUrlQueryValue(value: unknown): UrlQueryValue {
+  if (typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean' || value === null) {
+    return value;
+  }
+
+  if (Array.isArray(value)) {
+    return value.map(String);
+  }
+
+  return String(value);
+}
+
+function toHistoryLocationDescriptor(to: RouterTo): HistoryLocationDescriptor {
   if (typeof to === 'string') {
     return to;
+  }
+
+  return {
+    pathname: to.pathname ?? '',
+    search: to.search ?? '',
+    hash: to.hash ?? '',
+  };
+}
+
+function toHistoryPathDescriptor(to: RouterTo): H.LocationDescriptorObject<unknown> {
+  if (typeof to === 'string') {
+    const encoded = new URL(to, 'http://localhost');
+    return {
+      pathname: encoded.pathname,
+      search: encoded.search,
+      hash: encoded.hash,
+    };
   }
 
   return {

--- a/public/app/core/components/AppNotifications/AppNotificationList.tsx
+++ b/public/app/core/components/AppNotifications/AppNotificationList.tsx
@@ -1,6 +1,6 @@
 import { css } from '@emotion/css';
 import { useEffect, useRef } from 'react';
-import { useLocation } from 'react-router-dom';
+import { useLocation } from 'react-router-dom-v5-compat';
 
 import { AlertErrorPayload, AlertPayload, AppEvents, GrafanaTheme2 } from '@grafana/data';
 import { useStyles2, Stack } from '@grafana/ui';

--- a/public/app/features/dashboard-scene/scene/layout-tabs/TabItemRenderer.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-tabs/TabItemRenderer.tsx
@@ -1,6 +1,6 @@
 import { css, cx } from '@emotion/css';
 import { Draggable, DraggableStateSnapshot } from '@hello-pangea/dnd';
-import { useLocation } from 'react-router';
+import { useLocation } from 'react-router-dom-v5-compat';
 
 import { GrafanaTheme2, locationUtil, textUtil } from '@grafana/data';
 import { t } from '@grafana/i18n';

--- a/public/app/features/explore/spec/helper/setup.tsx
+++ b/public/app/features/explore/spec/helper/setup.tsx
@@ -7,8 +7,7 @@ import { fromPairs } from 'lodash';
 import { stringify } from 'querystring';
 import { ComponentType, ReactNode } from 'react';
 import { Provider } from 'react-redux';
-// eslint-disable-next-line no-restricted-imports
-import { Route, Router } from 'react-router-dom';
+import { Route, Routes, unstable_HistoryRouter as HistoryRouter } from 'react-router-dom-v5-compat';
 import { of } from 'rxjs';
 import { getGrafanaContextMock } from 'test/mocks/getGrafanaContextMock';
 
@@ -36,7 +35,7 @@ import { DataSourceRef } from '@grafana/schema';
 import { getTestFeatureFlagClient } from '@grafana/test-utils/unstable';
 import { AppChrome } from 'app/core/components/AppChrome/AppChrome';
 import { GrafanaContext } from 'app/core/context/GrafanaContext';
-import { GrafanaRoute } from 'app/core/navigation/GrafanaRoute';
+import { GrafanaRouteWrapper } from 'app/core/navigation/GrafanaRoute';
 import { Echo } from 'app/core/services/echo/Echo';
 import { setLastUsedDatasourceUID } from 'app/core/utils/explore';
 import { MIXED_DATASOURCE_NAME } from 'app/plugins/datasource/mixed/MixedDataSource';
@@ -201,31 +200,25 @@ export function setupExplore(options?: SetupOptions): {
     <OpenFeatureProvider client={getTestFeatureFlagClient()}>
       <Provider store={storeState}>
         <GrafanaContext.Provider value={contextMock}>
-          <Router history={history}>
+          <HistoryRouter history={location.getRouterHistory()}>
             <QueriesDrawerContextProvider>
               <FinalProvider>
                 {options?.withAppChrome ? (
                   <KBarProvider>
                     <AppChrome>
-                      <Route
-                        path="/explore"
-                        exact
-                        render={(props) => (
-                          <GrafanaRoute {...props} route={{ component: ExplorePage, path: '/explore' }} />
-                        )}
-                      />
+                      <Routes>
+                        <Route path="/explore" element={<GrafanaRouteWrapper route={{ component: ExplorePage, path: '/explore' }} />} />
+                      </Routes>
                     </AppChrome>
                   </KBarProvider>
                 ) : (
-                  <Route
-                    path="/explore"
-                    exact
-                    render={(props) => <GrafanaRoute {...props} route={{ component: ExplorePage, path: '/explore' }} />}
-                  />
+                  <Routes>
+                    <Route path="/explore" element={<GrafanaRouteWrapper route={{ component: ExplorePage, path: '/explore' }} />} />
+                  </Routes>
                 )}
               </FinalProvider>
             </QueriesDrawerContextProvider>
-          </Router>
+          </HistoryRouter>
         </GrafanaContext.Provider>
       </Provider>
     </OpenFeatureProvider>

--- a/public/app/features/explore/spec/helper/setup.tsx
+++ b/public/app/features/explore/spec/helper/setup.tsx
@@ -7,6 +7,7 @@ import { fromPairs } from 'lodash';
 import { stringify } from 'querystring';
 import { ComponentType, ReactNode } from 'react';
 import { Provider } from 'react-redux';
+import { Router as LegacyRouter } from 'react-router-dom';
 import { Route, Routes, unstable_HistoryRouter as HistoryRouter } from 'react-router-dom-v5-compat';
 import { of } from 'rxjs';
 import { getGrafanaContextMock } from 'test/mocks/getGrafanaContextMock';
@@ -200,25 +201,36 @@ export function setupExplore(options?: SetupOptions): {
     <OpenFeatureProvider client={getTestFeatureFlagClient()}>
       <Provider store={storeState}>
         <GrafanaContext.Provider value={contextMock}>
-          <HistoryRouter history={location.getRouterHistory()}>
-            <QueriesDrawerContextProvider>
-              <FinalProvider>
-                {options?.withAppChrome ? (
-                  <KBarProvider>
-                    <AppChrome>
-                      <Routes>
-                        <Route path="/explore" element={<GrafanaRouteWrapper route={{ component: ExplorePage, path: '/explore' }} />} />
-                      </Routes>
-                    </AppChrome>
-                  </KBarProvider>
-                ) : (
-                  <Routes>
-                    <Route path="/explore" element={<GrafanaRouteWrapper route={{ component: ExplorePage, path: '/explore' }} />} />
-                  </Routes>
-                )}
-              </FinalProvider>
-            </QueriesDrawerContextProvider>
-          </HistoryRouter>
+          <LegacyRouter history={history}>
+            <HistoryRouter
+              history={location.getRouterHistory()}
+              future={{ v7_startTransition: true, v7_relativeSplatPath: true }}
+            >
+              <QueriesDrawerContextProvider>
+                <FinalProvider>
+                  {options?.withAppChrome ? (
+                    <KBarProvider>
+                      <AppChrome>
+                        <Routes>
+                          <Route
+                            path="/explore"
+                            element={<GrafanaRouteWrapper route={{ component: ExplorePage, path: '/explore' }} />}
+                          />
+                        </Routes>
+                      </AppChrome>
+                    </KBarProvider>
+                  ) : (
+                    <Routes>
+                      <Route
+                        path="/explore"
+                        element={<GrafanaRouteWrapper route={{ component: ExplorePage, path: '/explore' }} />}
+                      />
+                    </Routes>
+                  )}
+                </FinalProvider>
+              </QueriesDrawerContextProvider>
+            </HistoryRouter>
+          </LegacyRouter>
         </GrafanaContext.Provider>
       </Provider>
     </OpenFeatureProvider>

--- a/public/app/features/provisioning/File/FileStatusPage.tsx
+++ b/public/app/features/provisioning/File/FileStatusPage.tsx
@@ -1,6 +1,5 @@
 import { useEffect, useState } from 'react';
-import { useLocation } from 'react-router';
-import { useParams } from 'react-router-dom-v5-compat';
+import { useLocation, useParams } from 'react-router-dom-v5-compat';
 import AutoSizer from 'react-virtualized-auto-sizer';
 
 import { urlUtil } from '@grafana/data';

--- a/public/app/features/provisioning/Repository/RepositoryStatusPage.tsx
+++ b/public/app/features/provisioning/Repository/RepositoryStatusPage.tsx
@@ -1,6 +1,5 @@
 import { useMemo } from 'react';
-import { useLocation } from 'react-router';
-import { useParams } from 'react-router-dom-v5-compat';
+import { useLocation, useParams } from 'react-router-dom-v5-compat';
 
 import { SelectableValue, urlUtil } from '@grafana/data';
 import { Trans, t } from '@grafana/i18n';

--- a/public/app/routes/RoutesWrapper.tsx
+++ b/public/app/routes/RoutesWrapper.tsx
@@ -1,6 +1,5 @@
 import { ComponentType, ReactNode, type JSX } from 'react';
-import { Router } from 'react-router-dom';
-import { CompatRouter } from 'react-router-dom-v5-compat';
+import { unstable_HistoryRouter as HistoryRouter } from 'react-router-dom-v5-compat';
 
 import { locationService, LocationServiceProvider } from '@grafana/runtime';
 import { ModalRoot, Stack } from '@grafana/ui';
@@ -25,31 +24,29 @@ type RouterWrapperProps = {
 };
 export function RouterWrapper(props: RouterWrapperProps) {
   return (
-    <Router history={locationService.getHistory()}>
+    <HistoryRouter history={locationService.getRouterHistory()}>
       <LocationServiceProvider service={locationService}>
-        <CompatRouter>
-          <QueriesDrawerContextProvider>
-            <ExtraProviders providers={props.providers}>
-              <ModalsContextProvider>
-                <AppChrome>
-                  <AppNotificationList />
-                  <Stack gap={0} grow={1} direction="column">
-                    <AppChromeExtensionPoint />
-                    {props.pageBanners.map((Banner, index) => (
-                      <Banner key={index.toString()} />
-                    ))}
-                    {props.routes}
-                  </Stack>
-                  {props.bodyRenderHooks.map((Hook, index) => (
-                    <Hook key={index.toString()} />
+        <QueriesDrawerContextProvider>
+          <ExtraProviders providers={props.providers}>
+            <ModalsContextProvider>
+              <AppChrome>
+                <AppNotificationList />
+                <Stack gap={0} grow={1} direction="column">
+                  <AppChromeExtensionPoint />
+                  {props.pageBanners.map((Banner, index) => (
+                    <Banner key={index.toString()} />
                   ))}
-                </AppChrome>
-                <ModalRoot />
-              </ModalsContextProvider>
-            </ExtraProviders>
-          </QueriesDrawerContextProvider>
-        </CompatRouter>
+                  {props.routes}
+                </Stack>
+                {props.bodyRenderHooks.map((Hook, index) => (
+                  <Hook key={index.toString()} />
+                ))}
+              </AppChrome>
+              <ModalRoot />
+            </ModalsContextProvider>
+          </ExtraProviders>
+        </QueriesDrawerContextProvider>
       </LocationServiceProvider>
-    </Router>
+    </HistoryRouter>
   );
 }

--- a/public/app/routes/RoutesWrapper.tsx
+++ b/public/app/routes/RoutesWrapper.tsx
@@ -1,4 +1,5 @@
 import { ComponentType, ReactNode, type JSX } from 'react';
+import { Router as LegacyRouter } from 'react-router-dom';
 import { unstable_HistoryRouter as HistoryRouter } from 'react-router-dom-v5-compat';
 
 import { locationService, LocationServiceProvider } from '@grafana/runtime';
@@ -24,29 +25,34 @@ type RouterWrapperProps = {
 };
 export function RouterWrapper(props: RouterWrapperProps) {
   return (
-    <HistoryRouter history={locationService.getRouterHistory()}>
-      <LocationServiceProvider service={locationService}>
-        <QueriesDrawerContextProvider>
-          <ExtraProviders providers={props.providers}>
-            <ModalsContextProvider>
-              <AppChrome>
-                <AppNotificationList />
-                <Stack gap={0} grow={1} direction="column">
-                  <AppChromeExtensionPoint />
-                  {props.pageBanners.map((Banner, index) => (
-                    <Banner key={index.toString()} />
+    <LegacyRouter history={locationService.getHistory()}>
+      <HistoryRouter
+        history={locationService.getRouterHistory()}
+        future={{ v7_startTransition: true, v7_relativeSplatPath: true }}
+      >
+        <LocationServiceProvider service={locationService}>
+          <QueriesDrawerContextProvider>
+            <ExtraProviders providers={props.providers}>
+              <ModalsContextProvider>
+                <AppChrome>
+                  <AppNotificationList />
+                  <Stack gap={0} grow={1} direction="column">
+                    <AppChromeExtensionPoint />
+                    {props.pageBanners.map((Banner, index) => (
+                      <Banner key={index.toString()} />
+                    ))}
+                    {props.routes}
+                  </Stack>
+                  {props.bodyRenderHooks.map((Hook, index) => (
+                    <Hook key={index.toString()} />
                   ))}
-                  {props.routes}
-                </Stack>
-                {props.bodyRenderHooks.map((Hook, index) => (
-                  <Hook key={index.toString()} />
-                ))}
-              </AppChrome>
-              <ModalRoot />
-            </ModalsContextProvider>
-          </ExtraProviders>
-        </QueriesDrawerContextProvider>
-      </LocationServiceProvider>
-    </HistoryRouter>
+                </AppChrome>
+                <ModalRoot />
+              </ModalsContextProvider>
+            </ExtraProviders>
+          </QueriesDrawerContextProvider>
+        </LocationServiceProvider>
+      </HistoryRouter>
+    </LegacyRouter>
   );
 }

--- a/public/test/helpers/TestProvider.tsx
+++ b/public/test/helpers/TestProvider.tsx
@@ -1,9 +1,7 @@
 import { Store } from '@reduxjs/toolkit';
 import * as React from 'react';
 import { Provider } from 'react-redux';
-// eslint-disable-next-line no-restricted-imports
-import { Router } from 'react-router-dom';
-import { CompatRouter } from 'react-router-dom-v5-compat';
+import { unstable_HistoryRouter as HistoryRouter } from 'react-router-dom-v5-compat';
 import { getGrafanaContextMock } from 'test/mocks/getGrafanaContextMock';
 
 import { locationService } from '@grafana/runtime';
@@ -35,14 +33,12 @@ export function TestProvider(props: Props) {
 
   return (
     <Provider store={store}>
-      <Router history={locationService.getHistory()}>
+      <HistoryRouter history={locationService.getRouterHistory()}>
         <ModalsContextProvider>
-          <CompatRouter>
-            <GrafanaContext.Provider value={context}>{children}</GrafanaContext.Provider>
-            <ModalRoot />
-          </CompatRouter>
+          <GrafanaContext.Provider value={context}>{children}</GrafanaContext.Provider>
+          <ModalRoot />
         </ModalsContextProvider>
-      </Router>
+      </HistoryRouter>
     </Provider>
   );
 }

--- a/public/test/helpers/TestProvider.tsx
+++ b/public/test/helpers/TestProvider.tsx
@@ -1,6 +1,7 @@
 import { Store } from '@reduxjs/toolkit';
 import * as React from 'react';
 import { Provider } from 'react-redux';
+import { Router } from 'react-router-dom';
 import { unstable_HistoryRouter as HistoryRouter } from 'react-router-dom-v5-compat';
 import { getGrafanaContextMock } from 'test/mocks/getGrafanaContextMock';
 
@@ -33,12 +34,17 @@ export function TestProvider(props: Props) {
 
   return (
     <Provider store={store}>
-      <HistoryRouter history={locationService.getRouterHistory()}>
-        <ModalsContextProvider>
-          <GrafanaContext.Provider value={context}>{children}</GrafanaContext.Provider>
-          <ModalRoot />
-        </ModalsContextProvider>
-      </HistoryRouter>
+      <Router history={locationService.getHistory()}>
+        <HistoryRouter
+          history={locationService.getRouterHistory()}
+          future={{ v7_startTransition: true, v7_relativeSplatPath: true }}
+        >
+          <ModalsContextProvider>
+            <GrafanaContext.Provider value={context}>{children}</GrafanaContext.Provider>
+            <ModalRoot />
+          </ModalsContextProvider>
+        </HistoryRouter>
+      </Router>
     </Provider>
   );
 }

--- a/public/test/test-utils.tsx
+++ b/public/test/test-utils.tsx
@@ -6,6 +6,7 @@ import { createMemoryHistory, MemoryHistoryBuildOptions } from 'history';
 import { Fragment, PropsWithChildren } from 'react';
 import * as React from 'react';
 import { Provider } from 'react-redux';
+import { Router } from 'react-router-dom';
 import { unstable_HistoryRouter as HistoryRouter } from 'react-router-dom-v5-compat';
 import { getGrafanaContextMock } from 'test/mocks/getGrafanaContextMock';
 
@@ -69,7 +70,16 @@ const getWrapper = ({
    * Conditional router - either a MemoryRouter or just a Fragment
    */
   const PotentialRouter = renderWithRouter
-    ? ({ children }: PropsWithChildren) => <HistoryRouter history={locationService.getRouterHistory()}>{children}</HistoryRouter>
+    ? ({ children }: PropsWithChildren) => (
+        <Router history={history}>
+          <HistoryRouter
+            history={locationService.getRouterHistory()}
+            future={{ v7_startTransition: true, v7_relativeSplatPath: true }}
+          >
+            {children}
+          </HistoryRouter>
+        </Router>
+      )
     : ({ children }: PropsWithChildren) => <Fragment>{children}</Fragment>;
 
   const context = {

--- a/public/test/test-utils.tsx
+++ b/public/test/test-utils.tsx
@@ -6,9 +6,7 @@ import { createMemoryHistory, MemoryHistoryBuildOptions } from 'history';
 import { Fragment, PropsWithChildren } from 'react';
 import * as React from 'react';
 import { Provider } from 'react-redux';
-// eslint-disable-next-line no-restricted-imports
-import { Router } from 'react-router-dom';
-import { CompatRouter } from 'react-router-dom-v5-compat';
+import { unstable_HistoryRouter as HistoryRouter } from 'react-router-dom-v5-compat';
 import { getGrafanaContextMock } from 'test/mocks/getGrafanaContextMock';
 
 import { FeatureToggles } from '@grafana/data';
@@ -71,10 +69,8 @@ const getWrapper = ({
    * Conditional router - either a MemoryRouter or just a Fragment
    */
   const PotentialRouter = renderWithRouter
-    ? ({ children }: PropsWithChildren) => <Router history={history}>{children}</Router>
+    ? ({ children }: PropsWithChildren) => <HistoryRouter history={locationService.getRouterHistory()}>{children}</HistoryRouter>
     : ({ children }: PropsWithChildren) => <Fragment>{children}</Fragment>;
-
-  const PotentialCompatRouter = renderWithRouter ? CompatRouter : Fragment;
 
   const context = {
     ...getGrafanaContextMock(),
@@ -92,9 +88,7 @@ const getWrapper = ({
           <GrafanaContext.Provider value={context}>
             <PotentialRouter>
               <LocationServiceProvider service={locationService}>
-                <PotentialCompatRouter>
-                  <ModalsContextProvider>{children}</ModalsContextProvider>
-                </PotentialCompatRouter>
+                <ModalsContextProvider>{children}</ModalsContextProvider>
               </LocationServiceProvider>
             </PotentialRouter>
           </GrafanaContext.Provider>

--- a/yarn.lock
+++ b/yarn.lock
@@ -3895,6 +3895,7 @@ __metadata:
     "@openfeature/core": "npm:^1.9.0"
     "@openfeature/ofrep-web-provider": "npm:^0.3.3"
     "@openfeature/react-sdk": "npm:^1.2.0"
+    "@remix-run/router": "npm:1.23.2"
     "@rollup/plugin-node-resolve": "npm:16.0.1"
     "@rollup/plugin-terser": "npm:0.4.4"
     "@testing-library/dom": "npm:10.4.1"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
**What is this feature?**

Moves Grafana's root routing wrappers and shared frontend test wrappers off the v5 `CompatRouter` bridge and onto a history-backed v6 router, while temporarily preserving an outer v5 `Router` context for legacy consumers that still import raw `react-router` hooks.

This slice also adds a `LocationService` router-history adapter so the existing `history@4` service can drive the inner v6 router during the migration.

<a href="https://cursor.com/agents/bc-e1c1828c-f9b4-416a-a30e-d50142781ca0/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Frouter_v6_root_wrapper_smoke_test.mp4"><img src="https://cursor.com/artifacts/c/art-77b34231-e16e-46d0-a644-99f502e20e22" alt="router_v6_root_wrapper_smoke_test.mp4" /></a>
![Dashboard link navigation succeeds](https://cursor.com/artifacts/c/art-ed6849d1-625b-47d9-b650-59c49f56328a)
![Explore route navigation succeeds](https://cursor.com/artifacts/c/art-2ca0bf8b-ac67-4a92-97b5-0b3ed69e2127)
![Connections nested route renders](https://cursor.com/artifacts/c/art-1762d2d6-9204-4fc1-9ea5-34d4ff2e4bbb)

**Why do we need this feature?**

The React Router v5 -> v6 migration was blocked by the app runtime still mounting a v5 router plus `CompatRouter` at the root. This change establishes a native v6 route context for the app shell and tests, while keeping legacy v5-only consumers working until later migration slices remove them.

**Who is this feature for?**

Grafana frontend engineers working on the router migration and users relying on core app navigation.

**Which issue(s) does this PR fix?**:

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a notable improvement, it's added to our What's New doc.

Additional context:
- The initial pure-v6 wrapper change exposed a client-side navigation regression for link clicks. The follow-up commit fixes this by binding the router adapter methods and preserving an outer v5 router context for remaining raw `react-router` consumers.
- This PR intentionally does not yet migrate `FormPrompt`/`history.block` flows.
- This PR intentionally does not yet remove `react-router-dom-v5-compat` imports repo-wide.
- Shared test wrappers and the Explore helper now mirror the app's dual-context router stack, and `LocationService` has a regression test covering detached router-history navigation calls.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e1c1828c-f9b4-416a-a30e-d50142781ca0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e1c1828c-f9b4-416a-a30e-d50142781ca0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

