### PR TITLE
Labs feature flag hub with instance-wide overrides

### DIFF
--- a/docs/sources/datasources/prometheus/configure/aws-authentication.md
+++ b/docs/sources/datasources/prometheus/configure/aws-authentication.md
@@ -66,12 +66,7 @@ For air-gapped environments, download and install [Amazon Managed Service for Pr
 
 ### Migrate
 
-1. Enable the `prometheusTypeMigration` feature toggle. For more information on feature toggles, refer to [Manage feature toggles](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/setup-grafana/configure-grafana/feature-toggles/#manage-feature-toggles).
-2. Restart Grafana for the changes to take effect.
-
-{{< admonition type="note" >}}
-This feature toggle will be removed in Grafana 13, and the migration will be automatic.
-{{< /admonition >}}
+1. Restart Grafana. Grafana runs the Prometheus data source type migration automatically on startup when migration is needed.
 
 ### Check migration status
 
@@ -93,8 +88,7 @@ The following sections contain troubleshooting guidance.
 
 **Migration banner not appearing**
 
-- Verify the `prometheusTypeMigration` feature toggle is enabled
-- Restart Grafana after enabling the feature toggle
+- Restart Grafana to trigger the automatic migration.
 
 **Amazon Managed Service for Prometheus is not installed**
 
@@ -108,14 +102,13 @@ The following sections contain troubleshooting guidance.
 
 ### Rollback self-hosted Grafana without a backup
 
-If you don’t have a backup of your Grafana instance before the migration, remove the `prometheusTypeMigration` feature toggle, and run the following script. It reverts all Amazon Managed Service for Prometheus data sources back to core Prometheus.
+If you don’t have a backup of your Grafana instance before the migration, run the following script. It reverts all Amazon Managed Service for Prometheus data sources back to core Prometheus.
 
 To revert the migration:
 
-1. Disable the `prometheusTypeMigration` feature toggle. For more information on feature toggles, refer to [Manage feature toggles](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/setup-grafana/configure-grafana/feature-toggles/#manage-feature-toggles).
-2. Obtain a bearer token that has `read` and `write` permissions for your Grafana data source API. For more information on the data source API, refer to [Data source API](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/developers/http_api/data_source/).
-3. Run the script below. Make sure to provide your Grafana URL and bearer token.
-4. (Optional) Report the issue you were experiencing on the [Grafana repository](https://github.com/grafana/grafana/issues). Tag the issue with "datasource/migrate-prometheus-type"
+1. Obtain a bearer token that has `read` and `write` permissions for your Grafana data source API. For more information on the data source API, refer to [Data source API](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/developers/http_api/data_source/).
+2. Run the script below. Make sure to provide your Grafana URL and bearer token.
+3. (Optional) Report the issue you were experiencing on the [Grafana repository](https://github.com/grafana/grafana/issues). Tag the issue with "datasource/migrate-prometheus-type"
 
 ```bash
 #!/bin/bash

--- a/docs/sources/datasources/prometheus/configure/azure-authentication.md
+++ b/docs/sources/datasources/prometheus/configure/azure-authentication.md
@@ -80,12 +80,7 @@ For air-gapped environments, download and install [Azure Monitor Managed Service
 
 ### Migrate
 
-1. Enable the `prometheusTypeMigration` feature toggle. For more information on feature toggles, refer to [Manage feature toggles](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/setup-grafana/configure-grafana/feature-toggles/#manage-feature-toggles).
-2. Restart Grafana for the changes to take effect.
-
-{{< admonition type="note" >}}
-This feature toggle will be removed in Grafana 13, and the migration will be automatic.
-{{< /admonition >}}
+1. Restart Grafana. Grafana runs the Prometheus data source type migration automatically on startup when migration is needed.
 
 To determine if your Prometheus data sources have been migrated:
 
@@ -105,8 +100,7 @@ The following sections contain troubleshooting guidance.
 
 **Migration banner not appearing**
 
-- Verify the `prometheusTypeMigration` feature toggle is enabled.
-- Restart Grafana after enabling the feature toggle
+- Restart Grafana to trigger the automatic migration.
 
 **Azure Monitor Managed Service for Prometheus is not installed**
 
@@ -120,14 +114,13 @@ The following sections contain troubleshooting guidance.
 
 ### Rollback self-hosted Grafana without a backup
 
-If you don’t have a backup of your Grafana instance before the migration, remove the `prometheusTypeMigration` feature toggle, and run the following script. It reverts all the Azure Monitor Managed Service data source instances back to core Prometheus.
+If you don’t have a backup of your Grafana instance before the migration, run the following script. It reverts all the Azure Monitor Managed Service data source instances back to core Prometheus.
 
 To revert the migration:
 
-1. Disable the `prometheusTypeMigration` feature toggle. For more information on feature toggles, refer to [Manage feature toggles](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/setup-grafana/configure-grafana/feature-toggles/#manage-feature-toggles).
-2. Obtain a bearer token that has `read` and `write` permissions for your Grafana data source API. For more information on the data source API, refer to [Data source API](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/developers/http_api/data_source/).
-3. Run the script below. Make sure to provide your Grafana URL and bearer token.
-4. (Optional) Report the issue you were experiencing on the [Grafana repository](https://github.com/grafana/grafana/issues). Tag the issue with "datasource/migrate-prometheus-type"
+1. Obtain a bearer token that has `read` and `write` permissions for your Grafana data source API. For more information on the data source API, refer to [Data source API](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/developers/http_api/data_source/).
+2. Run the script below. Make sure to provide your Grafana URL and bearer token.
+3. (Optional) Report the issue you were experiencing on the [Grafana repository](https://github.com/grafana/grafana/issues). Tag the issue with "datasource/migrate-prometheus-type"
 
 ```bash
 #!/bin/bash

--- a/packages/grafana-data/src/types/featureToggles.gen.ts
+++ b/packages/grafana-data/src/types/featureToggles.gen.ts
@@ -1341,12 +1341,6 @@ export interface FeatureToggles {
   */
   azureResourcePickerUpdates?: boolean;
   /**
-  * Checks for deprecated Prometheus authentication methods (SigV4 and Azure), installs the relevant data source, and migrates the Prometheus data sources
-  * @deprecated
-  * @default true
-  */
-  prometheusTypeMigration?: boolean;
-  /**
   * Enables running plugins in containers
   * @default false
   */

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -571,6 +571,10 @@ func (hs *HTTPServer) registerRoutes() {
 		adminRoute.Post("/provisioning/plugins/reload", authorize(ac.EvalPermission(ActionProvisioningReload, ScopeProvisionersPlugins)), routing.Wrap(hs.AdminProvisioningReloadPlugins))
 		adminRoute.Post("/provisioning/datasources/reload", authorize(ac.EvalPermission(ActionProvisioningReload, ScopeProvisionersDatasources)), routing.Wrap(hs.AdminProvisioningReloadDatasources))
 		adminRoute.Post("/provisioning/alerting/reload", authorize(ac.EvalPermission(ActionProvisioningReload, ScopeProvisionersAlertRules)), routing.Wrap(hs.AdminProvisioningReloadAlerting))
+
+		adminRoute.Get("/labs/feature-toggles", routing.Wrap(hs.AdminLabsFeatureTogglesList))
+		adminRoute.Put("/labs/feature-toggles/:name", routing.Wrap(hs.AdminLabsFeatureToggleSet))
+		adminRoute.Delete("/labs/feature-toggles/:name", routing.Wrap(hs.AdminLabsFeatureToggleDelete))
 	}, reqSignedIn)
 
 	// Administering users

--- a/pkg/api/http_server.go
+++ b/pkg/api/http_server.go
@@ -661,6 +661,7 @@ func (hs *HTTPServer) tlsCertificates() ([]tls.Certificate, error) {
 }
 
 func (hs *HTTPServer) applyRoutes() {
+	hs.loadLabsFeatureOverridesIntoManager()
 	// start with middlewares & static routes
 	hs.addMiddlewaresAndStaticRoutes()
 	// then add view routes & api routes

--- a/pkg/api/labs_feature_toggles.go
+++ b/pkg/api/labs_feature_toggles.go
@@ -1,0 +1,182 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+
+	"github.com/grafana/grafana/pkg/api/response"
+	ac "github.com/grafana/grafana/pkg/services/accesscontrol"
+	contextmodel "github.com/grafana/grafana/pkg/services/contexthandler/model"
+	"github.com/grafana/grafana/pkg/services/featuremgmt"
+	"github.com/grafana/grafana/pkg/web"
+)
+
+const (
+	labsFeatureToggleKVNamespace = "labs.feature_toggles"
+	labsFeatureToggleKVKey       = "overrides"
+)
+
+func (hs *HTTPServer) labsFeatureToggleKVGet(ctx context.Context) (featuremgmt.LabsOverrides, error) {
+	raw, ok, err := hs.kvStore.Get(ctx, 0, labsFeatureToggleKVNamespace, labsFeatureToggleKVKey)
+	if err != nil {
+		return featuremgmt.LabsOverrides{}, err
+	}
+	if !ok || raw == "" {
+		return featuremgmt.LabsOverrides{}, nil
+	}
+	var out featuremgmt.LabsOverrides
+	if err := json.Unmarshal([]byte(raw), &out); err != nil {
+		return nil, fmt.Errorf("parse labs overrides: %w", err)
+	}
+	if out == nil {
+		out = featuremgmt.LabsOverrides{}
+	}
+	return out, nil
+}
+
+func (hs *HTTPServer) labsFeatureToggleKVSet(ctx context.Context, overrides featuremgmt.LabsOverrides) error {
+	if overrides == nil {
+		overrides = featuremgmt.LabsOverrides{}
+	}
+	b, err := json.Marshal(overrides)
+	if err != nil {
+		return err
+	}
+	return hs.kvStore.Set(ctx, 0, labsFeatureToggleKVNamespace, labsFeatureToggleKVKey, string(b))
+}
+
+func (hs *HTTPServer) loadLabsFeatureOverridesIntoManager() {
+	fm, ok := hs.Features.(*featuremgmt.FeatureManager)
+	if !ok {
+		return
+	}
+	overrides, err := hs.labsFeatureToggleKVGet(context.Background())
+	if err != nil {
+		hs.log.Warn("Failed to load Labs feature toggle overrides", "err", err)
+		return
+	}
+	fm.SetLabsOverrides(overrides)
+}
+
+// GET /api/admin/labs/feature-toggles
+func (hs *HTTPServer) AdminLabsFeatureTogglesList(c *contextmodel.ReqContext) response.Response {
+	if c.SignedInUser == nil || !c.SignedInUser.GetIsGrafanaAdmin() {
+		return response.Error(http.StatusForbidden, "Permission denied", nil)
+	}
+	ok, err := hs.AccessControl.Evaluate(c.Req.Context(), c.SignedInUser, ac.EvalPermission(ac.ActionFeatureManagementRead))
+	if err != nil {
+		return response.Error(http.StatusInternalServerError, "Failed to evaluate permissions", err)
+	}
+	if !ok {
+		return response.Error(http.StatusForbidden, "Permission denied", nil)
+	}
+
+	fm, fmOk := hs.Features.(*featuremgmt.FeatureManager)
+	if !fmOk {
+		return response.Error(http.StatusInternalServerError, "Feature manager unavailable", nil)
+	}
+
+	return response.JSON(http.StatusOK, fm.ListLabsFlags(c.Req.Context()))
+}
+
+type labsSetFlagBody struct {
+	Enabled bool `json:"enabled"`
+}
+
+// PUT /api/admin/labs/feature-toggles/:name
+func (hs *HTTPServer) AdminLabsFeatureToggleSet(c *contextmodel.ReqContext) response.Response {
+	if c.SignedInUser == nil || !c.SignedInUser.GetIsGrafanaAdmin() {
+		return response.Error(http.StatusForbidden, "Permission denied", nil)
+	}
+	ok, err := hs.AccessControl.Evaluate(c.Req.Context(), c.SignedInUser, ac.EvalPermission(ac.ActionFeatureManagementWrite))
+	if err != nil {
+		return response.Error(http.StatusInternalServerError, "Failed to evaluate permissions", err)
+	}
+	if !ok {
+		return response.Error(http.StatusForbidden, "Permission denied", nil)
+	}
+
+	name := web.Params(c.Req)[":name"]
+	if name == "" {
+		return response.Error(http.StatusBadRequest, "missing flag name", nil)
+	}
+
+	bodyBytes, err := io.ReadAll(c.Req.Body)
+	if err != nil {
+		return response.Error(http.StatusBadRequest, "invalid request body", err)
+	}
+	var body labsSetFlagBody
+	if err := json.Unmarshal(bodyBytes, &body); err != nil {
+		return response.Error(http.StatusBadRequest, "invalid JSON body", err)
+	}
+
+	fm, fmOk := hs.Features.(*featuremgmt.FeatureManager)
+	if !fmOk {
+		return response.Error(http.StatusInternalServerError, "Feature manager unavailable", nil)
+	}
+
+	flag := fm.GetFlagDefinition(name)
+	if flag == nil {
+		return response.Error(http.StatusNotFound, "unknown feature flag", nil)
+	}
+	if !fm.LabsWritable(flag) {
+		return response.Error(http.StatusBadRequest, "this flag cannot be changed from Labs (restart-required, dev-only, or runtime blocked)", nil)
+	}
+
+	overrides, err := hs.labsFeatureToggleKVGet(c.Req.Context())
+	if err != nil {
+		return response.Error(http.StatusInternalServerError, "failed to read overrides", err)
+	}
+	if overrides == nil {
+		overrides = featuremgmt.LabsOverrides{}
+	}
+	overrides[name] = body.Enabled
+	if err := hs.labsFeatureToggleKVSet(c.Req.Context(), overrides); err != nil {
+		return response.Error(http.StatusInternalServerError, "failed to save overrides", err)
+	}
+	fm.SetLabsOverrides(overrides)
+
+	return response.JSON(http.StatusOK, map[string]any{"name": name, "enabled": body.Enabled})
+}
+
+// DELETE /api/admin/labs/feature-toggles/:name
+func (hs *HTTPServer) AdminLabsFeatureToggleDelete(c *contextmodel.ReqContext) response.Response {
+	if c.SignedInUser == nil || !c.SignedInUser.GetIsGrafanaAdmin() {
+		return response.Error(http.StatusForbidden, "Permission denied", nil)
+	}
+	ok, err := hs.AccessControl.Evaluate(c.Req.Context(), c.SignedInUser, ac.EvalPermission(ac.ActionFeatureManagementWrite))
+	if err != nil {
+		return response.Error(http.StatusInternalServerError, "Failed to evaluate permissions", err)
+	}
+	if !ok {
+		return response.Error(http.StatusForbidden, "Permission denied", nil)
+	}
+
+	name := web.Params(c.Req)[":name"]
+	if name == "" {
+		return response.Error(http.StatusBadRequest, "missing flag name", nil)
+	}
+
+	fm, fmOk := hs.Features.(*featuremgmt.FeatureManager)
+	if !fmOk {
+		return response.Error(http.StatusInternalServerError, "Feature manager unavailable", nil)
+	}
+
+	overrides, err := hs.labsFeatureToggleKVGet(c.Req.Context())
+	if err != nil {
+		return response.Error(http.StatusInternalServerError, "failed to read overrides", err)
+	}
+	if overrides == nil {
+		overrides = featuremgmt.LabsOverrides{}
+	}
+	delete(overrides, name)
+	if err := hs.labsFeatureToggleKVSet(c.Req.Context(), overrides); err != nil {
+		return response.Error(http.StatusInternalServerError, "failed to save overrides", err)
+	}
+	fm.SetLabsOverrides(overrides)
+
+	return response.JSON(http.StatusOK, map[string]any{"name": name, "cleared": true})
+}

--- a/pkg/server/wire_gen.go
+++ b/pkg/server/wire_gen.go
@@ -682,7 +682,7 @@ func Initialize(ctx context.Context, cfg *setting.Cfg, opts Options, apiOpts api
 	}
 	azurePromMigrationService := promtypemigration.ProvideAzurePromMigrationService(service14, inMemory, repoManager, pluginInstaller, cfg)
 	amazonPromMigrationService := promtypemigration.ProvideAmazonPromMigrationService(service14, inMemory, repoManager, pluginInstaller, cfg)
-	promTypeMigrationProviderImpl := promtypemigration.ProvidePromTypeMigrationProvider(serverLockService, featureToggles, azurePromMigrationService, amazonPromMigrationService)
+	promTypeMigrationProviderImpl := promtypemigration.ProvidePromTypeMigrationProvider(serverLockService, azurePromMigrationService, amazonPromMigrationService)
 	routePermissionsService, err := ossaccesscontrol.ProvideRoutePermissionsService(cfg, featureToggles, routeRegisterImpl, sqlStore, accessControl, ossLicensingService, acimplService, teamimplService, userimplService, actionSetService)
 	if err != nil {
 		return nil, err
@@ -1372,7 +1372,7 @@ func InitializeForTest(ctx context.Context, t sqlutil.ITestDB, testingT interfac
 	}
 	azurePromMigrationService := promtypemigration.ProvideAzurePromMigrationService(service14, inMemory, repoManager, pluginInstaller, cfg)
 	amazonPromMigrationService := promtypemigration.ProvideAmazonPromMigrationService(service14, inMemory, repoManager, pluginInstaller, cfg)
-	promTypeMigrationProviderImpl := promtypemigration.ProvidePromTypeMigrationProvider(serverLockService, featureToggles, azurePromMigrationService, amazonPromMigrationService)
+	promTypeMigrationProviderImpl := promtypemigration.ProvidePromTypeMigrationProvider(serverLockService, azurePromMigrationService, amazonPromMigrationService)
 	routePermissionsService, err := ossaccesscontrol.ProvideRoutePermissionsService(cfg, featureToggles, routeRegisterImpl, sqlStore, accessControl, ossLicensingService, acimplService, teamimplService, userimplService, actionSetService)
 	if err != nil {
 		return nil, err

--- a/pkg/services/featuremgmt/labs_types.go
+++ b/pkg/services/featuremgmt/labs_types.go
@@ -1,0 +1,19 @@
+package featuremgmt
+
+// LabsOverrides is persisted instance-wide feature toggle overrides from the Labs UI.
+type LabsOverrides map[string]bool
+
+// LabsFlagDetail is returned by the Labs admin API for each registered feature flag.
+type LabsFlagDetail struct {
+	Name            string `json:"name"`
+	Description     string `json:"description"`
+	Stage           string `json:"stage"`
+	FrontendOnly    bool   `json:"frontendOnly"`
+	RequiresRestart bool   `json:"requiresRestart"`
+	RequiresDevMode bool   `json:"requiresDevMode"`
+	Enabled         bool   `json:"enabled"`
+	Source          string `json:"source"` // default | config | labs
+	Writable        bool   `json:"writable"`
+	MeetsRuntime    bool   `json:"meetsRuntime"`
+	BlockedReason   string `json:"blockedReason,omitempty"`
+}

--- a/pkg/services/featuremgmt/manager.go
+++ b/pkg/services/featuremgmt/manager.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"reflect"
+	"sync"
 
 	"github.com/grafana/grafana/pkg/infra/log"
 )
@@ -20,6 +21,9 @@ type FeatureManager struct {
 	startup  map[string]bool   // the explicit values registered at startup
 	warnings map[string]string // potential warnings about the flag
 	log      log.Logger
+
+	labsMu      sync.RWMutex
+	labsEnabled LabsOverrides // instance-wide Labs overrides (from kv_store)
 }
 
 // This will merge the flags with the current configuration
@@ -73,6 +77,13 @@ func (fm *FeatureManager) meetsRequirements(ff *FeatureFlag) (bool, string) {
 
 // Update
 func (fm *FeatureManager) update() {
+	fm.labsMu.RLock()
+	labs := fm.labsEnabled
+	fm.labsMu.RUnlock()
+	if labs == nil {
+		labs = LabsOverrides{}
+	}
+
 	enabled := make(map[string]bool)
 	for _, flag := range fm.flags {
 		// if grafana cannot run the feature, omit metrics around it
@@ -86,7 +97,11 @@ func (fm *FeatureManager) update() {
 		track := 0.0
 
 		startup, ok := fm.startup[flag.Name]
-		if startup || (!ok && flag.Expression == "true") {
+		baseOn := startup || (!ok && flag.Expression == "true")
+		if v, hasLab := labs[flag.Name]; hasLab {
+			baseOn = v
+		}
+		if baseOn {
 			track = 1
 			enabled[flag.Name] = true
 		}
@@ -95,6 +110,95 @@ func (fm *FeatureManager) update() {
 		featureToggleInfo.WithLabelValues(flag.Name).Set(track)
 	}
 	fm.enabled = enabled
+}
+
+// SetLabsOverrides replaces Labs (in-app) overrides and recomputes enabled flags.
+func (fm *FeatureManager) SetLabsOverrides(overrides LabsOverrides) {
+	fm.labsMu.Lock()
+	if overrides == nil {
+		fm.labsEnabled = LabsOverrides{}
+	} else {
+		fm.labsEnabled = make(LabsOverrides, len(overrides))
+		for k, v := range overrides {
+			fm.labsEnabled[k] = v
+		}
+	}
+	fm.labsMu.Unlock()
+	fm.update()
+}
+
+// GetLabsOverridesCopy returns a copy of current Labs overrides for persistence.
+func (fm *FeatureManager) GetLabsOverridesCopy() LabsOverrides {
+	fm.labsMu.RLock()
+	defer fm.labsMu.RUnlock()
+	if len(fm.labsEnabled) == 0 {
+		return LabsOverrides{}
+	}
+	out := make(LabsOverrides, len(fm.labsEnabled))
+	for k, v := range fm.labsEnabled {
+		out[k] = v
+	}
+	return out
+}
+
+// LabsWritable reports whether Labs may change this flag at runtime.
+func (fm *FeatureManager) LabsWritable(flag *FeatureFlag) bool {
+	if flag.RequiresRestart {
+		return false
+	}
+	if flag.RequiresDevMode && !fm.isDevMod {
+		return false
+	}
+	ok, _ := fm.meetsRequirements(flag)
+	return ok
+}
+
+// ListLabsFlags returns metadata for every registered flag for the Labs UI.
+func (fm *FeatureManager) ListLabsFlags(ctx context.Context) []LabsFlagDetail {
+	fm.labsMu.RLock()
+	labs := fm.labsEnabled
+	fm.labsMu.RUnlock()
+	if labs == nil {
+		labs = LabsOverrides{}
+	}
+
+	out := make([]LabsFlagDetail, 0, len(fm.flags))
+	for _, flag := range fm.flags {
+		ok, reason := fm.meetsRequirements(flag)
+		_, inStartup := fm.startup[flag.Name]
+		baseOn := false
+		if inStartup {
+			baseOn = fm.startup[flag.Name]
+		} else {
+			baseOn = flag.Expression == "true"
+		}
+		source := "default"
+		if inStartup {
+			source = "config"
+		}
+		effective := baseOn
+		if v, has := labs[flag.Name]; has {
+			effective = v
+			source = "labs"
+		}
+
+		d := LabsFlagDetail{
+			Name:            flag.Name,
+			Description:     flag.Description,
+			Stage:           flag.Stage.String(),
+			FrontendOnly:    flag.FrontendOnly,
+			RequiresRestart: flag.RequiresRestart,
+			RequiresDevMode: flag.RequiresDevMode,
+			Enabled:         effective,
+			Source:          source,
+			Writable:        fm.LabsWritable(flag),
+			MeetsRuntime:    ok,
+			BlockedReason:   reason,
+		}
+		out = append(out, d)
+	}
+	_ = ctx
+	return out
 }
 
 // IsEnabled checks if a feature is enabled
@@ -125,6 +229,16 @@ func (fm *FeatureManager) GetFlags() []FeatureFlag {
 		v = append(v, *value)
 	}
 	return v
+}
+
+// GetFlagDefinition returns the registered flag definition, or nil if unknown.
+func (fm *FeatureManager) GetFlagDefinition(name string) *FeatureFlag {
+	f, ok := fm.flags[name]
+	if !ok {
+		return nil
+	}
+	cp := *f
+	return &cp
 }
 
 // ############# Test Functions #############

--- a/pkg/services/featuremgmt/manager_test.go
+++ b/pkg/services/featuremgmt/manager_test.go
@@ -65,4 +65,22 @@ func TestFeatureManager(t *testing.T) {
 		require.False(t, ft.IsEnabledGlobally("b"))
 		require.False(t, ft.IsEnabledGlobally("c"))
 	})
+
+	t.Run("labs overrides take precedence", func(t *testing.T) {
+		ft := FeatureManager{
+			flags: map[string]*FeatureFlag{},
+			startup: map[string]bool{
+				"x": false,
+			},
+		}
+		ft.registerFlags(FeatureFlag{
+			Name:       "x",
+			Expression: "false",
+		})
+		require.False(t, ft.IsEnabledGlobally("x"))
+		ft.SetLabsOverrides(LabsOverrides{"x": true})
+		require.True(t, ft.IsEnabledGlobally("x"))
+		ft.SetLabsOverrides(LabsOverrides{"x": false})
+		require.False(t, ft.IsEnabledGlobally("x"))
+	})
 }

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -2120,14 +2120,6 @@ var (
 			Expression:   "true",
 		},
 		{
-			Name:            "prometheusTypeMigration",
-			Description:     "Checks for deprecated Prometheus authentication methods (SigV4 and Azure), installs the relevant data source, and migrates the Prometheus data sources",
-			Stage:           FeatureStageDeprecated,
-			RequiresRestart: true,
-			Owner:           grafanaDataSourcesPlugins,
-			Expression:      "true",
-		},
-		{
 			Name:            "pluginContainers",
 			Description:     "Enables running plugins in containers",
 			Stage:           FeatureStagePrivatePreview,

--- a/pkg/services/featuremgmt/toggles_gen.csv
+++ b/pkg/services/featuremgmt/toggles_gen.csv
@@ -263,7 +263,6 @@ Created,Name,Stage,Owner,requiresDevMode,RequiresRestart,FrontendOnly
 2026-02-18,alertingAlertsActivityBanner,experimental,@grafana/alerting-squad,false,false,true
 2025-07-31,graphiteBackendMode,privatePreview,@grafana/data-sources-plugins,false,false,false
 2025-07-31,azureResourcePickerUpdates,GA,@grafana/data-sources-plugins,false,false,true
-2025-07-31,prometheusTypeMigration,deprecated,@grafana/data-sources-plugins,false,true,false
 2025-07-31,pluginContainers,privatePreview,@grafana/plugins-platform-backend,false,true,false
 2025-08-29,cdnPluginsLoadFirst,experimental,@grafana/plugins-platform-backend,false,false,false
 2025-08-29,cdnPluginsUrls,experimental,@grafana/plugins-platform-backend,false,false,false

--- a/pkg/services/featuremgmt/toggles_gen.go
+++ b/pkg/services/featuremgmt/toggles_gen.go
@@ -718,10 +718,6 @@ const (
 	// Enables the Graphite data source full backend mode
 	FlagGraphiteBackendMode = "graphiteBackendMode"
 
-	// FlagPrometheusTypeMigration
-	// Checks for deprecated Prometheus authentication methods (SigV4 and Azure), installs the relevant data source, and migrates the Prometheus data sources
-	FlagPrometheusTypeMigration = "prometheusTypeMigration"
-
 	// FlagPluginContainers
 	// Enables running plugins in containers
 	FlagPluginContainers = "pluginContainers"

--- a/pkg/services/navtree/models.go
+++ b/pkg/services/navtree/models.go
@@ -31,6 +31,7 @@ const (
 	WeightApplication
 	WeightAsserts
 	WeightDataConnections
+	WeightLabs
 	WeightApps
 	WeightPlugin
 	WeightConfig
@@ -56,6 +57,7 @@ const (
 	NavIDCfgPlugins           = "cfg/plugins"
 	NavIDCfgAccess            = "cfg/access"
 	NavIDBookmarks            = "bookmarks"
+	NavIDLabs                 = "labs"
 )
 
 type NavLink struct {

--- a/pkg/services/navtree/navtreeimpl/navtree.go
+++ b/pkg/services/navtree/navtreeimpl/navtree.go
@@ -164,6 +164,18 @@ func (s *ServiceImpl) GetNavTree(c *contextmodel.ReqContext, prefs *pref.Prefere
 		treeRoot.AddSection(connectionsSection)
 	}
 
+	if hasAccess(ac.EvalPermission(ac.ActionFeatureManagementRead)) {
+		treeRoot.AddSection(&navtree.NavLink{
+			Text:          "Labs",
+			Id:            navtree.NavIDLabs,
+			SubTitle:      "View and manage instance feature flags",
+			Icon:          "flask",
+			SortWeight:    navtree.WeightLabs,
+			Url:           s.cfg.AppSubURL + "/labs",
+			HighlightText: "Beta",
+		})
+	}
+
 	orgAdminNode, err := s.getAdminNode(c)
 
 	if orgAdminNode != nil && len(orgAdminNode.Children) > 0 {

--- a/pkg/services/promtypemigration/migrator.go
+++ b/pkg/services/promtypemigration/migrator.go
@@ -8,7 +8,6 @@ import (
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/infra/serverlock"
 	"github.com/grafana/grafana/pkg/registry"
-	"github.com/grafana/grafana/pkg/services/featuremgmt"
 )
 
 var logger = log.New("promds.migration")
@@ -25,28 +24,21 @@ type PromTypeMigrationProvider interface {
 
 type PromTypeMigrationProviderImpl struct {
 	services          []PromTypeMigrationService
-	features          featuremgmt.FeatureToggles
 	ServerLockService *serverlock.ServerLockService
 }
 
 func ProvidePromTypeMigrationProvider(
 	serverLockService *serverlock.ServerLockService,
-	features featuremgmt.FeatureToggles,
 	promAzureAuthMigrationService *AzurePromMigrationService,
 	promAmazonAuthMigrationService *AmazonPromMigrationService,
 ) *PromTypeMigrationProviderImpl {
 	return &PromTypeMigrationProviderImpl{
 		ServerLockService: serverLockService,
-		features:          features,
 		services:          []PromTypeMigrationService{promAzureAuthMigrationService, promAmazonAuthMigrationService},
 	}
 }
 
 func (s *PromTypeMigrationProviderImpl) Run(ctx context.Context) error {
-	//nolint:staticcheck // not yet migrated to OpenFeature
-	if !s.features.IsEnabled(ctx, featuremgmt.FlagPrometheusTypeMigration) {
-		return nil
-	}
 	return s.migrate(ctx)
 }
 

--- a/public/app/core/components/AppChrome/MegaMenu/MegaMenu.test.tsx
+++ b/public/app/core/components/AppChrome/MegaMenu/MegaMenu.test.tsx
@@ -67,4 +67,21 @@ describe('MegaMenu', () => {
 
     expect(screen.queryByLabelText('Profile')).not.toBeInTheDocument();
   });
+
+  it('should render highlightText badge on root items', async () => {
+    const navBarTree: NavModelItem[] = [
+      {
+        text: 'Labs',
+        id: 'labs',
+        url: '/labs',
+        highlightText: 'Beta',
+        icon: 'flask',
+      },
+      { text: 'Profile', id: 'profile', url: 'profile' },
+    ];
+    const store = configureStore({ navBarTree });
+    render(<MegaMenu onClose={() => {}} />, { store });
+
+    expect(await screen.findByText('Beta')).toBeInTheDocument();
+  });
 });

--- a/public/app/core/components/AppChrome/MegaMenu/MegaMenuItem.tsx
+++ b/public/app/core/components/AppChrome/MegaMenu/MegaMenuItem.tsx
@@ -6,7 +6,7 @@ import { useLocalStorage } from 'react-use';
 
 import { FeatureState, type GrafanaTheme2, type NavModelItem, toIconName } from '@grafana/data';
 import { t } from '@grafana/i18n';
-import { useStyles2, Text, IconButton, Icon, Stack, FeatureBadge } from '@grafana/ui';
+import { useStyles2, Text, IconButton, Icon, Stack, FeatureBadge, Badge } from '@grafana/ui';
 import { useGrafana } from 'app/core/context/GrafanaContext';
 
 import { Indent } from '../../Indent/Indent';
@@ -105,6 +105,7 @@ export function MegaMenuItem({ link, activeItem, level = 0, onClick, onPin, isPi
               <Text truncate element="p">
                 {link.text}
               </Text>
+              {link.highlightText && <Badge text={link.highlightText} color="blue" />}
               {link.isNew && <FeatureBadge featureState={FeatureState.new} />}
             </div>
           </MegaMenuItemText>

--- a/public/app/core/utils/navBarItem-translations.ts
+++ b/public/app/core/utils/navBarItem-translations.ts
@@ -179,6 +179,8 @@ export function getNavTitle(navId: string | undefined) {
       return t('nav.sign-out.title', 'Sign out');
     case 'search':
       return t('nav.search-dashboards.title', 'Search dashboards');
+    case 'labs':
+      return t('nav.labs.title', 'Labs');
     case 'connections':
       return t('nav.connections.title', 'Connections');
     case 'connections-add-new-connection':
@@ -308,6 +310,8 @@ export function getNavSubTitle(navId: string | undefined) {
       return t('nav.alerts-and-incidents.subtitle', 'Alerting and incident management apps');
     case 'testing-and-synthetics':
       return t('nav.testing-and-synthetics.subtitle', 'Optimize performance with k6 and Synthetic Monitoring insights');
+    case 'labs':
+      return t('nav.labs.subtitle', 'View and manage instance feature flags');
     case 'connections-add-new-connection':
       return t('nav.connections.subtitle', 'Browse and create new connections');
     case 'connections-datasources':

--- a/public/app/features/labs/LabsFeatureTogglesPage.test.tsx
+++ b/public/app/features/labs/LabsFeatureTogglesPage.test.tsx
@@ -1,0 +1,84 @@
+import { screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { render } from 'test/test-utils';
+
+import { getBackendSrv } from '@grafana/runtime';
+
+import { contextSrv } from 'app/core/services/context_srv';
+import { AccessControlAction } from 'app/types/accessControl';
+
+import LabsFeatureTogglesPage from './LabsFeatureTogglesPage';
+
+jest.mock('@grafana/runtime', () => ({
+  ...jest.requireActual('@grafana/runtime'),
+  getBackendSrv: jest.fn(),
+}));
+
+jest.mock('app/core/services/context_srv', () => ({
+  contextSrv: {
+    user: { isGrafanaAdmin: true },
+    hasPermission: jest.fn(),
+    evaluatePermission: jest.fn(),
+  },
+}));
+
+describe('LabsFeatureTogglesPage', () => {
+  const get = jest.fn();
+  const put = jest.fn();
+  const del = jest.fn();
+
+  beforeEach(() => {
+    (getBackendSrv as jest.Mock).mockReturnValue({ get, put, delete: del });
+    (contextSrv.hasPermission as jest.Mock).mockImplementation((action: string) => {
+      return (
+        action === AccessControlAction.FeatureManagementRead || action === AccessControlAction.FeatureManagementWrite
+      );
+    });
+    get.mockResolvedValue([
+      {
+        name: 'fooFlag',
+        description: 'A test flag',
+        stage: 'experimental',
+        frontendOnly: false,
+        requiresRestart: false,
+        requiresDevMode: false,
+        enabled: false,
+        source: 'default',
+        writable: true,
+        meetsRuntime: true,
+      },
+    ]);
+    put.mockResolvedValue({});
+    del.mockResolvedValue({});
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('loads and filters flags', async () => {
+    render(<LabsFeatureTogglesPage />);
+
+    await waitFor(() => expect(get).toHaveBeenCalledWith('/api/admin/labs/feature-toggles'));
+    expect(await screen.findByText('fooFlag')).toBeInTheDocument();
+
+    const search = screen.getByPlaceholderText('Filter by name, description, or stage');
+    await userEvent.type(search, 'nomatch');
+    expect(screen.queryByText('fooFlag')).not.toBeInTheDocument();
+
+    await userEvent.clear(search);
+    await userEvent.type(search, 'foo');
+    expect(await screen.findByText('fooFlag')).toBeInTheDocument();
+  });
+
+  it('toggles a flag when writable', async () => {
+    render(<LabsFeatureTogglesPage />);
+
+    const toggle = await screen.findByRole('switch');
+    await userEvent.click(toggle);
+
+    await waitFor(() =>
+      expect(put).toHaveBeenCalledWith('/api/admin/labs/feature-toggles/fooFlag', { enabled: true })
+    );
+  });
+});

--- a/public/app/features/labs/LabsFeatureTogglesPage.tsx
+++ b/public/app/features/labs/LabsFeatureTogglesPage.tsx
@@ -1,0 +1,239 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+
+import { type Column } from '@grafana/data';
+import { t, Trans } from '@grafana/i18n';
+import { getBackendSrv } from '@grafana/runtime';
+import {
+  Alert,
+  Button,
+  Field,
+  Input,
+  InteractiveTable,
+  Stack,
+  Switch,
+  Text,
+  TextLink,
+} from '@grafana/ui';
+import { Page } from 'app/core/components/Page/Page';
+import { contextSrv } from 'app/core/services/context_srv';
+import { AccessControlAction } from 'app/types/accessControl';
+
+export interface LabsFlagRow {
+  name: string;
+  description: string;
+  stage: string;
+  frontendOnly: boolean;
+  requiresRestart: boolean;
+  requiresDevMode: boolean;
+  enabled: boolean;
+  source: string;
+  writable: boolean;
+  meetsRuntime: boolean;
+  blockedReason?: string;
+}
+
+export function LabsFeatureTogglesPage() {
+  const [rows, setRows] = useState<LabsFlagRow[]>([]);
+  const [filter, setFilter] = useState('');
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const canRead = contextSrv.hasPermission(AccessControlAction.FeatureManagementRead);
+  const canWrite = contextSrv.hasPermission(AccessControlAction.FeatureManagementWrite);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const data = await getBackendSrv().get<LabsFlagRow[]>('/api/admin/labs/feature-toggles');
+      setRows(Array.isArray(data) ? data : []);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (canRead) {
+      load();
+    } else {
+      setLoading(false);
+    }
+  }, [canRead, load]);
+
+  const filtered = useMemo(() => {
+    const q = filter.trim().toLowerCase();
+    if (!q) {
+      return rows;
+    }
+    return rows.filter(
+      (r) =>
+        r.name.toLowerCase().includes(q) ||
+        r.description.toLowerCase().includes(q) ||
+        r.stage.toLowerCase().includes(q)
+    );
+  }, [rows, filter]);
+
+  const setFlag = async (name: string, enabled: boolean) => {
+    try {
+      await getBackendSrv().put(`/api/admin/labs/feature-toggles/${encodeURIComponent(name)}`, { enabled });
+      await load();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    }
+  };
+
+  const clearOverride = async (name: string) => {
+    try {
+      await getBackendSrv().delete(`/api/admin/labs/feature-toggles/${encodeURIComponent(name)}`);
+      await load();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    }
+  };
+
+  const columns: Array<Column<LabsFlagRow>> = useMemo(
+    () => [
+      {
+        id: 'name',
+        header: t('labs-page.column.name', 'Name'),
+        cell: ({ row }) => (
+          <Stack direction="column" gap={0.5}>
+            <Text weight="bold">{row.original.name}</Text>
+            {row.original.description && (
+              <Text variant="bodySmall" color="secondary">
+                {row.original.description}
+              </Text>
+            )}
+            {(row.original.requiresRestart || row.original.frontendOnly || !row.original.meetsRuntime) && (
+              <Stack direction="row" gap={1} wrap>
+                {row.original.requiresRestart && (
+                  <Text variant="bodySmall" color="warning">
+                    <Trans i18nKey="labs-page.badge.restart">Restart may be required for full effect</Trans>
+                  </Text>
+                )}
+                {row.original.frontendOnly && (
+                  <Text variant="bodySmall" color="secondary">
+                    <Trans i18nKey="labs-page.badge.frontend">Frontend only</Trans>
+                  </Text>
+                )}
+                {!row.original.meetsRuntime && row.original.blockedReason && (
+                  <Text variant="bodySmall" color="error">
+                    {row.original.blockedReason}
+                  </Text>
+                )}
+              </Stack>
+            )}
+          </Stack>
+        ),
+      },
+      {
+        id: 'stage',
+        header: t('labs-page.column.stage', 'Stage'),
+        cell: ({ row }) => row.original.stage,
+      },
+      {
+        id: 'source',
+        header: t('labs-page.column.source', 'Source'),
+        cell: ({ row }) => row.original.source,
+      },
+      {
+        id: 'enabled',
+        header: t('labs-page.column.enabled', 'Enabled'),
+        cell: ({ row }) => {
+          const r = row.original;
+          const disabled = !canWrite || !r.writable || !r.meetsRuntime;
+          return (
+            <Switch
+              value={r.enabled}
+              disabled={disabled}
+              onChange={(e) => void setFlag(r.name, e.currentTarget.checked)}
+            />
+          );
+        },
+      },
+      {
+        id: 'actions',
+        header: t('labs-page.column.actions', 'Actions'),
+        cell: ({ row }) => {
+          const r = row.original;
+          if (r.source !== 'labs' || !canWrite) {
+            return null;
+          }
+          return (
+            <Button
+              size="sm"
+              variant="secondary"
+              fill="outline"
+              onClick={() => void clearOverride(r.name)}
+            >
+              <Trans i18nKey="labs-page.reset">Reset to inherited</Trans>
+            </Button>
+          );
+        },
+      },
+    ],
+    [canWrite, setFlag, clearOverride]
+  );
+
+  if (!contextSrv.user.isGrafanaAdmin || !canRead) {
+    return (
+      <Page navId="labs">
+        <Page.Contents>
+          <Alert title={t('labs-page.forbidden.title', 'Access denied')} severity="warning">
+            <Trans i18nKey="labs-page.forbidden.body">
+              You need Grafana server admin access and feature management permissions to use Labs.
+            </Trans>
+          </Alert>
+        </Page.Contents>
+      </Page>
+    );
+  }
+
+  return (
+    <Page navId="labs">
+      <Page.Contents>
+        <Stack direction="column" gap={2}>
+          <div>
+            <Text element="h1" variant="h2">
+              <Trans i18nKey="labs-page.title">Feature flags</Trans>
+            </Text>
+            <Text color="secondary">
+              <Trans i18nKey="labs-page.intro">
+                Toggle instance-wide feature flags. Changes apply immediately for flags that do not require a restart.
+                For configuration reference, see{' '}
+                <TextLink href="https://grafana.com/docs/grafana/latest/setup-grafana/configure-grafana/#feature_toggles">
+                  Configure Grafana
+                </TextLink>
+                .
+              </Trans>
+            </Text>
+          </div>
+          {error && (
+            <Alert title={t('labs-page.error.title', 'Something went wrong')} severity="error" onRemove={() => setError(null)}>
+              {error}
+            </Alert>
+          )}
+          <Field label={t('labs-page.filter.label', 'Search')}>
+            <Input
+              width={50}
+              placeholder={t('labs-page.filter.placeholder', 'Filter by name, description, or stage')}
+              value={filter}
+              onChange={(e) => setFilter(e.currentTarget.value)}
+            />
+          </Field>
+          <InteractiveTable
+            columns={columns}
+            data={filtered}
+            getRowId={(r) => r.name}
+            isLoading={loading}
+            emptyMessage={t('labs-page.empty', 'No feature flags match your filter.')}
+          />
+        </Stack>
+      </Page.Contents>
+    </Page>
+  );
+}
+
+export default LabsFeatureTogglesPage;

--- a/public/app/routes/routes.tsx
+++ b/public/app/routes/routes.tsx
@@ -539,6 +539,15 @@ export function getAppRoutes(): RouteDescriptor[] {
       ),
     },
     {
+      path: '/labs',
+      roles: () =>
+        contextSrv.user.isGrafanaAdmin &&
+        contextSrv.evaluatePermission([AccessControlAction.FeatureManagementRead]),
+      component: SafeDynamicImport(
+        () => import(/* webpackChunkName: "LabsFeatureTogglesPage" */ 'app/features/labs/LabsFeatureTogglesPage')
+      ),
+    },
+    {
       path: '/theme-playground',
       component: SafeDynamicImport(
         () => import(/* webpackChunkName: "ThemePlayground"*/ 'app/features/theme-playground/ThemePlayground')

--- a/public/app/types/accessControl.ts
+++ b/public/app/types/accessControl.ts
@@ -179,6 +179,9 @@ export enum AccessControlAction {
   SettingsRead = 'settings:read',
   SettingsWrite = 'settings:write',
 
+  FeatureManagementRead = 'featuremgmt.read',
+  FeatureManagementWrite = 'featuremgmt.write',
+
   // GroupSync
   GroupSyncMappingsRead = 'groupsync.mappings:read',
   GroupSyncMappingsWrite = 'groupsync.mappings:write',


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
This change adds a **Labs** section in the left navigation (flask icon and **Beta** badge) for users with `featuremgmt.read`, and a **`/labs`** page for Grafana server admins to list and toggle feature flags.

**Backend**

- Labs overrides are stored in **`kv_store`** (org0, namespace `labs.feature_toggles`, key `overrides`) as JSON and applied on top of registry defaults and `[feature_toggles]` config inside **`FeatureManager`**.
- New admin APIs (Grafana admin + RBAC): `GET/PUT/DELETE /api/admin/labs/feature-toggles` (PUT body: `{"enabled": true|false}`). Flags that require restart or fail runtime requirements are read-only from Labs.
- Overrides are loaded when the HTTP server applies routes so they take effect after migrations.

**Frontend**

- Searchable table with enable/disable and **Reset to inherited** when a Labs override exists.

**Cleanup**

- Removed the deprecated **`prometheusTypeMigration`** flag; the Prometheus type migration background job now always runs. Docs for Azure/AWS Prometheus migration were updated accordingly. Generated toggle artifacts were refreshed.

**Tests**

- `go test -short` for `pkg/services/featuremgmt`, `pkg/services/promtypemigration`, and `pkg/api`.
- Jest: `MegaMenu.test.tsx` and `LabsFeatureTogglesPage.test.tsx`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-05b0cd3f-f1be-4a34-b0f7-77d1f23866d2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-05b0cd3f-f1be-4a34-b0f7-77d1f23866d2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

