### PR TITLE
Refactor: Replace console.log with structured logging

### DIFF
--- a/packages/grafana-data/src/utils/LocalStorageValueProvider.tsx
+++ b/packages/grafana-data/src/utils/LocalStorageValueProvider.tsx
@@ -41,7 +41,7 @@ export const LocalStorageValueProvider = <T,>(props: Props<T>) => {
     try {
       store.delete(storageKey);
     } catch (error) {
-      console.log(error);
+      console.error('Failed to delete from local storage:', error);
     }
     setState({ value: defaultValue });
   };

--- a/packages/grafana-prometheus/src/datasource.ts
+++ b/packages/grafana-prometheus/src/datasource.ts
@@ -31,6 +31,7 @@ import {
 import {
   type BackendSrvRequest,
   config,
+  createMonitoringLogger,
   DataSourceWithBackend,
   type FetchResponse,
   getBackendSrv,
@@ -38,6 +39,8 @@ import {
   isFetchError,
   type TemplateSrv,
 } from '@grafana/runtime';
+
+const logger = createMonitoringLogger('datasource.prometheus');
 
 import { addLabelToQuery } from './add_label_to_query';
 import { PrometheusAnnotationSupport } from './annotations';
@@ -172,8 +175,7 @@ export class PrometheusDatasource
         this.ruleMappings = extractRuleMappingFromGroups(ruleGroups);
       }
     } catch (err) {
-      console.log('Rules API is experimental. Ignore next error.');
-      console.error(err);
+      logger.logDebug('Rules API request failed (experimental API)', { error: err instanceof Error ? err.message : String(err) });
     }
   }
 

--- a/packages/grafana-runtime/src/config.ts
+++ b/packages/grafana-runtime/src/config.ts
@@ -313,7 +313,8 @@ function overrideFeatureTogglesFromLocalStorage(config: GrafanaBootConfig) {
       const toggleState = featureValue === 'true' || featureValue === '1';
       // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
       featureToggles[featureName as keyof FeatureToggles] = toggleState;
-      console.log(`Setting feature toggle ${featureName} = ${toggleState} via localstorage`);
+      // eslint-disable-next-line no-console
+      console.info(`[FeatureToggles] Setting ${featureName} = ${toggleState} via localStorage`);
     }
   }
 }
@@ -339,9 +340,11 @@ function overrideFeatureTogglesFromUrl(config: GrafanaBootConfig) {
       if (toggleState !== featureToggles[key]) {
         if (isDevelopment || safeRuntimeFeatureFlags.has(featureName)) {
           featureToggles[featureName] = toggleState;
-          console.log(`Setting feature toggle ${featureName} = ${toggleState} via url`);
+          // eslint-disable-next-line no-console
+          console.info(`[FeatureToggles] Setting ${featureName} = ${toggleState} via URL`);
         } else {
-          console.log(`Unable to change feature toggle ${featureName} via url in production.`);
+          // eslint-disable-next-line no-console
+          console.warn(`[FeatureToggles] Cannot change ${featureName} via URL in production`);
         }
       }
     }

--- a/public/app/core/services/FetchQueue.ts
+++ b/public/app/core/services/FetchQueue.ts
@@ -2,6 +2,8 @@ import { type Observable, Subject } from 'rxjs';
 
 import { type BackendSrvRequest } from '@grafana/runtime';
 
+import { createDebugLog } from '../utils/debugLog';
+
 export interface QueueState extends Record<string, { state: FetchStatus; options: BackendSrvRequest }> {}
 
 export enum FetchStatus {
@@ -76,6 +78,8 @@ export class FetchQueue {
     this.updates.next(update);
   };
 
+  private static debugLog = createDebugLog('fetchQueue', 'FetchQueue');
+
   private printState = (update: FetchQueueUpdate, debug: boolean): void => {
     if (!debug) {
       return;
@@ -90,8 +94,6 @@ export class FetchQueue {
       []
     );
 
-    console.log('FetchQueue noOfStarted', update.noOfInProgress);
-    console.log('FetchQueue noOfNotStarted', update.noOfPending);
-    console.log('FetchQueue state', entriesWithoutOptions);
+    FetchQueue.debugLog(`noOfStarted: ${update.noOfInProgress}, noOfNotStarted: ${update.noOfPending}`, entriesWithoutOptions);
   };
 }

--- a/public/app/core/services/backend_srv.ts
+++ b/public/app/core/services/backend_srv.ts
@@ -31,6 +31,7 @@ import {
   type BackendSrv as BackendService,
   type BackendSrvRequest,
   config,
+  createMonitoringLogger,
   type FetchError,
   type FetchResponse,
 } from '@grafana/runtime';
@@ -47,6 +48,8 @@ import { type FolderDTO } from 'app/types/folders';
 import { ShowModalReactEvent } from '../../types/events';
 import { isContentTypeJson, parseInitFromOptions, parseResponseBody, parseUrlFromOptions } from '../utils/fetch';
 import { isDataQuery, isLocalUrl } from '../utils/query';
+
+const logger = createMonitoringLogger('core.backend-srv');
 
 import { FetchQueue } from './FetchQueue';
 import { FetchQueueWorker } from './FetchQueueWorker';
@@ -241,7 +244,7 @@ export class BackendSrv implements BackendService {
             observer.complete();
           }) // runs in background
           .catch((e) => {
-            console.log(requestId, 'catch', e);
+            logger.logError(e instanceof Error ? e : new Error(String(e)), { requestId, context: 'chunked response' });
             observer.error(e);
           }); // from abort
       },

--- a/public/app/core/utils/dag.ts
+++ b/public/app/core/utils/dag.ts
@@ -1,3 +1,7 @@
+import { createDebugLog } from './debugLog';
+
+const debugLog = createDebugLog('dag', 'DAG');
+
 export class Edge {
   inputNode?: Node;
   outputNode?: Node;
@@ -268,7 +272,7 @@ export const printGraph = (g: Graph) => {
     if (!inputEdges) {
       inputEdges = '<none>';
     }
-    console.log(`${n.name}:\n - links to:   ${outputEdges}\n - links from: ${inputEdges}`);
+    debugLog(`${n.name}: links to: ${outputEdges}, links from: ${inputEdges}`);
   });
 };
 

--- a/public/app/features/auth-config/FieldRenderer.tsx
+++ b/public/app/features/auth-config/FieldRenderer.tsx
@@ -3,11 +3,14 @@ import { useEffect, useState } from 'react';
 import { type UseFormReturn, Controller } from 'react-hook-form';
 
 import { type SelectableValue } from '@grafana/data';
+import { createMonitoringLogger } from '@grafana/runtime';
 import { Checkbox, Field, Input, SecretInput, Select, Switch, useTheme2 } from '@grafana/ui';
 
 import { fieldMap } from './fields';
 import { type SSOProviderDTO, type SSOSettingsField } from './types';
 import { isSelectableValueArray } from './utils/guards';
+
+const logger = createMonitoringLogger('features.auth-config.field-renderer');
 
 interface FieldRendererProps
   extends Pick<
@@ -78,7 +81,7 @@ export const FieldRenderer = ({
   }, [isDisabled, disabledWhen?.disabledValue, name, setValue]);
 
   if (!field) {
-    console.log('missing field:', name);
+    logger.logWarning('Missing field configuration', { fieldName: name, provider });
     return null;
   }
 

--- a/public/app/features/auth-config/state/actions.ts
+++ b/public/app/features/auth-config/state/actions.ts
@@ -1,7 +1,9 @@
 import { lastValueFrom } from 'rxjs';
 
-import { getBackendSrv, isFetchError } from '@grafana/runtime';
+import { createMonitoringLogger, getBackendSrv, isFetchError } from '@grafana/runtime';
 import { contextSrv } from 'app/core/services/context_srv';
+
+const logger = createMonitoringLogger('features.auth-config');
 import { AccessControlAction } from 'app/types/accessControl';
 import { type Settings, type UpdateSettingsQuery } from 'app/types/settings';
 import { type ThunkResult } from 'app/types/store';
@@ -78,7 +80,7 @@ export function saveSettings(data: UpdateSettingsQuery): ThunkResult<Promise<boo
         dispatch(resetError());
         return true;
       } catch (error) {
-        console.log(error);
+        logger.logError(error instanceof Error ? error : new Error(String(error)), { context: 'settings update' });
         if (isFetchError(error)) {
           error.isHandled = true;
           const updateErr: SettingsError = {

--- a/public/app/features/canvas/runtime/frame.tsx
+++ b/public/app/features/canvas/runtime/frame.tsx
@@ -1,9 +1,12 @@
 import { cloneDeep } from 'lodash';
 
+import { createMonitoringLogger } from '@grafana/runtime';
 import { notFoundItem } from 'app/features/canvas/elements/notFound';
 import { type DimensionContext } from 'app/features/dimensions/context';
 import { HorizontalConstraint, type Placement, VerticalConstraint } from 'app/plugins/panel/canvas/panelcfg.gen';
 import { LayerActionID } from 'app/plugins/panel/canvas/types';
+
+const logger = createMonitoringLogger('features.canvas.runtime.frame');
 
 import { updateConnectionsForSource } from '../../../plugins/panel/canvas/utils';
 import { type CanvasElementItem } from '../element';
@@ -129,7 +132,7 @@ export class FrameState extends ElementState {
         break;
       case LayerActionID.Duplicate:
         if (element.item.id === 'frame') {
-          console.log('Can not duplicate frames (yet)', action, element);
+          logger.logDebug('Frame duplication not yet supported', { action, elementName: element.options.name });
           return;
         }
         const opts = cloneDeep(element.options);
@@ -239,7 +242,7 @@ export class FrameState extends ElementState {
         break;
 
       default:
-        console.log('DO action', action, element);
+        logger.logDebug('Unhandled layer action', { action, elementName: element.options.name });
         return;
     }
   };

--- a/public/app/features/dashboard-scene/inspect/HelpWizard/SupportSnapshotService.ts
+++ b/public/app/features/dashboard-scene/inspect/HelpWizard/SupportSnapshotService.ts
@@ -2,6 +2,7 @@ import saveAs from 'file-saver';
 
 import { dateTimeFormat, formattedValueToString, getValueFormat, type SelectableValue } from '@grafana/data';
 import { t } from '@grafana/i18n';
+import { createMonitoringLogger } from '@grafana/runtime';
 import { sceneGraph, type SceneObject, type VizPanel } from '@grafana/scenes';
 import { StateManagerBase } from 'app/core/services/StateManagerBase';
 
@@ -9,6 +10,8 @@ import { transformSaveModelToScene } from '../../serialization/transformSaveMode
 
 import { type Randomize } from './randomizer';
 import { getDebugDashboard, getGithubMarkdown } from './utils';
+
+const logger = createMonitoringLogger('features.dashboard-scene.support-snapshot');
 
 interface SupportSnapshotState {
   currentTab: SnapshotTab;
@@ -84,7 +87,7 @@ export class SupportSnapshotService extends StateManagerBase<SupportSnapshotStat
         const dash = transformSaveModelToScene({ dashboard: snapshot, meta: { isEmbedded: true } });
         scene = dash.state.body; // skip the wrappers
       } catch (ex) {
-        console.log('Error creating scene:', ex);
+        logger.logError(ex instanceof Error ? ex : new Error(String(ex)), { context: 'scene creation' });
       }
     }
 

--- a/public/app/features/dashboard-scene/pages/DashboardScenePage.tsx
+++ b/public/app/features/dashboard-scene/pages/DashboardScenePage.tsx
@@ -3,8 +3,10 @@ import { type Params, useParams } from 'react-router-dom-v5-compat';
 import { usePrevious } from 'react-use';
 
 import { PageLayoutType } from '@grafana/data';
-import { locationService } from '@grafana/runtime';
+import { createMonitoringLogger, locationService } from '@grafana/runtime';
 import { UrlSyncContextProvider } from '@grafana/scenes';
+
+const logger = createMonitoringLogger('features.dashboard-scene.page');
 import { Box } from '@grafana/ui';
 import { Page } from 'app/core/components/Page/Page';
 import PageLoader from 'app/core/components/PageLoader/PageLoader';
@@ -126,7 +128,7 @@ export function DashboardScenePage({ route, queryParams, location }: Props) {
   // A bit tricky for transition to or from Home dashboard that does not have a uid in the url (but could have it in the dashboard model)
   // if prevMatch is undefined we are going from normal route to home route or vice versa
   if (type !== 'snapshot' && (!prevMatch || uid !== prevMatch?.params.uid)) {
-    console.log('skipping rendering');
+    logger.logDebug('Skipping render during route transition', { currentUid: uid ?? '', prevUid: prevMatch?.params.uid ?? '' });
     return null;
   }
 

--- a/public/app/features/dashboard-scene/pages/DashboardScenePageStateManager.ts
+++ b/public/app/features/dashboard-scene/pages/DashboardScenePageStateManager.ts
@@ -1,6 +1,6 @@
 import { locationUtil, type UrlQueryMap } from '@grafana/data';
 import { t } from '@grafana/i18n';
-import { config, getBackendSrv, getDataSourceSrv, isFetchError, locationService } from '@grafana/runtime';
+import { config, createMonitoringLogger, getBackendSrv, getDataSourceSrv, isFetchError, locationService } from '@grafana/runtime';
 import { UserStorage } from '@grafana/runtime/internal';
 import { sceneGraph } from '@grafana/scenes';
 import {
@@ -58,6 +58,8 @@ import {
 import { restoreDashboardStateFromLocalStorage } from '../utils/dashboardSessionState';
 
 import { processQueryParamsForDashboardLoad, updateNavModel } from './utils';
+
+const logger = createMonitoringLogger('features.dashboard-scene.page-state-manager');
 
 /**
  * Initialize both performance services to ensure they're ready before profiling starts
@@ -797,7 +799,7 @@ export class DashboardScenePageStateManager extends DashboardScenePageStateManag
             ...locationService.getLocation(),
             pathname: dashboardUrl,
           });
-          console.log('not correct url correcting', dashboardUrl, currentPath);
+          logger.logDebug('URL corrected', { dashboardUrl, currentPath });
         }
       }
 
@@ -1017,7 +1019,7 @@ export class DashboardScenePageStateManagerV2 extends DashboardScenePageStateMan
             ...locationService.getLocation(),
             pathname: dashboardUrl,
           });
-          console.log('not correct url correcting', dashboardUrl, currentPath);
+          logger.logDebug('URL corrected', { dashboardUrl, currentPath });
         }
       }
       // Populate nav model in global store according to the folder

--- a/public/app/features/dashboard-scene/settings/VersionsEditView.tsx
+++ b/public/app/features/dashboard-scene/settings/VersionsEditView.tsx
@@ -4,8 +4,11 @@ import { useMemo } from 'react';
 
 import { PageLayoutType, dateTimeFormat, dateTimeFormatTimeAgo } from '@grafana/data';
 import { Trans } from '@grafana/i18n';
+import { createMonitoringLogger } from '@grafana/runtime';
 import { type SceneComponentProps, SceneObjectBase, sceneGraph } from '@grafana/scenes';
 import { Alert, Spinner, Stack } from '@grafana/ui';
+
+const logger = createMonitoringLogger('features.dashboard-scene.versions');
 import { useGetDisplayMappingQuery } from 'app/api/clients/iam/v0alpha1';
 import { Page } from 'app/core/components/Page/Page';
 import {
@@ -118,7 +121,7 @@ export class VersionsEditView extends SceneObjectBase<VersionsEditViewState> imp
         // Update the continueToken for the next request, if available
         this._continueToken = result.metadata.continue ?? '';
       })
-      .catch((err) => console.log(err))
+      .catch((err) => logger.logError(err instanceof Error ? err : new Error(String(err)), { context: 'fetch more versions' }))
       .finally(() => this.setState({ isAppending: false }));
   };
 

--- a/public/app/features/dashboard/components/DashboardSettings/VersionsSettings.tsx
+++ b/public/app/features/dashboard/components/DashboardSettings/VersionsSettings.tsx
@@ -1,8 +1,11 @@
 import { PureComponent } from 'react';
 import * as React from 'react';
 
+import { createMonitoringLogger } from '@grafana/runtime';
 import { Spinner, Stack } from '@grafana/ui';
 import { Page } from 'app/core/components/Page/Page';
+
+const logger = createMonitoringLogger('features.dashboard.versions-settings');
 import { type Resource } from 'app/features/apiserver/types';
 import { getDashboardAPI } from 'app/features/dashboard/api/dashboard_api';
 import {
@@ -69,7 +72,7 @@ export class VersionsSettings extends PureComponent<Props, State> {
         // Update the continueToken for the next request, if available
         this.continueToken = result.metadata.continue ?? '';
       })
-      .catch((err) => console.log(err))
+      .catch((err) => logger.logError(err instanceof Error ? err : new Error(String(err)), { context: 'fetch more versions' }))
       .finally(() => this.setState({ isAppending: false }));
   };
 

--- a/public/app/features/dashboard/components/HelpWizard/SupportSnapshotService.ts
+++ b/public/app/features/dashboard/components/HelpWizard/SupportSnapshotService.ts
@@ -2,10 +2,13 @@ import saveAs from 'file-saver';
 
 import { dateTimeFormat, formattedValueToString, getValueFormat, type SelectableValue } from '@grafana/data';
 import { t } from '@grafana/i18n';
+import { createMonitoringLogger } from '@grafana/runtime';
 import { type SceneObject } from '@grafana/scenes';
 import { StateManagerBase } from 'app/core/services/StateManagerBase';
 import { type Randomize } from 'app/features/dashboard-scene/inspect/HelpWizard/randomizer';
 import { createDashboardSceneFromDashboardModel } from 'app/features/dashboard-scene/serialization/transformSaveModelToScene';
+
+const logger = createMonitoringLogger('features.dashboard.support-snapshot');
 
 import { getTimeSrv } from '../../services/TimeSrv';
 import { DashboardModel } from '../../state/DashboardModel';
@@ -88,7 +91,7 @@ export class SupportSnapshotService extends StateManagerBase<SupportSnapshotStat
       const dash = createDashboardSceneFromDashboardModel(oldModel, snapshot);
       scene = dash.state.body; // skip the wrappers
     } catch (ex) {
-      console.log('Error creating scene:', ex);
+      logger.logError(ex instanceof Error ? ex : new Error(String(ex)), { context: 'scene creation' });
     }
 
     this.setState({ snapshot, snapshotText, markdownText, snapshotSize, snapshotUpdate: snapshotUpdate + 1, scene });

--- a/public/app/features/dashboard/dashgrid/DashboardGrid.tsx
+++ b/public/app/features/dashboard/dashgrid/DashboardGrid.tsx
@@ -4,8 +4,10 @@ import * as React from 'react';
 import ReactGridLayout, { type ItemCallback } from 'react-grid-layout';
 import { Subscription } from 'rxjs';
 
-import { config } from '@grafana/runtime';
+import { config, createMonitoringLogger } from '@grafana/runtime';
 import { appEvents } from 'app/core/app_events';
+
+const logger = createMonitoringLogger('features.dashboard.grid');
 import { GRID_CELL_HEIGHT, GRID_CELL_VMARGIN, GRID_COLUMN_COUNT } from 'app/core/constants';
 import { contextSrv } from 'app/core/services/context_srv';
 import { VariablesChanged } from 'app/features/variables/types';
@@ -115,7 +117,7 @@ export class DashboardGrid extends PureComponent<Props, State> {
       this.panelMap[panel.key] = panel;
 
       if (!panel.gridPos) {
-        console.log('panel without gridpos');
+        logger.logWarning('Panel missing gridPos', { panelId: String(panel.id), panelKey: panel.key ?? '' });
         continue;
       }
 

--- a/public/app/features/dashboard/dashgrid/PanelStateWrapper.tsx
+++ b/public/app/features/dashboard/dashgrid/PanelStateWrapper.tsx
@@ -23,8 +23,10 @@ import {
   toDataFrameDTO,
   toUtc,
 } from '@grafana/data';
-import { RefreshEvent } from '@grafana/runtime';
+import { createMonitoringLogger, RefreshEvent } from '@grafana/runtime';
 import { type VizLegendOptions } from '@grafana/schema';
+
+const logger = createMonitoringLogger('features.dashboard.panel-state');
 import {
   ErrorBoundary,
   PanelChrome,
@@ -257,7 +259,7 @@ export class PanelStateWrapper extends PureComponent<Props, State> {
       const delta = liveTime.to.valueOf() - data.timeRange.to.valueOf();
       if (delta < 100) {
         // 10hz
-        console.log('Skip tick render', this.props.panel.title, delta);
+        logger.logDebug('Skipping tick render due to throttling', { panelTitle: this.props.panel.title, deltaMs: String(delta) });
         return;
       }
     }

--- a/public/app/features/dashboard/state/DashboardModel.ts
+++ b/public/app/features/dashboard/state/DashboardModel.ts
@@ -18,7 +18,7 @@ import {
   type UrlQueryValue,
 } from '@grafana/data';
 import { type PromQuery } from '@grafana/prometheus';
-import { RefreshEvent, TimeRangeUpdatedEvent } from '@grafana/runtime';
+import { createMonitoringLogger, RefreshEvent, TimeRangeUpdatedEvent } from '@grafana/runtime';
 import { type Dashboard, type DashboardLink, type VariableModel } from '@grafana/schema';
 import { DEFAULT_ANNOTATION_COLOR } from '@grafana/ui';
 import { GRID_CELL_HEIGHT, GRID_CELL_VMARGIN, GRID_COLUMN_COUNT, REPEAT_DIR_VERTICAL } from 'app/core/constants';
@@ -48,6 +48,8 @@ import { getTimeSrv } from '../services/TimeSrv';
 import { mergePanels, type PanelMergeInfo } from '../utils/panelMerge';
 
 import { DashboardMigrator } from './DashboardMigrator';
+
+const logger = createMonitoringLogger('features.dashboard.model');
 import { PanelModel } from './PanelModel';
 import { type TimeModel } from './TimeModel';
 import { deleteScopeVars, isOnTheSameGridRow } from './utils';
@@ -1115,13 +1117,13 @@ export class DashboardModel implements TimeModel {
 
   /** @deprecated */
   on<T>(event: AppEvent<T>, callback: (payload?: T) => void) {
-    console.log('DashboardModel.on is deprecated use events.subscribe');
+    logger.logWarning('DashboardModel.on is deprecated use events.subscribe');
     this.events.on(event, callback);
   }
 
   /** @deprecated */
   off<T>(event: AppEvent<T>, callback: (payload?: T) => void) {
-    console.log('DashboardModel.off is deprecated');
+    logger.logWarning('DashboardModel.off is deprecated');
     this.events.off(event, callback);
   }
 

--- a/public/app/features/dashboard/state/initDashboard.ts
+++ b/public/app/features/dashboard/state/initDashboard.ts
@@ -1,6 +1,6 @@
 import { type DataQuery, locationUtil, setWeekStart, DashboardLoadedEvent, store } from '@grafana/data';
 import { t } from '@grafana/i18n';
-import { config, isFetchError, locationService } from '@grafana/runtime';
+import { config, createMonitoringLogger, isFetchError, locationService } from '@grafana/runtime';
 import { appEvents } from 'app/core/app_events';
 import { createErrorNotification } from 'app/core/copy/appNotification';
 import { notifyApp } from 'app/core/reducers/appNotification';
@@ -40,6 +40,7 @@ import { type PanelModel } from './PanelModel';
 import { emitDashboardViewEvent } from './analyticsProcessor';
 import { dashboardInitCompleted, dashboardInitFailed, dashboardInitFetching, dashboardInitServices } from './reducers';
 
+const logger = createMonitoringLogger('features.dashboard.init');
 const INIT_DASHBOARD_MEASUREMENT = 'initDashboard';
 
 export interface InitDashboardArgs {
@@ -109,7 +110,7 @@ async function fetchDashboard(
               ...locationService.getLocation(),
               pathname: dashboardUrl,
             });
-            console.log('not correct url correcting', dashboardUrl, currentPath);
+            logger.logDebug('URL corrected', { dashboardUrl, currentPath });
           }
         }
         return dashDTO;

--- a/public/app/features/explore/TraceView/components/CriticalPath/index.tsx
+++ b/public/app/features/explore/TraceView/components/CriticalPath/index.tsx
@@ -14,7 +14,11 @@
 
 import memoizeOne from 'memoize-one';
 
+import { createMonitoringLogger } from '@grafana/runtime';
+
 import { type TraceSpan, type CriticalPathSection, type Trace } from '../types/trace';
+
+const logger = createMonitoringLogger('features.explore.trace-view.critical-path');
 
 import findLastFinishingChildSpan from './utils/findLastFinishingChildSpan';
 import getChildOfSpans from './utils/getChildOfSpans';
@@ -103,8 +107,7 @@ function criticalPathForTrace(trace: Trace) {
       const sanitizedSpanMap = sanitizeOverFlowingChildren(refinedSpanMap);
       criticalPath = computeCriticalPath(sanitizedSpanMap, rootSpanId, criticalPath);
     } catch (error) {
-      /* eslint-disable no-console */
-      console.log('error while computing critical path for a trace', error);
+      logger.logError(error instanceof Error ? error : new Error(String(error)), { context: 'critical path computation' });
     }
   }
   return criticalPath;

--- a/public/app/features/explore/state/query.ts
+++ b/public/app/features/explore/state/query.ts
@@ -20,7 +20,9 @@ import {
   type SupplementaryQueryType,
 } from '@grafana/data';
 import { combinePanelData } from '@grafana/o11y-ds-frontend';
-import { config, getDataSourceSrv } from '@grafana/runtime';
+import { config, createMonitoringLogger, getDataSourceSrv } from '@grafana/runtime';
+
+const logger = createMonitoringLogger('features.explore.query');
 import { type DataQuery } from '@grafana/schema';
 import { notifyApp } from 'app/core/reducers/appNotification';
 import {
@@ -657,7 +659,7 @@ export const runQueries = createAsyncThunk<void, RunQueriesOptions>(
 
           // Keep scanning for results if this was the last scanning transaction
           if (exploreState!.scanning) {
-            console.log(data.series);
+            logger.logDebug('Scanning data series', { seriesCount: String(data.series.length), state: String(data.state) });
             if (data.state === LoadingState.Done && data.series.length === 0) {
               const range = getShiftedTimeRange(-1, exploreState!.range);
               dispatch(updateTime({ exploreId, absoluteRange: range }));

--- a/public/app/features/live/centrifuge/channel.ts
+++ b/public/app/features/live/centrifuge/channel.ts
@@ -19,6 +19,9 @@ import {
   type DataFrameJSON,
   isValidLiveChannelAddress,
 } from '@grafana/data';
+import { createMonitoringLogger } from '@grafana/runtime';
+
+const logger = createMonitoringLogger('features.live.centrifuge.channel');
 
 /**
  * Internal class that maps Centrifuge support to GrafanaLive
@@ -81,7 +84,7 @@ export class CentrifugeLiveChannel<T = any> {
           this.sendStatus();
         }
       } catch (err) {
-        console.log('publish error', this.addr, err);
+        logger.logError(err instanceof Error ? err : new Error(String(err)), { context: 'publication', channelId: this.id });
         this.currentStatus.error = err;
         this.currentStatus.timestamp = Date.now();
         this.sendStatus();

--- a/public/app/features/live/centrifuge/service.ts
+++ b/public/app/features/live/centrifuge/service.ts
@@ -26,8 +26,11 @@ import {
   StreamingFrameAction,
   type StreamingFrameOptions,
   type BackendDataSourceResponse,
+  createMonitoringLogger,
   getBackendSrv,
 } from '@grafana/runtime';
+
+const logger = createMonitoringLogger('features.live.centrifuge.service');
 
 import { type StreamingResponseData } from '../data/utils';
 
@@ -126,7 +129,7 @@ export class CentrifugeService implements CentrifugeSrv {
   };
 
   private onServerSideMessage = (context: ServerPublicationContext) => {
-    console.log('Publication from server-side channel', context);
+    logger.logDebug('Publication from server-side channel', { channel: context.channel });
   };
 
   private onError = (context: ErrorContext) => {

--- a/public/app/features/panel/state/actions.ts
+++ b/public/app/features/panel/state/actions.ts
@@ -1,5 +1,8 @@
 import { type DataTransformerConfig, type FieldConfigSource, getPanelOptionsWithDefaults } from '@grafana/data';
+import { createMonitoringLogger } from '@grafana/runtime';
 import { type PanelModel } from 'app/features/dashboard/state/PanelModel';
+
+const logger = createMonitoringLogger('features.panel');
 import { getLibraryPanel } from 'app/features/library-panels/state/api';
 import { type LibraryElementDTO } from 'app/features/library-panels/types';
 import { getPanelPluginNotFound } from 'app/features/panel/components/PanelPluginError';
@@ -165,7 +168,7 @@ export function loadLibraryPanelAndUpdate(panel: PanelModel): ThunkResult<void> 
 
       await dispatch(initPanelState(panel));
     } catch (ex) {
-      console.log('ERROR: ', ex);
+      logger.logError(ex instanceof Error ? ex : new Error(String(ex)), { context: 'library panel load', uid });
       dispatch(
         panelModelAndPluginReady({
           key: panel.key,

--- a/public/app/features/plugins/admin/state/actions.ts
+++ b/public/app/features/plugins/admin/state/actions.ts
@@ -2,8 +2,10 @@ import { createAction, createAsyncThunk, type Update } from '@reduxjs/toolkit';
 import { from, forkJoin, timeout, lastValueFrom, catchError, of } from 'rxjs';
 
 import { type PanelPlugin, type PluginError } from '@grafana/data';
-import { config, getBackendSrv, isFetchError } from '@grafana/runtime';
+import { config, createMonitoringLogger, getBackendSrv, isFetchError } from '@grafana/runtime';
 import { refetchPanelPluginMetas } from '@grafana/runtime/internal';
+
+const logger = createMonitoringLogger('features.plugins.admin');
 import { importPanelPlugin } from 'app/features/plugins/importPanelPlugin';
 import { type StoreState, type ThunkResult } from 'app/types/store';
 
@@ -121,7 +123,7 @@ export const fetchAll = createAsyncThunk(`${STATE_PREFIX}/fetchAll`, async (_, t
           }
         },
         (error) => {
-          console.log(error);
+          logger.logError(error instanceof Error ? error : new Error(String(error)), { context: 'fetch all plugins' });
           thunkApi.dispatch({ type: `${STATE_PREFIX}/fetchLocal/rejected` });
           thunkApi.dispatch({ type: `${STATE_PREFIX}/fetchRemote/rejected` });
           return thunkApi.rejectWithValue('Unknown error.');

--- a/public/app/features/plugins/loader/utils.ts
+++ b/public/app/features/plugins/loader/utils.ts
@@ -1,9 +1,11 @@
-import { config } from '@grafana/runtime';
+import { config, createMonitoringLogger } from '@grafana/runtime';
 
 import { sandboxPluginDependencies } from '../sandbox/pluginDependencies';
 
 import { SHARED_DEPENDENCY_PREFIX } from './constants';
 import { SystemJS } from './systemjs';
+
+const logger = createMonitoringLogger('features.plugins.loader');
 
 export function buildImportMap(importMap: Record<string, System.Module>) {
   return Object.keys(importMap).reduce<Record<string, string>>((acc, key) => {
@@ -29,7 +31,7 @@ function addPreload(id: string, preload: (() => Promise<System.Module>) | System
   try {
     resolvedId = SystemJS.resolve(id);
   } catch (e) {
-    console.log(e);
+    logger.logError(e instanceof Error ? e : new Error(String(e)), { context: 'SystemJS resolve', moduleId: id });
   }
 
   if (resolvedId && SystemJS.has(resolvedId)) {

--- a/public/app/features/search/service/unified.ts
+++ b/public/app/features/search/service/unified.ts
@@ -14,7 +14,9 @@ import {
   type SelectableValue,
 } from '@grafana/data';
 import { t } from '@grafana/i18n';
-import { config, getBackendSrv } from '@grafana/runtime';
+import { config, createMonitoringLogger, getBackendSrv } from '@grafana/runtime';
+
+const logger = createMonitoringLogger('features.search.unified');
 import { generatedAPI, type ListStarsApiResponse } from 'app/api/clients/collections/v1alpha1';
 import { getAPIBaseURL } from 'app/api/utils';
 import { type TermCount } from 'app/core/components/TagFilter/TagFilter';
@@ -209,7 +211,7 @@ export class UnifiedSearcher implements GrafanaSearcher {
         const resp = await this.fetchResponse(nextPageUrl);
         const frame = toDashboardResults(resp, query.sort ?? '');
         if (!frame) {
-          console.log('no results', frame);
+          logger.logDebug('No results from search', { offset: String(offset) });
           return;
         }
 

--- a/public/app/features/templating/LegacyVariableWrapper.ts
+++ b/public/app/features/templating/LegacyVariableWrapper.ts
@@ -1,7 +1,10 @@
 import { type VariableValue, type FormatVariable } from '@grafana/scenes';
+import { createMonitoringLogger } from '@grafana/runtime';
 import { type VariableModel, type VariableType } from '@grafana/schema';
 
 import { ALL_VARIABLE_TEXT, ALL_VARIABLE_VALUE } from '../variables/constants';
+
+const logger = createMonitoringLogger('features.templating');
 
 export class LegacyVariableWrapper implements FormatVariable {
   state: { name: string; value: VariableValue; text: VariableValue; type: VariableType };
@@ -31,7 +34,7 @@ export class LegacyVariableWrapper implements FormatVariable {
       return text.join(' + ');
     }
 
-    console.log('value', text);
+    logger.logDebug('Unexpected variable text type', { text: String(text), variableName: this.state.name });
     return String(text);
   }
 }

--- a/public/app/features/transformers/spatial/SpatialTransformerEditor.tsx
+++ b/public/app/features/transformers/spatial/SpatialTransformerEditor.tsx
@@ -12,8 +12,11 @@ import {
   TransformerCategory,
 } from '@grafana/data';
 import { t } from '@grafana/i18n';
+import { createMonitoringLogger } from '@grafana/runtime';
 import { FrameGeometrySourceMode } from '@grafana/schema';
 import { useTheme2 } from '@grafana/ui';
+
+const logger = createMonitoringLogger('features.transformers.spatial');
 import { addLocationFields } from 'app/features/geo/editor/locationEditor';
 
 import darkImage from '../images/dark/spatial.svg';
@@ -137,7 +140,7 @@ export const SetGeometryTransformerEditor = (props: Props) => {
     if (!props.options.source?.mode) {
       const opts = getDefaultOptions(supplier);
       props.onChange({ ...opts, ...props.options });
-      console.log('geometry useEffect', opts);
+      logger.logDebug('Applied default geometry options', { mode: opts.source?.mode ?? 'unknown' });
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);

--- a/public/app/plugins/datasource/grafana-testdata-datasource/components/RawFrameEditor.tsx
+++ b/public/app/plugins/datasource/grafana-testdata-datasource/components/RawFrameEditor.tsx
@@ -2,10 +2,12 @@ import { isArray } from 'lodash';
 import { useState } from 'react';
 
 import { dataFrameToJSON, toDataFrame, toDataFrameDTO } from '@grafana/data';
-import { toDataQueryResponse } from '@grafana/runtime';
+import { createMonitoringLogger, toDataQueryResponse } from '@grafana/runtime';
 import { Alert, CodeEditor } from '@grafana/ui';
 
 import { type EditorProps } from '../QueryEditor';
+
+const logger = createMonitoringLogger('datasource.testdata.raw-frame-editor');
 
 export const RawFrameEditor = ({ onChange, query }: EditorProps) => {
   const [error, setError] = useState<string>();
@@ -35,8 +37,7 @@ export const RawFrameEditor = ({ onChange, query }: EditorProps) => {
       }
 
       if (data) {
-        console.log('Original', json);
-        console.log('Save', data);
+        logger.logDebug('Converted raw frame data', { originalType: typeof json, frameCount: data.length });
         setError(undefined);
         setWarning('Converted to direct frame result');
         onChange({ ...query, rawFrameContent: JSON.stringify(data, null, 2) });
@@ -45,7 +46,7 @@ export const RawFrameEditor = ({ onChange, query }: EditorProps) => {
 
       setError('Unable to read dataframes in text');
     } catch (e) {
-      console.log('Error parsing json', e);
+      logger.logError(e instanceof Error ? e : new Error(String(e)), { context: 'JSON parsing' });
       setError('Enter JSON array of data frames (or raw query results body)');
       setWarning(undefined);
     }

--- a/public/app/plugins/datasource/grafana-testdata-datasource/runStreams.ts
+++ b/public/app/plugins/datasource/grafana-testdata-datasource/runStreams.ts
@@ -18,7 +18,9 @@ import {
   getDisplayProcessor,
   createTheme,
 } from '@grafana/data';
-import { getBackendSrv } from '@grafana/runtime';
+import { createMonitoringLogger, getBackendSrv } from '@grafana/runtime';
+
+const logger = createMonitoringLogger('datasource.testdata.streams');
 
 import { getRandomLine } from './LogIpsum';
 import { type TestDataDataQuery, type StreamingQuery } from './dataquery';
@@ -125,7 +127,7 @@ export function runSignalStream(
     setTimeout(pushNextEvent, 5);
 
     return () => {
-      console.log('unsubscribing to stream ' + streamId);
+      logger.logDebug('Unsubscribing from stream', { streamId });
       clearTimeout(timeoutId);
     };
   });
@@ -171,7 +173,7 @@ export function runLogsStream(
     setTimeout(pushNextEvent, 5);
 
     return () => {
-      console.log('unsubscribing to stream ' + streamId);
+      logger.logDebug('Unsubscribing from logs stream', { streamId });
       clearTimeout(timeoutId);
     };
   });
@@ -246,15 +248,15 @@ export function runWatchStream(
             });
         },
         error: (err) => {
-          console.warn('error in stream', streamId, err);
+          logger.logWarning('Error in watch stream', { streamId, error: String(err) });
         },
         complete: () => {
-          console.info('complete stream', streamId);
+          logger.logInfo('Watch stream completed', { streamId });
         },
       });
 
     return () => {
-      console.log('unsubscribing to stream', streamId);
+      logger.logDebug('Unsubscribing from watch stream', { streamId });
       sub.unsubscribe();
     };
   });
@@ -314,7 +316,7 @@ export function runFetchStream(
       });
 
       if (value.done) {
-        console.log('Finished stream');
+        logger.logDebug('Fetch stream completed', { streamId });
         subscriber.complete(); // necessary?
         return;
       }
@@ -334,8 +336,7 @@ export function runFetchStream(
     });
 
     return () => {
-      // Cancel fetch?
-      console.log('unsubscribing to stream ' + streamId);
+      logger.logDebug('Unsubscribing from fetch stream', { streamId });
     };
   });
 }
@@ -368,7 +369,7 @@ export function runTracesStream(
     setTimeout(pushNextEvent, 5);
 
     return () => {
-      console.log('unsubscribing to stream ' + streamId);
+      logger.logDebug('Unsubscribing from trace stream', { streamId });
       clearTimeout(timeoutId);
     };
   });

--- a/public/app/plugins/datasource/loki/shardQuerySplitting.ts
+++ b/public/app/plugins/datasource/loki/shardQuerySplitting.ts
@@ -4,6 +4,7 @@ import { v4 as uuidv4 } from 'uuid';
 
 import { type DataQueryRequest, type DataQueryResponse, LoadingState, type QueryResultMetaStat } from '@grafana/data';
 import { config } from '@grafana/runtime';
+import { createDebugLog } from 'app/core/utils/debugLog';
 
 import { type LokiDatasource } from './datasource';
 import { combineResponses, replaceResponses } from './mergeResponses';
@@ -369,11 +370,4 @@ function getInitialGroupSize(shards: number[]) {
   return Math.floor(Math.sqrt(shards.length));
 }
 
-// Enable to output debugging logs
-const DEBUG_ENABLED = Boolean(localStorage.getItem(`loki.sharding_debug_enabled`));
-function debug(message: string) {
-  if (!DEBUG_ENABLED) {
-    return;
-  }
-  console.log(message);
-}
+const debug = createDebugLog('loki.sharding', 'LokiSharding');

--- a/public/app/plugins/panel/canvas/components/connections/Connections.tsx
+++ b/public/app/plugins/panel/canvas/components/connections/Connections.tsx
@@ -1,8 +1,10 @@
 import * as React from 'react';
 import { BehaviorSubject } from 'rxjs';
 
-import { config } from '@grafana/runtime';
+import { config, createMonitoringLogger } from '@grafana/runtime';
 import { type CanvasConnection, type ConnectionCoordinates, ConnectionPath } from 'app/features/canvas/element';
+
+const logger = createMonitoringLogger('plugins.panel.canvas.connections');
 import { type ElementState } from 'app/features/canvas/runtime/element';
 import { type Scene } from 'app/features/canvas/runtime/scene';
 import { findElementByTarget } from 'app/features/canvas/runtime/sceneElementManagement';
@@ -131,7 +133,7 @@ export class Connections {
     let element: ElementState | undefined = this.findElementTarget(event.target);
 
     if (!element) {
-      console.log('no element');
+      logger.logDebug('No element found at mouse position');
       return;
     }
 
@@ -140,7 +142,7 @@ export class Connections {
     } else {
       this.connectionSource = element;
       if (!this.connectionSource) {
-        console.log('no connection source');
+        logger.logDebug('No connection source available');
         return;
       }
     }

--- a/public/app/plugins/panel/canvas/components/connections/Connections2.tsx
+++ b/public/app/plugins/panel/canvas/components/connections/Connections2.tsx
@@ -1,8 +1,10 @@
 import * as React from 'react';
 import { BehaviorSubject } from 'rxjs';
 
-import { config } from '@grafana/runtime';
+import { config, createMonitoringLogger } from '@grafana/runtime';
 import { type CanvasConnection, type ConnectionCoordinates, ConnectionPath } from 'app/features/canvas/element';
+
+const logger = createMonitoringLogger('plugins.panel.canvas.connections2');
 import { type ElementState } from 'app/features/canvas/runtime/element';
 import { type Scene } from 'app/features/canvas/runtime/scene';
 import { findElementByTarget } from 'app/features/canvas/runtime/sceneElementManagement';
@@ -126,7 +128,7 @@ export class Connections2 {
     let element: ElementState | undefined = this.findElementTarget(event.target);
 
     if (!element) {
-      console.log('no element');
+      logger.logDebug('No element found at mouse position');
       return;
     }
 
@@ -135,7 +137,7 @@ export class Connections2 {
     } else {
       this.connectionSource = element;
       if (!this.connectionSource) {
-        console.log('no connection source');
+        logger.logDebug('No connection source available');
         return;
       }
     }

--- a/public/app/plugins/panel/live/LivePanel.tsx
+++ b/public/app/plugins/panel/live/LivePanel.tsx
@@ -19,8 +19,10 @@ import {
   StreamingDataFrame,
 } from '@grafana/data';
 import { Trans, t } from '@grafana/i18n';
-import { config, getGrafanaLiveSrv } from '@grafana/runtime';
+import { config, createMonitoringLogger, getGrafanaLiveSrv } from '@grafana/runtime';
 import { Alert, stylesFactory, JSONFormatter, CustomScrollbar } from '@grafana/ui';
+
+const logger = createMonitoringLogger('plugins.panel.live');
 
 import { TablePanel } from '../table/TablePanel';
 
@@ -72,7 +74,7 @@ export class LivePanel extends PureComponent<Props, State> {
       } else if (isLiveChannelMessageEvent(event)) {
         this.setState({ message: event.message, changed: Date.now() });
       } else {
-        console.log('ignore', event);
+        logger.logDebug('Ignoring unhandled live channel event', { eventType: typeof event });
       }
     },
   };
@@ -87,7 +89,7 @@ export class LivePanel extends PureComponent<Props, State> {
   async loadChannel() {
     const addr = this.props.options?.channel;
     if (!isValidLiveChannelAddress(addr)) {
-      console.log('INVALID', addr);
+      logger.logDebug('Invalid channel address', { addr: JSON.stringify(addr) });
       this.unsubscribe();
       this.setState({
         addr: undefined,
@@ -96,13 +98,13 @@ export class LivePanel extends PureComponent<Props, State> {
     }
 
     if (isEqual(addr, this.state.addr)) {
-      console.log('Same channel', this.state.addr);
+      logger.logDebug('Channel unchanged, skipping reload', { scope: addr.scope, namespace: addr.namespace ?? '', path: addr.path });
       return;
     }
 
     const live = getGrafanaLiveSrv();
     if (!live) {
-      console.log('INVALID', addr);
+      logger.logWarning('Grafana Live service not available');
       this.unsubscribe();
       this.setState({
         addr: undefined,
@@ -111,7 +113,7 @@ export class LivePanel extends PureComponent<Props, State> {
     }
     this.unsubscribe();
 
-    console.log('LOAD', addr);
+    logger.logDebug('Loading channel', { scope: addr.scope, namespace: addr.namespace ?? '', path: addr.path });
 
     // Subscribe to new events
     try {

--- a/public/app/plugins/panel/live/LivePublish.tsx
+++ b/public/app/plugins/panel/live/LivePublish.tsx
@@ -2,10 +2,12 @@ import { useMemo } from 'react';
 
 import { type LiveChannelAddress, isValidLiveChannelAddress } from '@grafana/data';
 import { Trans } from '@grafana/i18n';
-import { getBackendSrv, getGrafanaLiveSrv } from '@grafana/runtime';
+import { createMonitoringLogger, getBackendSrv, getGrafanaLiveSrv } from '@grafana/runtime';
 import { CodeEditor, Button } from '@grafana/ui';
 
 import { MessagePublishMode } from './types';
+
+const logger = createMonitoringLogger('plugins.panel.live.publish');
 
 interface Props {
   height: number;
@@ -45,8 +47,8 @@ export function LivePublish({ height, mode, body, addr, onSave }: Props) {
       return;
     }
 
-    const rsp = await getGrafanaLiveSrv().publish(addr, body);
-    console.log('onPublishClicked (response from publish)', rsp);
+    await getGrafanaLiveSrv().publish(addr, body);
+    logger.logDebug('Message published', { scope: addr.scope, namespace: addr.namespace ?? '', path: addr.path });
   };
 
   return (

--- a/public/app/plugins/panel/table/migrations.ts
+++ b/public/app/plugins/panel/table/migrations.ts
@@ -12,8 +12,11 @@ import {
   ByNamesMatcherMode,
 } from '@grafana/data';
 import { type ReduceTransformerOptions } from '@grafana/data/internal';
+import { createMonitoringLogger } from '@grafana/runtime';
 
 import { type Options } from './panelcfg.gen';
+
+const logger = createMonitoringLogger('plugins.panel.table');
 
 /**
  * At 7.0, the `table` panel was swapped from an angular implementation to a react one.
@@ -23,7 +26,7 @@ import { type Options } from './panelcfg.gen';
 export const tableMigrationHandler = (panel: PanelModel<Options>): Partial<Options> => {
   // Table was saved as an angular table, lets just swap to the 'table-old' panel
   if (!panel.pluginVersion && 'columns' in panel) {
-    console.log('Was angular table', panel);
+    logger.logInfo('Migrating angular table panel');
   }
 
   // ensure overrides array exists before applying rest of overrides

--- a/public/app/plugins/panel/timeseries/migrations.ts
+++ b/public/app/plugins/panel/timeseries/migrations.ts
@@ -16,6 +16,7 @@ import {
   type Threshold,
   ThresholdsMode,
 } from '@grafana/data';
+import { createMonitoringLogger } from '@grafana/runtime';
 import {
   LegendDisplayMode,
   TooltipDisplayMode,
@@ -34,6 +35,8 @@ import {
   type AnnotationQuery,
   ComparisonOperation,
 } from '@grafana/schema';
+
+const logger = createMonitoringLogger('plugins.panel.timeseries');
 import { type TimeRegionConfig } from 'app/core/utils/timeRegions';
 import { getDashboardSrv } from 'app/features/dashboard/services/DashboardSrv';
 import { getTimeSrv } from 'app/features/dashboard/services/TimeSrv';
@@ -283,7 +286,7 @@ export function graphToTimeseriesOptions(angular: any): {
             });
             break;
           default:
-            console.log('Ignore override migration:', seriesOverride.alias, p, v);
+            logger.logDebug('Ignored override migration', { alias: seriesOverride.alias, property: p, value: String(v) });
         }
       }
       if (dashOverride) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
**What is this feature?**

This PR replaces ad-hoc `console.log` statements throughout the codebase with structured logging using `createMonitoringLogger` from `@grafana/runtime`. This provides consistent, structured logging with integration into Grafana's monitoring infrastructure (Faro).

**Why do we need this feature?**

Scattered `console.log` statements create several problems:
- Inconsistent log formatting across the codebase
- No integration with monitoring/observability infrastructure
- Difficult to filter or analyze logs
- No structured context for debugging

Structured logging via `createMonitoringLogger` provides:
- Consistent log formatting with source identifiers
- Integration with Grafana Faro monitoring
- Structured context objects for better log analysis
- Appropriate log levels (debug, info, warning, error)

**Who is this feature for?**

- Developers debugging Grafana issues
- SRE/Operations teams monitoring Grafana instances
- Contributors maintaining code quality standards

**Which issue(s) does this PR fix?**

N/A - Code quality improvement

**Special notes for your reviewer:**

### Changes by category

**Frontend features:**
- Dashboard init, model, and grid components
- Dashboard-scene page state manager and views
- Explore query state and trace view
- Auth config, panel state, plugins loader
- Live centrifuge channels and services
- Canvas runtime and connections
- Search service, templating, transformers

**Plugins:**
- Testdata datasource streams and frame editor
- Loki shard query splitting (uses `createDebugLog`)
- Live panel and publish components
- Canvas connections
- Table and timeseries migrations

**Core services:**
- Backend service fetch queue
- DAG utilities (uses `createDebugLog`)

**Packages:**
- `@grafana/runtime` config (feature toggle logging - uses `console.info`/`console.warn` with structured prefix)
- `@grafana/prometheus` datasource
- `@grafana/data` LocalStorageValueProvider (uses `console.error` - no runtime dependency)

### Intentionally excluded from changes

- **Test utilities** (`reducerTester`, `thunkTester`, `reduxTester`) - Debug output controlled by test flags
- **Story files** - Storybook interactive examples need console for user interaction
- **Build/script files** - CLI tools appropriately use console
- **BrowseConsoleBackend** - Intentional console output for analytics debugging
- **Sandbox distortions** - Intentional plugin log prefixing mechanism
- **Comments and mock files** - Non-executable code

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c634200b-e3ab-43cf-8277-f0d0b9721428"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c634200b-e3ab-43cf-8277-f0d0b9721428"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

