### PR TITLE
fix(agents): correct Go version in AGENTS.md from 1.25.7 to 1.25.9

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -139,7 +139,7 @@ Build a specific plugin: `yarn workspace @grafana-plugins/<name> dev`
 ### Prerequisites
 
 - **Node.js v24.x** (see `.nvmrc` for exact version). Use `nvm install` / `nvm use` to match.
-- **Go 1.25.7** (see `go.mod`). Pre-installed in the VM.
+- **Go 1.25.9** (see `go.mod`). Pre-installed in the VM.
 - **Yarn 4.11.0** via corepack (bundled in `.yarn/releases/`). Run `corepack enable` if `yarn` is not found.
 - **GCC** required for CGo/SQLite compilation of the backend.
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes an incorrect Go version reference in `AGENTS.md` — the Cursor Cloud specific instructions listed Go 1.25.7 but `go.mod` specifies Go 1.25.9.

### Changes
- Updated Go version in `AGENTS.md` prerequisites from `1.25.7` to `1.25.9` to match `go.mod`.

### Verification
Development environment was fully set up and validated:
- Backend (`make run`) — running on `localhost:3000`
- Frontend (`yarn start`) — webpack compiled successfully
- Lint (`yarn lint`) — passed
- Backend tests (`go test`) — passed
- Frontend tests (`yarn jest --no-watch`) — passed
- Created and viewed a dashboard via API to confirm full-stack functionality

<a href="https://cursor.com/agents/bc-4cbc90c4-55e3-49a2-a668-142a2025dac4/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fgrafana_login_and_dashboard_demo.mp4"><img src="https://cursor.com/artifacts/c/art-604a3af9-86ca-4160-89de-af82a87a3d9f" alt="grafana_login_and_dashboard_demo.mp4" /></a>
![Hello World Dashboard](https://cursor.com/artifacts/c/art-646116f0-b335-419f-a0bd-f62c04888077)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4cbc90c4-55e3-49a2-a668-142a2025dac4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4cbc90c4-55e3-49a2-a668-142a2025dac4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

