### PR TITLE
Typography: Migrate DataSourceTypeCard from v1 heading to v2 typography API

### DIFF
--- a/packages/grafana-data/src/themes/createV1Theme.test.ts
+++ b/packages/grafana-data/src/themes/createV1Theme.test.ts
@@ -1,0 +1,38 @@
+import { createTheme } from './createTheme';
+import { createV1Theme } from './createV1Theme';
+
+describe('createV1Theme', () => {
+  const theme = createTheme();
+  const v1Theme = createV1Theme(theme);
+
+  describe('typography.heading', () => {
+    it('maps v2 h1-h6 fontSize values into v1 heading properties', () => {
+      expect(v1Theme.typography.heading.h1).toBe(theme.typography.h1.fontSize);
+      expect(v1Theme.typography.heading.h2).toBe(theme.typography.h2.fontSize);
+      expect(v1Theme.typography.heading.h3).toBe(theme.typography.h3.fontSize);
+      expect(v1Theme.typography.heading.h4).toBe(theme.typography.h4.fontSize);
+      expect(v1Theme.typography.heading.h5).toBe(theme.typography.h5.fontSize);
+      expect(v1Theme.typography.heading.h6).toBe(theme.typography.h6.fontSize);
+    });
+
+    it('v1 heading.h5 matches v2 typography.h5.fontSize', () => {
+      expect(v1Theme.typography.heading.h5).toBe(theme.typography.h5.fontSize);
+    });
+  });
+
+  describe('typography.size', () => {
+    it('maps v2 size values into v1 size properties', () => {
+      expect(v1Theme.typography.size.xs).toBe(theme.typography.size.xs);
+      expect(v1Theme.typography.size.sm).toBe(theme.typography.size.sm);
+      expect(v1Theme.typography.size.md).toBe(theme.typography.size.md);
+      expect(v1Theme.typography.size.lg).toBe(theme.typography.size.lg);
+    });
+  });
+
+  describe('typography.fontFamily', () => {
+    it('maps v2 font families into v1 font family properties', () => {
+      expect(v1Theme.typography.fontFamily.sansSerif).toBe(theme.typography.fontFamily);
+      expect(v1Theme.typography.fontFamily.monospace).toBe(theme.typography.fontFamilyMonospace);
+    });
+  });
+});

--- a/packages/grafana-data/src/types/theme.ts
+++ b/packages/grafana-data/src/types/theme.ts
@@ -40,7 +40,7 @@ export interface GrafanaThemeCommons {
       md: number; // 4/3
       lg: number; // 1.5
     };
-    // TODO: Refactor to use size instead of custom defs
+    /** @deprecated Use theme.typography.h1 through h6 (v2 theme) instead. Will be removed in the next major version. */
     heading: {
       h1: string;
       h2: string;

--- a/public/app/features/datasources/components/DataSourceTypeCard.test.tsx
+++ b/public/app/features/datasources/components/DataSourceTypeCard.test.tsx
@@ -1,0 +1,48 @@
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { render } from 'test/test-utils';
+
+import { createTheme } from '@grafana/data';
+
+import { getMockDataSourceMeta } from '../mocks/dataSourcesMocks';
+
+import { DataSourceTypeCard, type Props } from './DataSourceTypeCard';
+
+const setup = (overrides: Partial<Props> = {}) => {
+  const defaultProps: Props = {
+    dataSourcePlugin: getMockDataSourceMeta(),
+    onClick: jest.fn(),
+  };
+
+  return { ...render(<DataSourceTypeCard {...defaultProps} {...overrides} />), props: { ...defaultProps, ...overrides } };
+};
+
+describe('DataSourceTypeCard', () => {
+  it('renders the data source name', () => {
+    setup();
+    expect(screen.getByText('datasource-test')).toBeInTheDocument();
+  });
+
+  it('renders the data source description', () => {
+    setup();
+    expect(screen.getByText('Some sample description.')).toBeInTheDocument();
+  });
+
+  it('calls onClick when clicked', async () => {
+    const onClick = jest.fn();
+    setup({ onClick });
+    const card = screen.getByText('datasource-test').closest('[role="button"]') ?? screen.getByText('datasource-test');
+    await userEvent.click(card);
+    expect(onClick).toHaveBeenCalled();
+  });
+
+  it('renders the learn more link', () => {
+    setup();
+    expect(screen.getByText('Website')).toBeInTheDocument();
+  });
+
+  it('v1 heading.h5 and v2 typography.h5.fontSize produce equivalent values', () => {
+    const theme = createTheme();
+    expect(theme.v1.typography.heading.h5).toBe(theme.typography.h5.fontSize);
+  });
+});

--- a/public/app/features/datasources/components/DataSourceTypeCard.test.tsx
+++ b/public/app/features/datasources/components/DataSourceTypeCard.test.tsx
@@ -14,7 +14,10 @@ const setup = (overrides: Partial<Props> = {}) => {
     onClick: jest.fn(),
   };
 
-  return { ...render(<DataSourceTypeCard {...defaultProps} {...overrides} />), props: { ...defaultProps, ...overrides } };
+  return {
+    ...render(<DataSourceTypeCard {...defaultProps} {...overrides} />),
+    props: { ...defaultProps, ...overrides },
+  };
 };
 
 describe('DataSourceTypeCard', () => {

--- a/public/app/features/datasources/components/DataSourceTypeCard.tsx
+++ b/public/app/features/datasources/components/DataSourceTypeCard.tsx
@@ -68,7 +68,7 @@ export function DataSourceTypeCard({ onClick, dataSourcePlugin }: Props) {
 function getStyles(theme: GrafanaTheme2) {
   return {
     heading: css({
-      fontSize: theme.v1.typography.heading.h5,
+      fontSize: theme.typography.h5.fontSize,
       fontWeight: 'inherit',
     }),
     figure: css({


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
**What is this feature?**

Migrates the single remaining consumer of `GrafanaThemeCommons.typography.heading` (the v1 theme API) to the v2 typography API and marks the `heading` property as `@deprecated`.

**Why do we need this feature?**

The v1 theme `typography.heading` object defines h1-h6 as raw pixel strings, completely separate from the `typography.size` scale. The v2 theme resolved this by using `buildVariant()` to generate full `ThemeTypographyVariant` objects. There was a longstanding TODO (from October 2019) to refactor this. With only 1 consumer remaining, this migration is trivial and eliminates usage of the deprecated v1 path.

**Who is this feature for?**

Grafana contributors and plugin developers who work with the theme system.

**Which issue(s) does this PR fix?**:

Fixes GRAF-71

**Changes:**
- `DataSourceTypeCard.tsx`: Changed `theme.v1.typography.heading.h5` to `theme.typography.h5.fontSize` (functionally equivalent — both resolve to the same rem value)
- `theme.ts`: Marked `heading` property as `@deprecated` with JSDoc on `GrafanaThemeCommons`
- Added test for `DataSourceTypeCard` component (rendering, click behavior, learn-more link, v1/v2 typography equivalence)
- Added test for `createV1Theme` typography heading mapping (h1-h6 mapping, size, fontFamily)

**Test evidence:**

![All 9 tests passing across both test suites](https://cursor.com/artifacts/c/art-19393a4b-134d-455a-aa68-05acf4fd0f89)

**Special notes for your reviewer:**

- The `heading` property is marked `@deprecated` but NOT removed — removal is deferred to the next major version per the ticket's acceptance criteria, to give external plugin authors time to migrate.
- `h5` is `'18px'` in v1 vs `pxToRem(16)` in v2 (both derived from the same `buildVariant` call). The v1 `heading.h5` already delegates to `theme.typography.h5.fontSize`, so the migration is a no-op in terms of rendered output.

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle. (N/A — this is a refactor)
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc. (N/A — internal refactor)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3ccb090e-5396-4c6b-819d-3d386bd90945"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3ccb090e-5396-4c6b-819d-3d386bd90945"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

