### PR TITLE
Docs: Update AGENTS.md with correct Go version and lint-go timing

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -139,7 +139,7 @@ Build a specific plugin: `yarn workspace @grafana-plugins/<name> dev`
 ### Prerequisites
 
 - **Node.js v24.x** (see `.nvmrc` for exact version). Use `nvm install` / `nvm use` to match.
-- **Go 1.25.7** (see `go.mod`). Pre-installed in the VM.
+- **Go 1.25.9** (see `go.mod`). Pre-installed in the VM.
 - **Yarn 4.11.0** via corepack (bundled in `.yarn/releases/`). Run `corepack enable` if `yarn` is not found.
 - **GCC** required for CGo/SQLite compilation of the backend.
 
@@ -153,4 +153,5 @@ Build a specific plugin: `yarn workspace @grafana-plugins/<name> dev`
 
 - **Frontend tests**: The `yarn test` script includes `--watch` by default. Always use `yarn jest --no-watch` or add `--watchAll=false` to run tests once and exit.
 - **Backend tests**: Some packages (e.g. `pkg/api/`) have slow test compilation (~2 min) due to large dependency graphs. Use targeted test runs with `-run TestName` where possible.
+- **Go linter**: `make lint-go` runs the full suite and takes ~13 minutes. Prefer targeted lint checks when possible.
 - All standard build/test/lint commands are documented in the Commands section above.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
**What is this feature?**

Updates `AGENTS.md` Cloud-specific instructions with two corrections:
- Fixed Go version from `1.25.7` to `1.25.9` (matching `go.mod`)
- Added note about `make lint-go` taking ~13 minutes

**Why do we need this feature?**

Ensures future Cloud Agents have accurate environment information and are aware of the long lint-go runtime to avoid unnecessary timeouts.

**Who is this feature for?**

AI agents and developers working in Cursor Cloud environments.

**Special notes for your reviewer:**

Minor documentation-only change — no code modifications.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-40199964-d6ce-4e2a-b28c-43a303a47506"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-40199964-d6ce-4e2a-b28c-43a303a47506"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

