### PR TITLE
Tooling: Add Cursor plugin manifest for grafana-dev

### DIFF
--- a/.cursor-plugin/README.md
+++ b/.cursor-plugin/README.md
@@ -1,0 +1,51 @@
+# Grafana Dev Plugin
+
+A Cursor plugin for Grafana development on the fieldsphere/grafana fork.
+
+## Features
+
+### Skills
+
+- **initial-setup**: Run initial local development setup commands (frontend deps, backend build)
+- **start-dev-server**: Start Grafana dev servers after initial setup
+- **dev-server-hot-reload**: Start backend and frontend with hot reloading
+- **github-fieldsphere-fork**: Ensure GitHub operations target fieldsphere/grafana
+
+### Hooks
+
+- **beforeShellExecution**: Enforces that mutating `gh` CLI commands target `fieldsphere/grafana` instead of upstream `grafana/grafana`
+
+## Usage
+
+### Initial Setup
+
+Ask the agent to set up local development:
+
+```
+Set up the Grafana dev environment
+```
+
+### Start Dev Servers
+
+After setup, start the development servers:
+
+```
+Start the dev server
+```
+
+### GitHub Operations
+
+All GitHub-related tasks (PRs, issues, commits) automatically target `fieldsphere/grafana`.
+
+## Requirements
+
+- Node.js v24.x (see `.nvmrc`)
+- Go 1.25.7 (see `go.mod`)
+- Yarn 4.11.0 via corepack
+- GCC for CGo/SQLite compilation
+
+## Default Credentials
+
+- URL: `http://localhost:3000`
+- Username: `admin`
+- Password: `admin`

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,0 +1,13 @@
+{
+  "name": "grafana-dev",
+  "version": "1.0.0",
+  "description": "Grafana development environment setup, skills, and hooks for the fieldsphere/grafana fork",
+  "author": {
+    "name": "fieldsphere"
+  },
+  "keywords": ["grafana", "development", "devtools", "fieldsphere"],
+  "repository": "https://github.com/fieldsphere/grafana",
+  "license": "Apache-2.0",
+  "skills": ".cursor/skills",
+  "hooks": ".cursor/hooks.json"
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
**What is this feature?**

Adds a Cursor plugin manifest (`.cursor-plugin/plugin.json`) that packages the existing skills and hooks into a distributable plugin following the [Cursor plugin reference](https://cursor.com/docs/reference/plugins#plugin-structure).

**Why do we need this feature?**

The `.cursor/skills/` and `.cursor/hooks.json` assets were built to streamline Grafana development in Cursor. Packaging them as a formal plugin enables:
- Easier distribution and versioning
- Discovery via the Cursor marketplace (if published)
- Clear documentation of available capabilities

**Who is this feature for?**

Developers using Cursor to work on the fieldsphere/grafana fork.

**Which issue(s) does this PR fix?**:

N/A - New feature

**Special notes for your reviewer:**

Plugin structure:
```
.cursor-plugin/
  plugin.json      # Manifest with name, version, skills/hooks paths
  README.md        # Documentation

.cursor/
  skills/          # 4 existing skills (initial-setup, start-dev-server, etc.)
  hooks.json       # beforeShellExecution hook for gh command enforcement
  hooks/           # Hook scripts
```

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.

Note: This is tooling/developer experience only, no runtime code changes.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f29c4530-7759-42ba-b21d-9277664c183e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f29c4530-7759-42ba-b21d-9277664c183e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

