### PR TITLE
Bookmarks page: categorization and filtering (design scaffold)

### DIFF
--- a/public/app/features/bookmarks/BookmarksPage.tsx
+++ b/public/app/features/bookmarks/BookmarksPage.tsx
@@ -1,31 +1,80 @@
 import { css } from '@emotion/css';
+import { useEffect, useMemo, useState } from 'react';
 
 import { type GrafanaTheme2, type NavModelItem } from '@grafana/data';
 import { Trans, t } from '@grafana/i18n';
 import { EmptyState, useStyles2 } from '@grafana/ui';
 import { usePinnedItems } from 'app/core/components/AppChrome/MegaMenu/hooks';
-import { findByUrl } from 'app/core/components/AppChrome/MegaMenu/utils';
 import { NavLandingPageCard } from 'app/core/components/NavLandingPage/NavLandingPageCard';
 import { Page } from 'app/core/components/Page/Page';
 import { useSelector } from 'app/types/store';
+
+import { BookmarksPageToolbar } from './BookmarksPageToolbar';
+import {
+  ALL_CATEGORIES,
+  bookmarkMatchesCategory,
+  bookmarkMatchesQuery,
+  buildBookmarkList,
+  sortBookmarksBySectionThenTitle,
+} from './utils';
+
+const sectionLabelCollator = new Intl.Collator(undefined, { sensitivity: 'base' });
 
 export function BookmarksPage() {
   const styles = useStyles2(getStyles);
   const pinnedItems = usePinnedItems();
   const navTree = useSelector((state) => state.navBarTree);
 
-  const validItems = pinnedItems.reduce((acc: NavModelItem[], url) => {
-    const item = findByUrl(navTree, url);
-    if (item) {
-      acc.push(item);
+  const [search, setSearch] = useState('');
+  const [selectedCategory, setSelectedCategory] = useState(ALL_CATEGORIES);
+
+  const bookmarks = useMemo(
+    () => buildBookmarkList(navTree, pinnedItems).sort(sortBookmarksBySectionThenTitle),
+    [navTree, pinnedItems]
+  );
+
+  const categoryOptions = useMemo(() => {
+    const seen = new Set<string>();
+    const options: Array<{ value: string; label: string }> = [];
+    for (const { section } of bookmarks) {
+      const value = section.id ?? section.url ?? '';
+      if (!value || seen.has(value)) {
+        continue;
+      }
+      seen.add(value);
+      options.push({ value, label: section.text });
     }
-    return acc;
-  }, []);
+    return options.sort((a, b) => sectionLabelCollator.compare(a.label, b.label));
+  }, [bookmarks]);
+
+  useEffect(() => {
+    if (selectedCategory === ALL_CATEGORIES) {
+      return;
+    }
+    const isValid = categoryOptions.some((o) => o.value === selectedCategory);
+    if (!isValid) {
+      setSelectedCategory(ALL_CATEGORIES);
+    }
+  }, [categoryOptions, selectedCategory]);
+
+  const hasBookmarks = bookmarks.length > 0;
+
+  const visibleBookmarks = useMemo(() => {
+    if (!hasBookmarks) {
+      return [];
+    }
+    return bookmarks.filter(({ item, section }) => {
+      if (!bookmarkMatchesCategory(section, selectedCategory)) {
+        return false;
+      }
+      return bookmarkMatchesQuery(item, section, search);
+    });
+  }, [bookmarks, hasBookmarks, search, selectedCategory]);
 
   return (
     <Page navId="bookmarks">
       <Page.Contents>
-        {validItems.length === 0 ? (
+        {!hasBookmarks ? (
           <EmptyState
             variant="call-to-action"
             message={t('bookmarks-page.empty.message', 'It looks like you haven’t created any bookmarks yet')}
@@ -35,31 +84,110 @@ export function BookmarksPage() {
             </Trans>
           </EmptyState>
         ) : (
-          <section className={styles.grid}>
-            {validItems.map((item) => {
-              return (
-                <NavLandingPageCard
-                  key={item.id || item.url}
-                  description={item.subTitle}
-                  text={item.text}
-                  url={item.url ?? ''}
-                />
-              );
-            })}
-          </section>
+          <div className={styles.layout}>
+            <BookmarksPageToolbar
+              search={search}
+              onSearchChange={setSearch}
+              categoryOptions={categoryOptions}
+              selectedCategory={selectedCategory}
+              onCategoryChange={setSelectedCategory}
+              showCategories
+            />
+            {visibleBookmarks.length === 0 ? (
+              <EmptyState
+                variant="not-found"
+                message={t(
+                  'bookmarks-page.empty-filter.message',
+                  'No bookmarks match your search or filter. Try a different search or category.'
+                )}
+              />
+            ) : (
+              <BookmarkSections bookmarks={visibleBookmarks} />
+            )}
+          </div>
         )}
       </Page.Contents>
     </Page>
   );
 }
 
+function BookmarkSections({ bookmarks }: { bookmarks: Array<{ item: NavModelItem; section: NavModelItem }> }) {
+  const styles = useStyles2(getStyles);
+  const groups = useMemo(() => {
+    const map = new Map<string, { section: NavModelItem; items: NavModelItem[] }>();
+    for (const { item, section } of bookmarks) {
+      const key = section.id ?? section.url ?? section.text;
+      const existing = map.get(key);
+      if (existing) {
+        existing.items.push(item);
+      } else {
+        map.set(key, { section, items: [item] });
+      }
+    }
+    return [...map.values()].sort((a, b) => sectionLabelCollator.compare(a.section.text, b.section.text));
+  }, [bookmarks]);
+
+  return (
+    <div className={styles.sections}>
+      {groups.map(({ section, items }) => (
+        <section key={section.id ?? section.url} className={styles.section} aria-labelledby={sectionHeadingId(section)}>
+          <h2 className={styles.sectionHeading} id={sectionHeadingId(section)}>
+            {section.text}
+          </h2>
+          <div className={styles.grid} role="list">
+            {items.map((item) => (
+              <div className={styles.listItem} key={item.id || item.url} role="listitem">
+                <NavLandingPageCard
+                  description={item.subTitle}
+                  text={item.text}
+                  url={item.url ?? ''}
+                />
+              </div>
+            ))}
+          </div>
+        </section>
+      ))}
+    </div>
+  );
+}
+
+function sectionHeadingId(section: NavModelItem): string {
+  const key = (section.id ?? section.url ?? 'section').replace(/[^a-zA-Z0-9_-]/g, '-');
+  return `bookmarks-section-${key}`;
+}
+
 const getStyles = (theme: GrafanaTheme2) => ({
+  layout: css({
+    display: 'flex',
+    flexDirection: 'column',
+    gap: theme.spacing(2),
+  }),
+  sections: css({
+    display: 'flex',
+    flexDirection: 'column',
+    gap: theme.spacing(3),
+  }),
+  section: css({
+    display: 'flex',
+    flexDirection: 'column',
+    gap: theme.spacing(1.5),
+  }),
+  sectionHeading: css({
+    margin: 0,
+    fontSize: theme.typography.h5.fontSize,
+    fontWeight: theme.typography.fontWeightMedium,
+    lineHeight: theme.typography.h5.lineHeight,
+    color: theme.colors.text.primary,
+  }),
   grid: css({
     display: 'grid',
     gap: theme.spacing(3),
     gridTemplateColumns: 'repeat(auto-fill, minmax(300px, 1fr))',
     gridAutoRows: '138px',
-    padding: theme.spacing(2, 0),
+    padding: theme.spacing(2, 0, 0),
+  }),
+  listItem: css({
+    minWidth: 0,
   }),
 });
 

--- a/public/app/features/bookmarks/BookmarksPage.tsx
+++ b/public/app/features/bookmarks/BookmarksPage.tsx
@@ -137,11 +137,7 @@ function BookmarkSections({ bookmarks }: { bookmarks: Array<{ item: NavModelItem
           <div className={styles.grid} role="list">
             {items.map((item) => (
               <div className={styles.listItem} key={item.id || item.url} role="listitem">
-                <NavLandingPageCard
-                  description={item.subTitle}
-                  text={item.text}
-                  url={item.url ?? ''}
-                />
+                <NavLandingPageCard description={item.subTitle} text={item.text} url={item.url ?? ''} />
               </div>
             ))}
           </div>

--- a/public/app/features/bookmarks/BookmarksPageToolbar.tsx
+++ b/public/app/features/bookmarks/BookmarksPageToolbar.tsx
@@ -1,0 +1,79 @@
+import { css } from '@emotion/css';
+
+import { type GrafanaTheme2 } from '@grafana/data';
+import { t } from '@grafana/i18n';
+import { FilterInput, FilterPill, Stack, useStyles2 } from '@grafana/ui';
+
+import { ALL_CATEGORIES } from './utils';
+
+export interface BookmarksPageToolbarProps {
+  search: string;
+  onSearchChange: (value: string) => void;
+  /** Distinct top-level section labels for pills (e.g. Starred, Dashboards). */
+  categoryOptions: Array<{ value: string; label: string }>;
+  /** `ALL_CATEGORIES` or a section id. */
+  selectedCategory: string;
+  onCategoryChange: (value: string) => void;
+  /** If false, category pills are hidden (no resolved sections). */
+  showCategories: boolean;
+}
+
+export function BookmarksPageToolbar({
+  search,
+  onSearchChange,
+  categoryOptions,
+  selectedCategory,
+  onCategoryChange,
+  showCategories,
+}: BookmarksPageToolbarProps) {
+  const styles = useStyles2(getStyles);
+  const allLabel = t('bookmarks-page.toolbar.filter.category-all', 'All');
+
+  return (
+    <Stack direction="column" gap={1}>
+      <div className={styles.filterRow}>
+        <FilterInput
+          escapeRegex={false}
+          placeholder={t('bookmarks-page.toolbar.search.placeholder', 'Search bookmarks')}
+          value={search}
+          onChange={onSearchChange}
+          aria-label={t('bookmarks-page.toolbar.search.aria-label', 'Search bookmarks')}
+        />
+      </div>
+      {showCategories && categoryOptions.length > 0 && (
+        <div
+          className={styles.pills}
+          role="group"
+          aria-label={t('bookmarks-page.toolbar.filter.category-aria', 'Filter by app section')}
+        >
+          <FilterPill
+            key="all"
+            label={allLabel}
+            selected={selectedCategory === ALL_CATEGORIES}
+            onClick={() => onCategoryChange(ALL_CATEGORIES)}
+          />
+          {categoryOptions.map((opt) => (
+            <FilterPill
+              key={opt.value}
+              label={opt.label}
+              selected={selectedCategory === opt.value}
+              onClick={() => onCategoryChange(opt.value)}
+            />
+          ))}
+        </div>
+      )}
+    </Stack>
+  );
+}
+
+const getStyles = (theme: GrafanaTheme2) => ({
+  filterRow: css({
+    maxWidth: '480px',
+  }),
+  pills: css({
+    display: 'flex',
+    flexWrap: 'wrap',
+    alignItems: 'center',
+    gap: theme.spacing(1),
+  }),
+});

--- a/public/app/features/bookmarks/utils.test.ts
+++ b/public/app/features/bookmarks/utils.test.ts
@@ -1,0 +1,73 @@
+import { type NavModelItem } from '@grafana/data';
+
+import {
+  ALL_CATEGORIES,
+  bookmarkMatchesCategory,
+  bookmarkMatchesQuery,
+  buildBookmarkList,
+  resolveBookmarkInNavTree,
+  sortBookmarksBySectionThenTitle,
+} from './utils';
+
+const tree: NavModelItem[] = [
+  {
+    id: 'bookmarks',
+    text: 'Bookmarks',
+    url: '/bookmarks',
+    children: [
+      { id: 'b1', text: 'Admin duplicate', url: '/admin' },
+    ],
+  },
+  {
+    id: 'config',
+    text: 'Administration',
+    url: '/admin',
+  },
+  {
+    id: 'home',
+    text: 'Home',
+    url: '/',
+  },
+];
+
+describe('bookmarks utils', () => {
+  it('resolveBookmarkInNavTree prefers a match outside the Bookmarks section', () => {
+    const resolved = resolveBookmarkInNavTree(tree, '/admin');
+    expect(resolved?.section.id).toBe('config');
+    expect(resolved?.item.id).toBe('config');
+  });
+
+  it('resolveBookmarkInNavTree falls back to the Bookmarks section', () => {
+    const onlyBookmarks: NavModelItem[] = [
+      { id: 'bookmarks', text: 'Bookmarks', url: '/bookmarks', children: [{ id: 'x', text: 'X', url: '/only' }] },
+    ];
+    const resolved = resolveBookmarkInNavTree(onlyBookmarks, '/only');
+    expect(resolved?.section.id).toBe('bookmarks');
+  });
+
+  it('buildBookmarkList preserves order and skips unknown URLs', () => {
+    const list = buildBookmarkList(tree, ['/', '/nope', '/admin']);
+    expect(list.map((b) => b.item.url)).toEqual(['/', '/admin']);
+  });
+
+  it('sortBookmarksBySectionThenTitle', () => {
+    const a = { item: { text: 'B' } as NavModelItem, section: { id: 's1', text: 'S1' } as NavModelItem };
+    const b = { item: { text: 'A' } as NavModelItem, section: { id: 's2', text: 'S2' } as NavModelItem };
+    expect([b, a].sort(sortBookmarksBySectionThenTitle).map((x) => x.item.text)).toEqual(['B', 'A']);
+  });
+
+  it('bookmarkMatchesQuery', () => {
+    const item = { text: 'My Dashboard' } as NavModelItem;
+    const section = { text: 'Starred' } as NavModelItem;
+    expect(bookmarkMatchesQuery(item, section, 'dash')).toBe(true);
+    expect(bookmarkMatchesQuery(item, section, 'star')).toBe(true);
+    expect(bookmarkMatchesQuery(item, section, 'nope')).toBe(false);
+  });
+
+  it('bookmarkMatchesCategory', () => {
+    const section = { id: 'home', text: 'Home' } as NavModelItem;
+    expect(bookmarkMatchesCategory(section, ALL_CATEGORIES)).toBe(true);
+    expect(bookmarkMatchesCategory(section, 'home')).toBe(true);
+    expect(bookmarkMatchesCategory(section, 'other')).toBe(false);
+  });
+});

--- a/public/app/features/bookmarks/utils.test.ts
+++ b/public/app/features/bookmarks/utils.test.ts
@@ -14,9 +14,7 @@ const tree: NavModelItem[] = [
     id: 'bookmarks',
     text: 'Bookmarks',
     url: '/bookmarks',
-    children: [
-      { id: 'b1', text: 'Admin duplicate', url: '/admin' },
-    ],
+    children: [{ id: 'b1', text: 'Admin duplicate', url: '/admin' }],
   },
   {
     id: 'config',

--- a/public/app/features/bookmarks/utils.ts
+++ b/public/app/features/bookmarks/utils.ts
@@ -1,0 +1,89 @@
+import { type NavModelItem } from '@grafana/data';
+import { findByUrl } from 'app/core/components/AppChrome/MegaMenu/utils';
+
+const bookmarkNameCollator = new Intl.Collator(undefined, { sensitivity: 'base' });
+
+export const BOOKMARKS_SECTION_ID = 'bookmarks';
+
+export interface BookmarkWithSection {
+  item: NavModelItem;
+  section: NavModelItem;
+}
+
+/**
+ * Resolves a bookmark URL to a nav item and the top-level section it belongs to.
+ * Matches outside the "Bookmarks" nav subsection first so pinned items that also
+ * appear as bookmark shortcuts use the same metadata as the rest of the app nav.
+ */
+export function resolveBookmarkInNavTree(
+  topLevel: NavModelItem[],
+  url: string
+): BookmarkWithSection | null {
+  for (const section of topLevel) {
+    if (section.id === BOOKMARKS_SECTION_ID) {
+      continue;
+    }
+    const item = findByUrl([section], url);
+    if (item) {
+      return { item, section };
+    }
+  }
+  const bookmarks = topLevel.find((s) => s.id === BOOKMARKS_SECTION_ID);
+  if (bookmarks) {
+    const item = findByUrl([bookmarks], url);
+    if (item) {
+      return { item, section: bookmarks };
+    }
+  }
+  return null;
+}
+
+export function buildBookmarkList(navTree: NavModelItem[], bookmarkUrls: string[]): BookmarkWithSection[] {
+  return bookmarkUrls.reduce<BookmarkWithSection[]>((acc, url) => {
+    const resolved = resolveBookmarkInNavTree(navTree, url);
+    if (resolved) {
+      acc.push(resolved);
+    }
+    return acc;
+  }, []);
+}
+
+const normalizeSearch = (value: string) => value.trim().toLowerCase();
+
+/**
+ * True if the bookmark matches the search string on title, subtitle, or section label.
+ */
+export function bookmarkMatchesQuery(item: NavModelItem, section: NavModelItem, search: string): boolean {
+  if (!search) {
+    return true;
+  }
+  const q = normalizeSearch(search);
+  const inText = normalizeSearch(item.text).includes(q);
+  const inSub = item.subTitle ? normalizeSearch(item.subTitle).includes(q) : false;
+  const inSection = normalizeSearch(section.text).includes(q);
+  return inText || inSub || inSection;
+}
+
+export const ALL_CATEGORIES = '__all__';
+
+/**
+ * @param sectionId - `ALL_CATEGORIES` for no filter, otherwise `NavModelItem.id` (or url fallback) of the top-level section.
+ */
+export function bookmarkMatchesCategory(
+  section: NavModelItem,
+  sectionId: string
+): boolean {
+  if (sectionId === ALL_CATEGORIES) {
+    return true;
+  }
+  const id = section.id ?? section.url ?? '';
+  return id === sectionId;
+}
+
+export function sortBookmarksBySectionThenTitle(a: BookmarkWithSection, b: BookmarkWithSection): number {
+  const bySection = bookmarkNameCollator.compare(a.section.text, b.section.text);
+  if (bySection !== 0) {
+    return bySection;
+  }
+  return bookmarkNameCollator.compare(a.item.text, b.item.text);
+}

--- a/public/app/features/bookmarks/utils.ts
+++ b/public/app/features/bookmarks/utils.ts
@@ -15,10 +15,7 @@ export interface BookmarkWithSection {
  * Matches outside the "Bookmarks" nav subsection first so pinned items that also
  * appear as bookmark shortcuts use the same metadata as the rest of the app nav.
  */
-export function resolveBookmarkInNavTree(
-  topLevel: NavModelItem[],
-  url: string
-): BookmarkWithSection | null {
+export function resolveBookmarkInNavTree(topLevel: NavModelItem[], url: string): BookmarkWithSection | null {
   for (const section of topLevel) {
     if (section.id === BOOKMARKS_SECTION_ID) {
       continue;
@@ -69,10 +66,7 @@ export const ALL_CATEGORIES = '__all__';
 /**
  * @param sectionId - `ALL_CATEGORIES` for no filter, otherwise `NavModelItem.id` (or url fallback) of the top-level section.
  */
-export function bookmarkMatchesCategory(
-  section: NavModelItem,
-  sectionId: string
-): boolean {
+export function bookmarkMatchesCategory(section: NavModelItem, sectionId: string): boolean {
   if (sectionId === ALL_CATEGORIES) {
     return true;
   }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Scaffolds the Bookmarks page UX for **derived categorization** (by top-level nav section) and **filtering** (search + section pills), reusing existing Grafana UI patterns.

## UI patterns used
- **FilterInput** + flexible toolbar row, aligned with `RichHistoryStarredTab` / Rich History.
- **FilterPill** for "All" + one pill per top-level section (see also Trace filter pills / transformation picker).
- **Stack** for vertical spacing; **useStyles2** + **theme** tokens (`spacing`, `typography.h5`, `colors.text`) for the section headings and layout.
- **EmptyState** `variant="not-found"` when search/filter yields no matches; existing CTA empty state when there are no bookmarks.
- **NavLandingPageCard** unchanged; grid spacing matches `NavLandingPage` (300px min column, 138px row).

## Files
- `public/app/features/bookmarks/BookmarksPage.tsx` — state, resolution, grouped sections, filtered list.
- `public/app/features/bookmarks/BookmarksPageToolbar.tsx` — search + category pills.
- `public/app/features/bookmarks/utils.ts` — `resolveBookmarkInNavTree` (prefer match outside `bookmarks` section), search/category helpers, `Intl.Collator` sorts.
- `public/app/features/bookmarks/utils.test.ts` — unit tests for resolution and matching.

## Follow-ups (if needed)
- E2E for `/bookmarks` filter flow.
- `reportInteraction` for filter usage.
- Design polish: responsive pill wrapping (already `flex-wrap`), optional URL query for filter state.

## CI fix
- Applied Prettier to new bookmark files so `yarn prettier:check` passes in Fieldsphere CI.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-298c8b7d-7fe3-47e9-822b-f64837df4946"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-298c8b7d-7fe3-47e9-822b-f64837df4946"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

