### PR TITLE
style(alerting): change Learn more button to green

### DIFF
--- a/public/app/features/alerting/unified/home/AdCard.tsx
+++ b/public/app/features/alerting/unified/home/AdCard.tsx
@@ -58,7 +58,7 @@ export default function AdCard({ title, description, href, logoUrl, items, helpF
         ))}
       </div>
       <Divider />
-      <Button fill="solid" variant="secondary" onClick={() => window.open(href, '_blank')} className={styles.button}>
+      <Button fill="solid" variant="success" onClick={() => window.open(href, '_blank')} className={styles.button}>
         <Trans i18nKey="alerting.ad.learn-more">Learn more</Trans>
         <Icon name="external-link-alt" className={styles.buttonIcon} />
       </Button>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Changed the "Learn more" button in the Alerting AdCard component from gray (secondary variant) to green (success variant).

## Changes
- Updated `AdCard.tsx` to use `variant="success"` instead of `variant="secondary"` for the Learn more button

## Screenshots
![Green Learn more button](https://cursor.com/artifacts/c/art-143e0b8c-c95a-406d-aa70-e3de3ceb0082)

## Testing
- Verified visually in the Alerting home page that both AdCard components now display green "Learn more" buttons
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-84201638-e948-4bab-b275-76295768867d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-84201638-e948-4bab-b275-76295768867d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

