### PR TITLE
feat: Labs admin UI for feature toggle overrides

### DIFF
--- a/.cursor/skills/dev-server-hot-reload/SKILL.md
+++ b/.cursor/skills/dev-server-hot-reload/SKILL.md
@@ -1,0 +1,25 @@
+---
+name: dev-server-hot-reload
+description: Start Grafana development servers with hot reloading for both backend and frontend. Use when the user wants to run the dev server, start development with hot reload, or build the app with live reloading enabled.
+---
+
+# Development Server with Hot Reloading
+
+## Quick Start
+
+Start both backend and frontend development servers with hot reloading:
+
+1. **Backend**: Run `make run` in one terminal
+2. **Frontend**: Run `yarn start:liveReload` in a separate terminal
+
+## Workflow
+
+The backend (`make run`) uses Air for hot reloading and watches for Go file changes. The frontend (`yarn start:liveReload`) runs the webpack dev server with live reload enabled.
+
+Both processes should run simultaneously in separate terminal sessions. The backend typically runs on port 3000, and the frontend dev server proxies to it.
+
+## Notes
+
+- Do not run these commands unless explicitly requested by the user
+- Both commands run indefinitely until stopped (Ctrl+C)
+- Ensure dependencies are installed (`make deps`) before starting

--- a/packages/grafana-data/src/themes/registry.ts
+++ b/packages/grafana-data/src/themes/registry.ts
@@ -8,6 +8,7 @@ import gildedgrove from './themeDefinitions/gildedgrove.json';
 import gloom from './themeDefinitions/gloom.json';
 import mars from './themeDefinitions/mars.json';
 import matrix from './themeDefinitions/matrix.json';
+import orange from './themeDefinitions/orange.json';
 import sapphiredusk from './themeDefinitions/sapphiredusk.json';
 import synthwave from './themeDefinitions/synthwave.json';
 import tron from './themeDefinitions/tron.json';
@@ -28,6 +29,7 @@ const extraThemes: { [key: string]: unknown } = {
   gloom,
   mars,
   matrix,
+  orange,
   sapphiredusk,
   synthwave,
   tron,

--- a/packages/grafana-data/src/themes/themeDefinitions/orange.json
+++ b/packages/grafana-data/src/themes/themeDefinitions/orange.json
@@ -1,0 +1,66 @@
+{
+  "name": "Orange",
+  "id": "orange",
+  "colors": {
+    "mode": "light",
+    "background": {
+      "canvas": "#FFF7F2",
+      "primary": "#FFFFFF",
+      "secondary": "#FFEDE1",
+      "elevated": "#FFFFFF"
+    },
+    "text": {
+      "primary": "#2E2118",
+      "secondary": "#6B4A35",
+      "disabled": "rgba(46, 33, 24, 0.55)",
+      "link": "#CC4A00",
+      "maxContrast": "#1B120C"
+    },
+    "border": {
+      "weak": "rgba(204, 74, 0, 0.2)",
+      "medium": "rgba(204, 74, 0, 0.38)",
+      "strong": "#CC4A00"
+    },
+    "primary": {
+      "main": "#F56A00",
+      "text": "#CC4A00",
+      "border": "#B74300",
+      "name": "primary",
+      "shade": "#B74300",
+      "transparent": "#F56A0026",
+      "contrastText": "#FFFFFF",
+      "borderTransparent": "#F56A0040"
+    },
+    "secondary": {
+      "main": "#FFFFFF",
+      "text": "#7A553C",
+      "border": "#E8D1C2",
+      "name": "secondary",
+      "shade": "#E8D1C2",
+      "transparent": "#FFFFFF26",
+      "contrastText": "#3A281C",
+      "borderTransparent": "#FFFFFF40"
+    },
+    "info": {
+      "main": "#1A82E2"
+    },
+    "success": {
+      "main": "#3DA45D"
+    },
+    "warning": {
+      "main": "#FF9A1F"
+    },
+    "action": {
+      "hover": "rgba(245, 106, 0, 0.08)",
+      "selected": "rgba(245, 106, 0, 0.24)",
+      "selectedBorder": "#F56A00",
+      "focus": "rgba(245, 106, 0, 0.42)",
+      "disabledText": "rgba(46, 33, 24, 0.45)",
+      "disabledBackground": "rgba(245, 106, 0, 0.06)"
+    },
+    "gradients": {
+      "brandHorizontal": "linear-gradient(90deg, #F56A00 0%, #FFB347 100%)",
+      "brandVertical": "linear-gradient(0deg, #F56A00 0%, #FFB347 100%)"
+    }
+  }
+}

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -563,6 +563,10 @@ func (hs *HTTPServer) registerRoutes() {
 		adminRoute.Post("/encryption/reencrypt-secrets", reqGrafanaAdmin, routing.Wrap(hs.AdminReEncryptSecrets))
 		adminRoute.Post("/encryption/rollback-secrets", reqGrafanaAdmin, routing.Wrap(hs.AdminRollbackSecrets))
 
+		adminRoute.Get("/feature-toggles/labs", reqGrafanaAdmin, routing.Wrap(hs.AdminGetLabsFeatureToggles))
+		adminRoute.Put("/feature-toggles/labs/:name", reqGrafanaAdmin, routing.Wrap(hs.AdminPutLabsFeatureToggle))
+		adminRoute.Delete("/feature-toggles/labs/:name", reqGrafanaAdmin, routing.Wrap(hs.AdminDeleteLabsFeatureToggle))
+
 		adminRoute.Post("/provisioning/dashboards/reload", authorize(ac.EvalPermission(ActionProvisioningReload, ScopeProvisionersDashboards)), routing.Wrap(hs.AdminProvisioningReloadDashboards))
 		adminRoute.Post("/provisioning/plugins/reload", authorize(ac.EvalPermission(ActionProvisioningReload, ScopeProvisionersPlugins)), routing.Wrap(hs.AdminProvisioningReloadPlugins))
 		adminRoute.Post("/provisioning/datasources/reload", authorize(ac.EvalPermission(ActionProvisioningReload, ScopeProvisionersDatasources)), routing.Wrap(hs.AdminProvisioningReloadDatasources))

--- a/pkg/api/feature_toggle_lab.go
+++ b/pkg/api/feature_toggle_lab.go
@@ -1,0 +1,126 @@
+package api
+
+import (
+	"net/http"
+	"sort"
+
+	"github.com/grafana/grafana/pkg/api/response"
+	"github.com/grafana/grafana/pkg/apimachinery/apis/common/v0alpha1"
+	contextmodel "github.com/grafana/grafana/pkg/services/contexthandler/model"
+	"github.com/grafana/grafana/pkg/services/featuremgmt"
+	"github.com/grafana/grafana/pkg/services/featuremgmt/feature_toggle_api"
+	"github.com/grafana/grafana/pkg/web"
+)
+
+type labsFeatureToggleUpdateDTO struct {
+	Enabled bool `json:"enabled"`
+}
+
+func (hs *HTTPServer) AdminGetLabsFeatureToggles(c *contextmodel.ReqContext) response.Response {
+	fm, ok := hs.Features.(*featuremgmt.FeatureManager)
+	if !ok {
+		return response.Error(http.StatusInternalServerError, "Feature manager unavailable", nil)
+	}
+
+	state := buildResolvedLabsToggleState(fm)
+	return response.JSON(http.StatusOK, state)
+}
+
+func (hs *HTTPServer) AdminPutLabsFeatureToggle(c *contextmodel.ReqContext) response.Response {
+	fm, ok := hs.Features.(*featuremgmt.FeatureManager)
+	if !ok {
+		return response.Error(http.StatusInternalServerError, "Feature manager unavailable", nil)
+	}
+
+	flagName := web.Params(c.Req)[":name"]
+	if flagName == "" {
+		return response.Error(http.StatusBadRequest, "Missing flag name", nil)
+	}
+
+	var body labsFeatureToggleUpdateDTO
+	if err := web.Bind(c.Req, &body); err != nil {
+		return response.Error(http.StatusBadRequest, "Invalid request body", err)
+	}
+
+	if err := upsertLabsFeatureToggle(c.Req.Context(), hs.SQLStore, fm, flagName, body.Enabled); err != nil {
+		return response.Error(http.StatusBadRequest, err.Error(), err)
+	}
+
+	state := buildResolvedLabsToggleState(fm)
+	return response.JSON(http.StatusOK, state)
+}
+
+func (hs *HTTPServer) AdminDeleteLabsFeatureToggle(c *contextmodel.ReqContext) response.Response {
+	fm, ok := hs.Features.(*featuremgmt.FeatureManager)
+	if !ok {
+		return response.Error(http.StatusInternalServerError, "Feature manager unavailable", nil)
+	}
+
+	flagName := web.Params(c.Req)[":name"]
+	if flagName == "" {
+		return response.Error(http.StatusBadRequest, "Missing flag name", nil)
+	}
+
+	if err := deleteLabsFeatureToggle(c.Req.Context(), hs.SQLStore, fm, flagName); err != nil {
+		return response.Error(http.StatusBadRequest, err.Error(), err)
+	}
+
+	state := buildResolvedLabsToggleState(fm)
+	return response.JSON(http.StatusOK, state)
+}
+
+func buildResolvedLabsToggleState(fm *featuremgmt.FeatureManager) *feature_toggle_api.ResolvedToggleState {
+	flags := fm.GetFlags()
+	lab := fm.LabOverrides()
+	sort.Slice(flags, func(i, j int) bool {
+		return flags[i].Name < flags[j].Name
+	})
+
+	restartRequired := false
+	toggles := make([]feature_toggle_api.ToggleStatus, 0, len(flags))
+	enabledMap := make(map[string]bool)
+
+	for _, f := range flags {
+		effective := fm.IsEnabledGlobally(f.Name)
+		enabledMap[f.Name] = effective
+
+		writeable := isLabsWritableFlag(f)
+		if _, hasLab := lab[f.Name]; hasLab {
+			if f.RequiresRestart {
+				restartRequired = true
+			}
+		}
+
+		ts := feature_toggle_api.ToggleStatus{
+			Name:        f.Name,
+			Description: f.Description,
+			Stage:       f.Stage.String(),
+			Enabled:     effective,
+			Writeable:   writeable,
+		}
+		if w, ok := fm.WarningForFlag(f.Name); ok {
+			ts.Warning = w
+		}
+		if _, hasLab := lab[f.Name]; hasLab {
+			ts.Source = &v0alpha1.ObjectReference{Kind: "LabsOverride", Name: f.Name}
+		}
+		toggles = append(toggles, ts)
+	}
+
+	return &feature_toggle_api.ResolvedToggleState{
+		AllowEditing:    true,
+		RestartRequired: restartRequired,
+		Enabled:         enabledMap,
+		Toggles:         toggles,
+	}
+}
+
+func isLabsWritableFlag(f featuremgmt.FeatureFlag) bool {
+	if f.RequiresDevMode {
+		return false
+	}
+	if f.FrontendOnly {
+		return true
+	}
+	return false
+}

--- a/pkg/api/feature_toggle_lab_apply.go
+++ b/pkg/api/feature_toggle_lab_apply.go
@@ -1,0 +1,64 @@
+package api
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/grafana/grafana/pkg/infra/db"
+	"github.com/grafana/grafana/pkg/services/featuremgmt"
+	"github.com/grafana/grafana/pkg/services/featuremgmt/labdb"
+)
+
+func upsertLabsFeatureToggle(ctx context.Context, sqlStore db.DB, fm *featuremgmt.FeatureManager, flagName string, enabled bool) error {
+	if sqlStore == nil {
+		return errors.New("database unavailable")
+	}
+	def, ok := featureDefinitionByName(fm, flagName)
+	if !ok {
+		return fmt.Errorf("unknown feature toggle: %s", flagName)
+	}
+	if !isLabsWritableFlag(def) {
+		return fmt.Errorf("feature toggle %s cannot be changed from Labs", flagName)
+	}
+	if err := labdb.Upsert(ctx, sqlStore, flagName, enabled); err != nil {
+		return err
+	}
+	reloadLabsOverrides(ctx, sqlStore, fm)
+	return nil
+}
+
+func deleteLabsFeatureToggle(ctx context.Context, sqlStore db.DB, fm *featuremgmt.FeatureManager, flagName string) error {
+	if sqlStore == nil {
+		return errors.New("database unavailable")
+	}
+	if _, ok := featureDefinitionByName(fm, flagName); !ok {
+		return fmt.Errorf("unknown feature toggle: %s", flagName)
+	}
+	if err := labdb.Delete(ctx, sqlStore, flagName); err != nil {
+		return err
+	}
+	reloadLabsOverrides(ctx, sqlStore, fm)
+	return nil
+}
+
+func reloadLabsOverrides(ctx context.Context, sqlStore db.DB, fm *featuremgmt.FeatureManager) {
+	merged, err := labdb.LoadOverrides(ctx, sqlStore)
+	if err != nil {
+		return
+	}
+	if len(merged) == 0 {
+		fm.SetLabOverrides(nil)
+	} else {
+		fm.SetLabOverrides(merged)
+	}
+}
+
+func featureDefinitionByName(fm *featuremgmt.FeatureManager, name string) (featuremgmt.FeatureFlag, bool) {
+	for _, f := range fm.GetFlags() {
+		if f.Name == name {
+			return f, true
+		}
+	}
+	return featuremgmt.FeatureFlag{}, false
+}

--- a/pkg/api/feature_toggle_lab_init.go
+++ b/pkg/api/feature_toggle_lab_init.go
@@ -1,0 +1,23 @@
+package api
+
+import (
+	"context"
+
+	"github.com/grafana/grafana/pkg/infra/db"
+	"github.com/grafana/grafana/pkg/services/featuremgmt"
+	"github.com/grafana/grafana/pkg/services/featuremgmt/labdb"
+)
+
+func loadLabsOverridesIntoFeatureManager(fm *featuremgmt.FeatureManager, sqlStore db.DB) {
+	if fm == nil || sqlStore == nil {
+		return
+	}
+	overrides, err := labdb.LoadOverrides(context.Background(), sqlStore)
+	if err != nil {
+		fm.WarnLabsOverrideLoad(err)
+		return
+	}
+	if len(overrides) > 0 {
+		fm.SetLabOverrides(overrides)
+	}
+}

--- a/pkg/api/http_server.go
+++ b/pkg/api/http_server.go
@@ -400,6 +400,11 @@ func ProvideHTTPServer(opts ServerOptions, cfg *setting.Cfg, routeRegister routi
 	if err := hs.declareFixedRoles(); err != nil {
 		return nil, err
 	}
+
+	if fm, ok := hs.Features.(*featuremgmt.FeatureManager); ok {
+		loadLabsOverridesIntoFeatureManager(fm, sqlStore)
+	}
+
 	return hs, nil
 }
 

--- a/pkg/services/featuremgmt/labdb/labdb.go
+++ b/pkg/services/featuremgmt/labdb/labdb.go
@@ -1,0 +1,72 @@
+package labdb
+
+import (
+	"context"
+	"time"
+
+	"github.com/grafana/grafana/pkg/infra/db"
+)
+
+const TableName = "feature_toggle_lab_override"
+
+type row struct {
+	ID       int64     `xorm:"pk autoincr 'id'"`
+	FlagName string    `xorm:"flag_name"`
+	Enabled  bool      `xorm:"enabled"`
+	Created  time.Time `xorm:"created"`
+	Updated  time.Time `xorm:"updated"`
+}
+
+func (row) TableName() string {
+	return TableName
+}
+
+func LoadOverrides(ctx context.Context, sqlStore db.DB) (map[string]bool, error) {
+	out := make(map[string]bool)
+	err := sqlStore.WithDbSession(ctx, func(sess *db.Session) error {
+		var rows []row
+		if err := sess.Find(&rows); err != nil {
+			return err
+		}
+		for _, r := range rows {
+			out[r.FlagName] = r.Enabled
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func Upsert(ctx context.Context, sqlStore db.DB, flagName string, enabled bool) error {
+	now := time.Now()
+	return sqlStore.WithDbSession(ctx, func(sess *db.Session) error {
+		var existing row
+		found, err := sess.Where("flag_name = ?", flagName).Get(&existing)
+		if err != nil {
+			return err
+		}
+		if found {
+			existing.Enabled = enabled
+			existing.Updated = now
+			_, err = sess.ID(existing.ID).Update(&existing)
+			return err
+		}
+		r := row{
+			FlagName: flagName,
+			Enabled:  enabled,
+			Created:  now,
+			Updated:  now,
+		}
+		_, err = sess.Insert(&r)
+		return err
+	})
+}
+
+func Delete(ctx context.Context, sqlStore db.DB, flagName string) error {
+	return sqlStore.WithDbSession(ctx, func(sess *db.Session) error {
+		_, err := sess.Exec("DELETE FROM "+TableName+" WHERE flag_name = ?", flagName)
+		return err
+	})
+}

--- a/pkg/services/featuremgmt/manager.go
+++ b/pkg/services/featuremgmt/manager.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"reflect"
+	"sync"
 
 	"github.com/grafana/grafana/pkg/infra/log"
 )
@@ -20,6 +21,9 @@ type FeatureManager struct {
 	startup  map[string]bool   // the explicit values registered at startup
 	warnings map[string]string // potential warnings about the flag
 	log      log.Logger
+
+	mu          sync.RWMutex
+	labOverride map[string]bool // instance-wide overrides from Labs (DB)
 }
 
 // This will merge the flags with the current configuration
@@ -59,7 +63,9 @@ func (fm *FeatureManager) registerFlags(flags ...FeatureFlag) {
 	}
 
 	// This will evaluate all flags
-	fm.update()
+	fm.mu.Lock()
+	fm.updateLocked()
+	fm.mu.Unlock()
 }
 
 // meetsRequirements checks if grafana is able to run the given feature due to dev mode or licensing requirements
@@ -73,6 +79,12 @@ func (fm *FeatureManager) meetsRequirements(ff *FeatureFlag) (bool, string) {
 
 // Update
 func (fm *FeatureManager) update() {
+	fm.mu.Lock()
+	defer fm.mu.Unlock()
+	fm.updateLocked()
+}
+
+func (fm *FeatureManager) updateLocked() {
 	enabled := make(map[string]bool)
 	for _, flag := range fm.flags {
 		// if grafana cannot run the feature, omit metrics around it
@@ -91,24 +103,55 @@ func (fm *FeatureManager) update() {
 			enabled[flag.Name] = true
 		}
 
+		if ov, hasLab := fm.labOverride[flag.Name]; hasLab {
+			if ov {
+				track = 1
+				enabled[flag.Name] = true
+			} else {
+				track = 0
+				delete(enabled, flag.Name)
+			}
+		}
+
 		// Register value with prometheus metric
 		featureToggleInfo.WithLabelValues(flag.Name).Set(track)
 	}
 	fm.enabled = enabled
 }
 
+// SetLabOverrides replaces in-memory Labs overrides and recomputes enabled flags.
+func (fm *FeatureManager) SetLabOverrides(overrides map[string]bool) {
+	fm.mu.Lock()
+	defer fm.mu.Unlock()
+	if overrides == nil {
+		fm.labOverride = nil
+	} else {
+		fm.labOverride = make(map[string]bool, len(overrides))
+		for k, v := range overrides {
+			fm.labOverride[k] = v
+		}
+	}
+	fm.updateLocked()
+}
+
 // IsEnabled checks if a feature is enabled
 func (fm *FeatureManager) IsEnabled(ctx context.Context, flag string) bool {
+	fm.mu.RLock()
+	defer fm.mu.RUnlock()
 	return fm.enabled[flag]
 }
 
 // IsEnabledGlobally checks if a feature is for all tenants
 func (fm *FeatureManager) IsEnabledGlobally(flag string) bool {
+	fm.mu.RLock()
+	defer fm.mu.RUnlock()
 	return fm.enabled[flag]
 }
 
 // GetEnabled returns a map containing only the features that are enabled
 func (fm *FeatureManager) GetEnabled(ctx context.Context) map[string]bool {
+	fm.mu.RLock()
+	defer fm.mu.RUnlock()
 	enabled := make(map[string]bool, len(fm.enabled))
 	for key, val := range fm.enabled {
 		if val {
@@ -120,11 +163,40 @@ func (fm *FeatureManager) GetEnabled(ctx context.Context) map[string]bool {
 
 // GetFlags returns all flag definitions
 func (fm *FeatureManager) GetFlags() []FeatureFlag {
+	fm.mu.RLock()
+	defer fm.mu.RUnlock()
 	v := make([]FeatureFlag, 0, len(fm.flags))
 	for _, value := range fm.flags {
 		v = append(v, *value)
 	}
 	return v
+}
+
+// LabOverrides returns a copy of current Labs DB override map.
+func (fm *FeatureManager) LabOverrides() map[string]bool {
+	fm.mu.RLock()
+	defer fm.mu.RUnlock()
+	if len(fm.labOverride) == 0 {
+		return nil
+	}
+	out := make(map[string]bool, len(fm.labOverride))
+	for k, v := range fm.labOverride {
+		out[k] = v
+	}
+	return out
+}
+
+// WarnLabsOverrideLoad logs a non-fatal error when Labs overrides cannot be read from the database.
+func (fm *FeatureManager) WarnLabsOverrideLoad(err error) {
+	fm.log.Warn("Failed to load Labs feature toggle overrides from database", "err", err)
+}
+
+// WarningForFlag returns a warning string for a flag if one exists (e.g. unknown config flag).
+func (fm *FeatureManager) WarningForFlag(name string) (string, bool) {
+	fm.mu.RLock()
+	defer fm.mu.RUnlock()
+	w, ok := fm.warnings[name]
+	return w, ok
 }
 
 // ############# Test Functions #############

--- a/pkg/services/featuremgmt/manager_test.go
+++ b/pkg/services/featuremgmt/manager_test.go
@@ -65,4 +65,21 @@ func TestFeatureManager(t *testing.T) {
 		require.False(t, ft.IsEnabledGlobally("b"))
 		require.False(t, ft.IsEnabledGlobally("c"))
 	})
+
+	t.Run("labs override enables frontend-only flag", func(t *testing.T) {
+		ft := FeatureManager{
+			flags:   map[string]*FeatureFlag{},
+			startup: map[string]bool{},
+		}
+		ft.registerFlags(FeatureFlag{
+			Name:         "ffOnly",
+			Expression:   "false",
+			FrontendOnly: true,
+		})
+		require.False(t, ft.IsEnabledGlobally("ffOnly"))
+		ft.SetLabOverrides(map[string]bool{"ffOnly": true})
+		require.True(t, ft.IsEnabledGlobally("ffOnly"))
+		ft.SetLabOverrides(map[string]bool{"ffOnly": false})
+		require.False(t, ft.IsEnabledGlobally("ffOnly"))
+	})
 }

--- a/pkg/services/navtree/models.go
+++ b/pkg/services/navtree/models.go
@@ -37,6 +37,9 @@ const (
 	WeightHelp
 )
 
+// WeightLabs sits between Connections and Administration without shifting other section weights.
+const WeightLabs = WeightDataConnections + 50
+
 const (
 	NavIDRoot                 = "root"
 	NavIDDashboards           = "dashboards/browse"
@@ -55,6 +58,7 @@ const (
 	NavIDCfgPlugins           = "cfg/plugins"
 	NavIDCfgAccess            = "cfg/access"
 	NavIDBookmarks            = "bookmarks"
+	NavIDLabs                 = "labs"
 )
 
 type NavLink struct {

--- a/pkg/services/navtree/navtreeimpl/navtree.go
+++ b/pkg/services/navtree/navtreeimpl/navtree.go
@@ -162,6 +162,18 @@ func (s *ServiceImpl) GetNavTree(c *contextmodel.ReqContext, prefs *pref.Prefere
 		treeRoot.AddSection(connectionsSection)
 	}
 
+	if c.IsSignedIn && c.GetIsGrafanaAdmin() {
+		treeRoot.AddSection(&navtree.NavLink{
+			Text:          "Labs",
+			Id:            navtree.NavIDLabs,
+			SubTitle:      "View and manage frontend feature toggles for this Grafana instance",
+			Icon:          "flask",
+			Url:           s.cfg.AppSubURL + "/labs",
+			SortWeight:    navtree.WeightLabs,
+			HighlightText: "Beta",
+		})
+	}
+
 	orgAdminNode, err := s.getAdminNode(c)
 
 	if orgAdminNode != nil && len(orgAdminNode.Children) > 0 {

--- a/pkg/services/preference/themes_generated.go
+++ b/pkg/services/preference/themes_generated.go
@@ -13,6 +13,7 @@ var themes = []ThemeDTO{
 	{ID: "gloom", Type: "dark", IsExtra: true},
 	{ID: "mars", Type: "dark", IsExtra: true},
 	{ID: "matrix", Type: "dark", IsExtra: true},
+	{ID: "orange", Type: "light", IsExtra: true},
 	{ID: "sapphiredusk", Type: "dark", IsExtra: true},
 	{ID: "synthwave", Type: "dark", IsExtra: true},
 	{ID: "tron", Type: "dark", IsExtra: true},

--- a/pkg/services/sqlstore/migrations/feature_toggle_lab_mig.go
+++ b/pkg/services/sqlstore/migrations/feature_toggle_lab_mig.go
@@ -1,0 +1,23 @@
+package migrations
+
+import (
+	. "github.com/grafana/grafana/pkg/services/sqlstore/migrator"
+)
+
+func addFeatureToggleLabOverridesMigration(mg *Migrator) {
+	table := Table{
+		Name: "feature_toggle_lab_override",
+		Columns: []*Column{
+			{Name: "id", Type: DB_BigInt, Nullable: false, IsPrimaryKey: true, IsAutoIncrement: true},
+			{Name: "flag_name", Type: DB_NVarchar, Length: 190, Nullable: false},
+			{Name: "enabled", Type: DB_Bool, Nullable: false},
+			{Name: "created", Type: DB_DateTime, Nullable: false},
+			{Name: "updated", Type: DB_DateTime, Nullable: false},
+		},
+		Indices: []*Index{
+			{Cols: []string{"flag_name"}, Type: UniqueIndex},
+		},
+	}
+
+	mg.AddMigration("create feature_toggle_lab_override table", NewAddTableMigration(table))
+}

--- a/pkg/services/sqlstore/migrations/migrations.go
+++ b/pkg/services/sqlstore/migrations/migrations.go
@@ -176,4 +176,6 @@ func (oss *OSSMigrations) AddMigration(mg *Migrator) {
 	ualert.AddStateLastResultColumn(mg)
 
 	accesscontrol.AddScopedReceiverTestingPermissions(mg)
+
+	addFeatureToggleLabOverridesMigration(mg)
 }

--- a/pkg/tests/apis/annotations/annotations_test.go
+++ b/pkg/tests/apis/annotations/annotations_test.go
@@ -1,0 +1,142 @@
+package annotations
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	annotationV0 "github.com/grafana/grafana/apps/annotation/pkg/apis/annotation/v0alpha1"
+	grafanarest "github.com/grafana/grafana/pkg/apiserver/rest"
+	"github.com/grafana/grafana/pkg/services/featuremgmt"
+	"github.com/grafana/grafana/pkg/setting"
+	"github.com/grafana/grafana/pkg/tests/apis"
+	"github.com/grafana/grafana/pkg/tests/testinfra"
+	"github.com/grafana/grafana/pkg/tests/testsuite"
+	"github.com/grafana/grafana/pkg/util/testutil"
+)
+
+func TestMain(m *testing.M) {
+	testsuite.Run(m)
+}
+
+func TestIntegrationAnnotations(t *testing.T) {
+	testutil.SkipIntegrationTestInShortMode(t)
+
+	for _, mode := range []grafanarest.DualWriterMode{
+		grafanarest.Mode0, // Only legacy for now
+	} {
+		t.Run(fmt.Sprintf("annotations (mode:%d)", mode), func(t *testing.T) {
+			helper := apis.NewK8sTestHelper(t, testinfra.GrafanaOpts{
+				DisableAnonymous:     true,
+				EnableFeatureToggles: []string{featuremgmt.FlagKubernetesAnnotations},
+				UnifiedStorageConfig: map[string]setting.UnifiedStorageConfig{
+					"annotation.annotation.grafana.app": {
+						DualWriterMode: mode,
+					},
+				},
+			})
+
+			ctx := context.Background()
+			kind := annotationV0.AnnotationKind()
+			annotationsClient := helper.GetResourceClient(apis.ResourceClientArgs{
+				User: helper.Org1.Admin,
+				GVR:  kind.GroupVersionResource(),
+			})
+			namespace := helper.Namespacer(helper.Org1.OrgID)
+
+			legacyCreateBody, err := json.Marshal(map[string]any{
+				"text": "from-legacy",
+				"time": int64(1700000000000),
+				"tags": []string{"legacy-tag"},
+			})
+			require.NoError(t, err)
+
+			legacyCreate := apis.DoRequest(helper, apis.RequestParams{
+				User:   annotationsClient.Args.User,
+				Method: http.MethodPost,
+				Path:   "/api/annotations",
+				Body:   legacyCreateBody,
+			}, &map[string]any{})
+			require.Equal(t, http.StatusOK, legacyCreate.Response.StatusCode, "create annotation via legacy /api")
+
+			legacyIDRaw, ok := (*legacyCreate.Result)["id"].(float64)
+			require.True(t, ok, "legacy response should contain numeric id")
+			legacyName := fmt.Sprintf("a-%d", int64(legacyIDRaw))
+
+			listResults, err := annotationsClient.Resource.List(ctx, v1.ListOptions{})
+			require.NoError(t, err)
+			require.NotEmpty(t, listResults.Items)
+
+			foundLegacy := false
+			for _, item := range listResults.Items {
+				if item.GetName() == legacyName {
+					foundLegacy = true
+					break
+				}
+			}
+			require.True(t, foundLegacy, "legacy-created annotation should be visible via /apis")
+
+			k8sAnnotation := &unstructured.Unstructured{
+				Object: map[string]any{
+					"spec": map[string]any{
+						"text":    "from-k8s",
+						"time":    int64(1700000001000),
+						"panelID": int64(7),
+						"tags":    []string{"k8s-tag"},
+					},
+				},
+			}
+			k8sAnnotation.SetGenerateName("anno-")
+			k8sAnnotation.SetNamespace(namespace)
+			k8sAnnotation.SetAPIVersion(kind.GroupVersionResource().GroupVersion().String())
+			k8sAnnotation.SetKind("Annotation")
+
+			createdK8s, err := annotationsClient.Resource.Create(ctx, k8sAnnotation, v1.CreateOptions{})
+			require.NoError(t, err)
+			require.True(t, strings.HasPrefix(createdK8s.GetName(), "a-"), "created annotation name should use legacy ID format")
+
+			k8sID := strings.TrimPrefix(createdK8s.GetName(), "a-")
+			_, err = strconv.ParseInt(k8sID, 10, 64)
+			require.NoError(t, err)
+
+			legacyGet := apis.DoRequest(helper, apis.RequestParams{
+				User:   annotationsClient.Args.User,
+				Method: http.MethodGet,
+				Path:   fmt.Sprintf("/api/annotations/%s", k8sID),
+			}, &map[string]any{})
+			require.Equal(t, http.StatusOK, legacyGet.Response.StatusCode, "read /apis-created annotation via legacy /api")
+			require.Equal(t, "from-k8s", (*legacyGet.Result)["text"])
+
+			tagsRsp := apis.DoRequest(helper, apis.RequestParams{
+				User:   annotationsClient.Args.User,
+				Method: http.MethodGet,
+				Path:   fmt.Sprintf("/apis/%s/%s/namespaces/%s/tags", annotationV0.APIGroup, annotationV0.APIVersion, namespace),
+			}, &map[string]any{})
+			require.Equal(t, http.StatusOK, tagsRsp.Response.StatusCode, "read custom tags route via /apis")
+
+			tags, ok := (*tagsRsp.Result)["tags"].([]any)
+			require.True(t, ok, "custom tags response should include tags array")
+
+			foundK8sTag := false
+			for _, raw := range tags {
+				tagItem, ok := raw.(map[string]any)
+				if !ok {
+					continue
+				}
+				if tagName, ok := tagItem["tag"].(string); ok && tagName == "k8s-tag" {
+					foundK8sTag = true
+					break
+				}
+			}
+			require.True(t, foundK8sTag, "tag from /apis-created annotation should be returned by /apis tags route")
+		})
+	}
+}

--- a/pkg/tests/apis/correlations/correlations_test.go
+++ b/pkg/tests/apis/correlations/correlations_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/utils/ptr"
 
 	correlationsV0 "github.com/grafana/grafana/apps/correlations/pkg/apis/correlation/v0alpha1"
@@ -108,6 +109,43 @@ func TestIntegrationCorrelations(t *testing.T) {
 			getResults, err := correlationsClient.Resource.Get(ctx, uidAtoB, v1.GetOptions{})
 			require.NoError(t, err)
 			require.Equal(t, uidAtoB, getResults.GetName())
+
+			// Create via /apis and ensure legacy /api can read it.
+			k8sOnly := &unstructured.Unstructured{
+				Object: map[string]any{
+					"spec": map[string]any{
+						"type":  "query",
+						"label": "from-k8s",
+						"source": map[string]any{
+							"group": "testdata",
+							"name":  "test-A",
+						},
+						"target": map[string]any{
+							"group": "testdata",
+							"name":  "test-B",
+						},
+						"config": map[string]any{
+							"field":  "traceID",
+							"target": map[string]any{},
+						},
+					},
+				},
+			}
+			k8sOnly.SetGenerateName("corr-")
+			k8sOnly.SetNamespace(helper.Namespacer(helper.Org1.OrgID))
+			k8sOnly.SetAPIVersion(kind.GroupVersionResource().GroupVersion().String())
+			k8sOnly.SetKind("Correlation")
+			createdK8s, err := correlationsClient.Resource.Create(ctx, k8sOnly, v1.CreateOptions{})
+			require.NoError(t, err)
+			require.NotEmpty(t, createdK8s.GetName())
+
+			legacyGet := apis.DoRequest(helper, apis.RequestParams{
+				User:   correlationsClient.Args.User,
+				Method: http.MethodGet,
+				Path:   fmt.Sprintf("/api/datasources/uid/test-A/correlations/%s", createdK8s.GetName()),
+			}, &map[string]any{})
+			require.Equal(t, http.StatusOK, legacyGet.Response.StatusCode, "read /apis-created correlation via legacy /api")
+			require.Equal(t, createdK8s.GetName(), (*legacyGet.Result)["uid"])
 		})
 	}
 }

--- a/pkg/tests/apis/openapi_snapshots/annotation.grafana.app-v0alpha1.json
+++ b/pkg/tests/apis/openapi_snapshots/annotation.grafana.app-v0alpha1.json
@@ -1,0 +1,1806 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "annotation.grafana.app/v0alpha1"
+  },
+  "paths": {
+    "/apis/annotation.grafana.app/v0alpha1/": {
+      "get": {
+        "tags": [
+          "API Discovery"
+        ],
+        "description": "Describe the available kubernetes resources",
+        "operationId": "getAPIResources",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.APIResourceList"
+                }
+              },
+              "application/yaml": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.APIResourceList"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/apis/annotation.grafana.app/v0alpha1/namespaces/{namespace}/annotations": {
+      "get": {
+        "tags": [
+          "Annotation"
+        ],
+        "description": "list objects of kind Annotation",
+        "operationId": "listAnnotation",
+        "parameters": [
+          {
+            "name": "allowWatchBookmarks",
+            "in": "query",
+            "description": "allowWatchBookmarks requests watch events with type \"BOOKMARK\". Servers that do not implement bookmarks may ignore this flag and bookmarks are sent at the server's discretion. Clients should not assume bookmarks are returned at any specific interval, nor may they assume the server will send any BOOKMARK event during a session. If this is not a watch, this field is ignored.",
+            "schema": {
+              "type": "boolean",
+              "uniqueItems": true
+            }
+          },
+          {
+            "name": "continue",
+            "in": "query",
+            "description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+            "schema": {
+              "type": "string",
+              "uniqueItems": true
+            }
+          },
+          {
+            "name": "fieldSelector",
+            "in": "query",
+            "description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+            "schema": {
+              "type": "string",
+              "uniqueItems": true
+            }
+          },
+          {
+            "name": "labelSelector",
+            "in": "query",
+            "description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+            "schema": {
+              "type": "string",
+              "uniqueItems": true
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+            "schema": {
+              "type": "integer",
+              "uniqueItems": true
+            }
+          },
+          {
+            "name": "resourceVersion",
+            "in": "query",
+            "description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+            "schema": {
+              "type": "string",
+              "uniqueItems": true
+            }
+          },
+          {
+            "name": "resourceVersionMatch",
+            "in": "query",
+            "description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+            "schema": {
+              "type": "string",
+              "uniqueItems": true
+            }
+          },
+          {
+            "name": "sendInitialEvents",
+            "in": "query",
+            "description": "`sendInitialEvents=true` may be set together with `watch=true`. In that case, the watch stream will begin with synthetic events to produce the current state of objects in the collection. Once all such events have been sent, a synthetic \"Bookmark\" event  will be sent. The bookmark will report the ResourceVersion (RV) corresponding to the set of objects, and be marked with `\"k8s.io/initial-events-end\": \"true\"` annotation. Afterwards, the watch stream will proceed as usual, sending watch events corresponding to changes (subsequent to the RV) to objects watched.\n\nWhen `sendInitialEvents` option is set, we require `resourceVersionMatch` option to also be set. The semantic of the watch request is as following: - `resourceVersionMatch` = NotOlderThan\n  is interpreted as \"data at least as new as the provided `resourceVersion`\"\n  and the bookmark event is send when the state is synced\n  to a `resourceVersion` at least as fresh as the one provided by the ListOptions.\n  If `resourceVersion` is unset, this is interpreted as \"consistent read\" and the\n  bookmark event is send when the state is synced at least to the moment\n  when request started being processed.\n- `resourceVersionMatch` set to any other value or unset\n  Invalid error is returned.\n\nDefaults to true if `resourceVersion=\"\"` or `resourceVersion=\"0\"` (for backward compatibility reasons) and to false otherwise.",
+            "schema": {
+              "type": "boolean",
+              "uniqueItems": true
+            }
+          },
+          {
+            "name": "timeoutSeconds",
+            "in": "query",
+            "description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+            "schema": {
+              "type": "integer",
+              "uniqueItems": true
+            }
+          },
+          {
+            "name": "watch",
+            "in": "query",
+            "description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+            "schema": {
+              "type": "boolean",
+              "uniqueItems": true
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/com.github.grafana.grafana.apps.annotation.pkg.apis.annotation.v0alpha1.AnnotationList"
+                }
+              },
+              "application/json;stream=watch": {
+                "schema": {
+                  "$ref": "#/components/schemas/com.github.grafana.grafana.apps.annotation.pkg.apis.annotation.v0alpha1.AnnotationList"
+                }
+              },
+              "application/yaml": {
+                "schema": {
+                  "$ref": "#/components/schemas/com.github.grafana.grafana.apps.annotation.pkg.apis.annotation.v0alpha1.AnnotationList"
+                }
+              }
+            }
+          }
+        },
+        "x-kubernetes-action": "list",
+        "x-kubernetes-group-version-kind": {
+          "group": "annotation.grafana.app",
+          "version": "v0alpha1",
+          "kind": "Annotation"
+        }
+      },
+      "post": {
+        "tags": [
+          "Annotation"
+        ],
+        "description": "create an Annotation",
+        "operationId": "createAnnotation",
+        "parameters": [
+          {
+            "name": "dryRun",
+            "in": "query",
+            "description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+            "schema": {
+              "type": "string",
+              "uniqueItems": true
+            }
+          },
+          {
+            "name": "fieldManager",
+            "in": "query",
+            "description": "fieldManager is a name associated with the actor or entity that is making these changes. The value must be less than or 128 characters long, and only contain printable characters, as defined by https://golang.org/pkg/unicode/#IsPrint.",
+            "schema": {
+              "type": "string",
+              "uniqueItems": true
+            }
+          },
+          {
+            "name": "fieldValidation",
+            "in": "query",
+            "description": "fieldValidation instructs the server on how to handle objects in the request (POST/PUT/PATCH) containing unknown or duplicate fields. Valid values are: - Ignore: This will ignore any unknown fields that are silently dropped from the object, and will ignore all but the last duplicate field that the decoder encounters. This is the default behavior prior to v1.23. - Warn: This will send a warning via the standard warning response header for each unknown field that is dropped from the object, and for each duplicate field that is encountered. The request will still succeed if there are no other errors, and will only persist the last of any duplicate fields. This is the default in v1.23+ - Strict: This will fail the request with a BadRequest error if any unknown fields would be dropped from the object, or if any duplicate fields are present. The error returned from the server will contain all unknown and duplicate fields encountered.",
+            "schema": {
+              "type": "string",
+              "uniqueItems": true
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/com.github.grafana.grafana.apps.annotation.pkg.apis.annotation.v0alpha1.Annotation"
+              }
+            },
+            "application/yaml": {
+              "schema": {
+                "$ref": "#/components/schemas/com.github.grafana.grafana.apps.annotation.pkg.apis.annotation.v0alpha1.Annotation"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/com.github.grafana.grafana.apps.annotation.pkg.apis.annotation.v0alpha1.Annotation"
+                }
+              },
+              "application/yaml": {
+                "schema": {
+                  "$ref": "#/components/schemas/com.github.grafana.grafana.apps.annotation.pkg.apis.annotation.v0alpha1.Annotation"
+                }
+              }
+            }
+          },
+          "201": {
+            "description": "Created",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/com.github.grafana.grafana.apps.annotation.pkg.apis.annotation.v0alpha1.Annotation"
+                }
+              },
+              "application/yaml": {
+                "schema": {
+                  "$ref": "#/components/schemas/com.github.grafana.grafana.apps.annotation.pkg.apis.annotation.v0alpha1.Annotation"
+                }
+              }
+            }
+          },
+          "202": {
+            "description": "Accepted",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/com.github.grafana.grafana.apps.annotation.pkg.apis.annotation.v0alpha1.Annotation"
+                }
+              },
+              "application/yaml": {
+                "schema": {
+                  "$ref": "#/components/schemas/com.github.grafana.grafana.apps.annotation.pkg.apis.annotation.v0alpha1.Annotation"
+                }
+              }
+            }
+          }
+        },
+        "x-kubernetes-action": "post",
+        "x-kubernetes-group-version-kind": {
+          "group": "annotation.grafana.app",
+          "version": "v0alpha1",
+          "kind": "Annotation"
+        }
+      },
+      "delete": {
+        "tags": [
+          "Annotation"
+        ],
+        "description": "delete collection of Annotation",
+        "operationId": "deletecollectionAnnotation",
+        "parameters": [
+          {
+            "name": "continue",
+            "in": "query",
+            "description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+            "schema": {
+              "type": "string",
+              "uniqueItems": true
+            }
+          },
+          {
+            "name": "dryRun",
+            "in": "query",
+            "description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+            "schema": {
+              "type": "string",
+              "uniqueItems": true
+            }
+          },
+          {
+            "name": "fieldSelector",
+            "in": "query",
+            "description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+            "schema": {
+              "type": "string",
+              "uniqueItems": true
+            }
+          },
+          {
+            "name": "gracePeriodSeconds",
+            "in": "query",
+            "description": "The duration in seconds before the object should be deleted. Value must be non-negative integer. The value zero indicates delete immediately. If this value is nil, the default grace period for the specified type will be used. Defaults to a per object value if not specified. zero means delete immediately.",
+            "schema": {
+              "type": "integer",
+              "uniqueItems": true
+            }
+          },
+          {
+            "name": "ignoreStoreReadErrorWithClusterBreakingPotential",
+            "in": "query",
+            "description": "if set to true, it will trigger an unsafe deletion of the resource in case the normal deletion flow fails with a corrupt object error. A resource is considered corrupt if it can not be retrieved from the underlying storage successfully because of a) its data can not be transformed e.g. decryption failure, or b) it fails to decode into an object. NOTE: unsafe deletion ignores finalizer constraints, skips precondition checks, and removes the object from the storage. WARNING: This may potentially break the cluster if the workload associated with the resource being unsafe-deleted relies on normal deletion flow. Use only if you REALLY know what you are doing. The default value is false, and the user must opt in to enable it",
+            "schema": {
+              "type": "boolean",
+              "uniqueItems": true
+            }
+          },
+          {
+            "name": "labelSelector",
+            "in": "query",
+            "description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+            "schema": {
+              "type": "string",
+              "uniqueItems": true
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+            "schema": {
+              "type": "integer",
+              "uniqueItems": true
+            }
+          },
+          {
+            "name": "orphanDependents",
+            "in": "query",
+            "description": "Deprecated: please use the PropagationPolicy, this field will be deprecated in 1.7. Should the dependent objects be orphaned. If true/false, the \"orphan\" finalizer will be added to/removed from the object's finalizers list. Either this field or PropagationPolicy may be set, but not both.",
+            "schema": {
+              "type": "boolean",
+              "uniqueItems": true
+            }
+          },
+          {
+            "name": "propagationPolicy",
+            "in": "query",
+            "description": "Whether and how garbage collection will be performed. Either this field or OrphanDependents may be set, but not both. The default policy is decided by the existing finalizer set in the metadata.finalizers and the resource-specific default policy. Acceptable values are: 'Orphan' - orphan the dependents; 'Background' - allow the garbage collector to delete the dependents in the background; 'Foreground' - a cascading policy that deletes all dependents in the foreground.",
+            "schema": {
+              "type": "string",
+              "uniqueItems": true
+            }
+          },
+          {
+            "name": "resourceVersion",
+            "in": "query",
+            "description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+            "schema": {
+              "type": "string",
+              "uniqueItems": true
+            }
+          },
+          {
+            "name": "resourceVersionMatch",
+            "in": "query",
+            "description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+            "schema": {
+              "type": "string",
+              "uniqueItems": true
+            }
+          },
+          {
+            "name": "sendInitialEvents",
+            "in": "query",
+            "description": "`sendInitialEvents=true` may be set together with `watch=true`. In that case, the watch stream will begin with synthetic events to produce the current state of objects in the collection. Once all such events have been sent, a synthetic \"Bookmark\" event  will be sent. The bookmark will report the ResourceVersion (RV) corresponding to the set of objects, and be marked with `\"k8s.io/initial-events-end\": \"true\"` annotation. Afterwards, the watch stream will proceed as usual, sending watch events corresponding to changes (subsequent to the RV) to objects watched.\n\nWhen `sendInitialEvents` option is set, we require `resourceVersionMatch` option to also be set. The semantic of the watch request is as following: - `resourceVersionMatch` = NotOlderThan\n  is interpreted as \"data at least as new as the provided `resourceVersion`\"\n  and the bookmark event is send when the state is synced\n  to a `resourceVersion` at least as fresh as the one provided by the ListOptions.\n  If `resourceVersion` is unset, this is interpreted as \"consistent read\" and the\n  bookmark event is send when the state is synced at least to the moment\n  when request started being processed.\n- `resourceVersionMatch` set to any other value or unset\n  Invalid error is returned.\n\nDefaults to true if `resourceVersion=\"\"` or `resourceVersion=\"0\"` (for backward compatibility reasons) and to false otherwise.",
+            "schema": {
+              "type": "boolean",
+              "uniqueItems": true
+            }
+          },
+          {
+            "name": "timeoutSeconds",
+            "in": "query",
+            "description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+            "schema": {
+              "type": "integer",
+              "uniqueItems": true
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+                }
+              },
+              "application/yaml": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+                }
+              }
+            }
+          }
+        },
+        "x-kubernetes-action": "deletecollection",
+        "x-kubernetes-group-version-kind": {
+          "group": "annotation.grafana.app",
+          "version": "v0alpha1",
+          "kind": "Annotation"
+        }
+      },
+      "parameters": [
+        {
+          "name": "namespace",
+          "in": "path",
+          "description": "object name and auth scope, such as for teams and projects",
+          "required": true,
+          "schema": {
+            "type": "string",
+            "uniqueItems": true
+          }
+        },
+        {
+          "name": "pretty",
+          "in": "query",
+          "description": "If 'true', then the output is pretty printed. Defaults to 'false' unless the user-agent indicates a browser or command-line HTTP tool (curl and wget).",
+          "schema": {
+            "type": "string",
+            "uniqueItems": true
+          }
+        }
+      ]
+    },
+    "/apis/annotation.grafana.app/v0alpha1/namespaces/{namespace}/annotations/{name}": {
+      "get": {
+        "tags": [
+          "Annotation"
+        ],
+        "description": "read the specified Annotation",
+        "operationId": "getAnnotation",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/com.github.grafana.grafana.apps.annotation.pkg.apis.annotation.v0alpha1.Annotation"
+                }
+              },
+              "application/yaml": {
+                "schema": {
+                  "$ref": "#/components/schemas/com.github.grafana.grafana.apps.annotation.pkg.apis.annotation.v0alpha1.Annotation"
+                }
+              }
+            }
+          }
+        },
+        "x-kubernetes-action": "get",
+        "x-kubernetes-group-version-kind": {
+          "group": "annotation.grafana.app",
+          "version": "v0alpha1",
+          "kind": "Annotation"
+        }
+      },
+      "put": {
+        "tags": [
+          "Annotation"
+        ],
+        "description": "replace the specified Annotation",
+        "operationId": "replaceAnnotation",
+        "parameters": [
+          {
+            "name": "dryRun",
+            "in": "query",
+            "description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+            "schema": {
+              "type": "string",
+              "uniqueItems": true
+            }
+          },
+          {
+            "name": "fieldManager",
+            "in": "query",
+            "description": "fieldManager is a name associated with the actor or entity that is making these changes. The value must be less than or 128 characters long, and only contain printable characters, as defined by https://golang.org/pkg/unicode/#IsPrint.",
+            "schema": {
+              "type": "string",
+              "uniqueItems": true
+            }
+          },
+          {
+            "name": "fieldValidation",
+            "in": "query",
+            "description": "fieldValidation instructs the server on how to handle objects in the request (POST/PUT/PATCH) containing unknown or duplicate fields. Valid values are: - Ignore: This will ignore any unknown fields that are silently dropped from the object, and will ignore all but the last duplicate field that the decoder encounters. This is the default behavior prior to v1.23. - Warn: This will send a warning via the standard warning response header for each unknown field that is dropped from the object, and for each duplicate field that is encountered. The request will still succeed if there are no other errors, and will only persist the last of any duplicate fields. This is the default in v1.23+ - Strict: This will fail the request with a BadRequest error if any unknown fields would be dropped from the object, or if any duplicate fields are present. The error returned from the server will contain all unknown and duplicate fields encountered.",
+            "schema": {
+              "type": "string",
+              "uniqueItems": true
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/com.github.grafana.grafana.apps.annotation.pkg.apis.annotation.v0alpha1.Annotation"
+              }
+            },
+            "application/yaml": {
+              "schema": {
+                "$ref": "#/components/schemas/com.github.grafana.grafana.apps.annotation.pkg.apis.annotation.v0alpha1.Annotation"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/com.github.grafana.grafana.apps.annotation.pkg.apis.annotation.v0alpha1.Annotation"
+                }
+              },
+              "application/yaml": {
+                "schema": {
+                  "$ref": "#/components/schemas/com.github.grafana.grafana.apps.annotation.pkg.apis.annotation.v0alpha1.Annotation"
+                }
+              }
+            }
+          },
+          "201": {
+            "description": "Created",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/com.github.grafana.grafana.apps.annotation.pkg.apis.annotation.v0alpha1.Annotation"
+                }
+              },
+              "application/yaml": {
+                "schema": {
+                  "$ref": "#/components/schemas/com.github.grafana.grafana.apps.annotation.pkg.apis.annotation.v0alpha1.Annotation"
+                }
+              }
+            }
+          }
+        },
+        "x-kubernetes-action": "put",
+        "x-kubernetes-group-version-kind": {
+          "group": "annotation.grafana.app",
+          "version": "v0alpha1",
+          "kind": "Annotation"
+        }
+      },
+      "delete": {
+        "tags": [
+          "Annotation"
+        ],
+        "description": "delete an Annotation",
+        "operationId": "deleteAnnotation",
+        "parameters": [
+          {
+            "name": "dryRun",
+            "in": "query",
+            "description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+            "schema": {
+              "type": "string",
+              "uniqueItems": true
+            }
+          },
+          {
+            "name": "gracePeriodSeconds",
+            "in": "query",
+            "description": "The duration in seconds before the object should be deleted. Value must be non-negative integer. The value zero indicates delete immediately. If this value is nil, the default grace period for the specified type will be used. Defaults to a per object value if not specified. zero means delete immediately.",
+            "schema": {
+              "type": "integer",
+              "uniqueItems": true
+            }
+          },
+          {
+            "name": "ignoreStoreReadErrorWithClusterBreakingPotential",
+            "in": "query",
+            "description": "if set to true, it will trigger an unsafe deletion of the resource in case the normal deletion flow fails with a corrupt object error. A resource is considered corrupt if it can not be retrieved from the underlying storage successfully because of a) its data can not be transformed e.g. decryption failure, or b) it fails to decode into an object. NOTE: unsafe deletion ignores finalizer constraints, skips precondition checks, and removes the object from the storage. WARNING: This may potentially break the cluster if the workload associated with the resource being unsafe-deleted relies on normal deletion flow. Use only if you REALLY know what you are doing. The default value is false, and the user must opt in to enable it",
+            "schema": {
+              "type": "boolean",
+              "uniqueItems": true
+            }
+          },
+          {
+            "name": "orphanDependents",
+            "in": "query",
+            "description": "Deprecated: please use the PropagationPolicy, this field will be deprecated in 1.7. Should the dependent objects be orphaned. If true/false, the \"orphan\" finalizer will be added to/removed from the object's finalizers list. Either this field or PropagationPolicy may be set, but not both.",
+            "schema": {
+              "type": "boolean",
+              "uniqueItems": true
+            }
+          },
+          {
+            "name": "propagationPolicy",
+            "in": "query",
+            "description": "Whether and how garbage collection will be performed. Either this field or OrphanDependents may be set, but not both. The default policy is decided by the existing finalizer set in the metadata.finalizers and the resource-specific default policy. Acceptable values are: 'Orphan' - orphan the dependents; 'Background' - allow the garbage collector to delete the dependents in the background; 'Foreground' - a cascading policy that deletes all dependents in the foreground.",
+            "schema": {
+              "type": "string",
+              "uniqueItems": true
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+                }
+              },
+              "application/yaml": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+                }
+              }
+            }
+          },
+          "202": {
+            "description": "Accepted",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+                }
+              },
+              "application/yaml": {
+                "schema": {
+                  "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+                }
+              }
+            }
+          }
+        },
+        "x-kubernetes-action": "delete",
+        "x-kubernetes-group-version-kind": {
+          "group": "annotation.grafana.app",
+          "version": "v0alpha1",
+          "kind": "Annotation"
+        }
+      },
+      "patch": {
+        "tags": [
+          "Annotation"
+        ],
+        "description": "partially update the specified Annotation",
+        "operationId": "updateAnnotation",
+        "parameters": [
+          {
+            "name": "dryRun",
+            "in": "query",
+            "description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+            "schema": {
+              "type": "string",
+              "uniqueItems": true
+            }
+          },
+          {
+            "name": "fieldManager",
+            "in": "query",
+            "description": "fieldManager is a name associated with the actor or entity that is making these changes. The value must be less than or 128 characters long, and only contain printable characters, as defined by https://golang.org/pkg/unicode/#IsPrint. This field is required for apply requests (application/apply-patch) but optional for non-apply patch types (JsonPatch, MergePatch, StrategicMergePatch).",
+            "schema": {
+              "type": "string",
+              "uniqueItems": true
+            }
+          },
+          {
+            "name": "fieldValidation",
+            "in": "query",
+            "description": "fieldValidation instructs the server on how to handle objects in the request (POST/PUT/PATCH) containing unknown or duplicate fields. Valid values are: - Ignore: This will ignore any unknown fields that are silently dropped from the object, and will ignore all but the last duplicate field that the decoder encounters. This is the default behavior prior to v1.23. - Warn: This will send a warning via the standard warning response header for each unknown field that is dropped from the object, and for each duplicate field that is encountered. The request will still succeed if there are no other errors, and will only persist the last of any duplicate fields. This is the default in v1.23+ - Strict: This will fail the request with a BadRequest error if any unknown fields would be dropped from the object, or if any duplicate fields are present. The error returned from the server will contain all unknown and duplicate fields encountered.",
+            "schema": {
+              "type": "string",
+              "uniqueItems": true
+            }
+          },
+          {
+            "name": "force",
+            "in": "query",
+            "description": "Force is going to \"force\" Apply requests. It means user will re-acquire conflicting fields owned by other people. Force flag must be unset for non-apply patch requests.",
+            "schema": {
+              "type": "boolean",
+              "uniqueItems": true
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/apply-patch+yaml": {
+              "schema": {
+                "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+              }
+            },
+            "application/json-patch+json": {
+              "schema": {
+                "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+              }
+            },
+            "application/merge-patch+json": {
+              "schema": {
+                "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+              }
+            },
+            "application/strategic-merge-patch+json": {
+              "schema": {
+                "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/com.github.grafana.grafana.apps.annotation.pkg.apis.annotation.v0alpha1.Annotation"
+                }
+              },
+              "application/yaml": {
+                "schema": {
+                  "$ref": "#/components/schemas/com.github.grafana.grafana.apps.annotation.pkg.apis.annotation.v0alpha1.Annotation"
+                }
+              }
+            }
+          },
+          "201": {
+            "description": "Created",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/com.github.grafana.grafana.apps.annotation.pkg.apis.annotation.v0alpha1.Annotation"
+                }
+              },
+              "application/yaml": {
+                "schema": {
+                  "$ref": "#/components/schemas/com.github.grafana.grafana.apps.annotation.pkg.apis.annotation.v0alpha1.Annotation"
+                }
+              }
+            }
+          }
+        },
+        "x-kubernetes-action": "patch",
+        "x-kubernetes-group-version-kind": {
+          "group": "annotation.grafana.app",
+          "version": "v0alpha1",
+          "kind": "Annotation"
+        }
+      },
+      "parameters": [
+        {
+          "name": "name",
+          "in": "path",
+          "description": "name of the Annotation",
+          "required": true,
+          "schema": {
+            "type": "string",
+            "uniqueItems": true
+          }
+        },
+        {
+          "name": "namespace",
+          "in": "path",
+          "description": "object name and auth scope, such as for teams and projects",
+          "required": true,
+          "schema": {
+            "type": "string",
+            "uniqueItems": true
+          }
+        },
+        {
+          "name": "pretty",
+          "in": "query",
+          "description": "If 'true', then the output is pretty printed. Defaults to 'false' unless the user-agent indicates a browser or command-line HTTP tool (curl and wget).",
+          "schema": {
+            "type": "string",
+            "uniqueItems": true
+          }
+        }
+      ]
+    },
+    "/apis/annotation.grafana.app/v0alpha1/namespaces/{namespace}/annotations/{name}/status": {
+      "get": {
+        "tags": [
+          "Annotation"
+        ],
+        "description": "read status of the specified Annotation",
+        "operationId": "getAnnotationStatus",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/com.github.grafana.grafana.apps.annotation.pkg.apis.annotation.v0alpha1.Annotation"
+                }
+              },
+              "application/yaml": {
+                "schema": {
+                  "$ref": "#/components/schemas/com.github.grafana.grafana.apps.annotation.pkg.apis.annotation.v0alpha1.Annotation"
+                }
+              }
+            }
+          }
+        },
+        "x-kubernetes-action": "get",
+        "x-kubernetes-group-version-kind": {
+          "group": "annotation.grafana.app",
+          "version": "v0alpha1",
+          "kind": "Annotation"
+        }
+      },
+      "put": {
+        "tags": [
+          "Annotation"
+        ],
+        "description": "replace status of the specified Annotation",
+        "operationId": "replaceAnnotationStatus",
+        "parameters": [
+          {
+            "name": "dryRun",
+            "in": "query",
+            "description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+            "schema": {
+              "type": "string",
+              "uniqueItems": true
+            }
+          },
+          {
+            "name": "fieldManager",
+            "in": "query",
+            "description": "fieldManager is a name associated with the actor or entity that is making these changes. The value must be less than or 128 characters long, and only contain printable characters, as defined by https://golang.org/pkg/unicode/#IsPrint.",
+            "schema": {
+              "type": "string",
+              "uniqueItems": true
+            }
+          },
+          {
+            "name": "fieldValidation",
+            "in": "query",
+            "description": "fieldValidation instructs the server on how to handle objects in the request (POST/PUT/PATCH) containing unknown or duplicate fields. Valid values are: - Ignore: This will ignore any unknown fields that are silently dropped from the object, and will ignore all but the last duplicate field that the decoder encounters. This is the default behavior prior to v1.23. - Warn: This will send a warning via the standard warning response header for each unknown field that is dropped from the object, and for each duplicate field that is encountered. The request will still succeed if there are no other errors, and will only persist the last of any duplicate fields. This is the default in v1.23+ - Strict: This will fail the request with a BadRequest error if any unknown fields would be dropped from the object, or if any duplicate fields are present. The error returned from the server will contain all unknown and duplicate fields encountered.",
+            "schema": {
+              "type": "string",
+              "uniqueItems": true
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/com.github.grafana.grafana.apps.annotation.pkg.apis.annotation.v0alpha1.Annotation"
+              }
+            },
+            "application/yaml": {
+              "schema": {
+                "$ref": "#/components/schemas/com.github.grafana.grafana.apps.annotation.pkg.apis.annotation.v0alpha1.Annotation"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/com.github.grafana.grafana.apps.annotation.pkg.apis.annotation.v0alpha1.Annotation"
+                }
+              },
+              "application/yaml": {
+                "schema": {
+                  "$ref": "#/components/schemas/com.github.grafana.grafana.apps.annotation.pkg.apis.annotation.v0alpha1.Annotation"
+                }
+              }
+            }
+          },
+          "201": {
+            "description": "Created",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/com.github.grafana.grafana.apps.annotation.pkg.apis.annotation.v0alpha1.Annotation"
+                }
+              },
+              "application/yaml": {
+                "schema": {
+                  "$ref": "#/components/schemas/com.github.grafana.grafana.apps.annotation.pkg.apis.annotation.v0alpha1.Annotation"
+                }
+              }
+            }
+          }
+        },
+        "x-kubernetes-action": "put",
+        "x-kubernetes-group-version-kind": {
+          "group": "annotation.grafana.app",
+          "version": "v0alpha1",
+          "kind": "Annotation"
+        }
+      },
+      "patch": {
+        "tags": [
+          "Annotation"
+        ],
+        "description": "partially update status of the specified Annotation",
+        "operationId": "updateAnnotationStatus",
+        "parameters": [
+          {
+            "name": "dryRun",
+            "in": "query",
+            "description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+            "schema": {
+              "type": "string",
+              "uniqueItems": true
+            }
+          },
+          {
+            "name": "fieldManager",
+            "in": "query",
+            "description": "fieldManager is a name associated with the actor or entity that is making these changes. The value must be less than or 128 characters long, and only contain printable characters, as defined by https://golang.org/pkg/unicode/#IsPrint. This field is required for apply requests (application/apply-patch) but optional for non-apply patch types (JsonPatch, MergePatch, StrategicMergePatch).",
+            "schema": {
+              "type": "string",
+              "uniqueItems": true
+            }
+          },
+          {
+            "name": "fieldValidation",
+            "in": "query",
+            "description": "fieldValidation instructs the server on how to handle objects in the request (POST/PUT/PATCH) containing unknown or duplicate fields. Valid values are: - Ignore: This will ignore any unknown fields that are silently dropped from the object, and will ignore all but the last duplicate field that the decoder encounters. This is the default behavior prior to v1.23. - Warn: This will send a warning via the standard warning response header for each unknown field that is dropped from the object, and for each duplicate field that is encountered. The request will still succeed if there are no other errors, and will only persist the last of any duplicate fields. This is the default in v1.23+ - Strict: This will fail the request with a BadRequest error if any unknown fields would be dropped from the object, or if any duplicate fields are present. The error returned from the server will contain all unknown and duplicate fields encountered.",
+            "schema": {
+              "type": "string",
+              "uniqueItems": true
+            }
+          },
+          {
+            "name": "force",
+            "in": "query",
+            "description": "Force is going to \"force\" Apply requests. It means user will re-acquire conflicting fields owned by other people. Force flag must be unset for non-apply patch requests.",
+            "schema": {
+              "type": "boolean",
+              "uniqueItems": true
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/apply-patch+yaml": {
+              "schema": {
+                "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+              }
+            },
+            "application/json-patch+json": {
+              "schema": {
+                "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+              }
+            },
+            "application/merge-patch+json": {
+              "schema": {
+                "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+              }
+            },
+            "application/strategic-merge-patch+json": {
+              "schema": {
+                "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/com.github.grafana.grafana.apps.annotation.pkg.apis.annotation.v0alpha1.Annotation"
+                }
+              },
+              "application/yaml": {
+                "schema": {
+                  "$ref": "#/components/schemas/com.github.grafana.grafana.apps.annotation.pkg.apis.annotation.v0alpha1.Annotation"
+                }
+              }
+            }
+          },
+          "201": {
+            "description": "Created",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/com.github.grafana.grafana.apps.annotation.pkg.apis.annotation.v0alpha1.Annotation"
+                }
+              },
+              "application/yaml": {
+                "schema": {
+                  "$ref": "#/components/schemas/com.github.grafana.grafana.apps.annotation.pkg.apis.annotation.v0alpha1.Annotation"
+                }
+              }
+            }
+          }
+        },
+        "x-kubernetes-action": "patch",
+        "x-kubernetes-group-version-kind": {
+          "group": "annotation.grafana.app",
+          "version": "v0alpha1",
+          "kind": "Annotation"
+        }
+      },
+      "parameters": [
+        {
+          "name": "name",
+          "in": "path",
+          "description": "name of the Annotation",
+          "required": true,
+          "schema": {
+            "type": "string",
+            "uniqueItems": true
+          }
+        },
+        {
+          "name": "namespace",
+          "in": "path",
+          "description": "object name and auth scope, such as for teams and projects",
+          "required": true,
+          "schema": {
+            "type": "string",
+            "uniqueItems": true
+          }
+        },
+        {
+          "name": "pretty",
+          "in": "query",
+          "description": "If 'true', then the output is pretty printed. Defaults to 'false' unless the user-agent indicates a browser or command-line HTTP tool (curl and wget).",
+          "schema": {
+            "type": "string",
+            "uniqueItems": true
+          }
+        }
+      ]
+    },
+    "/apis/annotation.grafana.app/v0alpha1/namespaces/{namespace}/tags": {
+      "get": {
+        "operationId": "getTags",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/com.github.grafana.grafana.apps.annotation.pkg.apis.annotation.v0alpha1.GetTags"
+                }
+              },
+              "application/json;stream=watch": {
+                "schema": {
+                  "$ref": "#/components/schemas/com.github.grafana.grafana.apps.annotation.pkg.apis.annotation.v0alpha1.GetTags"
+                }
+              },
+              "application/yaml": {
+                "schema": {
+                  "$ref": "#/components/schemas/com.github.grafana.grafana.apps.annotation.pkg.apis.annotation.v0alpha1.GetTags"
+                }
+              }
+            }
+          }
+        }
+      },
+      "parameters": [
+        {
+          "name": "namespace",
+          "in": "path",
+          "description": "object name and auth scope, such as for teams and projects",
+          "required": true,
+          "schema": {
+            "type": "string",
+            "uniqueItems": true
+          }
+        }
+      ]
+    }
+  },
+  "components": {
+    "schemas": {
+      "com.github.grafana.grafana.apps.annotation.pkg.apis.annotation.v0alpha1.Annotation": {
+        "type": "object",
+        "required": [
+          "kind",
+          "apiVersion",
+          "metadata",
+          "spec"
+        ],
+        "properties": {
+          "apiVersion": {
+            "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+            "type": "string"
+          },
+          "kind": {
+            "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+            "type": "string"
+          },
+          "metadata": {
+            "default": {},
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta"
+              }
+            ]
+          },
+          "spec": {
+            "$ref": "#/components/schemas/com.github.grafana.grafana.apps.annotation.pkg.apis.annotation.v0alpha1.AnnotationSpec"
+          },
+          "status": {
+            "$ref": "#/components/schemas/com.github.grafana.grafana.apps.annotation.pkg.apis.annotation.v0alpha1.AnnotationStatus"
+          }
+        },
+        "x-kubernetes-group-version-kind": [
+          {
+            "group": "annotation.grafana.app",
+            "kind": "Annotation",
+            "version": "v0alpha1"
+          }
+        ]
+      },
+      "com.github.grafana.grafana.apps.annotation.pkg.apis.annotation.v0alpha1.AnnotationList": {
+        "type": "object",
+        "required": [
+          "metadata",
+          "items"
+        ],
+        "properties": {
+          "apiVersion": {
+            "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+            "type": "string"
+          },
+          "items": {
+            "type": "array",
+            "items": {
+              "default": {},
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/com.github.grafana.grafana.apps.annotation.pkg.apis.annotation.v0alpha1.Annotation"
+                }
+              ]
+            }
+          },
+          "kind": {
+            "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+            "type": "string"
+          },
+          "metadata": {
+            "default": {},
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta"
+              }
+            ]
+          }
+        },
+        "x-kubernetes-group-version-kind": [
+          {
+            "group": "annotation.grafana.app",
+            "kind": "AnnotationList",
+            "version": "v0alpha1"
+          }
+        ]
+      },
+      "com.github.grafana.grafana.apps.annotation.pkg.apis.annotation.v0alpha1.AnnotationOperatorState": {
+        "type": "object",
+        "required": [
+          "lastEvaluation",
+          "state"
+        ],
+        "properties": {
+          "descriptiveState": {
+            "description": "descriptiveState is an optional more descriptive state field which has no requirements on format",
+            "type": "string"
+          },
+          "details": {
+            "description": "details contains any extra information that is operator-specific",
+            "type": "object",
+            "additionalProperties": {
+              "type": "object",
+              "additionalProperties": {}
+            }
+          },
+          "lastEvaluation": {
+            "description": "lastEvaluation is the ResourceVersion last evaluated",
+            "type": "string"
+          },
+          "state": {
+            "description": "state describes the state of the lastEvaluation.\nIt is limited to three possible states for machine evaluation.",
+            "type": "string",
+            "enum": [
+              "success",
+              "in_progress",
+              "failed"
+            ]
+          }
+        },
+        "additionalProperties": false
+      },
+      "com.github.grafana.grafana.apps.annotation.pkg.apis.annotation.v0alpha1.AnnotationSpec": {
+        "type": "object",
+        "required": [
+          "text",
+          "time"
+        ],
+        "properties": {
+          "dashboardUID": {
+            "type": "string"
+          },
+          "panelID": {
+            "type": "integer"
+          },
+          "tags": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "text": {
+            "type": "string"
+          },
+          "time": {
+            "type": "integer"
+          },
+          "timeEnd": {
+            "type": "integer"
+          }
+        },
+        "additionalProperties": false
+      },
+      "com.github.grafana.grafana.apps.annotation.pkg.apis.annotation.v0alpha1.AnnotationStatus": {
+        "type": "object",
+        "properties": {
+          "additionalFields": {
+            "description": "additionalFields is reserved for future use",
+            "type": "object",
+            "additionalProperties": {
+              "type": "object",
+              "additionalProperties": {}
+            }
+          },
+          "operatorStates": {
+            "description": "operatorStates is a map of operator ID to operator state evaluations.\nAny operator which consumes this kind SHOULD add its state evaluation information to this field.",
+            "type": "object",
+            "additionalProperties": {
+              "$ref": "#/components/schemas/com.github.grafana.grafana.apps.annotation.pkg.apis.annotation.v0alpha1.AnnotationOperatorState"
+            }
+          }
+        },
+        "additionalProperties": false
+      },
+      "com.github.grafana.grafana.apps.annotation.pkg.apis.annotation.v0alpha1.GetTags": {
+        "type": "object",
+        "required": [
+          "tags",
+          "apiVersion",
+          "kind"
+        ],
+        "properties": {
+          "apiVersion": {
+            "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+            "type": "string"
+          },
+          "kind": {
+            "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+            "type": "string"
+          },
+          "tags": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "tag",
+                "count"
+              ],
+              "properties": {
+                "count": {
+                  "type": "number"
+                },
+                "tag": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      },
+      "io.k8s.apimachinery.pkg.apis.meta.v1.APIResource": {
+        "description": "APIResource specifies the name of a resource and whether it is namespaced.",
+        "type": "object",
+        "required": [
+          "name",
+          "singularName",
+          "namespaced",
+          "kind",
+          "verbs"
+        ],
+        "properties": {
+          "categories": {
+            "description": "categories is a list of the grouped resources this resource belongs to (e.g. 'all')",
+            "type": "array",
+            "items": {
+              "type": "string",
+              "default": ""
+            },
+            "x-kubernetes-list-type": "atomic"
+          },
+          "group": {
+            "description": "group is the preferred group of the resource.  Empty implies the group of the containing resource list. For subresources, this may have a different value, for example: Scale\".",
+            "type": "string"
+          },
+          "kind": {
+            "description": "kind is the kind for the resource (e.g. 'Foo' is the kind for a resource 'foo')",
+            "type": "string",
+            "default": ""
+          },
+          "name": {
+            "description": "name is the plural name of the resource.",
+            "type": "string",
+            "default": ""
+          },
+          "namespaced": {
+            "description": "namespaced indicates if a resource is namespaced or not.",
+            "type": "boolean",
+            "default": false
+          },
+          "shortNames": {
+            "description": "shortNames is a list of suggested short names of the resource.",
+            "type": "array",
+            "items": {
+              "type": "string",
+              "default": ""
+            },
+            "x-kubernetes-list-type": "atomic"
+          },
+          "singularName": {
+            "description": "singularName is the singular name of the resource.  This allows clients to handle plural and singular opaquely. The singularName is more correct for reporting status on a single item and both singular and plural are allowed from the kubectl CLI interface.",
+            "type": "string",
+            "default": ""
+          },
+          "storageVersionHash": {
+            "description": "The hash value of the storage version, the version this resource is converted to when written to the data store. Value must be treated as opaque by clients. Only equality comparison on the value is valid. This is an alpha feature and may change or be removed in the future. The field is populated by the apiserver only if the StorageVersionHash feature gate is enabled. This field will remain optional even if it graduates.",
+            "type": "string"
+          },
+          "verbs": {
+            "description": "verbs is a list of supported kube verbs (this includes get, list, watch, create, update, patch, delete, deletecollection, and proxy)",
+            "type": "array",
+            "items": {
+              "type": "string",
+              "default": ""
+            }
+          },
+          "version": {
+            "description": "version is the preferred version of the resource.  Empty implies the version of the containing resource list For subresources, this may have a different value, for example: v1 (while inside a v1beta1 version of the core resource's group)\".",
+            "type": "string"
+          }
+        }
+      },
+      "io.k8s.apimachinery.pkg.apis.meta.v1.APIResourceList": {
+        "description": "APIResourceList is a list of APIResource, it is used to expose the name of the resources supported in a specific group and version, and if the resource is namespaced.",
+        "type": "object",
+        "required": [
+          "groupVersion",
+          "resources"
+        ],
+        "properties": {
+          "apiVersion": {
+            "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+            "type": "string"
+          },
+          "groupVersion": {
+            "description": "groupVersion is the group and version this APIResourceList is for.",
+            "type": "string",
+            "default": ""
+          },
+          "kind": {
+            "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+            "type": "string"
+          },
+          "resources": {
+            "description": "resources contains the name of the resources and if they are namespaced.",
+            "type": "array",
+            "items": {
+              "default": {},
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.APIResource"
+                }
+              ]
+            },
+            "x-kubernetes-list-type": "atomic"
+          }
+        }
+      },
+      "io.k8s.apimachinery.pkg.apis.meta.v1.DeleteOptions": {
+        "description": "DeleteOptions may be provided when deleting an API object.",
+        "type": "object",
+        "properties": {
+          "apiVersion": {
+            "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+            "type": "string"
+          },
+          "dryRun": {
+            "description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+            "type": "array",
+            "items": {
+              "type": "string",
+              "default": ""
+            },
+            "x-kubernetes-list-type": "atomic"
+          },
+          "gracePeriodSeconds": {
+            "description": "The duration in seconds before the object should be deleted. Value must be non-negative integer. The value zero indicates delete immediately. If this value is nil, the default grace period for the specified type will be used. Defaults to a per object value if not specified. zero means delete immediately.",
+            "type": "integer",
+            "format": "int64"
+          },
+          "ignoreStoreReadErrorWithClusterBreakingPotential": {
+            "description": "if set to true, it will trigger an unsafe deletion of the resource in case the normal deletion flow fails with a corrupt object error. A resource is considered corrupt if it can not be retrieved from the underlying storage successfully because of a) its data can not be transformed e.g. decryption failure, or b) it fails to decode into an object. NOTE: unsafe deletion ignores finalizer constraints, skips precondition checks, and removes the object from the storage. WARNING: This may potentially break the cluster if the workload associated with the resource being unsafe-deleted relies on normal deletion flow. Use only if you REALLY know what you are doing. The default value is false, and the user must opt in to enable it",
+            "type": "boolean"
+          },
+          "kind": {
+            "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+            "type": "string"
+          },
+          "orphanDependents": {
+            "description": "Deprecated: please use the PropagationPolicy, this field will be deprecated in 1.7. Should the dependent objects be orphaned. If true/false, the \"orphan\" finalizer will be added to/removed from the object's finalizers list. Either this field or PropagationPolicy may be set, but not both.",
+            "type": "boolean"
+          },
+          "preconditions": {
+            "description": "Must be fulfilled before a deletion is carried out. If not possible, a 409 Conflict status will be returned.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Preconditions"
+              }
+            ]
+          },
+          "propagationPolicy": {
+            "description": "Whether and how garbage collection will be performed. Either this field or OrphanDependents may be set, but not both. The default policy is decided by the existing finalizer set in the metadata.finalizers and the resource-specific default policy. Acceptable values are: 'Orphan' - orphan the dependents; 'Background' - allow the garbage collector to delete the dependents in the background; 'Foreground' - a cascading policy that deletes all dependents in the foreground.",
+            "type": "string"
+          }
+        }
+      },
+      "io.k8s.apimachinery.pkg.apis.meta.v1.FieldsV1": {
+        "description": "FieldsV1 stores a set of fields in a data structure like a Trie, in JSON format.\n\nEach key is either a '.' representing the field itself, and will always map to an empty set, or a string representing a sub-field or item. The string will follow one of these four formats: 'f:\u003cname\u003e', where \u003cname\u003e is the name of a field in a struct, or key in a map 'v:\u003cvalue\u003e', where \u003cvalue\u003e is the exact json formatted value of a list item 'i:\u003cindex\u003e', where \u003cindex\u003e is position of a item in a list 'k:\u003ckeys\u003e', where \u003ckeys\u003e is a map of  a list item's key fields to their unique values If a key maps to an empty Fields value, the field that key represents is part of the set.\n\nThe exact format is defined in sigs.k8s.io/structured-merge-diff",
+        "type": "object"
+      },
+      "io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta": {
+        "description": "ListMeta describes metadata that synthetic resources must have, including lists and various status objects. A resource may have only one of {ObjectMeta, ListMeta}.",
+        "type": "object",
+        "properties": {
+          "continue": {
+            "description": "continue may be set if the user set a limit on the number of items returned, and indicates that the server has more data available. The value is opaque and may be used to issue another request to the endpoint that served this list to retrieve the next set of available objects. Continuing a consistent list may not be possible if the server configuration has changed or more than a few minutes have passed. The resourceVersion field returned when using this continue value will be identical to the value in the first response, unless you have received this token from an error message.",
+            "type": "string"
+          },
+          "remainingItemCount": {
+            "description": "remainingItemCount is the number of subsequent items in the list which are not included in this list response. If the list request contained label or field selectors, then the number of remaining items is unknown and the field will be left unset and omitted during serialization. If the list is complete (either because it is not chunking or because this is the last chunk), then there are no more remaining items and this field will be left unset and omitted during serialization. Servers older than v1.15 do not set this field. The intended use of the remainingItemCount is *estimating* the size of a collection. Clients should not rely on the remainingItemCount to be set or to be exact.",
+            "type": "integer",
+            "format": "int64"
+          },
+          "resourceVersion": {
+            "description": "String that identifies the server's internal version of this object that can be used by clients to determine when objects have changed. Value must be treated as opaque by clients and passed unmodified back to the server. Populated by the system. Read-only. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency",
+            "type": "string"
+          },
+          "selfLink": {
+            "description": "Deprecated: selfLink is a legacy read-only field that is no longer populated by the system.",
+            "type": "string"
+          }
+        }
+      },
+      "io.k8s.apimachinery.pkg.apis.meta.v1.ManagedFieldsEntry": {
+        "description": "ManagedFieldsEntry is a workflow-id, a FieldSet and the group version of the resource that the fieldset applies to.",
+        "type": "object",
+        "properties": {
+          "apiVersion": {
+            "description": "APIVersion defines the version of this resource that this field set applies to. The format is \"group/version\" just like the top-level APIVersion field. It is necessary to track the version of a field set because it cannot be automatically converted.",
+            "type": "string"
+          },
+          "fieldsType": {
+            "description": "FieldsType is the discriminator for the different fields format and version. There is currently only one possible value: \"FieldsV1\"",
+            "type": "string"
+          },
+          "fieldsV1": {
+            "description": "FieldsV1 holds the first JSON version format as described in the \"FieldsV1\" type.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.FieldsV1"
+              }
+            ]
+          },
+          "manager": {
+            "description": "Manager is an identifier of the workflow managing these fields.",
+            "type": "string"
+          },
+          "operation": {
+            "description": "Operation is the type of operation which lead to this ManagedFieldsEntry being created. The only valid values for this field are 'Apply' and 'Update'.",
+            "type": "string"
+          },
+          "subresource": {
+            "description": "Subresource is the name of the subresource used to update that object, or empty string if the object was updated through the main resource. The value of this field is used to distinguish between managers, even if they share the same name. For example, a status update will be distinct from a regular update using the same manager name. Note that the APIVersion field is not related to the Subresource field and it always corresponds to the version of the main resource.",
+            "type": "string"
+          },
+          "time": {
+            "description": "Time is the timestamp of when the ManagedFields entry was added. The timestamp will also be updated if a field is added, the manager changes any of the owned fields value or removes a field. The timestamp does not update when a field is removed from the entry because another manager took it over.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Time"
+              }
+            ]
+          }
+        }
+      },
+      "io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta": {
+        "description": "ObjectMeta is metadata that all persisted resources must have, which includes all objects users must create.",
+        "type": "object",
+        "properties": {
+          "annotations": {
+            "description": "Annotations is an unstructured key value map stored with a resource that may be set by external tools to store and retrieve arbitrary metadata. They are not queryable and should be preserved when modifying objects. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations",
+            "type": "object",
+            "additionalProperties": {
+              "type": "string",
+              "default": ""
+            }
+          },
+          "creationTimestamp": {
+            "description": "CreationTimestamp is a timestamp representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations. Clients may not set this value. It is represented in RFC3339 form and is in UTC.\n\nPopulated by the system. Read-only. Null for lists. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Time"
+              }
+            ]
+          },
+          "deletionGracePeriodSeconds": {
+            "description": "Number of seconds allowed for this object to gracefully terminate before it will be removed from the system. Only set when deletionTimestamp is also set. May only be shortened. Read-only.",
+            "type": "integer",
+            "format": "int64"
+          },
+          "deletionTimestamp": {
+            "description": "DeletionTimestamp is RFC 3339 date and time at which this resource will be deleted. This field is set by the server when a graceful deletion is requested by the user, and is not directly settable by a client. The resource is expected to be deleted (no longer visible from resource lists, and not reachable by name) after the time in this field, once the finalizers list is empty. As long as the finalizers list contains items, deletion is blocked. Once the deletionTimestamp is set, this value may not be unset or be set further into the future, although it may be shortened or the resource may be deleted prior to this time. For example, a user may request that a pod is deleted in 30 seconds. The Kubelet will react by sending a graceful termination signal to the containers in the pod. After that 30 seconds, the Kubelet will send a hard termination signal (SIGKILL) to the container and after cleanup, remove the pod from the API. In the presence of network partitions, this object may still exist after this timestamp, until an administrator or automated process can determine the resource is fully terminated. If not set, graceful deletion of the object has not been requested.\n\nPopulated by the system when a graceful deletion is requested. Read-only. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Time"
+              }
+            ]
+          },
+          "finalizers": {
+            "description": "Must be empty before the object is deleted from the registry. Each entry is an identifier for the responsible component that will remove the entry from the list. If the deletionTimestamp of the object is non-nil, entries in this list can only be removed. Finalizers may be processed and removed in any order.  Order is NOT enforced because it introduces significant risk of stuck finalizers. finalizers is a shared field, any actor with permission can reorder it. If the finalizer list is processed in order, then this can lead to a situation in which the component responsible for the first finalizer in the list is waiting for a signal (field value, external system, or other) produced by a component responsible for a finalizer later in the list, resulting in a deadlock. Without enforced ordering finalizers are free to order amongst themselves and are not vulnerable to ordering changes in the list.",
+            "type": "array",
+            "items": {
+              "type": "string",
+              "default": ""
+            },
+            "x-kubernetes-list-type": "set",
+            "x-kubernetes-patch-strategy": "merge"
+          },
+          "generateName": {
+            "description": "GenerateName is an optional prefix, used by the server, to generate a unique name ONLY IF the Name field has not been provided. If this field is used, the name returned to the client will be different than the name passed. This value will also be combined with a unique suffix. The provided value has the same validation rules as the Name field, and may be truncated by the length of the suffix required to make the value unique on the server.\n\nIf this field is specified and the generated name exists, the server will return a 409.\n\nApplied only if Name is not specified. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#idempotency",
+            "type": "string"
+          },
+          "generation": {
+            "description": "A sequence number representing a specific generation of the desired state. Populated by the system. Read-only.",
+            "type": "integer",
+            "format": "int64"
+          },
+          "labels": {
+            "description": "Map of string keys and values that can be used to organize and categorize (scope and select) objects. May match selectors of replication controllers and services. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels",
+            "type": "object",
+            "additionalProperties": {
+              "type": "string",
+              "default": ""
+            }
+          },
+          "managedFields": {
+            "description": "ManagedFields maps workflow-id and version to the set of fields that are managed by that workflow. This is mostly for internal housekeeping, and users typically shouldn't need to set or understand this field. A workflow can be the user's name, a controller's name, or the name of a specific apply path like \"ci-cd\". The set of fields is always in the version that the workflow used when modifying the object.",
+            "type": "array",
+            "items": {
+              "default": {},
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.ManagedFieldsEntry"
+                }
+              ]
+            },
+            "x-kubernetes-list-type": "atomic"
+          },
+          "name": {
+            "description": "Name must be unique within a namespace. Is required when creating resources, although some resources may allow a client to request the generation of an appropriate name automatically. Name is primarily intended for creation idempotence and configuration definition. Cannot be updated. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names#names",
+            "type": "string"
+          },
+          "namespace": {
+            "description": "Namespace defines the space within which each name must be unique. An empty namespace is equivalent to the \"default\" namespace, but \"default\" is the canonical representation. Not all objects are required to be scoped to a namespace - the value of this field for those objects will be empty.\n\nMust be a DNS_LABEL. Cannot be updated. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces",
+            "type": "string"
+          },
+          "ownerReferences": {
+            "description": "List of objects depended by this object. If ALL objects in the list have been deleted, this object will be garbage collected. If this object is managed by a controller, then an entry in this list will point to this controller, with the controller field set to true. There cannot be more than one managing controller.",
+            "type": "array",
+            "items": {
+              "default": {},
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.OwnerReference"
+                }
+              ]
+            },
+            "x-kubernetes-list-map-keys": [
+              "uid"
+            ],
+            "x-kubernetes-list-type": "map",
+            "x-kubernetes-patch-merge-key": "uid",
+            "x-kubernetes-patch-strategy": "merge"
+          },
+          "resourceVersion": {
+            "description": "An opaque value that represents the internal version of this object that can be used by clients to determine when objects have changed. May be used for optimistic concurrency, change detection, and the watch operation on a resource or set of resources. Clients must treat these values as opaque and passed unmodified back to the server. They may only be valid for a particular resource or set of resources.\n\nPopulated by the system. Read-only. Value must be treated as opaque by clients and . More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency",
+            "type": "string"
+          },
+          "selfLink": {
+            "description": "Deprecated: selfLink is a legacy read-only field that is no longer populated by the system.",
+            "type": "string"
+          },
+          "uid": {
+            "description": "UID is the unique in time and space value for this object. It is typically generated by the server on successful creation of a resource and is not allowed to change on PUT operations.\n\nPopulated by the system. Read-only. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names#uids",
+            "type": "string"
+          }
+        }
+      },
+      "io.k8s.apimachinery.pkg.apis.meta.v1.OwnerReference": {
+        "description": "OwnerReference contains enough information to let you identify an owning object. An owning object must be in the same namespace as the dependent, or be cluster-scoped, so there is no namespace field.",
+        "type": "object",
+        "required": [
+          "apiVersion",
+          "kind",
+          "name",
+          "uid"
+        ],
+        "properties": {
+          "apiVersion": {
+            "description": "API version of the referent.",
+            "type": "string",
+            "default": ""
+          },
+          "blockOwnerDeletion": {
+            "description": "If true, AND if the owner has the \"foregroundDeletion\" finalizer, then the owner cannot be deleted from the key-value store until this reference is removed. See https://kubernetes.io/docs/concepts/architecture/garbage-collection/#foreground-deletion for how the garbage collector interacts with this field and enforces the foreground deletion. Defaults to false. To set this field, a user needs \"delete\" permission of the owner, otherwise 422 (Unprocessable Entity) will be returned.",
+            "type": "boolean"
+          },
+          "controller": {
+            "description": "If true, this reference points to the managing controller.",
+            "type": "boolean"
+          },
+          "kind": {
+            "description": "Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+            "type": "string",
+            "default": ""
+          },
+          "name": {
+            "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names#names",
+            "type": "string",
+            "default": ""
+          },
+          "uid": {
+            "description": "UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names#uids",
+            "type": "string",
+            "default": ""
+          }
+        },
+        "x-kubernetes-map-type": "atomic"
+      },
+      "io.k8s.apimachinery.pkg.apis.meta.v1.Patch": {
+        "description": "Patch is provided to give a concrete name and type to the Kubernetes PATCH request body.",
+        "type": "object"
+      },
+      "io.k8s.apimachinery.pkg.apis.meta.v1.Preconditions": {
+        "description": "Preconditions must be fulfilled before an operation (update, delete, etc.) is carried out.",
+        "type": "object",
+        "properties": {
+          "resourceVersion": {
+            "description": "Specifies the target ResourceVersion",
+            "type": "string"
+          },
+          "uid": {
+            "description": "Specifies the target UID.",
+            "type": "string"
+          }
+        }
+      },
+      "io.k8s.apimachinery.pkg.apis.meta.v1.Status": {
+        "description": "Status is a return value for calls that don't return other objects.",
+        "type": "object",
+        "properties": {
+          "apiVersion": {
+            "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+            "type": "string"
+          },
+          "code": {
+            "description": "Suggested HTTP return code for this status, 0 if not set.",
+            "type": "integer",
+            "format": "int32"
+          },
+          "details": {
+            "description": "Extended data associated with the reason.  Each reason may define its own extended details. This field is optional and the data returned is not guaranteed to conform to any schema except that defined by the reason type.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.StatusDetails"
+              }
+            ],
+            "x-kubernetes-list-type": "atomic"
+          },
+          "kind": {
+            "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+            "type": "string"
+          },
+          "message": {
+            "description": "A human-readable description of the status of this operation.",
+            "type": "string"
+          },
+          "metadata": {
+            "description": "Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+            "default": {},
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta"
+              }
+            ]
+          },
+          "reason": {
+            "description": "A machine-readable description of why this operation is in the \"Failure\" status. If this value is empty there is no information available. A Reason clarifies an HTTP status code but does not override it.",
+            "type": "string"
+          },
+          "status": {
+            "description": "Status of the operation. One of: \"Success\" or \"Failure\". More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status",
+            "type": "string"
+          }
+        }
+      },
+      "io.k8s.apimachinery.pkg.apis.meta.v1.StatusCause": {
+        "description": "StatusCause provides more information about an api.Status failure, including cases when multiple errors are encountered.",
+        "type": "object",
+        "properties": {
+          "field": {
+            "description": "The field of the resource that has caused this error, as named by its JSON serialization. May include dot and postfix notation for nested attributes. Arrays are zero-indexed.  Fields may appear more than once in an array of causes due to fields having multiple errors. Optional.\n\nExamples:\n  \"name\" - the field \"name\" on the current resource\n  \"items[0].name\" - the field \"name\" on the first array entry in \"items\"",
+            "type": "string"
+          },
+          "message": {
+            "description": "A human-readable description of the cause of the error.  This field may be presented as-is to a reader.",
+            "type": "string"
+          },
+          "reason": {
+            "description": "A machine-readable description of the cause of the error. If this value is empty there is no information available.",
+            "type": "string"
+          }
+        }
+      },
+      "io.k8s.apimachinery.pkg.apis.meta.v1.StatusDetails": {
+        "description": "StatusDetails is a set of additional properties that MAY be set by the server to provide additional information about a response. The Reason field of a Status object defines what attributes will be set. Clients must ignore fields that do not match the defined type of each attribute, and should assume that any attribute may be empty, invalid, or under defined.",
+        "type": "object",
+        "properties": {
+          "causes": {
+            "description": "The Causes array includes more details associated with the StatusReason failure. Not all StatusReasons may provide detailed causes.",
+            "type": "array",
+            "items": {
+              "default": {},
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.StatusCause"
+                }
+              ]
+            },
+            "x-kubernetes-list-type": "atomic"
+          },
+          "group": {
+            "description": "The group attribute of the resource associated with the status StatusReason.",
+            "type": "string"
+          },
+          "kind": {
+            "description": "The kind attribute of the resource associated with the status StatusReason. On some operations may differ from the requested resource Kind. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+            "type": "string"
+          },
+          "name": {
+            "description": "The name attribute of the resource associated with the status StatusReason (when there is a single name which can be described).",
+            "type": "string"
+          },
+          "retryAfterSeconds": {
+            "description": "If specified, the time in seconds before the operation should be retried. Some errors may indicate the client must take an alternate action - for those errors this field may indicate how long to wait before taking the alternate action.",
+            "type": "integer",
+            "format": "int32"
+          },
+          "uid": {
+            "description": "UID of the resource. (when there is a single resource which can be described). More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names#uids",
+            "type": "string"
+          }
+        }
+      },
+      "io.k8s.apimachinery.pkg.apis.meta.v1.Time": {
+        "description": "Time is a wrapper around time.Time which supports correct marshaling to YAML and JSON.  Wrappers are provided for many of the factory methods that the time package offers.",
+        "type": "string",
+        "format": "date-time"
+      }
+    }
+  }
+}

--- a/pkg/tests/apis/openapi_test.go
+++ b/pkg/tests/apis/openapi_test.go
@@ -36,6 +36,7 @@ func TestIntegrationOpenAPIs(t *testing.T) {
 			featuremgmt.FlagQueryServiceWithConnections,
 			featuremgmt.FlagKubernetesShortURLs,
 			featuremgmt.FlagKubernetesCorrelations,
+			featuremgmt.FlagKubernetesAnnotations,
 			featuremgmt.FlagKubernetesAlertingHistorian,
 			featuremgmt.FlagKubernetesLogsDrilldown,
 		},
@@ -120,6 +121,9 @@ func TestIntegrationOpenAPIs(t *testing.T) {
 		Version: "v0alpha1",
 	}, {
 		Group:   "correlations.grafana.app",
+		Version: "v0alpha1",
+	}, {
+		Group:   "annotation.grafana.app",
 		Version: "v0alpha1",
 	}, {
 		Group:   "shorturl.grafana.app",

--- a/public/app/core/components/AppChrome/MegaMenu/MegaMenu.test.tsx
+++ b/public/app/core/components/AppChrome/MegaMenu/MegaMenu.test.tsx
@@ -11,6 +11,12 @@ import { MegaMenu } from './MegaMenu';
 const setup = () => {
   const navBarTree: NavModelItem[] = [
     {
+      text: 'Labs',
+      id: 'labs',
+      url: 'labs',
+      highlightText: 'Beta',
+    },
+    {
       text: 'Section name',
       id: 'section',
       url: 'section',
@@ -43,6 +49,8 @@ describe('MegaMenu', () => {
     setup();
 
     expect(await screen.findByTestId(selectors.components.NavMenu.Menu)).toBeInTheDocument();
+    expect(await screen.findByRole('link', { name: /Labs/i })).toBeInTheDocument();
+    expect(await screen.findByText('Beta')).toBeInTheDocument();
     expect(await screen.findByRole('link', { name: 'Section name' })).toBeInTheDocument();
   });
 

--- a/public/app/core/components/AppChrome/MegaMenu/MegaMenuItem.tsx
+++ b/public/app/core/components/AppChrome/MegaMenu/MegaMenuItem.tsx
@@ -105,6 +105,7 @@ export function MegaMenuItem({ link, activeItem, level = 0, onClick, onPin, isPi
                 {link.text}
               </Text>
               {link.isNew && <FeatureBadge featureState={FeatureState.new} />}
+              {link.highlightText === 'Beta' && <FeatureBadge featureState={FeatureState.beta} />}
             </div>
           </MegaMenuItemText>
         </div>

--- a/public/app/core/components/ThemeSelector/getSelectableThemes.test.ts
+++ b/public/app/core/components/ThemeSelector/getSelectableThemes.test.ts
@@ -1,0 +1,49 @@
+import { getBuiltInThemes } from '@grafana/data';
+
+import { getSelectableThemes } from './getSelectableThemes';
+
+jest.mock('@grafana/data', () => ({
+  getBuiltInThemes: jest.fn(() => []),
+}));
+
+jest.mock('@grafana/runtime', () => ({
+  config: {
+    featureToggles: {
+      grafanaconThemes: false,
+    },
+  },
+}));
+
+const { config } = jest.requireMock('@grafana/runtime');
+
+describe('getSelectableThemes', () => {
+  const originalGrafanaConThemesFlag = config.featureToggles.grafanaconThemes;
+
+  afterEach(() => {
+    config.featureToggles.grafanaconThemes = originalGrafanaConThemesFlag;
+    jest.clearAllMocks();
+  });
+
+  it('includes the orange theme when grafanacon themes are enabled', () => {
+    config.featureToggles.grafanaconThemes = true;
+
+    getSelectableThemes();
+
+    expect(getBuiltInThemes).toHaveBeenCalledWith([
+      'desertbloom',
+      'gildedgrove',
+      'sapphiredusk',
+      'tron',
+      'gloom',
+      'orange',
+    ]);
+  });
+
+  it('does not include extra themes when grafanacon themes are disabled', () => {
+    config.featureToggles.grafanaconThemes = false;
+
+    getSelectableThemes();
+
+    expect(getBuiltInThemes).toHaveBeenCalledWith([]);
+  });
+});

--- a/public/app/core/components/ThemeSelector/getSelectableThemes.ts
+++ b/public/app/core/components/ThemeSelector/getSelectableThemes.ts
@@ -10,6 +10,7 @@ export function getSelectableThemes() {
     allowedExtraThemes.push('sapphiredusk');
     allowedExtraThemes.push('tron');
     allowedExtraThemes.push('gloom');
+    allowedExtraThemes.push('orange');
   }
 
   return getBuiltInThemes(allowedExtraThemes);

--- a/public/app/core/utils/navBarItem-translations.ts
+++ b/public/app/core/utils/navBarItem-translations.ts
@@ -177,6 +177,8 @@ export function getNavTitle(navId: string | undefined) {
       return t('nav.search-dashboards.title', 'Search dashboards');
     case 'connections':
       return t('nav.connections.title', 'Connections');
+    case 'labs':
+      return t('nav.labs.title', 'Labs');
     case 'connections-add-new-connection':
       return t('nav.add-new-connections.title', 'Add new connection');
     case 'standalone-plugin-page-/connections/collector':
@@ -302,6 +304,11 @@ export function getNavSubTitle(navId: string | undefined) {
       return t('nav.testing-and-synthetics.subtitle', 'Optimize performance with k6 and Synthetic Monitoring insights');
     case 'connections-add-new-connection':
       return t('nav.connections.subtitle', 'Browse and create new connections');
+    case 'labs':
+      return t(
+        'nav.labs.subtitle',
+        'View and manage frontend feature toggles for this Grafana instance'
+      );
     case 'connections-datasources':
       return t('nav.data-sources.subtitle', 'View and manage your connected data source connections');
     case 'connections-private-data-source-connections':

--- a/public/app/features/alerting/unified/home/AdCard.tsx
+++ b/public/app/features/alerting/unified/home/AdCard.tsx
@@ -16,9 +16,18 @@ type AdCardProps = {
   logoUrl: string;
   items: string[];
   helpFlag: number;
+  buttonVariant?: 'secondary' | 'success';
 };
 
-export default function AdCard({ title, description, href, logoUrl, items, helpFlag }: AdCardProps) {
+export default function AdCard({
+  title,
+  description,
+  href,
+  logoUrl,
+  items,
+  helpFlag,
+  buttonVariant = 'secondary',
+}: AdCardProps) {
   const styles = useStyles2(getAddCardStyles);
 
   const helpFlags = contextSrv.user.helpFlags1;
@@ -58,7 +67,7 @@ export default function AdCard({ title, description, href, logoUrl, items, helpF
         ))}
       </div>
       <Divider />
-      <Button fill="solid" variant="secondary" onClick={() => window.open(href, '_blank')} className={styles.button}>
+      <Button fill="solid" variant={buttonVariant} onClick={() => window.open(href, '_blank')} className={styles.button}>
         <Trans i18nKey="alerting.ad.learn-more">Learn more</Trans>
         <Icon name="external-link-alt" className={styles.buttonIcon} />
       </Button>

--- a/public/app/features/alerting/unified/home/IRMCard.tsx
+++ b/public/app/features/alerting/unified/home/IRMCard.tsx
@@ -16,6 +16,7 @@ export default function IRMCard() {
       )}
       href={LINK}
       logoUrl={irmSvg}
+      buttonVariant="success"
       items={[
         t('alerting.home.irm-card-item-1', 'Manage on-call schedules with your calendar or Terraform.'),
         t('alerting.home.irm-card-item-2', 'Respond to incidents via web, app, Slack, or other channels.'),

--- a/public/app/features/labs/LabsPage.test.tsx
+++ b/public/app/features/labs/LabsPage.test.tsx
@@ -1,0 +1,69 @@
+import { screen, waitFor } from '@testing-library/react';
+import { render } from 'test/test-utils';
+
+import { contextSrv } from 'app/core/services/context_srv';
+
+import LabsPage, { type LabsResolvedState } from './LabsPage';
+
+const mockGet = jest.fn();
+const mockPut = jest.fn();
+const mockDelete = jest.fn();
+
+jest.mock('@grafana/runtime', () => ({
+  ...jest.requireActual('@grafana/runtime'),
+  getBackendSrv: () => ({
+    get: mockGet,
+    put: mockPut,
+    delete: mockDelete,
+  }),
+}));
+
+const sampleState: LabsResolvedState = {
+  allowEditing: true,
+  restartRequired: false,
+  enabled: { myFrontendFlag: true },
+  toggles: [
+    {
+      name: 'myFrontendFlag',
+      description: 'Test flag',
+      stage: 'preview',
+      enabled: true,
+      writeable: true,
+    },
+  ],
+};
+
+describe('LabsPage', () => {
+  let wasGrafanaAdmin: boolean;
+
+  beforeEach(() => {
+    wasGrafanaAdmin = contextSrv.isGrafanaAdmin;
+    contextSrv.isGrafanaAdmin = true;
+    mockGet.mockResolvedValue(sampleState);
+    mockPut.mockResolvedValue(sampleState);
+    mockDelete.mockResolvedValue(sampleState);
+  });
+
+  afterEach(() => {
+    contextSrv.isGrafanaAdmin = wasGrafanaAdmin;
+    mockGet.mockReset();
+    mockPut.mockReset();
+    mockDelete.mockReset();
+  });
+
+  it('shows access denied when user is not a Grafana admin', async () => {
+    contextSrv.isGrafanaAdmin = false;
+
+    render(<LabsPage />);
+
+    expect(await screen.findByText(/Access denied/i)).toBeInTheDocument();
+    expect(mockGet).not.toHaveBeenCalled();
+  });
+
+  it('loads toggles for Grafana admins', async () => {
+    render(<LabsPage />);
+
+    await waitFor(() => expect(mockGet).toHaveBeenCalledWith('/api/admin/feature-toggles/labs'));
+    expect(await screen.findByText('myFrontendFlag')).toBeInTheDocument();
+  });
+});

--- a/public/app/features/labs/LabsPage.tsx
+++ b/public/app/features/labs/LabsPage.tsx
@@ -1,0 +1,267 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+
+import { css } from '@emotion/css';
+
+import { GrafanaTheme2 } from '@grafana/data';
+import { t, Trans } from '@grafana/i18n';
+import { getBackendSrv } from '@grafana/runtime';
+import {
+  Alert,
+  Button,
+  Field,
+  Input,
+  InteractiveTable,
+  LoadingPlaceholder,
+  Stack,
+  Switch,
+  Text,
+  useStyles2,
+  type CellProps,
+  type Column,
+} from '@grafana/ui';
+import { Page } from 'app/core/components/Page/Page';
+import { contextSrv } from 'app/core/services/context_srv';
+
+export interface LabsToggleSource {
+  kind?: string;
+  name?: string;
+}
+
+export interface LabsToggleStatus {
+  name: string;
+  description?: string;
+  stage: string;
+  enabled: boolean;
+  writeable: boolean;
+  warning?: string;
+  source?: LabsToggleSource;
+}
+
+export interface LabsResolvedState {
+  allowEditing: boolean;
+  restartRequired: boolean;
+  enabled: Record<string, boolean>;
+  toggles: LabsToggleStatus[];
+}
+
+const apiPath = '/api/admin/feature-toggles/labs';
+
+export default function LabsPage() {
+  const styles = useStyles2(getStyles);
+  const isGrafanaAdmin = contextSrv.isGrafanaAdmin;
+  const [state, setState] = useState<LabsResolvedState | null>(null);
+  const [loading, setLoading] = useState(isGrafanaAdmin);
+  const [error, setError] = useState<string | null>(null);
+  const [query, setQuery] = useState('');
+  const [pending, setPending] = useState<Record<string, boolean>>({});
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const data = await getBackendSrv().get<LabsResolvedState>(apiPath);
+      setState(data);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (!isGrafanaAdmin) {
+      setLoading(false);
+      return;
+    }
+    void load();
+  }, [isGrafanaAdmin, load]);
+
+  const filteredRows = useMemo(() => {
+    if (!state?.toggles) {
+      return [];
+    }
+    const q = query.trim().toLowerCase();
+    if (!q) {
+      return state.toggles;
+    }
+    return state.toggles.filter(
+      (t) =>
+        t.name.toLowerCase().includes(q) ||
+        (t.description ?? '').toLowerCase().includes(q) ||
+        t.stage.toLowerCase().includes(q)
+    );
+  }, [state, query]);
+
+  const setToggle = useCallback(async (name: string, enabled: boolean) => {
+    setPending((p) => ({ ...p, [name]: true }));
+    try {
+      const data = await getBackendSrv().put<LabsResolvedState>(`${apiPath}/${encodeURIComponent(name)}`, {
+        enabled,
+      });
+      setState(data);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setPending((p) => {
+        const next = { ...p };
+        delete next[name];
+        return next;
+      });
+    }
+  }, []);
+
+  const clearOverride = useCallback(async (name: string) => {
+    setPending((p) => ({ ...p, [name]: true }));
+    try {
+      const data = await getBackendSrv().delete<LabsResolvedState>(`${apiPath}/${encodeURIComponent(name)}`);
+      setState(data);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setPending((p) => {
+        const next = { ...p };
+        delete next[name];
+        return next;
+      });
+    }
+  }, []);
+
+  const columns = useMemo((): Array<Column<LabsToggleStatus>> => {
+    return [
+      {
+        id: 'name',
+        header: t('labs-page.column.name', 'Flag'),
+        cell: ({ row: { original: row } }: CellProps<LabsToggleStatus, string>) => (
+          <Stack direction="column" gap={0.5}>
+            <Text element="span">{row.name}</Text>
+            {row.warning ? (
+              <Text element="span" variant="bodySmall" color="warning">
+                {row.warning}
+              </Text>
+            ) : null}
+          </Stack>
+        ),
+      },
+      {
+        id: 'stage',
+        header: t('labs-page.column.stage', 'Stage'),
+        cell: ({ row: { original: row } }: CellProps<LabsToggleStatus, string>) => row.stage,
+      },
+      {
+        id: 'description',
+        header: t('labs-page.column.description', 'Description'),
+        cell: ({ row: { original: row } }: CellProps<LabsToggleStatus, string>) => (
+          <Text truncate title={row.description}>
+            {row.description ?? '—'}
+          </Text>
+        ),
+      },
+      {
+        id: 'source',
+        header: t('labs-page.column.source', 'Source'),
+        cell: ({ row: { original: row } }: CellProps<LabsToggleStatus, string>) =>
+          row.source?.kind === 'LabsOverride'
+            ? t('labs-page.source.override', 'Labs override')
+            : t('labs-page.source.inherited', 'Inherited'),
+      },
+      {
+        id: 'enabled',
+        header: t('labs-page.column.enabled', 'Enabled'),
+        cell: ({ row: { original: row } }: CellProps<LabsToggleStatus, string>) =>
+          row.enabled ? t('labs-page.yes', 'Yes') : t('labs-page.no', 'No'),
+      },
+      {
+        id: 'actions',
+        header: t('labs-page.column.actions', 'Actions'),
+        cell: ({ row: { original: row } }: CellProps<LabsToggleStatus, string>) => {
+          const busy = Boolean(pending[row.name]);
+          return (
+            <Stack gap={1}>
+              <Switch
+                disabled={!row.writeable || busy || !isGrafanaAdmin}
+                value={row.enabled}
+                onChange={(ev) => void setToggle(row.name, ev.currentTarget.checked)}
+              />
+              {row.source?.kind === 'LabsOverride' ? (
+                <Button
+                  size="sm"
+                  variant="secondary"
+                  disabled={busy || !isGrafanaAdmin}
+                  onClick={() => void clearOverride(row.name)}
+                >
+                  <Trans i18nKey="labs-page.reset">Reset</Trans>
+                </Button>
+              ) : null}
+            </Stack>
+          );
+        },
+      },
+    ];
+  }, [clearOverride, isGrafanaAdmin, pending, setToggle]);
+
+  return (
+    <Page navId="labs">
+      <Page.Contents>
+        {!isGrafanaAdmin ? (
+          <Alert severity="warning" title={t('labs-page.access-denied.title', 'Access denied')}>
+            <Trans i18nKey="labs-page.access-denied.body">
+              Only Grafana server administrators can open Labs feature toggles.
+            </Trans>
+          </Alert>
+        ) : (
+        <Stack direction="column" gap={2}>
+          {state?.restartRequired ? (
+            <Alert severity="warning" title={t('labs-page.restart.title', 'Restart may be required')}>
+              <Trans i18nKey="labs-page.restart.body">
+                At least one flag has a Labs override that normally requires a full Grafana restart to apply safely.
+                The UI still updates effective values where possible; plan a restart for routing and startup-only flags.
+              </Trans>
+            </Alert>
+          ) : null}
+
+          {error ? (
+            <Alert severity="error" title={t('labs-page.error.title', 'Something went wrong')}>
+              {error}
+            </Alert>
+          ) : null}
+
+          <Text>
+            <Trans i18nKey="labs-page.intro">
+              Frontend-only feature toggles can be turned on or off for this instance. Overrides are stored in the
+              Grafana database and apply on top of configuration defaults.
+            </Trans>
+          </Text>
+
+          <Field label={t('labs-page.search', 'Search')}>
+            <Input
+              width={40}
+              placeholder={t('labs-page.search-placeholder', 'Filter by name, stage, or description')}
+              value={query}
+              onChange={(e) => setQuery(e.currentTarget.value)}
+            />
+          </Field>
+
+          {loading ? (
+            <LoadingPlaceholder text={t('labs-page.loading', 'Loading feature toggles…')} />
+          ) : (
+            <div className={styles.tableWrap}>
+              <InteractiveTable
+                columns={columns}
+                data={filteredRows}
+                getRowId={(row) => row.name}
+                pageSize={20}
+              />
+            </div>
+          )}
+        </Stack>
+        )}
+      </Page.Contents>
+    </Page>
+  );
+}
+
+const getStyles = (theme: GrafanaTheme2) => ({
+  tableWrap: css({
+    marginTop: theme.spacing(1),
+  }),
+});

--- a/public/app/routes/routes.tsx
+++ b/public/app/routes/routes.tsx
@@ -540,6 +540,13 @@ export function getAppRoutes(): RouteDescriptor[] {
       ),
     },
     {
+      path: '/labs',
+      roles: () => contextSrv.isGrafanaAdmin,
+      component: SafeDynamicImport(
+        () => import(/* webpackChunkName: "LabsPage"*/ 'app/features/labs/LabsPage')
+      ),
+    },
+    {
       path: '/theme-playground',
       component: SafeDynamicImport(
         () => import(/* webpackChunkName: "ThemePlayground"*/ 'app/features/theme-playground/ThemePlayground')


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
This change adds a Grafana-server-admin **Labs** section in the left navigation (with a **Beta** badge next to the icon) and a `/labs` page to inspect feature toggles and manage **database-backed instance overrides** for **frontend-only** flags.

Backend:
- New table `feature_toggle_lab_override` and persistence helpers in `pkg/services/featuremgmt/labdb`.
- `FeatureManager` merges Labs overrides on top of config/registry state (thread-safe) and reloads overrides from the DB after HTTP server construction.
- Admin-only APIs: `GET/PUT/DELETE /api/admin/feature-toggles/labs` (+ `:name` for mutations).

Frontend:
- Route `/labs` (Grafana admin only) with search, table, toggle, and reset-to-inherited behavior.
- Mega menu renders `highlightText: Beta` using `FeatureBadge` (beta state).

Tests:
- `pkg/services/featuremgmt` lab override behavior.
- Jest coverage for mega menu Beta badge and Labs page gating/loading.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1fa9af5e-2898-44a1-9ed8-83986eb069b4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1fa9af5e-2898-44a1-9ed8-83986eb069b4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

