### PR TITLE
Dashboard: Add quick start with examples card to empty state

### DIFF
--- a/public/app/features/dashboard/dashgrid/DashboardEmpty/DashboardEmpty.test.tsx
+++ b/public/app/features/dashboard/dashgrid/DashboardEmpty/DashboardEmpty.test.tsx
@@ -164,3 +164,41 @@ it('renders with buttons disabled when repository is read-only', () => {
   expect(screen.getByRole('button', { name: 'Import dashboard' })).toBeDisabled();
   expect(screen.getByRole('button', { name: 'Add library panel' })).toBeDisabled();
 });
+
+it('renders quick start with examples card', () => {
+  setup();
+
+  expect(screen.getByText('Quick start with examples')).toBeInTheDocument();
+  expect(screen.getByText('Explore ready-made dashboards to jumpstart your monitoring setup.')).toBeInTheDocument();
+});
+
+it('renders quick start CTA as a link to grafana.com dashboards', () => {
+  setup();
+
+  const ctaLink = screen.getByRole('link', { name: /Browse example dashboards/i });
+  expect(ctaLink).toBeInTheDocument();
+  expect(ctaLink).toHaveAttribute('href', 'https://grafana.com/grafana/dashboards/');
+  expect(ctaLink).toHaveAttribute('target', '_blank');
+});
+
+it('quick start card is always visible regardless of canCreate', () => {
+  setup({ canCreate: false });
+
+  expect(screen.getByText('Quick start with examples')).toBeInTheDocument();
+  const ctaLink = screen.getByRole('link', { name: /Browse example dashboards/i });
+  expect(ctaLink).toBeInTheDocument();
+});
+
+it('quick start card is visible even when repository is read-only', () => {
+  mockUseGetResourceRepositoryView.mockReturnValue({
+    isReadOnlyRepo: true,
+    isInstanceManaged: false,
+    isLoading: false,
+  });
+
+  setup({ canCreate: true });
+
+  expect(screen.getByText('Quick start with examples')).toBeInTheDocument();
+  const ctaLink = screen.getByRole('link', { name: /Browse example dashboards/i });
+  expect(ctaLink).toBeInTheDocument();
+});

--- a/public/app/features/dashboard/dashgrid/DashboardEmpty/DashboardEmpty.tsx
+++ b/public/app/features/dashboard/dashgrid/DashboardEmpty/DashboardEmpty.tsx
@@ -5,7 +5,7 @@ import { type GrafanaTheme2 } from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';
 import { Trans, t } from '@grafana/i18n';
 import { config } from '@grafana/runtime';
-import { Button, useStyles2, Text, Box, Stack, TextLink, Icon, FilterPill, Tooltip } from '@grafana/ui';
+import { Button, LinkButton, useStyles2, Text, Box, Stack, TextLink, Icon, FilterPill, Tooltip } from '@grafana/ui';
 import { type DashboardModel } from 'app/features/dashboard/state/DashboardModel';
 import { DashboardScene } from 'app/features/dashboard-scene/scene/DashboardScene';
 import { AutoGridLayoutManager } from 'app/features/dashboard-scene/scene/layout-auto-grid/AutoGridLayoutManager';
@@ -144,7 +144,53 @@ const NewLayoutEmpty = ({ dashboard, styles }: NewLayoutEmptyProps) => {
           </>
         )}
       </Box>
+      <QuickStartExamplesCard />
     </Stack>
+  );
+};
+
+const GRAFANA_EXAMPLE_DASHBOARDS_URL = 'https://grafana.com/grafana/dashboards/';
+
+interface QuickStartExamplesCardProps {
+  flex?: number;
+}
+
+const QuickStartExamplesCard = ({ flex }: QuickStartExamplesCardProps) => {
+  const styles = useStyles2(getQuickStartStyles);
+
+  return (
+    <Box
+      borderRadius="lg"
+      borderColor="strong"
+      borderStyle="dashed"
+      padding={3}
+      flex={flex}
+      data-testid={selectors.pages.AddDashboard.itemButton('Quick start with examples')}
+    >
+      <Stack direction="column" alignItems="center" gap={1}>
+        <Icon name="rocket" size="xl" className={styles.icon} />
+        <Text element="h3" textAlignment="center" weight="medium">
+          <Trans i18nKey="dashboard.empty.quick-start-header">Quick start with examples</Trans>
+        </Text>
+        <Box marginBottom={2}>
+          <Text element="p" textAlignment="center" color="secondary">
+            <Trans i18nKey="dashboard.empty.quick-start-body">
+              Explore ready-made dashboards to jumpstart your monitoring setup.
+            </Trans>
+          </Text>
+        </Box>
+        <LinkButton
+          icon="external-link-alt"
+          fill="outline"
+          href={GRAFANA_EXAMPLE_DASHBOARDS_URL}
+          target="_blank"
+          rel="noopener noreferrer"
+          data-testid={selectors.pages.AddDashboard.itemButton('Quick start examples button')}
+        >
+          <Trans i18nKey="dashboard.empty.quick-start-button">Browse example dashboards</Trans>
+        </LinkButton>
+      </Stack>
+    </Box>
   );
 };
 
@@ -233,6 +279,7 @@ const OldLayoutEmpty = ({ onAddVisualization, onAddLibraryPanel, onImportDashboa
           </Button>
         </Stack>
       </Box>
+      <QuickStartExamplesCard flex={1} />
     </Stack>
   </Stack>
 );
@@ -290,6 +337,14 @@ function getStyles(theme: GrafanaTheme2) {
     }),
     appsIcon: css({
       fill: theme.v1.palette.orange,
+    }),
+  };
+}
+
+function getQuickStartStyles(theme: GrafanaTheme2) {
+  return {
+    icon: css({
+      color: theme.colors.warning.text,
     }),
   };
 }

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -5710,6 +5710,9 @@
       "import-a-dashboard-header": "Import a dashboard",
       "import-dashboard-button": "Import dashboard",
       "layout-default-hint": "The selected layout will also be used as the default for all new tabs and rows. You can change this later in Dashboard Settings > General.",
+      "quick-start-body": "Explore ready-made dashboards to jumpstart your monitoring setup.",
+      "quick-start-button": "Browse example dashboards",
+      "quick-start-header": "Quick start with examples",
       "select-layout-header": "Select layout",
       "title": "New dashboard"
     },


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
**What is this feature?**

Adds a new "Quick start with examples" card to the empty dashboard state (`/dashboard/new`). The card includes a rocket icon, title, supporting text, and a CTA button that links to the Grafana example dashboards gallery.

<a href="https://cursor.com/agents/bc-d6603a39-9df5-44e5-a3bf-38964aa5e363/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fquick_start_card_demo.mp4"><img src="https://cursor.com/artifacts/c/art-d6f4c2e1-b599-4679-97d0-5f6811a12e54" alt="quick_start_card_demo.mp4" /></a>

![Quick start card in empty dashboard state](https://cursor.com/artifacts/c/art-18a08018-e406-4941-a5c0-53a00a6620a8)

**Why do we need this feature?**

New users arriving at an empty dashboard often don't know where to start. This card provides an immediate, discoverable path to pre-built example dashboards on grafana.com, reducing time-to-value and improving the onboarding experience.

**Who is this feature for?**

New Grafana users and anyone creating a new dashboard who wants inspiration or a quick starting point from example dashboards.

**Which issue(s) does this PR fix?**:

Fixes [GRAF-78](https://fe-anysphere-demo.atlassian.net/browse/GRAF-78)

**Special notes for your reviewer:**

- The card appears in both the old layout (alongside "Import panel" and "Import a dashboard" cards) and the new scenes-based layout empty states.
- The CTA is always visible regardless of `canCreate` or read-only repository status, since it navigates externally.
- i18n keys added for all new text content.
- Unit tests cover card rendering, CTA link attributes, and visibility in edge cases (read-only repo, canCreate=false).

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d6603a39-9df5-44e5-a3bf-38964aa5e363"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d6603a39-9df5-44e5-a3bf-38964aa5e363"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

