### PR TITLE
feat(frontend): structured app logging and console migration

### DIFF
--- a/packages/grafana-alerting/src/grafana/notificationPolicies/components/RoutingTreeSelector/RoutingTreeSelector.tsx
+++ b/packages/grafana-alerting/src/grafana/notificationPolicies/components/RoutingTreeSelector/RoutingTreeSelector.tsx
@@ -1,23 +1,20 @@
+import { structLog } from '@grafana/data';
 import { type ComponentProps, useMemo } from 'react';
-
 import { type RoutingTree } from '@grafana/api-clients/rtkq/notifications.alerting/v0alpha1';
 import { t } from '@grafana/i18n';
 import { Alert, Combobox, type ComboboxOption, MultiCombobox } from '@grafana/ui';
-
 import { type CustomComboBoxProps } from '../../../common/ComboBox.types';
 import { USER_DEFINED_TREE_NAME } from '../../consts';
 import { useListRoutingTrees } from '../../hooks/useRoutingTrees';
-
 const collator = new Intl.Collator('en', { sensitivity: 'accent' });
-
-type SingleSelectProps = CustomComboBoxProps<RoutingTree> & { multi?: false };
+type SingleSelectProps = CustomComboBoxProps<RoutingTree> & {
+  multi?: false;
+};
 type MultiSelectProps = Omit<ComponentProps<typeof MultiCombobox<string>>, 'options' | 'loading' | 'onChange'> & {
   multi: true;
   onChange: (trees: RoutingTree[]) => void;
 };
-
 export type RoutingTreeSelectorProps = SingleSelectProps | MultiSelectProps;
-
 /**
  * Routing Tree Combobox which lists all available notification policy trees.
  *
@@ -52,25 +49,24 @@ function RoutingTreeSelector(props: RoutingTreeSelectorProps) {
     isLoading,
     isError,
   } = useListRoutingTrees({}, { refetchOnFocus: true, refetchOnMountOrArgChange: true });
-
   // Build a lookup map from option value → RoutingTree for resolving onChange
   const { options, treeLookup } = useMemo(() => {
     if (!routingTrees?.items) {
-      const empty: { options: Array<ComboboxOption<string>>; treeLookup: Map<string, RoutingTree> } = {
+      const empty: {
+        options: Array<ComboboxOption<string>>;
+        treeLookup: Map<string, RoutingTree>;
+      } = {
         options: [],
         treeLookup: new Map(),
       };
       return empty;
     }
-
     const lookup = new Map<string, RoutingTree>();
     const opts: Array<ComboboxOption<string>> = routingTrees.items
       .map((tree) => {
         const name = tree.metadata.name ?? '';
         const isDefault = name === USER_DEFINED_TREE_NAME;
-
         lookup.set(name, tree);
-
         return {
           label: isDefault ? t('alerting.routing-tree-selector.default-policy', 'Default policy') : name,
           value: name,
@@ -94,10 +90,8 @@ function RoutingTreeSelector(props: RoutingTreeSelectorProps) {
         }
         return collator.compare(a.label, b.label);
       });
-
     return { options: opts, treeLookup: lookup };
   }, [routingTrees?.items]);
-
   if (isError) {
     return (
       <Alert
@@ -106,39 +100,31 @@ function RoutingTreeSelector(props: RoutingTreeSelectorProps) {
       />
     );
   }
-
   if (props.multi) {
     const { multi: _, onChange, ...rest } = props;
-
     const handleChange = (selectedOptions: Array<ComboboxOption<string>>) => {
       const trees = selectedOptions
         .map((opt) => treeLookup.get(opt.value))
         .filter((tree): tree is RoutingTree => tree != null);
       onChange(trees);
     };
-
     // @ts-expect-error TypeScript cannot narrow rest-spread from discriminated unions with conditional width types
     return <MultiCombobox {...rest} loading={isLoading} options={options} onChange={handleChange} />;
   }
-
   const handleChange = (selectedOption: ComboboxOption<string> | null) => {
     if (selectedOption == null && props.isClearable) {
       props.onChange(null);
       return;
     }
-
     if (selectedOption) {
       const tree = treeLookup.get(selectedOption.value);
       if (!tree) {
-        console.warn(`RoutingTreeSelector: could not find routing tree for value "${selectedOption.value}"`);
+        structLog('warn', `RoutingTreeSelector: could not find routing tree for value "${selectedOption.value}"`);
         return;
       }
-
       props.onChange(tree);
     }
   };
-
   return <Combobox {...props} loading={isLoading} options={options} onChange={handleChange} />;
 }
-
 export { RoutingTreeSelector };

--- a/packages/grafana-api-clients/src/generator/helpers.ts
+++ b/packages/grafana-api-clients/src/generator/helpers.ts
@@ -1,13 +1,12 @@
+import { structLog } from '@grafana/data';
 import { execSync } from 'child_process';
 import fs from 'fs';
 import { type OpenAPIV3 } from 'openapi-types';
 import path from 'path';
-
 type PlopActionFunction = (
   answers: Record<string, unknown>,
   config?: Record<string, unknown>
 ) => string | Promise<string>;
-
 // Helper to remove quotes from operation IDs
 export const removeQuotes = (str: string | unknown) => {
   if (typeof str !== 'string') {
@@ -15,25 +14,20 @@ export const removeQuotes = (str: string | unknown) => {
   }
   return str.replace(/^['"](.*)['"]$/, '$1');
 };
-
 export const formatEndpoints = () => (endpointsInput: string | string[]) => {
   if (Array.isArray(endpointsInput)) {
     return endpointsInput.map((op) => `'${removeQuotes(op)}'`).join(', ');
   }
-
   // Handle string input (comma-separated)
   if (typeof endpointsInput === 'string') {
     const endpointsArray = endpointsInput
       .split(',')
       .map((id) => id.trim())
       .filter(Boolean);
-
     return endpointsArray.map((op) => `'${removeQuotes(op)}'`).join(', ');
   }
-
   return '';
 };
-
 // List of created or modified files
 export const getFilesToFormat = (groupName: string, version: string, isEnterprise = false) => {
   const apiClientBasePath = isEnterprise
@@ -42,7 +36,6 @@ export const getFilesToFormat = (groupName: string, version: string, isEnterpris
   const generateScriptPath = isEnterprise
     ? 'local/generate-enterprise-apis.ts'
     : 'packages/grafana-api-clients/src/scripts/generate-rtk-apis.ts';
-
   return [
     `${apiClientBasePath}/${groupName}/${version}/baseAPI.ts`,
     `${apiClientBasePath}/${groupName}/${version}/index.ts`,
@@ -56,13 +49,11 @@ export const getFilesToFormat = (groupName: string, version: string, isEnterpris
         ]),
   ];
 };
-
 export const runGenerateApis =
   (basePath: string): PlopActionFunction =>
   (answers, config) => {
     try {
       const isEnterprise = answers.isEnterprise || (config && config.isEnterprise);
-
       let command;
       if (isEnterprise) {
         command =
@@ -70,76 +61,63 @@ export const runGenerateApis =
       } else {
         command = 'yarn workspace @grafana/api-clients generate-apis';
       }
-
-      console.log(`⏳ Running ${command} to generate endpoints...`);
+      structLog('log', `⏳ Running ${command} to generate endpoints...`);
       execSync(command, { stdio: 'inherit', cwd: basePath });
       return '✅ API endpoints generated successfully!';
     } catch (error) {
       const errorMessage = error instanceof Error ? error.message : String(error);
-      console.error('❌ Failed to generate API endpoints:', errorMessage);
+      structLog('error', '❌ Failed to generate API endpoints:', errorMessage);
       return '❌ Failed to generate API endpoints. See error above.';
     }
   };
-
 export const formatFiles =
   (basePath: string): PlopActionFunction =>
   (_, config) => {
     if (!config || !Array.isArray(config.files)) {
-      console.error('Invalid config passed to formatFiles action');
+      structLog('error', 'Invalid config passed to formatFiles action');
       return '❌ Formatting failed: Invalid configuration';
     }
-
     const filesToFormat = config.files.map((file: string) => path.join(basePath, file));
-
     try {
       const filesList = filesToFormat.map((file: string) => `"${file}"`).join(' ');
-
-      console.log('🧹 Running ESLint on generated/modified files...');
+      structLog('log', '🧹 Running ESLint on generated/modified files...');
       try {
         execSync(`yarn eslint --fix ${filesList}`, { cwd: basePath });
       } catch (error) {
         const errorMessage = error instanceof Error ? error.message : String(error);
-        console.warn(`⚠️ Warning: ESLint encountered issues: ${errorMessage}`);
+        structLog('warn', `⚠️ Warning: ESLint encountered issues: ${errorMessage}`);
       }
-
-      console.log('🧹 Running Prettier on generated/modified files...');
+      structLog('log', '🧹 Running Prettier on generated/modified files...');
       try {
         // '--ignore-path' is necessary so the gitignored files ('local/' folder) can still be formatted
         execSync(`yarn prettier --write ${filesList} --ignore-path=./.prettierignore`, { cwd: basePath });
       } catch (error) {
         const errorMessage = error instanceof Error ? error.message : String(error);
-        console.warn(`⚠️ Warning: Prettier encountered issues: ${errorMessage}`);
+        structLog('warn', `⚠️ Warning: Prettier encountered issues: ${errorMessage}`);
       }
-
       return '✅ Files linted and formatted successfully!';
     } catch (error) {
       const errorMessage = error instanceof Error ? error.message : String(error);
-      console.error('⚠️ Warning: Formatting operations failed:', errorMessage);
+      structLog('error', '⚠️ Warning: Formatting operations failed:', errorMessage);
       return '⚠️ Warning: Formatting operations failed.';
     }
   };
-
 export const validateGroup = (group: string) => {
   return group && group.includes('.grafana.app') ? true : 'Group should be in format: name.grafana.app';
 };
-
 export const validateVersion = (version: string) => {
   return version && /^v\d+[a-z]*\d+$/.test(version) ? true : 'Version should be in format: v0alpha1, v1beta2, etc.';
 };
-
 export const updatePackageJsonExports =
   (basePath: string): PlopActionFunction =>
   (answers) => {
     try {
       const { groupName, version } = answers;
-
       if (!groupName || !version) {
         return '❌ Missing groupName or version for package.json update';
       }
-
       const packageJsonPath = path.join(basePath, 'packages/grafana-api-clients/package.json');
       const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8'));
-
       // Create the new export entry
       const newExportKey = `./rtkq/${groupName}/${version}`;
       const newExportValue = {
@@ -148,26 +126,21 @@ export const updatePackageJsonExports =
         import: `./dist/esm/clients/rtkq/${groupName}/${version}/index.mjs`,
         require: `./dist/cjs/clients/rtkq/${groupName}/${version}/index.cjs`,
       };
-
       // Check if export already exists
       if (packageJson.exports[newExportKey]) {
         return `✅ Export for ${newExportKey} already exists in package.json`;
       }
-
       // Add the new export entry
       packageJson.exports[newExportKey] = newExportValue;
-
       // Write the updated package.json back to file
       fs.writeFileSync(packageJsonPath, JSON.stringify(packageJson, null, 2) + '\n');
-
       return `✅ Added export for ${newExportKey} to package.json`;
     } catch (error) {
       const errorMessage = error instanceof Error ? error.message : String(error);
-      console.error('❌ Failed to update package.json exports:', errorMessage);
+      structLog('error', '❌ Failed to update package.json exports:', errorMessage);
       return '❌ Failed to update package.json exports. See error above.';
     }
   };
-
 /**
  * TODO: Make this work more generically with endpoints that don't have operationIds defined -
  * then we can allow selection of endpoints in the generator

--- a/packages/grafana-data/package.json
+++ b/packages/grafana-data/package.json
@@ -30,6 +30,9 @@
       "import": "./dist/esm/unstable.mjs",
       "require": "./dist/cjs/unstable.cjs"
     },
+    "./structLog": {
+      "@grafana-app/source": "./src/utils/structLogBase.ts"
+    },
     "./internal": {
       "@grafana-app/source": "./src/internal/index.ts"
     },

--- a/packages/grafana-data/scripts/generateSchema.ts
+++ b/packages/grafana-data/scripts/generateSchema.ts
@@ -1,13 +1,11 @@
+import { structLog } from '../src/utils/structLogBase';
 import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
-
 import { NewThemeOptionsSchema } from '../src/themes/createTheme';
-
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const jsonOut = path.join(__dirname, '..', 'src', 'themes', 'schema.generated.json');
-
 fs.writeFileSync(
   jsonOut,
   JSON.stringify(
@@ -18,5 +16,4 @@ fs.writeFileSync(
     2
   )
 );
-
-console.log('Successfully generated theme schema');
+structLog('log', 'Successfully generated theme schema');

--- a/packages/grafana-data/src/dataframe/FieldCache.ts
+++ b/packages/grafana-data/src/dataframe/FieldCache.ts
@@ -1,23 +1,22 @@
+import { structLog } from '../utils/structLog';
 import { type DataFrame, type Field, FieldType } from '../types/dataFrame';
-
 import { guessFieldTypeForField } from './processDataFrame';
-
 export interface FieldWithIndex extends Field {
   index: number;
 }
-
 export class FieldCache {
   fields: FieldWithIndex[] = [];
-
-  private fieldByName: { [key: string]: FieldWithIndex } = {};
-  private fieldByType: { [key: string]: FieldWithIndex[] } = {};
-
+  private fieldByName: {
+    [key: string]: FieldWithIndex;
+  } = {};
+  private fieldByType: {
+    [key: string]: FieldWithIndex[];
+  } = {};
   constructor(data: DataFrame) {
     this.fields = data.fields.map((field, idx) => ({
       ...field,
       index: idx,
     }));
-
     for (let i = 0; i < data.fields.length; i++) {
       const field = data.fields[i];
       // Make sure it has a type
@@ -34,15 +33,13 @@ export class FieldCache {
         ...field,
         index: i,
       });
-
       if (this.fieldByName[field.name]) {
-        console.warn('Duplicate field names in DataFrame: ', field.name);
+        structLog('warn', 'Duplicate field names in DataFrame: ', field.name);
       } else {
         this.fieldByName[field.name] = { ...field, index: i };
       }
     }
   }
-
   getFields(type?: FieldType): FieldWithIndex[] {
     if (!type) {
       return [...this.fields]; // All fields
@@ -53,33 +50,27 @@ export class FieldCache {
     }
     return [];
   }
-
   hasFieldOfType(type: FieldType): boolean {
     const types = this.fieldByType[type];
     return types && types.length > 0;
   }
-
   getFirstFieldOfType(type: FieldType, includeHidden = false): FieldWithIndex | undefined {
     const fields = this.fieldByType[type];
     const firstField = fields?.find((field) => includeHidden || !field.config.custom?.hidden);
     return firstField;
   }
-
   hasFieldNamed(name: string): boolean {
     return !!this.fieldByName[name];
   }
-
   hasFieldWithNameAndType(name: string, type: FieldType): boolean {
     return !!this.fieldByName[name] && this.fieldByType[type].filter((field) => field.name === name).length > 0;
   }
-
   /**
    * Returns the first field with the given name.
    */
   getFieldByName(name: string): FieldWithIndex | undefined {
     return this.fieldByName[name];
   }
-
   /**
    * Returns the fields with the given label.
    */

--- a/packages/grafana-data/src/dataframe/processDataFrame.ts
+++ b/packages/grafana-data/src/dataframe/processDataFrame.ts
@@ -1,6 +1,6 @@
+import { structLog } from '../utils/structLog';
 // Libraries
 import { isArray, isBoolean, isNumber, isString } from 'lodash';
-
 import { isDateTime } from '../datetime/moment_wrapper';
 import { fieldIndexComparer } from '../field/fieldComparers';
 import { getFieldDisplayName } from '../field/fieldState';
@@ -19,14 +19,14 @@ import {
 import { type DataQueryResponseData } from '../types/datasource';
 import { type GraphSeriesXY, type GraphSeriesValue } from '../types/graph';
 import { type PanelData } from '../types/panel';
-
 import { arrayToDataFrame } from './ArrayDataFrame';
 import { dataFrameFromJSON } from './DataFrameJSON';
-
 function convertTableToDataFrame(table: TableData): DataFrame {
   const fields = table.columns.map((c) => {
     // TODO: should be Column but type does not exists there so not sure whats up here.
-    const { text, type, ...disp } = c as Column & { type?: FieldType };
+    const { text, type, ...disp } = c as Column & {
+      type?: FieldType;
+    };
     const values: unknown[] = [];
     return {
       name: text ?? c, // rename 'text' to the 'name' field
@@ -35,17 +35,14 @@ function convertTableToDataFrame(table: TableData): DataFrame {
       type: type && Object.values(FieldType).includes(type) ? type : FieldType.other,
     };
   });
-
   if (!isArray(table.rows)) {
     throw new Error(`Expected table rows to be array, got ${typeof table.rows}.`);
   }
-
   for (const row of table.rows) {
     for (let i = 0; i < fields.length; i++) {
       fields[i].values.push(row[i]);
     }
   }
-
   for (const f of fields) {
     if (f.type === FieldType.other) {
       const t = guessFieldTypeForField(f);
@@ -54,7 +51,6 @@ function convertTableToDataFrame(table: TableData): DataFrame {
       }
     }
   }
-
   return {
     fields,
     refId: table.refId,
@@ -63,18 +59,15 @@ function convertTableToDataFrame(table: TableData): DataFrame {
     length: table.rows.length,
   };
 }
-
 function convertTimeSeriesToDataFrame(timeSeries: TimeSeries): DataFrame {
   const times: number[] = [];
   const values: TimeSeriesValue[] = [];
-
   // Sometimes the points are sent as datapoints
   const points = timeSeries.datapoints || (timeSeries as any).points;
   for (const point of points) {
     values.push(point[0]);
     times.push(point[1] as number);
   }
-
   const fields = [
     {
       name: TIME_SERIES_TIME_FIELD_NAME,
@@ -92,11 +85,9 @@ function convertTimeSeriesToDataFrame(timeSeries: TimeSeries): DataFrame {
       labels: timeSeries.tags,
     },
   ];
-
   if (timeSeries.title) {
     (fields[1].config as FieldConfig).displayNameFromDS = timeSeries.title;
   }
-
   return {
     name: timeSeries.target || (timeSeries as any).name,
     refId: timeSeries.refId,
@@ -105,7 +96,6 @@ function convertTimeSeriesToDataFrame(timeSeries: TimeSeries): DataFrame {
     length: values.length,
   };
 }
-
 /**
  * This is added temporarily while we convert the LogsModel
  * to DataFrame.  See: https://github.com/grafana/grafana/issues/18528
@@ -113,13 +103,11 @@ function convertTimeSeriesToDataFrame(timeSeries: TimeSeries): DataFrame {
 function convertGraphSeriesToDataFrame(graphSeries: GraphSeriesXY): DataFrame {
   const x: GraphSeriesValue[] = [];
   const y: GraphSeriesValue[] = [];
-
   for (let i = 0; i < graphSeries.data.length; i++) {
     const row = graphSeries.data[i];
     x.push(row[1]);
     y.push(row[0]);
   }
-
   return {
     name: graphSeries.label,
     fields: [
@@ -141,7 +129,6 @@ function convertGraphSeriesToDataFrame(graphSeries: GraphSeriesXY): DataFrame {
     length: x.length,
   };
 }
-
 function convertJSONDocumentDataToDataFrame(timeSeries: TimeSeries): DataFrame {
   const fields: Field[] = [
     {
@@ -155,11 +142,9 @@ function convertJSONDocumentDataToDataFrame(timeSeries: TimeSeries): DataFrame {
       values: [],
     },
   ];
-
   for (const point of timeSeries.datapoints) {
     fields[0].values.push(point);
   }
-
   return {
     name: timeSeries.target,
     refId: timeSeries.target,
@@ -168,11 +153,9 @@ function convertJSONDocumentDataToDataFrame(timeSeries: TimeSeries): DataFrame {
     length: timeSeries.datapoints.length,
   };
 }
-
 // PapaParse Dynamic Typing regex:
 // https://github.com/mholt/PapaParse/blob/master/papaparse.js#L998
 const NUMBER = /^\s*(-?(\d*\.?\d+|\d+\.?\d*)(e[-+]?\d+)?|NAN)\s*$/i;
-
 /**
  * Given a name and value, this will pick a reasonable field type
  */
@@ -185,7 +168,6 @@ export function guessFieldTypeFromNameAndValue(name: string, v: unknown): FieldT
   }
   return guessFieldTypeFromValue(v);
 }
-
 /**
  * Check the field type to see what the contents are
  */
@@ -193,22 +175,17 @@ export function getFieldTypeFromValue(v: unknown): FieldType {
   if (v instanceof Date || isDateTime(v)) {
     return FieldType.time;
   }
-
   if (isNumber(v)) {
     return FieldType.number;
   }
-
   if (isString(v)) {
     return FieldType.string;
   }
-
   if (isBoolean(v)) {
     return FieldType.boolean;
   }
-
   return FieldType.other;
 }
-
 /**
  * Given a value this will guess the best column type
  *
@@ -218,30 +195,23 @@ export function guessFieldTypeFromValue(v: unknown): FieldType {
   if (v instanceof Date || isDateTime(v)) {
     return FieldType.time;
   }
-
   if (isNumber(v)) {
     return FieldType.number;
   }
-
   if (isString(v)) {
     if (NUMBER.test(v)) {
       return FieldType.number;
     }
-
     if (v === 'true' || v === 'TRUE' || v === 'True' || v === 'false' || v === 'FALSE' || v === 'False') {
       return FieldType.boolean;
     }
-
     return FieldType.string;
   }
-
   if (isBoolean(v)) {
     return FieldType.boolean;
   }
-
   return FieldType.other;
 }
-
 /**
  * Looks at the data to guess the column type.  This ignores any existing setting
  */
@@ -253,7 +223,6 @@ export function guessFieldTypeForField(field: Field): FieldType | undefined {
       return FieldType.time;
     }
   }
-
   // 2. Check the first non-null value
   for (let i = 0; i < field.values.length; i++) {
     const v = field.values[i];
@@ -261,11 +230,9 @@ export function guessFieldTypeForField(field: Field): FieldType | undefined {
       return guessFieldTypeFromValue(v);
     }
   }
-
   // Could not find anything
   return undefined;
 }
-
 /**
  * @returns A copy of the series with the best guess for each field type.
  * If the series already has field types defined, they will be used, unless `guessDefined` is true.
@@ -294,14 +261,10 @@ export const guessFieldTypes = (series: DataFrame, guessDefined = false): DataFr
   // No changes necessary
   return series;
 };
-
 export const isTableData = (data: unknown): data is DataFrame => Boolean(data && data.hasOwnProperty('columns'));
-
 export const isDataFrame = (data: unknown): data is DataFrame => Boolean(data && data.hasOwnProperty('fields'));
-
 export const isDataFrameWithValue = (data: unknown): data is DataFrameWithValue =>
   Boolean(isDataFrame(data) && data.hasOwnProperty('value'));
-
 /**
  * Inspect any object and return the results as a DataFrame
  */
@@ -311,52 +274,41 @@ export function toDataFrame(data: any): DataFrame {
     if ('length' in data && data.fields[0]?.values) {
       return data;
     }
-
     // This will convert the array values into Vectors
     return createDataFrame(data);
   }
-
   // Handle legacy docs/json type
   if (data.hasOwnProperty('type') && data.type === 'docs') {
     return convertJSONDocumentDataToDataFrame(data);
   }
-
   if (data.hasOwnProperty('datapoints') || data.hasOwnProperty('points')) {
     return convertTimeSeriesToDataFrame(data);
   }
-
   if (data.hasOwnProperty('data')) {
     if (data.hasOwnProperty('schema')) {
       return dataFrameFromJSON(data);
     }
     return convertGraphSeriesToDataFrame(data);
   }
-
   if (data.hasOwnProperty('columns')) {
     return convertTableToDataFrame(data);
   }
-
   if (Array.isArray(data)) {
     return arrayToDataFrame(data);
   }
-
-  console.warn('Can not convert', data);
+  structLog('warn', 'Can not convert', data);
   throw new Error('Unsupported data format');
 }
-
 export const toLegacyResponseData = (frame: DataFrame): TimeSeries | TableData => {
   const { fields } = frame;
-
   const rowCount = frame.length;
   const rows: unknown[][] = [];
-
   if (fields.length === 2) {
     const { timeField, timeIndex } = getTimeField(frame);
     if (timeField) {
       const valueIndex = timeIndex === 0 ? 1 : 0;
       const valueField = fields[valueIndex];
       const timeField = fields[timeIndex!];
-
       // Make sure it is [value,time]
       for (let i = 0; i < rowCount; i++) {
         rows.push([
@@ -364,7 +316,6 @@ export const toLegacyResponseData = (frame: DataFrame): TimeSeries | TableData =
           timeField.values[i], // time
         ]);
       }
-
       return {
         alias: frame.name,
         target: getFieldDisplayName(valueField, frame),
@@ -375,7 +326,6 @@ export const toLegacyResponseData = (frame: DataFrame): TimeSeries | TableData =
       } as TimeSeries;
     }
   }
-
   for (let i = 0; i < rowCount; i++) {
     const row: unknown[] = [];
     for (let j = 0; j < fields.length; j++) {
@@ -383,7 +333,6 @@ export const toLegacyResponseData = (frame: DataFrame): TimeSeries | TableData =
     }
     rows.push(row);
   }
-
   if (frame.meta && frame.meta.json) {
     return {
       alias: fields[0].name || frame.name,
@@ -393,7 +342,6 @@ export const toLegacyResponseData = (frame: DataFrame): TimeSeries | TableData =
       type: 'docs',
     } as TimeSeries;
   }
-
   return {
     columns: fields.map((f) => {
       const { name, config } = f;
@@ -412,32 +360,26 @@ export const toLegacyResponseData = (frame: DataFrame): TimeSeries | TableData =
     rows,
   };
 };
-
 export function sortDataFrame(data: DataFrame, sortIndex?: number, reverse = false): DataFrame {
   const field = data.fields[sortIndex!];
   if (!field) {
     return data;
   }
-
   // Natural order
   const index: number[] = [];
   for (let i = 0; i < data.length; i++) {
     index.push(i);
   }
-
   const fieldComparer = fieldIndexComparer(field, reverse);
   index.sort(fieldComparer);
-
   return {
     ...data,
     fields: data.fields.map((field) => {
       const newValues = Array.from({ length: field.values.length }, (_, i) => field.values[index[i]]);
-
       const newField = {
         ...field,
         values: newValues,
       };
-
       // only add .nanos if it exists
       const { nanos } = field;
       if (nanos !== undefined) {
@@ -447,7 +389,6 @@ export function sortDataFrame(data: DataFrame, sortIndex?: number, reverse = fal
     }),
   };
 }
-
 /**
  * Returns a copy with all values reversed
  */
@@ -457,12 +398,10 @@ export function reverseDataFrame(data: DataFrame): DataFrame {
     fields: data.fields.map((f) => {
       const values = [...f.values];
       values.reverse();
-
       const newF = {
         ...f,
         values,
       };
-
       // only add .nanos if it exists
       const { nanos } = f;
       if (nanos !== undefined) {
@@ -474,7 +413,6 @@ export function reverseDataFrame(data: DataFrame): DataFrame {
     }),
   };
 }
-
 /**
  * Wrapper to get an array from each field value
  */
@@ -485,14 +423,12 @@ export function getDataFrameRow(data: DataFrame, row: number): unknown[] {
   }
   return values;
 }
-
 /**
  * Returns a copy that does not include functions
  */
 export function toDataFrameDTO(data: DataFrame): DataFrameDTO {
   return toFilteredDataFrameDTO(data);
 }
-
 export function toFilteredDataFrameDTO(data: DataFrame, fieldPredicate?: (f: Field) => boolean): DataFrameDTO {
   const filteredFields = fieldPredicate ? data.fields.filter(fieldPredicate) : data.fields;
   const fields: FieldDTO[] = filteredFields.map((f) => {
@@ -505,7 +441,6 @@ export function toFilteredDataFrameDTO(data: DataFrame, fieldPredicate?: (f: Fie
       labels: f.labels,
     };
   });
-
   return {
     fields,
     refId: data.refId,
@@ -513,8 +448,12 @@ export function toFilteredDataFrameDTO(data: DataFrame, fieldPredicate?: (f: Fie
     name: data.name,
   };
 }
-
-export const getTimeField = (series: DataFrame): { timeField?: Field; timeIndex?: number } => {
+export const getTimeField = (
+  series: DataFrame
+): {
+  timeField?: Field;
+  timeIndex?: number;
+} => {
   for (let i = 0; i < series.fields.length; i++) {
     if (series.fields[i].type === FieldType.time) {
       return {
@@ -525,20 +464,16 @@ export const getTimeField = (series: DataFrame): { timeField?: Field; timeIndex?
   }
   return {};
 };
-
 function getProcessedDataFrame(data: DataQueryResponseData): DataFrame {
   const dataFrame = guessFieldTypes(toDataFrame(data));
-
   if (dataFrame.fields && dataFrame.fields.length) {
     // clear out the cached info
     for (const field of dataFrame.fields) {
       field.state = null;
     }
   }
-
   return dataFrame;
 }
-
 /**
  * Given data request results, will return data frames with field types set
  *
@@ -548,36 +483,30 @@ export function getProcessedDataFrames(results?: DataQueryResponseData[]): DataF
   if (!results || !isArray(results)) {
     return [];
   }
-
   return results.map((data) => getProcessedDataFrame(data));
 }
-
 /**
  * Will process the panel data frames and in case of loading state with no data, will return the last result data but with loading state
  * This is to have panels not flicker temporarily with "no data" while loading
  */
 export function preProcessPanelData(data: PanelData, lastResult?: PanelData): PanelData {
   const { series, annotations } = data;
-
   //  for loading states with no data, use last result
   if (data.state === LoadingState.Loading && series.length === 0) {
     if (!lastResult) {
       lastResult = data;
     }
-
     return {
       ...lastResult,
       state: LoadingState.Loading,
       request: data.request,
     };
   }
-
   // Make sure the data frames are properly formatted
   const STARTTIME = performance.now();
   const processedDataFrames = series.map((data) => getProcessedDataFrame(data));
   const annotationsProcessed = getProcessedDataFrames(annotations);
   const STOPTIME = performance.now();
-
   return {
     ...data,
     series: processedDataFrames,
@@ -585,11 +514,9 @@ export function preProcessPanelData(data: PanelData, lastResult?: PanelData): Pa
     timings: { dataProcessingTime: STOPTIME - STARTTIME },
   };
 }
-
 export interface PartialDataFrame extends Omit<DataFrame, 'fields' | 'length'> {
   fields: Array<Partial<Field>>;
 }
-
 export function createDataFrame(input: PartialDataFrame): DataFrame {
   let length = 0;
   const fields = input.fields.map((p, idx) => {
@@ -610,7 +537,6 @@ export function createDataFrame(input: PartialDataFrame): DataFrame {
     }
     return field as Field;
   });
-
   return {
     ...input,
     fields,

--- a/packages/grafana-data/src/index.ts
+++ b/packages/grafana-data/src/index.ts
@@ -242,6 +242,7 @@ export {
   updateDatasourcePluginResetOption,
 } from './utils/datasource';
 export { deprecationWarning } from './utils/deprecationWarning';
+export { structLog, type StructLogLevel } from './utils/structLogBase';
 export {
   CSVHeaderStyle,
   type CSVConfig,

--- a/packages/grafana-data/src/text/sanitize.ts
+++ b/packages/grafana-data/src/text/sanitize.ts
@@ -1,16 +1,14 @@
+import { structLog } from '../utils/structLog';
 import { sanitizeUrl as braintreeSanitizeUrl } from '@braintree/sanitize-url';
 import DOMPurify from 'dompurify';
 import * as xss from 'xss';
-
 const XSSWL = Object.keys(xss.whiteList).reduce<xss.IWhiteList>((acc, element) => {
   acc[element] = xss.whiteList[element]?.concat(['class', 'style']);
   return acc;
 }, {});
-
 // Add iframe tags to XSSWL.
 // We don't allow the sandbox attribute, since it can be overridden, instead we add it below.
 XSSWL.iframe = ['src', 'width', 'height'];
-
 const sanitizeTextPanelWhitelist = new xss.FilterXSS({
   // Add sandbox attribute to iframe tags if an attribute is allowed.
   onTagAttr(tag, name, value, isWhiteAttr) {
@@ -48,7 +46,6 @@ const sanitizeTextPanelWhitelist = new xss.FilterXSS({
     },
   },
 });
-
 /**
  * Return a sanitized string that is going to be rendered in the browser to prevent XSS attacks.
  * Note that sanitized tags will be removed, such as "<script>".
@@ -61,20 +58,18 @@ export function sanitize(unsanitizedString: string): string {
         node.setAttribute('rel', 'noopener noreferrer');
       }
     });
-
     return DOMPurify.sanitize(unsanitizedString, {
       USE_PROFILES: { html: true },
       FORBID_TAGS: ['form', 'input'],
       ADD_ATTR: ['target'],
     });
   } catch (error) {
-    console.error('String could not be sanitized', unsanitizedString);
+    structLog('error', 'String could not be sanitized', unsanitizedString);
     return escapeHtml(unsanitizedString);
   } finally {
     DOMPurify.removeHook('afterSanitizeAttributes');
   }
 }
-
 export function sanitizeTrustedTypesRSS(unsanitizedString: string): TrustedHTML {
   return DOMPurify.sanitize(unsanitizedString, {
     RETURN_TRUSTED_TYPE: true,
@@ -83,11 +78,9 @@ export function sanitizeTrustedTypesRSS(unsanitizedString: string): TrustedHTML 
     PARSER_MEDIA_TYPE: 'application/xhtml+xml',
   });
 }
-
 export function sanitizeTrustedTypes(unsanitizedString: string): TrustedHTML {
   return DOMPurify.sanitize(unsanitizedString, { RETURN_TRUSTED_TYPE: true });
 }
-
 /**
  * Returns string safe from XSS attacks to be used in the Text panel plugin.
  *
@@ -99,26 +92,22 @@ export function sanitizeTextPanelContent(unsanitizedString: string): string {
   try {
     return sanitizeTextPanelWhitelist.process(unsanitizedString);
   } catch (error) {
-    console.error('String could not be sanitized', unsanitizedString);
+    structLog('error', 'String could not be sanitized', unsanitizedString);
     return 'Text string could not be sanitized';
   }
 }
-
 // Returns sanitized SVG, free from XSS attacks to be used when rendering SVG content.
 export function sanitizeSVGContent(unsanitizedString: string): string {
   return DOMPurify.sanitize(unsanitizedString, { USE_PROFILES: { svg: true, svgFilters: true } });
 }
-
 // Return a sanitized URL, free from XSS attacks, such as javascript:alert(1)
 export function sanitizeUrl(url: string): string {
   return braintreeSanitizeUrl(url);
 }
-
 // Returns true if the string contains ANSI color codes.
 export function hasAnsiCodes(input: string): boolean {
   return /\u001b\[\d{1,2}m/.test(input);
 }
-
 // Returns a string with HTML entities escaped.
 export function escapeHtml(str: string): string {
   return String(str)
@@ -128,7 +117,6 @@ export function escapeHtml(str: string): string {
     .replace(/'/g, '&#39;')
     .replace(/"/g, '&quot;');
 }
-
 export class PathValidationError extends Error {
   constructor(message = 'Invalid request path') {
     super(message);
@@ -139,7 +127,6 @@ export class PathValidationError extends Error {
     }
   }
 }
-
 /**
  * Validates a path or URL, protecting against path traversal attacks.
  * Returns the original input if safe, or throw an error
@@ -154,13 +141,11 @@ export function validatePath<OriginalPath extends string>(path: OriginalPath): O
       }
       decoded = nextDecode;
     }
-
     // Validate the entire decoded string for traversal attempts
     // This prevents attacks that use query separators to hide traversal payloads
     if (/\.\.|\/\\|[\t\n\r]/.test(decoded)) {
       throw new PathValidationError();
     }
-
     // Return the original path (not the decoded version) to preserve the full URL
     return path;
   } catch (err) {
@@ -168,13 +153,11 @@ export function validatePath<OriginalPath extends string>(path: OriginalPath): O
     if (err instanceof PathValidationError) {
       throw err;
     }
-
     // A decoding error can happen with malformed URIs (e.g., % not followed by hex).
     // These are suspicious, so we treat them as traversal attempts.
     throw new PathValidationError('Error validating request path');
   }
 }
-
 export const textUtil = {
   escapeHtml,
   hasAnsiCodes,

--- a/packages/grafana-data/src/themes/colorManipulator.ts
+++ b/packages/grafana-data/src/themes/colorManipulator.ts
@@ -1,9 +1,8 @@
+import { structLog } from '../utils/structLog';
 // Code based on Material-UI
 // https://github.com/mui-org/material-ui/blob/1b096070faf102281f8e3c4f9b2bf50acf91f412/packages/material-ui/src/styles/colorManipulator.js#L97
 // MIT License Copyright (c) 2014 Call-Em-All
-
 import tinycolor from 'tinycolor2';
-
 /**
  * Returns a number whose value is limited to the given range.
  * @param value The value to be clamped
@@ -15,13 +14,11 @@ import tinycolor from 'tinycolor2';
 function clamp(value: number, min = 0, max = 1) {
   if (process.env.NODE_ENV !== 'production') {
     if (value < min || value > max) {
-      console.error(`The value provided ${value} is out of range [${min}, ${max}].`);
+      structLog('error', `The value provided ${value} is out of range [${min}, ${max}].`);
     }
   }
-
   return Math.min(Math.max(min, value), max);
 }
-
 /**
  * Converts a color from CSS hex format to CSS rgb format.
  * @param color - Hex color, i.e. #nnn or #nnnnnn
@@ -30,20 +27,15 @@ function clamp(value: number, min = 0, max = 1) {
  */
 export function hexToRgb(color: string) {
   color = color.slice(1);
-
   const re = new RegExp(`.{1,${color.length >= 6 ? 2 : 1}}`, 'g');
   let result = color.match(re);
-
   if (!result) {
     return '';
   }
-
   let colors = Array.from(result);
-
   if (colors[0].length === 1) {
     colors = colors.map((n) => n + n);
   }
-
   return colors
     ? `rgb${colors.length === 4 ? 'a' : ''}(${colors
         .map((n, index) => {
@@ -52,12 +44,10 @@ export function hexToRgb(color: string) {
         .join(', ')})`
     : '';
 }
-
 function intToHex(int: number) {
   const hex = int.toString(16);
   return hex.length === 1 ? `0${hex}` : hex;
 }
-
 /**
  * Converts a color from CSS rgb format to CSS hex format.
  * @param color - RGB color, i.e. rgb(n, n, n)
@@ -69,11 +59,9 @@ export function rgbToHex(color: string) {
   if (color.indexOf('#') === 0) {
     return color;
   }
-
   const { values } = decomposeColor(color);
   return `#${values.map((n: number) => intToHex(n)).join('')}`;
 }
-
 /**
  * Converts a color to hex6 format if there is no alpha, hex8 if there is.
  * @param color - Hex, RGB, HSL color
@@ -86,7 +74,6 @@ export function asHexString(color: string): string {
   const tColor = tinycolor(color);
   return tColor.getAlpha() === 1 ? tColor.toHexString() : tColor.toHex8String();
 }
-
 /**
  * Converts a color to rgb string
  */
@@ -94,10 +81,8 @@ export function asRgbString(color: string) {
   if (color.startsWith('rgb')) {
     return color;
   }
-
   return tinycolor(color).toRgbString();
 }
-
 /**
  * Converts a color from hsl format to rgb format.
  * @param color - HSL color values
@@ -112,18 +97,14 @@ export function hslToRgb(color: string | DecomposeColor) {
   const l = values[2] / 100;
   const a = s * Math.min(l, 1 - l);
   const f = (n: number, k = (n + h / 30) % 12) => l - a * Math.max(Math.min(k - 3, 9 - k, 1), -1);
-
   let type = 'rgb';
   const rgb = [Math.round(f(0) * 255), Math.round(f(8) * 255), Math.round(f(4) * 255)];
-
   if (parts.type === 'hsla') {
     type += 'a';
     rgb.push(values[3]);
   }
-
   return recomposeColor({ type, values: rgb });
 }
-
 /**
  * Returns an object with the type and values of a color.
  *
@@ -137,23 +118,18 @@ export function decomposeColor(color: string | DecomposeColor): DecomposeColor {
   if (typeof color !== 'string') {
     return color;
   }
-
   if (color.charAt(0) === '#') {
     return decomposeColor(hexToRgb(color));
   }
-
   const marker = color.indexOf('(');
   const type = color.substring(0, marker);
-
   if (['rgb', 'rgba', 'hsl', 'hsla', 'color'].indexOf(type) === -1) {
     throw new Error(
       `Unsupported '${color}' color. The following formats are supported: #nnn, #nnnnnn, rgb(), rgba(), hsl(), hsla(), color()`
     );
   }
-
   let values: any = color.substring(marker + 1, color.length - 1);
   let colorSpace;
-
   if (type === 'color') {
     values = values.split(' ');
     colorSpace = values.shift();
@@ -168,11 +144,9 @@ export function decomposeColor(color: string | DecomposeColor): DecomposeColor {
   } else {
     values = values.split(',');
   }
-
   values = values.map((value: string) => parseFloat(value));
   return { type, values, colorSpace };
 }
-
 /**
  * Converts a color object with type and values to a string.
  * @param {object} color - Decomposed color
@@ -184,7 +158,6 @@ export function decomposeColor(color: string | DecomposeColor): DecomposeColor {
 export function recomposeColor(color: DecomposeColor) {
   const { type, colorSpace } = color;
   let values = color.values;
-
   if (type.indexOf('rgb') !== -1) {
     // Only convert the first 3 values to int (i.e. not alpha)
     values = values.map((n: string, i: number) => (i < 3 ? parseInt(n, 10) : n));
@@ -197,10 +170,8 @@ export function recomposeColor(color: DecomposeColor) {
   } else {
     values = `${values.join(', ')}`;
   }
-
   return `${type}(${values})`;
 }
-
 /**
  * Calculates the contrast ratio between two colors.
  *
@@ -216,7 +187,6 @@ export function getContrastRatio(foreground: string, background: string, canvas?
   const lumB = getLuminance(background, canvas);
   return (Math.max(lumA, lumB) + 0.05) / (Math.min(lumA, lumB) + 0.05);
 }
-
 /**
  * The relative brightness of any point in a color space,
  * normalized to 0 for darkest black and 1 for lightest white.
@@ -229,9 +199,7 @@ export function getContrastRatio(foreground: string, background: string, canvas?
  */
 export function getLuminance(color: string, background?: string) {
   const parts = decomposeColor(color);
-
   let rgb = parts.type === 'hsl' ? decomposeColor(hslToRgb(color)).values : parts.values;
-
   if (background && parts.type === 'rgba') {
     const backgroundParts = decomposeColor(background);
     const alpha = rgb[3];
@@ -239,18 +207,15 @@ export function getLuminance(color: string, background?: string) {
     rgb[1] = rgb[1] * alpha + backgroundParts.values[1] * (1 - alpha);
     rgb[2] = rgb[2] * alpha + backgroundParts.values[2] * (1 - alpha);
   }
-
   const rgbNumbers = rgb.map((val: any) => {
     if (parts.type !== 'color') {
       val /= 255; // normalized
     }
     return val <= 0.03928 ? val / 12.92 : ((val + 0.055) / 1.055) ** 2.4;
   });
-
   // Truncate at 3 digits
   return Number((0.2126 * rgbNumbers[0] + 0.7152 * rgbNumbers[1] + 0.0722 * rgbNumbers[2]).toFixed(3));
 }
-
 /**
  * Darken or lighten a color, depending on its luminance.
  * Light colors are darkened, dark colors are lightened.
@@ -262,7 +227,6 @@ export function getLuminance(color: string, background?: string) {
 export function emphasize(color: string, coefficient = 0.15) {
   return getLuminance(color) > 0.5 ? darken(color, coefficient) : lighten(color, coefficient);
 }
-
 /**
  * Set the absolute transparency of a color.
  * Any existing alpha values are overwritten.
@@ -275,9 +239,7 @@ export function alpha(color: string, value: number) {
   if (color === '') {
     return '#000000';
   }
-
   value = clamp(value);
-
   // hex 3, hex 4 (w/alpha), hex 6, hex 8 (w/alpha)
   if (color[0] === '#') {
     if (color.length === 9) {
@@ -289,7 +251,6 @@ export function alpha(color: string, value: number) {
       }
       color = c;
     }
-
     return (
       color +
       Math.round(value * 255)
@@ -307,18 +268,14 @@ export function alpha(color: string, value: number) {
   else if (color[4] === '(') {
     return color.substring(0, color.lastIndexOf(',')) + `, ${value})`;
   }
-
   const parts = decomposeColor(color);
-
   if (parts.type === 'color') {
     parts.values[3] = `/${value}`;
   } else {
     parts.values[3] = value;
   }
-
   return recomposeColor(parts);
 }
-
 /**
  * Darkens a color.
  * @param color - CSS color, i.e. one of: #nnn, #nnnnnn, rgb(), rgba(), hsl(), hsla(), color()
@@ -329,7 +286,6 @@ export function alpha(color: string, value: number) {
 export function darken(color: string, coefficient: number) {
   const parts = decomposeColor(color);
   coefficient = clamp(coefficient);
-
   if (parts.type.indexOf('hsl') !== -1) {
     parts.values[2] *= 1 - coefficient;
   } else if (parts.type.indexOf('rgb') !== -1 || parts.type.indexOf('color') !== -1) {
@@ -339,7 +295,6 @@ export function darken(color: string, coefficient: number) {
   }
   return recomposeColor(parts);
 }
-
 /**
  * Lightens a color.
  * @param color - CSS color, i.e. one of: #nnn, #nnnnnn, rgb(), rgba(), hsl(), hsla(), color()
@@ -350,7 +305,6 @@ export function darken(color: string, coefficient: number) {
 export function lighten(color: string, coefficient: number) {
   const parts = decomposeColor(color);
   coefficient = clamp(coefficient);
-
   if (parts.type.indexOf('hsl') !== -1) {
     parts.values[2] += (100 - parts.values[2]) * coefficient;
   } else if (parts.type.indexOf('rgb') !== -1) {
@@ -362,10 +316,8 @@ export function lighten(color: string, coefficient: number) {
       parts.values[i] += (1 - parts.values[i]) * coefficient;
     }
   }
-
   return recomposeColor(parts);
 }
-
 /**
  * given foreground and background colors, returns the color of the foreground color on the background color.
  * this is valuable for foreground colors with alpha.
@@ -383,7 +335,6 @@ export const onBackground = (
   const fg = tinycolor(foreground).toRgb();
   const bg = tinycolor(background).toRgb();
   const alpha = fg.a + bg.a * (1 - fg.a);
-
   return tinycolor({
     r: (fg.r * fg.a + bg.r * bg.a * (1 - fg.a)) / alpha,
     g: (fg.g * fg.a + bg.g * bg.a * (1 - fg.a)) / alpha,
@@ -391,13 +342,11 @@ export const onBackground = (
     a: alpha,
   });
 };
-
 interface DecomposeColor {
   type: string;
   values: any;
   colorSpace?: string;
 }
-
 export const colorManipulator = {
   clamp,
   hexToRgb,

--- a/packages/grafana-data/src/themes/createSpacing.ts
+++ b/packages/grafana-data/src/themes/createSpacing.ts
@@ -1,19 +1,16 @@
+import { structLog } from '../utils/structLog';
 // Code based on Material UI
 // The MIT License (MIT)
 // Copyright (c) 2014 Call-Em-All
 import { z } from 'zod';
-
 /** @internal */
 export const ThemeSpacingOptionsSchema = z.object({
   gridSize: z.int().positive().optional(),
 });
-
 /** @internal */
 export type ThemeSpacingOptions = z.infer<typeof ThemeSpacingOptionsSchema>;
-
 /** @internal */
 export type ThemeSpacingArgument = number | string;
-
 /**
  * @beta
  * The different signatures imply different meaning for their arguments that can't be expressed structurally.
@@ -32,43 +29,35 @@ export interface ThemeSpacing extends SpacingTokens {
   ): string;
   gridSize: number;
 }
-
 // Possible spacing token options
 export type ThemeSpacingTokens = 0 | 0.25 | 0.5 | 1 | 1.5 | 2 | 2.5 | 3 | 4 | 5 | 6 | 8 | 10;
-
 // Spacing tokens as represented in the theme
 type SpacingTokens = {
   [key in `x${Exclude<ThemeSpacingTokens, 0.25 | 0.5 | 1.5 | 2.5> | '0_25' | '0_5' | '1_5' | '2_5'}`]: string;
 };
-
 /** @internal */
 export function createSpacing(options: ThemeSpacingOptions = {}): ThemeSpacing {
   const { gridSize = 8 } = options;
-
   const transform = (value: ThemeSpacingArgument) => {
     if (typeof value === 'string') {
       return value;
     }
-
     if (process.env.NODE_ENV !== 'production') {
       if (typeof value !== 'number') {
-        console.error(`Expected spacing argument to be a number or a string, got ${value}.`);
+        structLog('error', `Expected spacing argument to be a number or a string, got ${value}.`);
       }
     }
     return value * gridSize;
   };
-
   const spacing = (...args: Array<number | string>): string => {
     if (process.env.NODE_ENV !== 'production') {
       if (!(args.length <= 4)) {
-        console.error(`Too many arguments provided, expected between 0 and 4, got ${args.length}`);
+        structLog('error', `Too many arguments provided, expected between 0 and 4, got ${args.length}`);
       }
     }
-
     if (args.length === 0) {
       args[0] = 1;
     }
-
     return args
       .map((argument) => {
         const output = transform(argument);
@@ -76,9 +65,7 @@ export function createSpacing(options: ThemeSpacingOptions = {}): ThemeSpacing {
       })
       .join(' ');
   };
-
   spacing.gridSize = gridSize;
-
   // Design system spacing tokens
   // Added in v10.2 of Grafana, if using spacing in a plugin that needs compatibility with older versions
   // use the spacing function instead.
@@ -95,6 +82,5 @@ export function createSpacing(options: ThemeSpacingOptions = {}): ThemeSpacing {
   spacing.x6 = '48px';
   spacing.x8 = '64px';
   spacing.x10 = '80px';
-
   return spacing;
 }

--- a/packages/grafana-data/src/themes/createTypography.ts
+++ b/packages/grafana-data/src/themes/createTypography.ts
@@ -1,10 +1,9 @@
+import { structLog } from '../utils/structLog';
 // Code based on Material UI
 // The MIT License (MIT)
 // Copyright (c) 2014 Call-Em-All
 import { z } from 'zod';
-
 import { type ThemeColors } from './createColors';
-
 /** @beta */
 export interface ThemeTypography extends ThemeTypographyVariantTypes {
   fontFamily: string;
@@ -14,10 +13,8 @@ export interface ThemeTypography extends ThemeTypographyVariantTypes {
   fontWeightRegular: number;
   fontWeightMedium: number;
   fontWeightBold: number;
-
   // The font-size on the html element.
   htmlFontSize?: number;
-
   /**
    * @deprecated
    * from legacy old theme
@@ -29,10 +26,8 @@ export interface ThemeTypography extends ThemeTypographyVariantTypes {
     md: string;
     lg: string;
   };
-
   pxToRem: (px: number) => string;
 }
-
 export interface ThemeTypographyVariant {
   fontSize: string;
   fontWeight: number;
@@ -40,7 +35,6 @@ export interface ThemeTypographyVariant {
   fontFamily: string;
   letterSpacing?: string;
 }
-
 export const ThemeTypographyInputSchema = z.object({
   fontFamily: z.string().optional(),
   fontFamilyMonospace: z.string().optional(),
@@ -53,12 +47,9 @@ export const ThemeTypographyInputSchema = z.object({
   // 16px is the default font-size used by browsers.
   htmlFontSize: z.number().positive().optional(),
 });
-
 export type ThemeTypographyInput = z.infer<typeof ThemeTypographyInputSchema>;
-
 const defaultFontFamily = "'Inter', 'Helvetica', 'Arial', sans-serif";
 const defaultFontFamilyMonospace = "'Roboto Mono', monospace";
-
 export function createTypography(colors: ThemeColors, typographyInput: ThemeTypographyInput = {}): ThemeTypography {
   const {
     fontFamily = defaultFontFamily,
@@ -73,17 +64,14 @@ export function createTypography(colors: ThemeColors, typographyInput: ThemeTypo
     // 16px is the default font-size used by browsers.
     htmlFontSize = 14,
   } = typographyInput;
-
   if (process.env.NODE_ENV !== 'production') {
     if (typeof fontSize !== 'number') {
-      console.error('Grafana-UI: `fontSize` is required to be a number.');
+      structLog('error', 'Grafana-UI: `fontSize` is required to be a number.');
     }
-
     if (typeof htmlFontSize !== 'number') {
-      console.error('Grafana-UI: `htmlFontSize` is required to be a number.');
+      structLog('error', 'Grafana-UI: `htmlFontSize` is required to be a number.');
     }
   }
-
   const coef = fontSize / 14;
   const pxToRem = (size: number) => `${(size / htmlFontSize) * coef}rem`;
   const buildVariant = (
@@ -96,7 +84,6 @@ export function createTypography(colors: ThemeColors, typographyInput: ThemeTypo
     if (lineHeight % 2 !== 0 || size % 2 !== 0) {
       throw new Error('Font size and line height should be integer multiples of 2 to prevent issues with alignment');
     }
-
     return {
       fontFamily,
       fontWeight,
@@ -106,7 +93,6 @@ export function createTypography(colors: ThemeColors, typographyInput: ThemeTypo
       ...casing,
     };
   };
-
   // All our fonts/line heights should be integer multiples of 2 to prevent issues with alignment
   const variants = {
     h1: buildVariant(fontWeightRegular, 28, 32, -0.25),
@@ -119,7 +105,6 @@ export function createTypography(colors: ThemeColors, typographyInput: ThemeTypo
     bodySmall: buildVariant(fontWeightRegular, 12, 18, 0.15),
     code: { ...buildVariant(fontWeightRegular, 14, 16, 0.15), fontFamily: fontFamilyMonospace },
   };
-
   const size = {
     base: '14px',
     xs: '10px',
@@ -127,7 +112,6 @@ export function createTypography(colors: ThemeColors, typographyInput: ThemeTypo
     md: '14px',
     lg: '18px',
   };
-
   return {
     htmlFontSize,
     pxToRem,
@@ -142,11 +126,9 @@ export function createTypography(colors: ThemeColors, typographyInput: ThemeTypo
     ...variants,
   };
 }
-
 function round(value: number) {
   return Math.round(value * 1e5) / 1e5;
 }
-
 export interface ThemeTypographyVariantTypes {
   h1: ThemeTypographyVariant;
   h2: ThemeTypographyVariant;

--- a/packages/grafana-data/src/themes/registry.ts
+++ b/packages/grafana-data/src/themes/registry.ts
@@ -1,5 +1,5 @@
+import { structLog } from '../utils/structLog';
 import { Registry, type RegistryItem } from '../utils/Registry';
-
 import { createTheme, NewThemeOptionsSchema } from './createTheme';
 import aubergine from './themeDefinitions/aubergine.json';
 import debug from './themeDefinitions/debug.json';
@@ -18,13 +18,13 @@ import tron from './themeDefinitions/tron.json';
 import victorian from './themeDefinitions/victorian.json';
 import zen from './themeDefinitions/zen.json';
 import { type GrafanaTheme2 } from './types';
-
 export interface ThemeRegistryItem extends RegistryItem {
   isExtra?: boolean;
   build: () => GrafanaTheme2;
 }
-
-const extraThemes: { [key: string]: unknown } = {
+const extraThemes: {
+  [key: string]: unknown;
+} = {
   aubergine,
   debug,
   desertbloom,
@@ -42,7 +42,6 @@ const extraThemes: { [key: string]: unknown } = {
   victorian,
   zen,
 };
-
 /**
  * @internal
  * Only for internal use, never use this from a plugin
@@ -51,7 +50,6 @@ export function getThemeById(id: string): GrafanaTheme2 {
   const theme = themeRegistry.getIfExists(id) ?? themeRegistry.get('dark');
   return theme.build();
 }
-
 /**
  * @internal
  * For internal use only
@@ -75,7 +73,6 @@ export function getBuiltInThemes(allowedExtras: string[]) {
   });
   return sortedThemes;
 }
-
 const themeRegistry = new Registry<ThemeRegistryItem>(() => {
   return [
     { id: 'system', name: 'System preference', build: getSystemPreferenceTheme },
@@ -83,11 +80,10 @@ const themeRegistry = new Registry<ThemeRegistryItem>(() => {
     { id: 'light', name: 'Light', build: () => createTheme({ colors: { mode: 'light' } }) },
   ];
 });
-
 for (const [name, json] of Object.entries(extraThemes)) {
   const result = NewThemeOptionsSchema.safeParse(json);
   if (!result.success) {
-    console.error(`Invalid theme definition for theme ${name}: ${result.error.message}`);
+    structLog('error', `Invalid theme definition for theme ${name}: ${result.error.message}`);
   } else {
     const theme = result.data;
     themeRegistry.register({
@@ -98,7 +94,6 @@ for (const [name, json] of Object.entries(extraThemes)) {
     });
   }
 }
-
 function getSystemPreferenceTheme() {
   const mediaResult = window.matchMedia('(prefers-color-scheme: dark)');
   const id = mediaResult.matches ? 'dark' : 'light';

--- a/packages/grafana-data/src/transformations/matchers/nameMatcher.ts
+++ b/packages/grafana-data/src/transformations/matchers/nameMatcher.ts
@@ -1,16 +1,14 @@
+import { structLog } from '../../utils/structLog';
 import { getFieldDisplayName } from '../../field/fieldState';
 import { stringToJsRegex } from '../../text/string';
 import { type DataFrame, type Field, FieldType, TIME_SERIES_VALUE_FIELD_NAME } from '../../types/dataFrame';
 import { type FieldMatcher, type FieldMatcherInfo, type FrameMatcherInfo } from '../../types/transformations';
-
 import { FieldMatcherID, FrameMatcherID } from './ids';
-
 export interface RegexpOrNamesMatcherOptions {
   pattern?: string;
   names?: string[];
   variable?: string;
 }
-
 /**
  * Mode to be able to toggle if the names matcher should match fields in provided
  * list or all except provided names.
@@ -20,7 +18,6 @@ export enum ByNamesMatcherMode {
   exclude = 'exclude',
   include = 'include',
 }
-
 /**
  * Options to instruct the by names matcher to either match all fields in given list
  * or all except the fields in the list.
@@ -32,19 +29,15 @@ export interface ByNamesMatcherOptions {
   readOnly?: boolean;
   prefix?: string;
 }
-
 // General Field matcher
 const fieldNameMatcher: FieldMatcherInfo<string> = {
   id: FieldMatcherID.byName,
   name: 'Field Name',
   description: 'match the field name',
   defaultOptions: '',
-
   get: (name: string): FieldMatcher => {
     const uniqueNames = new Set<string>([name]);
-
     const fallback = fieldNameFallback(uniqueNames);
-
     return (field: Field, frame: DataFrame, allFrames: DataFrame[]) => {
       return (
         name === field.name ||
@@ -53,12 +46,10 @@ const fieldNameMatcher: FieldMatcherInfo<string> = {
       );
     };
   },
-
   getOptionsDisplayText: (name: string) => {
     return `Field name: ${name}`;
   },
 };
-
 const multipleFieldNamesMatcher: FieldMatcherInfo<ByNamesMatcherOptions> = {
   id: FieldMatcherID.byNames,
   name: 'Field Names',
@@ -67,13 +58,10 @@ const multipleFieldNamesMatcher: FieldMatcherInfo<ByNamesMatcherOptions> = {
     mode: ByNamesMatcherMode.include,
     names: [],
   },
-
   get: (options: ByNamesMatcherOptions): FieldMatcher => {
     const { names, mode = ByNamesMatcherMode.include } = options;
     const uniqueNames = new Set<string>(names ?? []);
-
     const fallback = fieldNameFallback(uniqueNames);
-
     const matcher = (field: Field, frame: DataFrame, frames: DataFrame[]) => {
       return (
         uniqueNames.has(field.name) ||
@@ -81,7 +69,6 @@ const multipleFieldNamesMatcher: FieldMatcherInfo<ByNamesMatcherOptions> = {
         Boolean(fallback && fallback(field, frame, frames))
       );
     };
-
     if (mode === ByNamesMatcherMode.exclude) {
       return (field: Field, frame: DataFrame, frames: DataFrame[]) => {
         return !matcher(field, frame, frames);
@@ -89,7 +76,6 @@ const multipleFieldNamesMatcher: FieldMatcherInfo<ByNamesMatcherOptions> = {
     }
     return matcher;
   },
-
   getOptionsDisplayText: (options: ByNamesMatcherOptions): string => {
     const { names, mode } = options;
     const displayText = (names ?? []).join(', ');
@@ -99,14 +85,12 @@ const multipleFieldNamesMatcher: FieldMatcherInfo<ByNamesMatcherOptions> = {
     return `All of: ${displayText}`;
   },
 };
-
 // In an effort to support migrating to a consistent data contract, the
 // naming conventions need to get normalized. However, many existing setups
 // exist that would no longer match names if that changes.  This injects
 // fallback logic when the data frame has not type version specified
 export function fieldNameFallback(fields: Set<string>) {
   let fallback: FieldMatcher | undefined = undefined;
-
   if (fields.has(TIME_SERIES_VALUE_FIELD_NAME)) {
     fallback = (field: Field, frame: DataFrame) => {
       return (
@@ -119,30 +103,24 @@ export function fieldNameFallback(fields: Set<string>) {
       return frame.meta?.typeVersion == null && field.type === FieldType.time;
     };
   }
-
   return fallback;
 }
-
 const regexpFieldNameMatcher: FieldMatcherInfo<string> = {
   id: FieldMatcherID.byRegexp,
   name: 'Field Name by Regexp',
   description: 'match the field name by a given regexp pattern',
   defaultOptions: '/.*/',
-
   get: (pattern: string): FieldMatcher => {
     const regexp = patternToRegex(pattern);
-
     return (field: Field, frame: DataFrame, allFrames: DataFrame[]) => {
       const displayName = getFieldDisplayName(field, frame, allFrames);
       return !!regexp && regexp.test(displayName);
     };
   },
-
   getOptionsDisplayText: (pattern: string): string => {
     return `Field name by pattern: ${pattern}`;
   },
 };
-
 /**
  * Field matcher that will match all fields that exists in a
  * data frame with configured refId.
@@ -153,18 +131,15 @@ const fieldsInFrameMatcher: FieldMatcherInfo<string> = {
   name: 'Fields by frame refId',
   description: 'match all fields returned in data frame with refId.',
   defaultOptions: '',
-
   get: (refId: string): FieldMatcher => {
     return (field: Field, frame: DataFrame, allFrames: DataFrame[]) => {
       return frame.refId === refId;
     };
   },
-
   getOptionsDisplayText: (refId: string): string => {
     return `Math all fields returned by query with reference ID: ${refId}`;
   },
 };
-
 const regexpOrMultipleNamesMatcher: FieldMatcherInfo<RegexpOrNamesMatcherOptions> = {
   id: FieldMatcherID.byRegexpOrNames,
   name: 'Field Name by Regexp or Names',
@@ -173,58 +148,49 @@ const regexpOrMultipleNamesMatcher: FieldMatcherInfo<RegexpOrNamesMatcherOptions
     pattern: '/.*/',
     names: [],
   },
-
   get: (options: RegexpOrNamesMatcherOptions): FieldMatcher => {
     const regexpMatcher = regexpFieldNameMatcher.get(options?.pattern || '');
     const namesMatcher = multipleFieldNamesMatcher.get({
       mode: ByNamesMatcherMode.include,
       names: options?.names ?? [],
     });
-
     return (field: Field, frame: DataFrame, allFrames: DataFrame[]) => {
       return namesMatcher(field, frame, allFrames) || regexpMatcher(field, frame, allFrames);
     };
   },
-
   getOptionsDisplayText: (options: RegexpOrNamesMatcherOptions): string => {
     const pattern = options?.pattern ?? '';
     const names = options?.names?.join(',') ?? '';
     return `Field name by pattern: ${pattern} or names: ${names}`;
   },
 };
-
 const patternToRegex = (pattern?: string): RegExp | undefined => {
   if (!pattern) {
     return undefined;
   }
-
   try {
     return stringToJsRegex(pattern);
   } catch (error) {
-    console.error(error);
+    structLog('error', error);
     return undefined;
   }
 };
-
 // General Frame matcher
 const frameNameMatcher: FrameMatcherInfo<string> = {
   id: FrameMatcherID.byName,
   name: 'Frame Name',
   description: 'match the frame name',
   defaultOptions: '/.*/',
-
   get: (pattern: string) => {
     const regex = stringToJsRegex(pattern);
     return (frame: DataFrame) => {
       return regex.test(frame.name || '');
     };
   },
-
   getOptionsDisplayText: (pattern: string) => {
     return `Frame name: ${pattern}`;
   },
 };
-
 /**
  * Registry Initialization
  */
@@ -237,7 +203,6 @@ export function getFieldNameMatchers(): FieldMatcherInfo[] {
     fieldsInFrameMatcher,
   ];
 }
-
 export function getFrameNameMatchers(): FrameMatcherInfo[] {
   return [frameNameMatcher];
 }

--- a/packages/grafana-data/src/transformations/matchers/refIdMatcher.ts
+++ b/packages/grafana-data/src/transformations/matchers/refIdMatcher.ts
@@ -1,25 +1,22 @@
+import { structLog } from '../../utils/structLog';
 import { escapeStringForRegex, stringStartsAsRegEx, stringToJsRegex } from '../../text/string';
 import { type DataFrame } from '../../types/dataFrame';
 import { type FrameMatcherInfo } from '../../types/transformations';
-
 import { FrameMatcherID } from './ids';
-
 // General Field matcher
 const refIdMatcher: FrameMatcherInfo<string> = {
   id: FrameMatcherID.byRefId,
   name: 'Query refId',
   description: 'match the refId',
   defaultOptions: 'A',
-
   get: (pattern: string) => {
     let regex: RegExp | null = null;
-
     if (stringStartsAsRegEx(pattern)) {
       try {
         regex = stringToJsRegex(pattern);
       } catch (error) {
         if (error instanceof Error) {
-          console.warn(error.message);
+          structLog('warn', error.message);
         }
       }
     }
@@ -29,17 +26,14 @@ const refIdMatcher: FrameMatcherInfo<string> = {
       const escapedUnion = pattern.split('|').map(escapeStringForRegex).join('|');
       regex = new RegExp(`^(?:${escapedUnion})$`);
     }
-
     return (frame: DataFrame) => {
       return regex?.test(frame.refId || '') ?? frame.refId === pattern;
     };
   },
-
   getOptionsDisplayText: (pattern: string) => {
     return `RefID: ${pattern}`;
   },
 };
-
 export function getRefIdMatchers(): FrameMatcherInfo[] {
   return [refIdMatcher];
 }

--- a/packages/grafana-data/src/transformations/transformers/filterByValue.test.ts
+++ b/packages/grafana-data/src/transformations/transformers/filterByValue.test.ts
@@ -5,6 +5,7 @@ import { mockTransformationsRegistry } from '../../utils/tests/mockTransformatio
 import { ValueMatcherID } from '../matchers/ids';
 import { type BasicValueMatcherOptions } from '../matchers/valueMatchers/types';
 import { transformDataFrame } from '../transformDataFrame';
+import * as structLogMod from '../../utils/structLog';
 
 import {
   FilterByValueMatch,
@@ -42,14 +43,14 @@ const multiSeriesWithSingleField = [
   }),
 ];
 
-let spyConsoleWarn: jest.SpyInstance;
+let structLogSpy: jest.SpyInstance;
 describe('FilterByValue transformer', () => {
   beforeAll(() => {
     mockTransformationsRegistry([filterByValueTransformer]);
   });
 
   beforeEach(() => {
-    spyConsoleWarn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    structLogSpy = jest.spyOn(structLogMod, 'structLog').mockImplementation(() => {});
   });
 
   it('should exclude values', async () => {
@@ -153,10 +154,10 @@ describe('FilterByValue transformer', () => {
         },
       ]);
 
-      expect(console.warn).toHaveBeenCalledTimes(2);
+      expect(structLogSpy).toHaveBeenCalledTimes(2);
     });
 
-    spyConsoleWarn.mockRestore();
+    structLogSpy.mockRestore();
   });
 
   it('should not cross frame boundaries', async () => {
@@ -211,7 +212,7 @@ describe('FilterByValue transformer', () => {
         },
       ]);
 
-      expect(console.warn).toHaveBeenCalledTimes(1);
+      expect(structLogSpy).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/packages/grafana-data/src/transformations/transformers/filterByValue.ts
+++ b/packages/grafana-data/src/transformations/transformers/filterByValue.ts
@@ -1,34 +1,28 @@
+import { structLog } from '../../utils/structLog';
 import { map } from 'rxjs/operators';
-
 import { getFieldDisplayName } from '../../field/fieldState';
 import { type DataFrame, type Field } from '../../types/dataFrame';
 import { type DataTransformerInfo, type MatcherConfig } from '../../types/transformations';
 import { getValueMatcher } from '../matchers';
-
 import { DataTransformerID } from './ids';
 import { noopTransformer } from './noop';
-
 export enum FilterByValueType {
   exclude = 'exclude',
   include = 'include',
 }
-
 export enum FilterByValueMatch {
   all = 'all',
   any = 'any',
 }
-
 export interface FilterByValueFilter {
   fieldName: string;
   config: MatcherConfig;
 }
-
 export interface FilterByValueTransformerOptions {
   filters: FilterByValueFilter[];
   type: FilterByValueType;
   match: FilterByValueMatch;
 }
-
 export const filterByValueTransformer: DataTransformerInfo<FilterByValueTransformerOptions> = {
   id: DataTransformerID.filterByValue,
   name: 'Filter data by values',
@@ -38,76 +32,58 @@ export const filterByValueTransformer: DataTransformerInfo<FilterByValueTransfor
     type: FilterByValueType.include,
     match: FilterByValueMatch.any,
   },
-
   operator: (options, ctx) => (source) => {
     const filters = options.filters;
     const matchAll = options.match === FilterByValueMatch.all;
     const include = options.type === FilterByValueType.include;
-
     if (!Array.isArray(filters) || filters.length === 0) {
       return source.pipe(noopTransformer.operator({}, ctx));
     }
-
     return source.pipe(
       map((data) => {
         if (data.length === 0) {
           return data;
         }
-
         const processed: DataFrame[] = [];
-
         for (const frame of data) {
           const rows = new Set<number>();
           const fieldIndexByName = groupFieldIndexByName(frame, data);
-
           const matchers = createFilterValueMatchers(filters, fieldIndexByName);
-
           for (let index = 0; index < frame.length; index++) {
             if (rows.has(index)) {
               continue;
             }
-
             let matching = true;
-
             for (const matcher of matchers) {
               const match = matcher(index, frame, data);
-
               if (!matchAll && match) {
                 matching = true;
                 break;
               }
-
               if (matchAll && !match) {
                 matching = false;
                 break;
               }
-
               matching = match;
             }
-
             if (matching) {
               rows.add(index);
             }
           }
-
           const fields: Field[] = [];
           const frameLength = include ? rows.size : data[0].length - rows.size;
-
           for (const field of frame.fields) {
             const buffer = [];
-
             for (let index = 0; index < frame.length; index++) {
               if (include && rows.has(index)) {
                 buffer.push(field.values[index]);
                 continue;
               }
-
               if (!include && !rows.has(index)) {
                 buffer.push(field.values[index]);
                 continue;
               }
             }
-
             // We keep field config, but clean the state as it's being recalculated when the field overrides are applied
             fields.push({
               ...field,
@@ -115,46 +91,37 @@ export const filterByValueTransformer: DataTransformerInfo<FilterByValueTransfor
               state: {},
             });
           }
-
           processed.push({
             ...frame,
             fields: fields,
             length: frameLength,
           });
         }
-
         return processed;
       })
     );
   },
 };
-
 const createFilterValueMatchers = (
   filters: FilterByValueFilter[],
   fieldIndexByName: Record<string, number>
 ): Array<(index: number, frame: DataFrame, data: DataFrame[]) => boolean> => {
   const noop = () => false;
-
   return filters.map((filter) => {
     const fieldIndex = fieldIndexByName[filter.fieldName] ?? -1;
-
     if (fieldIndex < 0) {
-      console.warn(`[FilterByValue] Could not find index for field name: ${filter.fieldName}`);
+      structLog('warn', `[FilterByValue] Could not find index for field name: ${filter.fieldName}`);
       return noop;
     }
-
     const matcher = getValueMatcher(filter.config);
     return (index, frame, data) => matcher(index, frame.fields[fieldIndex], frame, data);
   });
 };
-
 const groupFieldIndexByName = (frame: DataFrame, data: DataFrame[]) => {
   const lookup: Record<string, number> = {};
-
   frame.fields.forEach((field, fieldIndex) => {
     const fieldName = getFieldDisplayName(field, frame, data);
     lookup[fieldName] = fieldIndex;
   });
-
   return lookup;
 };

--- a/packages/grafana-data/src/types/app.ts
+++ b/packages/grafana-data/src/types/app.ts
@@ -1,7 +1,6 @@
+import { structLog } from '../utils/structLog';
 import { type ComponentType } from 'react';
-
 import { throwIfAngular } from '../utils/throwIfAngular';
-
 import { type KeyValue } from './data';
 import { type NavModel } from './navModel';
 import { type PluginMeta, GrafanaPlugin, PluginIncludeType } from './plugin';
@@ -11,7 +10,6 @@ import {
   type PluginExtensionAddedLinkConfig,
   type PluginExtensionAddedFunctionConfig,
 } from './pluginExtensions';
-
 /**
  * @public
  * The app container that is loading another plugin (panel or query editor)
@@ -26,53 +24,42 @@ export enum CoreApp {
   PanelEditor = 'panel-editor',
   PanelViewer = 'panel-viewer',
 }
-
 export interface AppRootProps<T extends KeyValue = KeyValue> {
   meta: AppPluginMeta<T>;
   /**
    * base URL segment for an app, /app/pluginId
    */
   basename: string; // The URL path to this page
-
   /**
    * Pass the nav model to the container... is there a better way?
    * @deprecated Use PluginPage component exported from @grafana/runtime instead
    */
   onNavChanged: (nav: NavModel) => void;
-
   /**
    * The URL query parameters
    * @deprecated Use react-router instead
    */
   query: KeyValue;
-
   /**
    * The URL path to this page
    * @deprecated Use react-router instead
    */
   path: string;
 }
-
-export interface AppPluginMeta<T extends KeyValue = KeyValue> extends PluginMeta<T> {
-  // TODO anything specific to apps?
-}
-
+export interface AppPluginMeta<T extends KeyValue = KeyValue> extends PluginMeta<T> {}
 export class AppPlugin<T extends KeyValue = KeyValue> extends GrafanaPlugin<AppPluginMeta<T>> {
   private _exposedComponentConfigs: PluginExtensionExposedComponentConfig[] = [];
   private _addedComponentConfigs: PluginExtensionAddedComponentConfig[] = [];
   private _addedLinkConfigs: PluginExtensionAddedLinkConfig[] = [];
   private _addedFunctionConfigs: PluginExtensionAddedFunctionConfig[] = [];
-
   // Content under: /a/${plugin-id}/*
   root?: ComponentType<AppRootProps<T>>;
-
   /**
    * Called after the module has loaded, and before the app is used.
    * This function may be called multiple times on the same instance.
    * The first time, `this.meta` will be undefined
    */
   init(meta: AppPluginMeta<T>) {}
-
   /**
    * Set the component displayed under:
    *   /a/${plugin-id}/*
@@ -83,65 +70,49 @@ export class AppPlugin<T extends KeyValue = KeyValue> extends GrafanaPlugin<AppP
     this.root = root;
     return this;
   }
-
   setComponentsFromLegacyExports(pluginExports: System.Module) {
     throwIfAngular(pluginExports);
-
     if (this.meta && this.meta.includes) {
       for (const include of this.meta.includes) {
         if (include.type === PluginIncludeType.page && include.component) {
           const exp = pluginExports[include.component];
-
           if (!exp) {
-            console.warn('App Page uses unknown component: ', include.component, this.meta);
+            structLog('warn', 'App Page uses unknown component: ', include.component, this.meta);
             continue;
           }
         }
       }
     }
   }
-
   get exposedComponentConfigs() {
     return this._exposedComponentConfigs;
   }
-
   get addedComponentConfigs() {
     return this._addedComponentConfigs;
   }
-
   get addedLinkConfigs() {
     return this._addedLinkConfigs;
   }
-
   get addedFunctionConfigs() {
     return this._addedFunctionConfigs;
   }
-
   addLink<Context extends object>(linkConfig: PluginExtensionAddedLinkConfig<Context>) {
     this._addedLinkConfigs.push(linkConfig as PluginExtensionAddedLinkConfig);
-
     return this;
   }
-
   addComponent<Props = {}>(addedComponentConfig: PluginExtensionAddedComponentConfig<Props>) {
     this._addedComponentConfigs.push(addedComponentConfig as PluginExtensionAddedComponentConfig);
-
     return this;
   }
-
   addFunction<Signature>(addedFunctionConfig: PluginExtensionAddedFunctionConfig<Signature>) {
     this._addedFunctionConfigs.push(addedFunctionConfig);
-
     return this;
   }
-
   exposeComponent<Props = {}>(componentConfig: PluginExtensionExposedComponentConfig<Props>) {
     this._exposedComponentConfigs.push(componentConfig as PluginExtensionExposedComponentConfig);
-
     return this;
   }
 }
-
 /**
  * Defines life cycle of a feature
  * @internal

--- a/packages/grafana-data/src/types/plugin.ts
+++ b/packages/grafana-data/src/types/plugin.ts
@@ -1,16 +1,14 @@
+import { structLog } from '../utils/structLog';
 import { type ComponentType } from 'react';
-
 import { type KeyValue } from './data';
 import { type IconName } from './icon';
-
 /** Describes plugins life cycle status */
 export enum PluginState {
   alpha = 'alpha', // Only included if `enable_alpha` config option is true
   beta = 'beta', // Will show a warning banner
   stable = 'stable', // Will not show anything
-  deprecated = 'deprecated', // Will continue to work -- but not show up in the options to add
+  deprecated = 'deprecated',
 }
-
 /** Describes {@link https://grafana.com/docs/grafana/latest/plugins | type of plugin} */
 export enum PluginType {
   panel = 'panel',
@@ -18,16 +16,14 @@ export enum PluginType {
   app = 'app',
   renderer = 'renderer',
 }
-
 /** Describes status of {@link https://grafana.com/docs/grafana/latest/plugins/plugin-signatures/ | plugin signature} */
 export enum PluginSignatureStatus {
   internal = 'internal', // core plugin, no signature
   valid = 'valid', // signed and accurate MANIFEST
   invalid = 'invalid', // invalid signature
   modified = 'modified', // valid signature, but content mismatch
-  missing = 'missing', // missing signature file
+  missing = 'missing',
 }
-
 /** Describes level of {@link https://grafana.com/docs/grafana/latest/plugins/plugin-signatures/#plugin-signature-levels/ | plugin signature level} */
 export enum PluginSignatureType {
   grafana = 'grafana',
@@ -36,7 +32,6 @@ export enum PluginSignatureType {
   private = 'private',
   core = 'core',
 }
-
 /** Describes error code returned from Grafana plugins API call */
 export enum PluginErrorCode {
   missingSignature = 'signatureMissing',
@@ -45,26 +40,22 @@ export enum PluginErrorCode {
   failedBackendStart = 'failedBackendStart',
   angular = 'angular',
 }
-
 /** Describes error returned from Grafana plugins API call */
 export interface PluginError {
   errorCode: PluginErrorCode;
   pluginId: string;
   pluginType?: PluginType;
 }
-
 /** @deprecated it will be removed in a future release */
 export interface AngularMeta {
   detected: boolean;
   hideDeprecation: boolean;
 }
-
 // Signals to SystemJS how to load frontend js assets.
 export enum PluginLoadingStrategy {
   fetch = 'fetch',
   script = 'script',
 }
-
 export interface PluginMeta<T extends KeyValue = {}> {
   id: string;
   name: string;
@@ -73,14 +64,11 @@ export interface PluginMeta<T extends KeyValue = {}> {
   includes?: PluginInclude[];
   state?: PluginState;
   aliasIDs?: string[];
-
   // System.load & relative URLS
   module: string;
   baseUrl: string;
-
   // Define plugin requirements
   dependencies?: PluginDependencies;
-
   // Filled in by the backend
   jsonData?: T;
   secureJsonData?: KeyValue;
@@ -101,18 +89,15 @@ export interface PluginMeta<T extends KeyValue = {}> {
   loadingStrategy?: PluginLoadingStrategy;
   extensions?: PluginExtensions;
   moduleHash?: string;
-
   // Paths to the translations for the plugin
   translations?: Record<string, string>;
 }
-
 interface PluginDependencyInfo {
   id: string;
   name: string;
   version: string;
   type: PluginType;
 }
-
 export interface PluginDependencies {
   grafanaDependency?: string;
   grafanaVersion: string;
@@ -122,29 +107,23 @@ export interface PluginDependencies {
     exposedComponents: string[];
   };
 }
-
 export type ExtensionInfo = {
   targets: string | string[];
   title: string;
   description?: string;
 };
-
 export interface PluginExtensions {
   // The component extensions that the plugin registers
   addedComponents: ExtensionInfo[];
-
   addedFunctions: ExtensionInfo[];
-
   // The link extensions that the plugin registers
   addedLinks: ExtensionInfo[];
-
   // The React components that the plugin exposes
   exposedComponents: Array<{
     id: string;
     title: string;
     description?: string;
   }>;
-
   // The extension points that the plugin provides
   extensionPoints: Array<{
     id: string;
@@ -152,42 +131,33 @@ export interface PluginExtensions {
     description?: string;
   }>;
 }
-
 export enum PluginIncludeType {
   dashboard = 'dashboard',
   page = 'page',
-
   // Only valid for apps
   panel = 'panel',
   datasource = 'datasource',
 }
-
 export interface PluginInclude {
   type: PluginIncludeType;
   name: string;
   path?: string;
   icon?: string;
-
   // "Admin", "Editor" or "Viewer". If set then the include will only show up in the navigation if the user has the required roles.
   role?: string;
-
   // if action is set then the include will only show up in the navigation if the user has the required permission.
   // The action will take precedence over the role.
   action?: string;
-
   // Adds the "page" or "dashboard" type includes to the navigation if set to `true`.
   addToNav?: boolean;
-
   // Angular app pages
   component?: string;
 }
-
 interface PluginMetaInfoLink {
   name: string;
   url: string;
   target?: '_blank' | '_self' | '_parent' | '_top';
 }
-
 export interface PluginBuildInfo {
   time?: number;
   repo?: string;
@@ -196,12 +166,10 @@ export interface PluginBuildInfo {
   number?: number;
   pr?: number;
 }
-
 export interface ScreenshotInfo {
   name: string;
   path: string;
 }
-
 export interface PluginMetaInfo {
   author: {
     name: string;
@@ -219,34 +187,26 @@ export interface PluginMetaInfo {
   version: string;
   keywords?: string[] | null;
 }
-
 export interface PluginConfigPageProps<T extends PluginMeta> {
   plugin: GrafanaPlugin<T>;
   query: KeyValue; // The URL query parameters
 }
-
 export interface PluginConfigPage<T extends PluginMeta> {
   title: string; // Display
   icon?: IconName;
   id: string; // Unique, in URL
-
   body: ComponentType<PluginConfigPageProps<T>>;
 }
-
 export class GrafanaPlugin<T extends PluginMeta = PluginMeta> {
   // Meta is filled in by the plugin loading system
   meta: T;
-
   // This is set if the plugin system had errors loading the plugin
   loadError?: boolean;
-
   // Config control (app/datasource)
   /** @deprecated it will be removed in a future release */
   angularConfigCtrl?: any;
-
   // Show configuration tabs on the plugin page
   configPages?: Array<PluginConfigPage<T>>;
-
   // Tabs on the plugin page
   addConfigPage(tab: PluginConfigPage<T>) {
     if (!this.configPages) {
@@ -255,15 +215,13 @@ export class GrafanaPlugin<T extends PluginMeta = PluginMeta> {
     this.configPages.push(tab);
     return this;
   }
-
   /**
    * @deprecated -- this is no longer necessary and will be removed
    */
   setChannelSupport() {
-    console.warn('[deprecation] plugin is using ignored option: setChannelSupport', this.meta);
+    structLog('warn', '[deprecation] plugin is using ignored option: setChannelSupport', this.meta);
     return this;
   }
-
   constructor() {
     this.meta = {} as T;
   }

--- a/packages/grafana-data/src/utils/LocalStorageValueProvider.tsx
+++ b/packages/grafana-data/src/utils/LocalStorageValueProvider.tsx
@@ -1,50 +1,41 @@
+import { structLog } from './structLog';
 import { useEffect, useState } from 'react';
 import * as React from 'react';
-
 import { store } from './store';
-
 export interface Props<T> {
   storageKey: string;
   defaultValue: T;
   children: (value: T, onSaveToStore: (value: T) => void, onDeleteFromStore: () => void) => React.ReactNode;
 }
-
 export const LocalStorageValueProvider = <T,>(props: Props<T>) => {
   const { children, storageKey, defaultValue } = props;
-
   const [state, setState] = useState({ value: store.getObject(props.storageKey, props.defaultValue) });
-
   useEffect(() => {
     const onStorageUpdate = (v: StorageEvent) => {
       if (v.key === storageKey) {
         setState({ value: store.getObject(props.storageKey, props.defaultValue) });
       }
     };
-
     window.addEventListener('storage', onStorageUpdate);
-
     return () => {
       window.removeEventListener('storage', onStorageUpdate);
     };
   });
-
   const onSaveToStore = (value: T) => {
     try {
       store.setObject(storageKey, value);
     } catch (error) {
-      console.error(error);
+      structLog('error', error);
     }
     setState({ value });
   };
-
   const onDeleteFromStore = () => {
     try {
       store.delete(storageKey);
     } catch (error) {
-      console.log(error);
+      structLog('log', error);
     }
     setState({ value: defaultValue });
   };
-
   return <>{children(state.value, onSaveToStore, onDeleteFromStore)}</>;
 };

--- a/packages/grafana-data/src/utils/deprecationWarning.test.ts
+++ b/packages/grafana-data/src/utils/deprecationWarning.test.ts
@@ -1,13 +1,14 @@
 import { deprecationWarning } from './deprecationWarning';
+import * as structLogMod from './structLog';
 
 test('It should not output deprecation warnings too often', () => {
   let dateNowValue = 10000000;
 
-  const spyConsoleWarn = jest.spyOn(console, 'warn').mockImplementation();
+  const structLogSpy = jest.spyOn(structLogMod, 'structLog').mockImplementation();
   const spyDateNow = jest.spyOn(global.Date, 'now').mockImplementation(() => dateNowValue);
   // Make sure the mock works
   expect(Date.now()).toEqual(dateNowValue);
-  expect(console.warn).toHaveBeenCalledTimes(0);
+  expect(structLogSpy).toHaveBeenCalledTimes(0);
 
   // Call the deprecation many times
   deprecationWarning('file', 'oldName', 'newName');
@@ -15,20 +16,20 @@ test('It should not output deprecation warnings too often', () => {
   deprecationWarning('file', 'oldName', 'newName');
   deprecationWarning('file', 'oldName', 'newName');
   deprecationWarning('file', 'oldName', 'newName');
-  expect(console.warn).toHaveBeenCalledTimes(1);
+  expect(structLogSpy).toHaveBeenCalledTimes(1);
 
   // Increment the time by 1min
   dateNowValue += 60000;
   deprecationWarning('file', 'oldName', 'newName');
   deprecationWarning('file', 'oldName', 'newName');
-  expect(console.warn).toHaveBeenCalledTimes(2);
+  expect(structLogSpy).toHaveBeenCalledTimes(2);
 
   deprecationWarning('file2', 'oldName', 'newName');
   deprecationWarning('file2', 'oldName', 'newName');
   deprecationWarning('file2', 'oldName', 'newName');
-  expect(console.warn).toHaveBeenCalledTimes(3);
+  expect(structLogSpy).toHaveBeenCalledTimes(3);
 
   // or restoreMocks automatically?
-  spyConsoleWarn.mockRestore();
+  structLogSpy.mockRestore();
   spyDateNow.mockRestore();
 });

--- a/packages/grafana-data/src/utils/deprecationWarning.ts
+++ b/packages/grafana-data/src/utils/deprecationWarning.ts
@@ -1,8 +1,7 @@
+import { structLog } from './structLog';
 import { type KeyValue } from '../types/data';
-
 // Avoid writing the warning message more than once every 10s
 const history: KeyValue<number> = {};
-
 export const deprecationWarning = (file: string, oldName: string, newName?: string) => {
   let message = `[Deprecation warning] ${file}: ${oldName} is deprecated`;
   if (newName) {
@@ -11,7 +10,7 @@ export const deprecationWarning = (file: string, oldName: string, newName?: stri
   const now = Date.now();
   const last = history[message];
   if (!last || now - last > 10000) {
-    console.warn(message);
+    structLog('warn', message);
     history[message] = now;
   }
 };

--- a/packages/grafana-data/src/utils/store.ts
+++ b/packages/grafana-data/src/utils/store.ts
@@ -1,12 +1,11 @@
+import { structLog } from './structLog';
 type StoreValue = string | number | boolean | null;
 type StoreSubscriber = () => void;
-
 /**
  * @deprecated Import singleton instance 'store' from '@grafana/data' instead
  */
 export class Store {
   private subscribers: Map<string, Set<StoreSubscriber>> = new Map();
-
   constructor() {
     // Changes from other tabs
     window.addEventListener('storage', (e) => {
@@ -15,20 +14,17 @@ export class Store {
       }
     });
   }
-
   private notifySubscribers(key: string) {
     const keySubscribers = this.subscribers.get(key);
     if (keySubscribers) {
       keySubscribers.forEach((subscriber) => subscriber());
     }
   }
-
   subscribe(key: string, callback: StoreSubscriber) {
     if (!this.subscribers.has(key)) {
       this.subscribers.set(key, new Set());
     }
     this.subscribers.get(key)!.add(callback);
-
     return () => {
       const keySubscribers = this.subscribers.get(key);
       if (keySubscribers) {
@@ -39,23 +35,19 @@ export class Store {
       }
     };
   }
-
   get(key: string) {
     return window.localStorage[key];
   }
-
   set(key: string, value: StoreValue) {
     window.localStorage[key] = value;
     this.notifySubscribers(key);
   }
-
   getBool(key: string, def: boolean): boolean {
     if (def !== void 0 && !this.exists(key)) {
       return def;
     }
     return window.localStorage[key] === 'true';
   }
-
   getObject<T = unknown>(key: string): T | undefined;
   getObject<T = unknown>(key: string, def: T): T;
   getObject<T = unknown>(key: string, def?: T) {
@@ -65,12 +57,11 @@ export class Store {
       try {
         ret = JSON.parse(json);
       } catch (error) {
-        console.error(`Error parsing store object: ${key}. Returning default: ${def}. [${error}]`);
+        structLog('error', `Error parsing store object: ${key}. Returning default: ${def}. [${error}]`);
       }
     }
     return ret;
   }
-
   /* Returns true when successfully stored, throws error if not successfully stored */
   setObject(key: string, value: unknown) {
     let json;
@@ -91,15 +82,12 @@ export class Store {
     }
     return true;
   }
-
   exists(key: string) {
     return window.localStorage[key] !== void 0;
   }
-
   delete(key: string) {
     window.localStorage.removeItem(key);
     this.notifySubscribers(key);
   }
 }
-
 export const store = new Store();

--- a/packages/grafana-data/src/utils/structLog.ts
+++ b/packages/grafana-data/src/utils/structLog.ts
@@ -1,0 +1,1 @@
+export { structLog, type StructLogLevel } from './structLogBase';

--- a/packages/grafana-data/src/utils/structLogBase.ts
+++ b/packages/grafana-data/src/utils/structLogBase.ts
@@ -1,0 +1,36 @@
+const isJest = typeof process !== 'undefined' && process.env && process.env.JEST_WORKER_ID;
+const isProd =
+  typeof process !== 'undefined' && process.env && process.env.NODE_ENV === 'production' && !isJest;
+
+export type StructLogLevel = 'log' | 'info' | 'warn' | 'error' | 'debug';
+
+/**
+ * Structured app logging: routes to the console in development and in tests, with production
+ * noise reduced for `log` / `info` / `debug` while keeping `warn` / `error` visible.
+ * Prefer this over `console.*` in application code. When the Grafana JavaScript agent is
+ * enabled, `logInfo` and related helpers in `@grafana/runtime` also forward to Faro.
+ *
+ * @public
+ */
+export function structLog(level: StructLogLevel, ...args: unknown[]): void {
+  if (isProd && (level === 'log' || level === 'info' || level === 'debug')) {
+    return;
+  }
+  const debugFn = console.debug ? console.debug.bind(console) : console.log.bind(console);
+  switch (level) {
+    case 'error':
+      console.error(...args);
+      break;
+    case 'warn':
+      console.warn(...args);
+      break;
+    case 'debug':
+      debugFn(...args);
+      break;
+    case 'log':
+    case 'info':
+    default:
+      console.log(...args);
+      break;
+  }
+}

--- a/packages/grafana-data/src/utils/url.ts
+++ b/packages/grafana-data/src/utils/url.ts
@@ -1,32 +1,28 @@
+import { structLog } from './structLog';
 /**
  * @preserve jquery-param (c) 2015 KNOWLEDGECODE | MIT
  */
-
 import { isDateTime } from '../datetime/moment_wrapper';
 import { type ExploreUrlState, type URLRange } from '../types/explore';
 import { type RawTimeRange } from '../types/time';
-
 /**
  * Type to represent the value of a single query variable.
  *
  * @public
  */
 export type UrlQueryValue = string | number | boolean | string[] | number[] | boolean[] | undefined | null;
-
 /**
  * Type to represent the values parsed from the query string.
  *
  * @public
  */
 export type UrlQueryMap = Record<string, UrlQueryValue>;
-
 function renderUrl(path: string, query: UrlQueryMap | undefined): string {
   if (query && Object.keys(query).length > 0) {
     path += '?' + toUrlParams(query);
   }
   return path;
 }
-
 function encodeURIComponentAsAngularJS(val: EncodeURIComponentParams, pctEncodeSpaces?: boolean) {
   return encodeURIComponent(val)
     .replace(/%40/gi, '@')
@@ -39,7 +35,6 @@ function encodeURIComponentAsAngularJS(val: EncodeURIComponentParams, pctEncodeS
       return '%' + c.charCodeAt(0).toString(16).toUpperCase();
     });
 }
-
 type EncodeURIComponentParams = Parameters<typeof encodeURIComponent>[0];
 /**
  *  Encodes URL parameters in the style of AngularJS.
@@ -48,24 +43,19 @@ type EncodeURIComponentParams = Parameters<typeof encodeURIComponent>[0];
 function toUrlParams(a: any, encodeAsAngularJS = true) {
   const s: any[] = [];
   const rbracket = /\[\]$/;
-
   const encodingFunction = encodeAsAngularJS
     ? (value: EncodeURIComponentParams, pctEncodeSpaces?: boolean) =>
         encodeURIComponentAsAngularJS(value, pctEncodeSpaces)
     : (value: EncodeURIComponentParams, _: boolean) => encodeURIComponent(value);
-
   const isArray = (obj: unknown) => {
     return Object.prototype.toString.call(obj) === '[object Array]';
   };
-
   const add = (k: string, v: any) => {
     v = typeof v === 'function' ? v() : v === null ? '' : v === undefined ? '' : v;
     s[s.length] = encodingFunction(k, true) + '=' + encodingFunction(v, true);
   };
-
   const buildParams = (prefix: string, obj: any) => {
     let i, len, key;
-
     if (prefix) {
       if (isArray(obj)) {
         for (i = 0, len = obj.length; i < len; i++) {
@@ -93,10 +83,8 @@ function toUrlParams(a: any, encodeAsAngularJS = true) {
     }
     return s;
   };
-
   return buildParams('', a).join('&');
 }
-
 /**
  * Converts params into a URL-encoded query string.
  *
@@ -106,7 +94,6 @@ function toUrlParams(a: any, encodeAsAngularJS = true) {
 function serializeParams(params: unknown): string {
   return toUrlParams(params, false);
 }
-
 function appendQueryToUrl(url: string, stringToAppend: string) {
   if (stringToAppend !== undefined && stringToAppend !== null && stringToAppend !== '') {
     const pos = url.indexOf('?');
@@ -119,10 +106,8 @@ function appendQueryToUrl(url: string, stringToAppend: string) {
     }
     url += stringToAppend;
   }
-
   return url;
 }
-
 /**
  * Return search part (as object) of current url
  */
@@ -149,7 +134,6 @@ function getUrlSearchParams(): UrlQueryMap {
   }
   return params;
 }
-
 /**
  * Parses an escaped url query string into key-value pairs.
  * Attribution: Code dervived from https://github.com/angular/angular.js/master/src/Angular.js#L1396
@@ -158,33 +142,26 @@ function getUrlSearchParams(): UrlQueryMap {
 export function parseKeyValue(keyValue: string) {
   const obj: any = {};
   const parts = (keyValue || '').split('&');
-
   for (let keyValue of parts) {
     let splitPoint: number | undefined;
     let key: string | undefined;
     let val: string | undefined | boolean;
-
     if (keyValue) {
       key = keyValue = keyValue.replace(/\+/g, '%20');
       splitPoint = keyValue.indexOf('=');
-
       if (splitPoint !== -1) {
         key = keyValue.substring(0, splitPoint);
         val = keyValue.substring(splitPoint + 1);
       }
-
       key = tryDecodeURIComponent(key);
-
       if (key !== undefined) {
         val = val !== undefined ? tryDecodeURIComponent(val as string) : true;
-
         let parsedVal: any;
         if (typeof val === 'string' && val !== '') {
           parsedVal = val === 'true' || val === 'false' ? val === 'true' : val;
         } else {
           parsedVal = val;
         }
-
         if (!obj.hasOwnProperty(key)) {
           obj[key] = isNaN(parsedVal) ? val : parsedVal;
         } else if (Array.isArray(obj[key])) {
@@ -195,10 +172,8 @@ export function parseKeyValue(keyValue: string) {
       }
     }
   }
-
   return obj;
 }
-
 function tryDecodeURIComponent(value: string): string | undefined {
   try {
     return decodeURIComponent(value);
@@ -206,7 +181,6 @@ function tryDecodeURIComponent(value: string): string | undefined {
     return undefined;
   }
 }
-
 export const urlUtil = {
   renderUrl,
   toUrlParams,
@@ -215,7 +189,6 @@ export const urlUtil = {
   parseKeyValue,
   serializeParams,
 };
-
 /**
  * Create an string that is used in URL to represent the Explore state. This is basically just a stringified json
  * that is used as a state of a single Explore pane so it does not represent full Explore URL so some properties
@@ -226,11 +199,10 @@ export const urlUtil = {
  */
 export function serializeStateToUrlParam(urlState: Partial<ExploreUrlState>, compact?: boolean): string {
   if (compact !== undefined) {
-    console.warn('`compact` parameter is deprecated and will be removed in a future release');
+    structLog('warn', '`compact` parameter is deprecated and will be removed in a future release');
   }
   return JSON.stringify(urlState);
 }
-
 /**
  * Converts RawTimeRange to a string that is stored in the URL
  * - relative - stays as it is (e.g. "now")
@@ -241,12 +213,10 @@ export const toURLRange = (range: RawTimeRange): URLRange => {
   if (isDateTime(from)) {
     from = from.valueOf().toString();
   }
-
   let to = range.to;
   if (isDateTime(to)) {
     to = to.valueOf().toString();
   }
-
   return {
     from,
     to,

--- a/packages/grafana-data/src/vector/ArrayVector.ts
+++ b/packages/grafana-data/src/vector/ArrayVector.ts
@@ -1,6 +1,6 @@
+import { structLog } from '../utils/structLog';
 const notice = 'ArrayVector is deprecated and will be removed in Grafana 11. Please use plain arrays for field.values.';
 let notified = false;
-
 /**
  * @public
  *
@@ -10,34 +10,26 @@ export class ArrayVector<T = unknown> extends Array<T> {
   get buffer() {
     return this;
   }
-
   get(index: number): T {
     return this[index];
   }
-
   set(index: number): T {
     return this[index];
   }
-
   add(v: T): number {
     return this.push(v);
   }
-
   set buffer(values: T[]) {
     this.length = 0;
-
     const len = values?.length;
-
     if (len) {
       let chonkSize = 65e3;
       let numChonks = Math.ceil(len / chonkSize);
-
       for (let chonkIdx = 0; chonkIdx < numChonks; chonkIdx++) {
         this.push.apply(this, values.slice(chonkIdx * chonkSize, (chonkIdx + 1) * chonkSize));
       }
     }
   }
-
   /**
    * ArrayVector is deprecated and should not be used. If you get a Typescript error here, use plain arrays for field.values.
    */
@@ -45,13 +37,11 @@ export class ArrayVector<T = unknown> extends Array<T> {
   constructor(buffer: never) {
     super();
     this.buffer = buffer ?? [];
-
     if (!notified) {
-      console.warn(notice);
+      structLog('warn', notice);
       notified = true;
     }
   }
-
   toJSON(): T[] {
     return [...this]; // copy to avoid circular reference (only for jest)
   }

--- a/packages/grafana-i18n/package.json
+++ b/packages/grafana-i18n/package.json
@@ -53,6 +53,7 @@
   },
   "dependencies": {
     "@formatjs/intl-durationformat": "^0.7.0",
+    "@grafana/data": "13.0.0-pre",
     "@typescript-eslint/utils": "^8.33.1",
     "fast-deep-equal": "^3.1.3",
     "i18next": "^25.0.0",

--- a/packages/grafana-i18n/src/i18n.tsx
+++ b/packages/grafana-i18n/src/i18n.tsx
@@ -1,17 +1,15 @@
+import { structLog } from '@grafana/data';
 import i18n, { type InitOptions, type ReactOptions, type TFunction as I18NextTFunction } from 'i18next';
 import LanguageDetector, { type DetectorOptions } from 'i18next-browser-languagedetector';
 import React from 'react';
 // eslint-disable-next-line no-restricted-imports
 import { initReactI18next, setDefaults, setI18n, Trans as I18NextTrans, getI18n } from 'react-i18next';
-
 import { DEFAULT_LANGUAGE, PSEUDO_LOCALE } from './constants';
 import { initRegionalFormat } from './dates';
 import { LANGUAGES } from './languages';
 import { type ResourceLoader, type Resources, type TFunction, type TransProps, type TransType } from './types';
-
 let tFunc: I18NextTFunction<string[], undefined> | undefined;
 let transComponent: TransType;
-
 const VALID_LANGUAGES = [
   ...LANGUAGES,
   {
@@ -19,44 +17,47 @@ const VALID_LANGUAGES = [
     code: PSEUDO_LOCALE,
   },
 ];
-
-function initTFuncAndTransComponent({ id, ns }: { id?: string; ns?: string[] } = {}) {
+function initTFuncAndTransComponent({
+  id,
+  ns,
+}: {
+  id?: string;
+  ns?: string[];
+} = {}) {
   if (id) {
     tFunc = getI18nInstance().getFixedT(null, id);
     transComponent = (props: TransProps) => <I18NextTrans shouldUnescape ns={id} {...props} />;
     return;
   }
-
   tFunc = getI18nInstance().t;
   transComponent = (props: TransProps) => <I18NextTrans shouldUnescape ns={ns} {...props} />;
 }
-
 export async function loadNamespacedResources(namespace: string, language: string, loaders?: ResourceLoader[]) {
   if (!loaders?.length) {
     return;
   }
-
   const resolvedLanguage = language === PSEUDO_LOCALE ? DEFAULT_LANGUAGE : language;
-
   return Promise.all(
     loaders.map(async (loader) => {
       try {
         const resources = await loader(resolvedLanguage);
         addResourceBundle(resolvedLanguage, namespace, resources);
       } catch (error) {
-        console.error(`Error loading resources for namespace ${namespace} and language: ${resolvedLanguage}`, error);
+        structLog(
+          'error',
+          `Error loading resources for namespace ${namespace} and language: ${resolvedLanguage}`,
+          error
+        );
       }
     })
   );
 }
-
 // exported for testing
 export function initDefaultI18nInstance() {
   // If the resources are not an object, we need to initialize the plugin translations
   if (getI18nInstance().options?.resources && typeof getI18nInstance().options.resources === 'object') {
     return;
   }
-
   const initPromise = getI18nInstance().use(initReactI18next).init({
     resources: {},
     returnEmptyString: false,
@@ -65,76 +66,61 @@ export function initDefaultI18nInstance() {
   initTFuncAndTransComponent();
   return initPromise;
 }
-
 // exported for testing
 export function initDefaultReactI18nInstance() {
   // If the initReactI18next is not set, we need to set them
   if (getI18n()?.options?.react) {
     return;
   }
-
   const options: ReactOptions = {};
   setDefaults(options);
   setI18n(getI18nInstance());
 }
-
 export async function initPluginTranslations(id: string, loaders?: ResourceLoader[]) {
   await initDefaultI18nInstance();
   initDefaultReactI18nInstance();
-
   const language = getResolvedLanguage();
   initTFuncAndTransComponent({ id });
-
   await loadNamespacedResources(id, language, loaders);
-
   return { language };
 }
-
 export function getI18nInstance(): typeof i18n {
   // in Grafana versions < 12.1.0 the i18n instance is exposed through the default export
   // used by plugins that support translations from Grafana >= 11.0.0
-  const instance: typeof i18n & { default?: typeof i18n } = i18n;
+  const instance: typeof i18n & {
+    default?: typeof i18n;
+  } = i18n;
   if (instance && instance.default) {
     return instance.default;
   }
-
   return instance;
 }
-
 interface Module {
   type: 'backend';
 }
-
 interface InitializeI18nOptions {
   ns?: string[];
   language?: string;
   module?: Module;
 }
-
-async function initTranslations({
-  ns,
-  language = DEFAULT_LANGUAGE,
-  module,
-}: InitializeI18nOptions): Promise<{ language: string | undefined }> {
+async function initTranslations({ ns, language = DEFAULT_LANGUAGE, module }: InitializeI18nOptions): Promise<{
+  language: string | undefined;
+}> {
   const options: InitOptions = {
     // We don't bundle any translations, we load them async
     partialBundledLanguages: true,
     resources: {},
-
     // If translations are empty strings (no translation), fall back to the default value in source code
     returnEmptyString: false,
-
     // Required to ensure that `resolvedLanguage` is set property when an invalid language is passed (such as through 'detect')
     supportedLngs: VALID_LANGUAGES.map((lang) => lang.code),
     fallbackLng: DEFAULT_LANGUAGE,
-
     ns,
     postProcess: [
       // Add pseudo processing even if we aren't necessarily going to use it
       PSEUDO_LOCALE,
     ],
   };
-
   if (language === 'detect') {
     getI18nInstance().use(LanguageDetector);
     const detection: DetectorOptions = { order: ['navigator'], caches: [] };
@@ -142,13 +128,11 @@ async function initTranslations({
   } else {
     options.lng = VALID_LANGUAGES.find((lang) => lang.code === language)?.code ?? undefined;
   }
-
   if (module) {
     getI18nInstance().use(module).use(initReactI18next); // passes i18n down to react-i18next
   } else {
     getI18nInstance().use(initReactI18next); // passes i18n down to react-i18next
   }
-
   if (language === PSEUDO_LOCALE) {
     const { default: Pseudo } = await import('i18next-pseudo');
     getI18nInstance().use(
@@ -159,64 +143,53 @@ async function initTranslations({
       })
     );
   }
-
   await getI18nInstance().init(options);
-
   initTFuncAndTransComponent({ ns });
-
   return {
     language: getResolvedLanguage(),
   };
 }
-
 export function getLanguage() {
   return getI18nInstance()?.language || DEFAULT_LANGUAGE;
 }
-
 export function getResolvedLanguage() {
   return getI18nInstance()?.resolvedLanguage || DEFAULT_LANGUAGE;
 }
-
 export function getNamespaces() {
   return getI18nInstance()?.options.ns;
 }
-
 export async function changeLanguage(language?: string) {
   const validLanguage = VALID_LANGUAGES.find((lang) => lang.code === language)?.code ?? DEFAULT_LANGUAGE;
   await getI18nInstance().changeLanguage(validLanguage);
 }
-
 export async function initializeI18n(
   { language, ns, module }: InitializeI18nOptions,
   regionalFormat: string
-): Promise<{ language: string | undefined }> {
+): Promise<{
+  language: string | undefined;
+}> {
   initRegionalFormat(regionalFormat);
   return initTranslations({ language, ns, module });
 }
-
 export function addResourceBundle(language: string, namespace: string, resources: Resources) {
   getI18nInstance().addResourceBundle(language, namespace, resources, true, false);
 }
-
 export const t: TFunction = (id: string, defaultMessage: string, values?: Record<string, unknown>) => {
   initDefaultI18nInstance();
   if (!tFunc) {
     if (process.env.NODE_ENV !== 'test') {
-      console.warn(
+      structLog(
+        'warn',
         't() was called before i18n was initialized. This is probably caused by calling t() in the root module scope, instead of lazily on render'
       );
     }
-
     if (process.env.NODE_ENV === 'development') {
       throw new Error('t() was called before i18n was initialized');
     }
-
     tFunc = getI18nInstance().t;
   }
-
   return tFunc(id, defaultMessage, values);
 };
-
 export function Trans(props: TransProps): React.ReactElement {
   initDefaultI18nInstance();
   const Component = transComponent ?? I18NextTrans;

--- a/packages/grafana-openapi/src/scripts/process-specs.ts
+++ b/packages/grafana-openapi/src/scripts/process-specs.ts
@@ -1,7 +1,7 @@
+import { structLog } from '@grafana/data';
 import fs from 'fs';
 import { type OpenAPIV3 } from 'openapi-types';
 import path from 'path';
-
 /**
  * Process an OpenAPI spec to remove k8s metadata from names and paths:
  * - Remove paths containing "/watch/" as they're deprecated.
@@ -14,7 +14,6 @@ import path from 'path';
 function processOpenAPISpec(spec: OpenAPIV3.Document) {
   // Create a deep copy of the spec to avoid mutating the original
   const newSpec = JSON.parse(JSON.stringify(spec));
-
   // Process 'paths' property
   const newPaths: Record<string, unknown> = {};
   for (const [path, pathItem] of Object.entries<OpenAPIV3.PathItemObject>(newSpec.paths)) {
@@ -24,19 +23,15 @@ function processOpenAPISpec(spec: OpenAPIV3.Document) {
     }
     // Remove the specified part from the path key
     const newPathKey = path.replace(/^\/apis\/[^\/]+\/[^\/]+/, '').replace(/^\/namespaces\/\{namespace}/, '');
-
     // Process each method in the path (e.g., get, post)
     const newPathItem: Record<string, unknown> = {};
-
     // Filter out namespace parameter at path level
     if (Array.isArray(pathItem.parameters)) {
       pathItem.parameters = filterNamespaceParameters(pathItem.parameters);
     }
-
     for (const method of Object.keys(pathItem)) {
       // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
       const operation = pathItem[method as keyof OpenAPIV3.PathItemObject];
-
       if (
         typeof operation === 'object' &&
         operation !== null &&
@@ -45,7 +40,6 @@ function processOpenAPISpec(spec: OpenAPIV3.Document) {
       ) {
         continue;
       }
-
       // Filter out namespace parameter at operation level
       if (
         operation &&
@@ -55,16 +49,12 @@ function processOpenAPISpec(spec: OpenAPIV3.Document) {
       ) {
         operation.parameters = filterNamespaceParameters(operation.parameters);
       }
-
       updateRefs(operation);
-
       newPathItem[method] = operation;
     }
-
     newPaths[newPathKey] = newPathItem;
   }
   newSpec.paths = newPaths;
-
   // Process 'components.schemas', i.e., type definitions
   const newSchemas: Record<string, unknown> = {};
   for (const schemaKey of Object.keys(newSpec.components.schemas)) {
@@ -74,24 +64,19 @@ function processOpenAPISpec(spec: OpenAPIV3.Document) {
       // it is better to fix the spec to avoid confusion.
       throw new Error(`Duplicate schema key found: ${newKey}. from: ${schemaKey}`);
     }
-
     const schemaObject = newSpec.components.schemas[schemaKey];
     updateRefs(schemaObject);
-
     newSchemas[newKey] = schemaObject;
   }
   newSpec.components.schemas = newSchemas;
-
   return newSpec;
 }
-
 /**
  * Filter out namespace parameters from an array of parameters
  */
 function filterNamespaceParameters(parameters: Array<OpenAPIV3.ReferenceObject | OpenAPIV3.ParameterObject>) {
   return parameters.filter((param) => 'name' in param && param.name !== 'namespace');
 }
-
 /**
  * Recursively update all $ref fields to remove k8s metadata from names
  */
@@ -115,25 +100,21 @@ function updateRefs(obj: unknown) {
     }
   }
 }
-
 /**
  * Simplify a schema name by removing the version prefix if present.
  * For example, 'io.k8s.apimachinery.pkg.apis.meta.v1.Time' becomes 'Time'.
  */
 function simplifySchemaName(schemaName: string) {
   const parts = schemaName.split('.');
-
   // Regex to match version segments like 'v1', 'v1beta1', 'v0alpha1', etc.
   const versionRegex = /^v\d+[a-zA-Z0-9]*$/;
   const versionIndex = parts.findIndex((part) => versionRegex.test(part));
-
   if (versionIndex !== -1 && versionIndex + 1 < parts.length) {
     return parts.slice(versionIndex + 1).join('.');
   } else {
     return schemaName;
   }
 }
-
 /**
  * Process all files in a source directory and write results to output directory
  */
@@ -142,50 +123,39 @@ function processDirectory(sourceDir: string, outputDir: string) {
   if (!fs.existsSync(sourceDir)) {
     return;
   }
-
   // Create the output directory if it doesn't exist
   if (!fs.existsSync(outputDir)) {
     fs.mkdirSync(outputDir, { recursive: true });
   }
-
   const files = fs.readdirSync(sourceDir).filter((file: string) => file.endsWith('.json'));
-
   for (const file of files) {
     const inputPath = path.join(sourceDir, file);
     const outputPath = path.join(outputDir, file);
-
-    console.log(`Processing file "${file}"...`);
-
+    structLog('log', `Processing file "${file}"...`);
     const fileContent = fs.readFileSync(inputPath, 'utf-8');
-
     let inputSpec;
     try {
       inputSpec = JSON.parse(fileContent);
     } catch (err) {
-      console.error(`Invalid JSON file "${file}". Skipping this file.`);
+      structLog('error', `Invalid JSON file "${file}". Skipping this file.`);
       continue;
     }
-
     const outputSpec = processOpenAPISpec(inputSpec);
     fs.writeFileSync(outputPath, JSON.stringify(outputSpec, null, 2), 'utf-8');
-    console.log(`Processing completed for file "${file}".`);
+    structLog('log', `Processing completed for file "${file}".`);
   }
 }
-
 // Grafana root path - navigate up from this script's directory
 const basePath = path.resolve(import.meta.dirname, '../../../..');
-
 const oss = {
   source: path.join(basePath, 'pkg/tests/apis/openapi_snapshots'),
   output: path.join(import.meta.dirname, '../apis'),
 };
-
 // This script is also used to process specs from the Enterprise repo but we're not publishing these as part of this package for now
 const enterprise = {
   source: path.join(basePath, 'pkg/extensions/apiserver/tests/openapi_snapshots'),
   output: path.join(basePath, 'data/openapi'),
 };
-
 for (const config of [oss, enterprise]) {
   processDirectory(config.source, config.output);
 }

--- a/packages/grafana-prometheus/src/components/metrics-browser/ValueSelector.tsx
+++ b/packages/grafana-prometheus/src/components/metrics-browser/ValueSelector.tsx
@@ -1,24 +1,19 @@
+import { structLog } from '@grafana/data';
 import { useEffect, useState } from 'react';
 import { FixedSizeList } from 'react-window';
-
 import { selectors } from '@grafana/e2e-selectors';
 import { t, Trans } from '@grafana/i18n';
 import { BrowserLabel as PromLabel, Input, Label, useStyles2, Spinner } from '@grafana/ui';
-
 import { LIST_ITEM_SIZE } from '../../constants';
-
 import { useMetricsBrowser } from './MetricsBrowserContext';
 import { getStylesMetricsBrowser, getStylesValueSelector } from './styles';
-
 export function ValueSelector() {
   const styles = useStyles2(getStylesValueSelector);
   const sharedStyles = useStyles2(getStylesMetricsBrowser);
-
   const [valueSearchTerm, setValueSearchTerm] = useState('');
   const { labelValues, selectedLabelValues, isLoadingLabelValues, onLabelValueClick, onLabelKeyClick } =
     useMetricsBrowser();
   const [filteredLabelValues, setFilteredLabelValues] = useState<Record<string, string[]>>({ ...labelValues });
-
   useEffect(() => {
     const filtered: Record<string, string[]> = {};
     for (const labelKey in labelValues) {
@@ -27,7 +22,6 @@ export function ValueSelector() {
     }
     setFilteredLabelValues(filtered);
   }, [labelValues, valueSearchTerm]);
-
   return (
     <div className={styles.section}>
       <Label
@@ -59,7 +53,7 @@ export function ValueSelector() {
         <div className={styles.valueListArea}>
           {Object.entries(filteredLabelValues).map(([lk, lv]) => {
             if (!lk || !lv) {
-              console.error('label values are empty:', { lk, lv });
+              structLog('error', 'label values are empty:', { lk, lv });
               return null;
             }
             return (

--- a/packages/grafana-prometheus/src/components/monaco-query-field/getOverrideServices.ts
+++ b/packages/grafana-prometheus/src/components/monaco-query-field/getOverrideServices.ts
@@ -1,6 +1,6 @@
+import { structLog } from '@grafana/data';
 // Core Grafana history https://github.com/grafana/grafana/blob/v11.0.0-preview/public/app/plugins/datasource/prometheus/components/monaco-query-field/getOverrideServices.ts
 import { type monacoTypes } from '@grafana/ui';
-
 // this thing here is a workaround in a way.
 // what we want to achieve, is that when the autocomplete-window
 // opens, the "second, extra popup" with the extra help,
@@ -18,27 +18,21 @@ import { type monacoTypes } from '@grafana/ui';
 // i am not 100% how the `scope` and `target` things work,
 // but so far it seems to work ok.
 // i would use an another approach, if there was one available.
-
 function makeStorageService() {
   // we need to return an object that fulfills this interface:
   // https://github.com/microsoft/vscode/blob/ff1e16eebb93af79fd6d7af1356c4003a120c563/src/vs/platform/storage/common/storage.ts#L37
   // unfortunately it is not export from monaco-editor
-
   const strings = new Map<string, string>();
-
   // we want this to be true by default
   strings.set('expandSuggestionDocs', true.toString());
-
   return {
     // we do not implement the on* handlers
     onDidChangeValue: (data: unknown): void => undefined,
     onDidChangeTarget: (data: unknown): void => undefined,
     onWillSaveState: (data: unknown): void => undefined,
-
     get: (key: string, scope: unknown, fallbackValue?: string): string | undefined => {
       return strings.get(key) ?? fallbackValue;
     },
-
     getBoolean: (key: string, scope: unknown, fallbackValue?: boolean): boolean | undefined => {
       const val = strings.get(key);
       if (val !== undefined) {
@@ -49,7 +43,6 @@ function makeStorageService() {
         return fallbackValue;
       }
     },
-
     getNumber: (key: string, scope: unknown, fallbackValue?: number): number | undefined => {
       const val = strings.get(key);
       if (val !== undefined) {
@@ -58,7 +51,6 @@ function makeStorageService() {
         return fallbackValue;
       }
     },
-
     store: (
       key: string,
       value: string | boolean | number | undefined | null,
@@ -72,39 +64,31 @@ function makeStorageService() {
         strings.set(key, value.toString());
       }
     },
-
     remove: (key: string, scope: unknown): void => {
       strings.delete(key);
     },
-
     keys: (scope: unknown, target: unknown): string[] => {
       return Array.from(strings.keys());
     },
-
     logStorage: (): void => {
-      console.log('logStorage: not implemented');
+      structLog('log', 'logStorage: not implemented');
     },
-
     migrate: (): Promise<void> => {
       // we do not implement this
       return Promise.resolve(undefined);
     },
-
     isNew: (scope: unknown): boolean => {
       // we create a new storage for every session, we do not persist it,
       // so we return `true`.
       return true;
     },
-
     flush: (reason?: unknown): Promise<void> => {
       // we do not implement this
       return Promise.resolve(undefined);
     },
   };
 }
-
 let overrideServices: monacoTypes.editor.IEditorOverrideServices | null = null;
-
 export function getOverrideServices(): monacoTypes.editor.IEditorOverrideServices {
   // only have one instance of this for every query editor
   if (overrideServices === null) {
@@ -112,6 +96,5 @@ export function getOverrideServices(): monacoTypes.editor.IEditorOverrideService
       storageService: makeStorageService(),
     };
   }
-
   return overrideServices;
 }

--- a/packages/grafana-prometheus/src/components/monaco-query-field/monaco-completion-provider/data_provider.ts
+++ b/packages/grafana-prometheus/src/components/monaco-query-field/monaco-completion-provider/data_provider.ts
@@ -1,18 +1,15 @@
+import { structLog } from '@grafana/data';
 import { type HistoryItem, type TimeRange } from '@grafana/data';
-
 import { DEFAULT_COMPLETION_LIMIT, METRIC_LABEL } from '../../../constants';
 import { type PrometheusLanguageProviderInterface } from '../../../language_provider';
 import { removeQuotesIfExist } from '../../../language_utils';
 import { type PromQuery } from '../../../types';
 import { escapeForUtf8Support, isValidLegacyName } from '../../../utf8_support';
-
 export const CODE_MODE_SUGGESTIONS_INCOMPLETE_EVENT = 'codeModeSuggestionsIncomplete';
-
 type SuggestionsIncompleteEvent = CustomEvent<{
   limit: number;
   datasourceUid: string;
 }>;
-
 export function isSuggestionsIncompleteEvent(e: Event): e is SuggestionsIncompleteEvent {
   return (
     e.type === CODE_MODE_SUGGESTIONS_INCOMPLETE_EVENT &&
@@ -23,23 +20,19 @@ export function isSuggestionsIncompleteEvent(e: Event): e is SuggestionsIncomple
     'datasourceUid' in e.detail
   );
 }
-
 interface Metric {
   name: string;
   help: string;
   type: string;
   isUtf8?: boolean;
 }
-
 export interface DataProviderParams {
   languageProvider: PrometheusLanguageProviderInterface;
   historyProvider: Array<HistoryItem<PromQuery>>;
 }
-
 export class DataProvider {
   readonly languageProvider: PrometheusLanguageProviderInterface;
   readonly historyProvider: Array<HistoryItem<PromQuery>>;
-
   readonly queryLabelKeys: typeof this.languageProvider.queryLabelKeys;
   readonly queryLabelValues: typeof this.languageProvider.queryLabelValues;
   /**
@@ -49,16 +42,13 @@ export class DataProvider {
    * This is useful with fuzzy searching items to provide as Monaco autocomplete suggestions.
    */
   private inputInRange: string;
-
   constructor(params: DataProviderParams) {
     this.languageProvider = params.languageProvider;
     this.historyProvider = params.historyProvider;
     this.inputInRange = '';
-
     this.queryLabelKeys = this.languageProvider.queryLabelKeys.bind(this.languageProvider);
     this.queryLabelValues = this.languageProvider.queryLabelValues.bind(this.languageProvider);
   }
-
   /**
    * Queries metric names with optional filtering.
    * Safely constructs regex patterns and handles errors.
@@ -70,29 +60,24 @@ export class DataProvider {
         const escapedWord = escapeForUtf8Support(removeQuotesIfExist(searchTerm));
         match = `{__name__=~".*${escapedWord}.*"}`;
       }
-
       const result = await this.languageProvider.queryLabelValues(
         timeRange,
         METRIC_LABEL,
         match,
         DEFAULT_COMPLETION_LIMIT
       );
-
       return Array.isArray(result) ? result : [];
     } catch (error) {
-      console.warn('Failed to query metric names:', error);
+      structLog('warn', 'Failed to query metric names:', error);
       return [];
     }
   };
-
   getHistory(): string[] {
     return this.historyProvider.map((h) => h.query.expr).filter(Boolean);
   }
-
   getAllMetricNames(): string[] {
     return this.languageProvider.retrieveMetrics();
   }
-
   metricNamesToMetrics(metricNames: string[]): Metric[] {
     const metricsMetadata = this.languageProvider.retrieveMetricsMetadata();
     const result: Metric[] = metricNames.map((m) => {
@@ -104,14 +89,11 @@ export class DataProvider {
         isUtf8: !isValidLegacyName(m),
       };
     });
-
     return result;
   }
-
   private setInputInRange(textInput: string): void {
     this.inputInRange = textInput;
   }
-
   get monacoSettings() {
     return {
       inputInRange: this.inputInRange,

--- a/packages/grafana-prometheus/src/datasource.ts
+++ b/packages/grafana-prometheus/src/datasource.ts
@@ -1,9 +1,9 @@
+import { structLog } from '@grafana/data';
 import { defaults } from 'lodash';
 import { tz } from 'moment-timezone';
 import { lastValueFrom, type Observable, throwError } from 'rxjs';
 import { map, tap } from 'rxjs/operators';
 import { gte } from 'semver';
-
 import {
   type AbstractQuery,
   type AdHocVariableFilter,
@@ -38,7 +38,6 @@ import {
   isFetchError,
   type TemplateSrv,
 } from '@grafana/runtime';
-
 import { addLabelToQuery } from './add_label_to_query';
 import { PrometheusAnnotationSupport } from './annotations';
 import { DEFAULT_SERIES_LIMIT, GET_AND_POST_METADATA_ENDPOINTS, InstantQueryRefIdIndex } from './constants';
@@ -70,7 +69,6 @@ import {
 } from './types';
 import { utf8Support, wrapUtf8Filters } from './utf8_support';
 import { PrometheusVariableSupport } from './variables';
-
 export class PrometheusDatasource
   extends DataSourceWithBackend<PromQuery, PromOptions>
   implements DataSourceWithQueryImportSupport<PromQuery>, DataSourceWithQueryExportSupport<PromQuery>
@@ -97,14 +95,12 @@ export class PrometheusDatasource
   url: string;
   withCredentials: boolean;
   defaultEditor?: QueryEditorMode;
-
   constructor(
     public readonly instanceSettings: DataSourceInstanceSettings<PromOptions>,
     private readonly templateSrv: TemplateSrv = getTemplateSrv(),
     languageProvider?: PrometheusLanguageProviderInterface
   ) {
     super(instanceSettings);
-
     // DATASOURCE CONFIGURATION PROPERTIES
     this.access = instanceSettings.access;
     this.basicAuth = instanceSettings.basicAuth;
@@ -131,16 +127,13 @@ export class PrometheusDatasource
     this.url = instanceSettings.url!;
     this.withCredentials = Boolean(instanceSettings.withCredentials);
     this.defaultEditor = instanceSettings.jsonData.defaultEditor;
-
     // INHERITED PROPERTIES
     this.annotations = PrometheusAnnotationSupport(this);
     this.variables = new PrometheusVariableSupport(this, this.templateSrv);
-
     // LANGUAGE PROVIDER
     // This needs to be the last thing we initialize.
     this.languageProvider = languageProvider ?? new PrometheusLanguageProvider(this);
   }
-
   /**
    * Initializes the Prometheus datasource by loading recording rules and checking exemplar availability.
    *
@@ -153,7 +146,6 @@ export class PrometheusDatasource
     }
     this.exemplarsAvailable = await this.areExemplarsAvailable();
   };
-
   /**
    * Loads recording rules from the Prometheus API and extracts rule mappings.
    *
@@ -167,16 +159,14 @@ export class PrometheusDatasource
       const options = { showErrorAlert: false };
       const res = await this.metadataRequest('/api/v1/rules', params, options);
       const ruleGroups = res.data?.data?.groups;
-
       if (ruleGroups) {
         this.ruleMappings = extractRuleMappingFromGroups(ruleGroups);
       }
     } catch (err) {
-      console.log('Rules API is experimental. Ignore next error.');
-      console.error(err);
+      structLog('log', 'Rules API is experimental. Ignore next error.');
+      structLog('error', err);
     }
   }
-
   /**
    * Checks if exemplars are available by testing the exemplars API endpoint.
    *
@@ -195,17 +185,14 @@ export class PrometheusDatasource
       };
       const options = { showErrorAlert: false };
       const res = await this.metadataRequest('/api/v1/query_exemplars', params, options);
-
       return res.data.status === 'success';
     } catch (err) {
       return false;
     }
   }
-
   getQueryDisplayText(query: PromQuery) {
     return query.expr;
   }
-
   /**
    * Get target signature for query caching
    * @param request
@@ -213,18 +200,14 @@ export class PrometheusDatasource
    */
   getPrometheusTargetSignature(request: DataQueryRequest<PromQuery>, query: PromQuery) {
     const targExpr = this.interpolateString(query.expr);
-    return `${targExpr}|${query.interval ?? request.interval}|${JSON.stringify(request.rangeRaw ?? '')}|${
-      query.exemplar
-    }`;
+    return `${targExpr}|${query.interval ?? request.interval}|${JSON.stringify(request.rangeRaw ?? '')}|${query.exemplar}`;
   }
-
   hasLabelsMatchAPISupport(): boolean {
     // users may choose the series endpoint as it has a POST method
     // while the label values is only GET
     if (this.seriesEndpoint) {
       return false;
     }
-
     return (
       // https://github.com/prometheus/prometheus/releases/tag/v2.24.0
       this._isDatasourceVersionGreaterOrEqualTo('2.24.0', PromApplication.Prometheus) ||
@@ -237,20 +220,16 @@ export class PrometheusDatasource
       this._isDatasourceVersionGreaterOrEqualTo('0.18.0', PromApplication.Thanos)
     );
   }
-
   _isDatasourceVersionGreaterOrEqualTo(targetVersion: string, targetFlavor: PromApplication): boolean {
     // User hasn't configured flavor/version yet, default behavior is to support labels match api support
     if (!this.datasourceConfigurationPrometheusVersion || !this.datasourceConfigurationPrometheusFlavor) {
       return true;
     }
-
     if (targetFlavor !== this.datasourceConfigurationPrometheusFlavor) {
       return false;
     }
-
     return gte(this.datasourceConfigurationPrometheusVersion, targetVersion);
   }
-
   _addTracingHeaders(httpOptions: PromQueryRequest, options: DataQueryRequest<PromQuery>) {
     httpOptions.headers = {};
     if (this.access === 'proxy') {
@@ -258,7 +237,6 @@ export class PrometheusDatasource
       httpOptions.headers['X-Panel-Id'] = options.panelId;
     }
   }
-
   directAccessError() {
     return throwError(
       () =>
@@ -267,7 +245,6 @@ export class PrometheusDatasource
         )
     );
   }
-
   /**
    * Any request done from this data source should go through here as it contains some common processing for the
    * request. Any processing done here needs to be also copied on the backend as this goes through data source proxy
@@ -281,26 +258,22 @@ export class PrometheusDatasource
     if (this.access === 'direct') {
       return this.directAccessError();
     }
-
     data = data || {};
     for (const [key, value] of this.customQueryParameters) {
       if (data[key] == null) {
         data[key] = value;
       }
     }
-
     let queryUrl = this.url + url;
     if (url.startsWith(`/api/datasources/uid/${this.uid}`)) {
       // This url is meant to be a replacement for the whole URL. Replace the entire URL
       queryUrl = url;
     }
-
     const options: BackendSrvRequest = defaults(overrides, {
       url: queryUrl,
       method: this.httpMethod,
       headers: {},
     });
-
     if (options.method === 'GET') {
       if (data && Object.keys(data).length) {
         options.url =
@@ -316,26 +289,20 @@ export class PrometheusDatasource
       }
       options.data = data;
     }
-
     if (this.basicAuth || this.withCredentials) {
       options.withCredentials = true;
     }
-
     if (this.basicAuth) {
       options.headers!.Authorization = this.basicAuth;
     }
-
     return getBackendSrv().fetch<T>(options);
   }
-
   async importFromAbstractQueries(abstractQueries: AbstractQuery[]): Promise<PromQuery[]> {
     return abstractQueries.map((abstractQuery) => importFromAbstractQuery(abstractQuery));
   }
-
   async exportToAbstractQueries(queries: PromQuery[]): Promise<AbstractQuery[]> {
     return queries.map((query) => exportToAbstractQuery(query));
   }
-
   // Use this for tab completion features, wont publish response to other components
   async metadataRequest<T = any>(url: string, params = {}, options?: Partial<BackendSrvRequest>) {
     // If URL includes endpoint that supports POST and GET method, try to use configured method. This might fail as POST is supported only in v2.10+.
@@ -352,13 +319,15 @@ export class PrometheusDatasource
       } catch (err) {
         // If status code of error is Method Not Allowed (405) and HTTP method is POST, retry with GET
         if (this.httpMethod === 'POST' && isFetchError(err) && (err.status === 405 || err.status === 400)) {
-          console.warn(`Couldn't use configured POST HTTP method for this request. Trying to use GET method instead.`);
+          structLog(
+            'warn',
+            `Couldn't use configured POST HTTP method for this request. Trying to use GET method instead.`
+          );
         } else {
           throw err;
         }
       }
     }
-
     return await lastValueFrom(
       this._request<T>(`/api/datasources/uid/${this.uid}/resources${url}`, params, {
         method: 'GET',
@@ -367,15 +336,12 @@ export class PrometheusDatasource
       })
     ); // toPromise until we change getTagValues, getLabelNames to Observable
   }
-
   interpolateQueryExpr(value: string | string[] = [], variable: QueryVariableModel | CustomVariableModel) {
     return interpolateQueryExpr(value, variable);
   }
-
   targetContainsTemplate(target: PromQuery) {
     return this.templateSrv.containsTemplate(target.expr);
   }
-
   shouldRunExemplarQuery(target: PromQuery, request: DataQueryRequest<PromQuery>): boolean {
     if (target.exemplar) {
       // We check all already processed targets and only create exemplar target for not used metric names
@@ -383,7 +349,6 @@ export class PrometheusDatasource
       // Remove targets that weren't processed yet (in targets array they are after current target)
       const currentTargetIdx = request.targets.findIndex((t) => t.refId === target.refId);
       const targets = request.targets.slice(0, currentTargetIdx).filter((t) => !t.hide);
-
       if (!metricName || (metricName && !targets.some((t) => t.expr.includes(metricName)))) {
         return true;
       }
@@ -391,7 +356,6 @@ export class PrometheusDatasource
     }
     return false;
   }
-
   processTargetV2(target: PromQuery, request: DataQueryRequest<PromQuery>) {
     // The `utcOffsetSec` parameter is required by the backend to correctly align time ranges.
     // This alignment ensures that relative time ranges (e.g., "Last N hours/days/years") are adjusted
@@ -419,7 +383,6 @@ export class PrometheusDatasource
     } else {
       utcOffset = tz(request.timezone).utcOffset();
     }
-
     const processedTargets: PromQuery[] = [];
     const processedTarget = {
       ...target,
@@ -427,18 +390,15 @@ export class PrometheusDatasource
       requestId: request.panelId + target.refId,
       utcOffsetSec: utcOffset * 60,
     };
-
     if (request.scopes) {
       processedTarget.scopes = (request.scopes ?? []).map((scope) => ({
         name: scope.metadata.name,
         ...scope.spec,
       }));
     }
-
     if (config.featureToggles.groupByVariable || config.featureToggles.dashboardUnifiedDrilldownControls) {
       processedTarget.groupByKeys = request.groupByKeys;
     }
-
     if (target.instant && target.range) {
       // We have query type "Both" selected
       // We should send separate queries with different refId
@@ -458,29 +418,23 @@ export class PrometheusDatasource
     } else {
       processedTargets.push(processedTarget);
     }
-
     return processedTargets;
   }
-
   query(request: DataQueryRequest<PromQuery>): Observable<DataQueryResponse> {
     if (this.access === 'direct') {
       return this.directAccessError();
     }
-
     // Use incremental query only if enabled and no instant queries or no $__range variables
     const shouldUseIncrementalQuery =
       this.hasIncrementalQuery &&
       !config.publicDashboardAccessToken &&
       !request.targets.some((target) => target.instant || target.expr?.includes('$__range'));
-
     let fullOrPartialRequest: DataQueryRequest<PromQuery> = request;
     let requestInfo: CacheRequestInfo<PromQuery> | undefined = undefined;
-
     if (shouldUseIncrementalQuery) {
       requestInfo = this.cache.requestInfo(request);
       fullOrPartialRequest = requestInfo.requests[0];
     }
-
     const targets = fullOrPartialRequest.targets.map((target) => this.processTargetV2(target, fullOrPartialRequest));
     const startTime = new Date();
     return super.query({ ...fullOrPartialRequest, targets: targets.flat() }).pipe(
@@ -498,14 +452,11 @@ export class PrometheusDatasource
       })
     );
   }
-
   metricFindQuery(query: string, options?: LegacyMetricFindQueryOptions) {
     if (!query) {
       return Promise.resolve([]);
     }
-
     const timeRange = options?.range ?? getDefaultTimeRange();
-
     const scopedVars = {
       ...this.getIntervalVars(),
       ...this.getRangeScopedVars(timeRange),
@@ -514,14 +465,12 @@ export class PrometheusDatasource
     const metricFindQuery = new PrometheusMetricFindQuery(this, interpolated);
     return metricFindQuery.process(timeRange);
   }
-
   getIntervalVars() {
     return {
       __interval: { text: this.interval, value: this.interval },
       __interval_ms: { text: rangeUtil.intervalToMs(this.interval), value: rangeUtil.intervalToMs(this.interval) },
     };
   }
-
   getRangeScopedVars(range: TimeRange) {
     const msRange = range.to.diff(range.from);
     const sRange = Math.round(msRange / 1000);
@@ -531,7 +480,6 @@ export class PrometheusDatasource
       __range: { text: sRange + 's', value: sRange + 's' },
     };
   }
-
   // By implementing getTagKeys and getTagValues we add ad-hoc filters functionality
   // this is used to get label keys, a.k.a label names
   // it is used in metric_find_query.ts
@@ -540,7 +488,6 @@ export class PrometheusDatasource
     if (!options.timeRange) {
       options.timeRange = getDefaultTimeRange();
     }
-
     if ((options?.scopes?.length ?? 0) > 0) {
       const suggestions = await this.languageProvider.fetchSuggestions(
         options.timeRange,
@@ -548,35 +495,28 @@ export class PrometheusDatasource
         options.scopes,
         options.filters
       );
-
       // filter out already used labels and empty labels
       return suggestions
         .filter((labelName) => !!labelName && !options.filters.find((filter) => filter.key === labelName))
         .map((k) => ({ value: k, text: k }));
     }
-
     const match = extractResourceMatcher(options.queries ?? [], options.filters);
-
     let labelKeys: string[] = await this.languageProvider.queryLabelKeys(options.timeRange, match);
-
     // filter out already used labels
     return labelKeys
       .filter((labelName) => !options.filters.find((filter) => filter.key === labelName))
       .map((k) => ({ value: k, text: k }));
   }
-
   // By implementing getGroupByKeys we add group by variable support independently from adhoc filters.
   // It delegates to getTagKeys
   async getGroupByKeys(options: DataSourceGetTagKeysOptions<PromQuery>): Promise<MetricFindValue[]> {
     return this.getTagKeys(options);
   }
-
   // By implementing getTagKeys and getTagValues we add ad-hoc filters functionality
   async getTagValues(options: DataSourceGetTagValuesOptions<PromQuery>): Promise<MetricFindValue[]> {
     if (!options.timeRange) {
       options.timeRange = getDefaultTimeRange();
     }
-
     const requestId = `[${this.uid}][${options.key}]`;
     if ((options?.scopes?.length ?? 0) > 0) {
       return (
@@ -591,15 +531,12 @@ export class PrometheusDatasource
         )
       ).map((v) => ({ value: v, text: v }));
     }
-
     const match = extractResourceMatcher(options.queries ?? [], options.filters);
-
     return (await this.languageProvider.queryLabelValues(options.timeRange, options.key, match)).map((v) => ({
       value: v,
       text: v,
     }));
   }
-
   interpolateVariablesInQueries(
     queries: PromQuery[],
     scopedVars: ScopedVars,
@@ -620,7 +557,6 @@ export class PrometheusDatasource
               scopedVars,
               this.interpolateQueryExpr
             );
-
         const expandedQuery = {
           ...query,
           ...(query.scopes && query.scopes.length > 0 ? { adhocFilters: this.generateScopeFilters(filters) } : {}),
@@ -628,17 +564,14 @@ export class PrometheusDatasource
           expr: replacedInterpolatedQuery,
           interval: this.templateSrv.replace(query.interval, scopedVars),
         };
-
         return expandedQuery;
       });
     }
     return expandedQueries;
   }
-
   getQueryHints(query: PromQuery, result: unknown[]) {
     return getQueryHints(query.expr ?? '', result, this);
   }
-
   modifyQuery(query: PromQuery, action: QueryFixAction): PromQuery {
     let expression = query.expr ?? '';
     switch (action.type) {
@@ -647,7 +580,6 @@ export class PrometheusDatasource
         if (key && value) {
           expression = addLabelToQuery(expression, key, value);
         }
-
         break;
       }
       case 'ADD_FILTER_OUT': {
@@ -704,14 +636,15 @@ export class PrometheusDatasource
     }
     return { ...query, expr: expression };
   }
-
   /**
    * Returns the adjusted "snapped" interval parameters
    */
-  getAdjustedInterval(timeRange: TimeRange): { start: string; end: string } {
+  getAdjustedInterval(timeRange: TimeRange): {
+    start: string;
+    end: string;
+  } {
     return getRangeSnapInterval(this.cacheLevel, timeRange);
   }
-
   /**
    * This will return a time range that always includes the users current time range,
    * and then a little extra padding to round up/down to the nearest nth minute,
@@ -722,13 +655,15 @@ export class PrometheusDatasource
    * resulting in us returning labels/values that might not be applicable for the given window,
    * this is a necessary trade-off if we want to cache larger durations
    */
-  getTimeRangeParams(timeRange: TimeRange): { start: string; end: string } {
+  getTimeRangeParams(timeRange: TimeRange): {
+    start: string;
+    end: string;
+  } {
     return {
       start: getPrometheusTime(timeRange.from, false).toString(),
       end: getPrometheusTime(timeRange.to, true).toString(),
     };
   }
-
   /**
    * This converts the adhocVariableFilter array and converts it to scopeFilter array
    * @param filters
@@ -737,7 +672,6 @@ export class PrometheusDatasource
     if (!filters) {
       return [];
     }
-
     return filters.map((f) => ({
       key: f.key,
       operator: scopeFilterOperatorMap[f.operator],
@@ -745,12 +679,10 @@ export class PrometheusDatasource
       values: f.values?.map((v) => this.templateSrv.replace(v, {}, this.interpolateQueryExpr)),
     }));
   }
-
   enhanceExprWithAdHocFilters(filters: AdHocVariableFilter[] | undefined, expr: string) {
     if (!filters || filters.length === 0) {
       return expr;
     }
-
     const finalQuery = filters.map(remapOneOf).reduce((acc, filter) => {
       const { key, operator } = filter;
       let { value } = filter;
@@ -761,7 +693,6 @@ export class PrometheusDatasource
     }, expr);
     return finalQuery;
   }
-
   // Used when running queries through backend
   filterQuery(query: PromQuery): boolean {
     if (query.hide || !query.expr) {
@@ -769,11 +700,9 @@ export class PrometheusDatasource
     }
     return true;
   }
-
   // Used when running queries through backend
   applyTemplateVariables(target: PromQuery, scopedVars: ScopedVars, filters?: AdHocVariableFilter[]) {
     const variables = { ...scopedVars };
-
     // We want to interpolate these variables on backend.
     // The pre-calculated values are replaced withe the variable strings.
     variables.__interval = {
@@ -782,9 +711,7 @@ export class PrometheusDatasource
     variables.__interval_ms = {
       value: '$__interval_ms',
     };
-
     // interpolate expression
-
     // We need a first replace to evaluate variables before applying adhoc filters
     // This is required for an expression like `metric > $VAR` where $VAR is a float to which we must not add adhoc filters
     const expr = this.templateSrv.replace(
@@ -792,13 +719,11 @@ export class PrometheusDatasource
       variables,
       this.interpolateExploreMetrics(target.fromExploreMetrics)
     );
-
     // Apply ad-hoc filters
     // When ad-hoc filters are applied, we replace again the variables in case the ad-hoc filters also reference a variable
     const exprWithAdhoc = targetHasScopes(target)
       ? expr
       : this.templateSrv.replace(this.enhanceExprWithAdHocFilters(filters, expr), variables, this.interpolateQueryExpr);
-
     return {
       ...target,
       ...(targetHasScopes(target) ? { adhocFilters: this.generateScopeFilters(filters) } : {}),
@@ -807,15 +732,12 @@ export class PrometheusDatasource
       legendFormat: this.templateSrv.replace(target.legendFormat, variables),
     };
   }
-
   getVariables(): string[] {
     return this.templateSrv.getVariables().map((v) => `$${v.name}`);
   }
-
   interpolateString(string: string, scopedVars?: ScopedVars) {
     return this.templateSrv.replace(string, scopedVars, this.interpolateQueryExpr);
   }
-
   interpolateExploreMetrics(fromExploreMetrics?: boolean) {
     return (value: string | string[] = [], variable: QueryVariableModel | CustomVariableModel) => {
       if (typeof value === 'string' && fromExploreMetrics) {
@@ -829,15 +751,12 @@ export class PrometheusDatasource
       return this.interpolateQueryExpr(value, variable);
     };
   }
-
   isUsingRelativeTimeRange(range: TimeRange): boolean {
     if (typeof range.raw.from !== 'string' || typeof range.raw.to !== 'string') {
       return false;
     }
-
     return range.raw.from.includes('now') || range.raw.to.includes('now');
   }
-
   getDefaultQuery(app: CoreApp): PromQuery {
     const defaults = {
       refId: 'A',
@@ -845,7 +764,6 @@ export class PrometheusDatasource
       range: true,
       instant: false,
     };
-
     if (app === CoreApp.UnifiedAlerting) {
       return {
         ...defaults,
@@ -853,7 +771,6 @@ export class PrometheusDatasource
         range: false,
       };
     }
-
     if (app === CoreApp.Explore) {
       return {
         ...defaults,
@@ -861,15 +778,12 @@ export class PrometheusDatasource
         range: true,
       };
     }
-
     return defaults;
   }
 }
-
 function targetHasScopes(target: PromQuery): boolean {
   return !!(target.scopes && target.scopes.length > 0);
 }
-
 export function extractRuleMappingFromGroups(groups: RawRecordingRules[]): RuleQueryMapping {
   return groups.reduce<RuleQueryMapping>(
     (mapping, group) =>
@@ -889,7 +803,6 @@ export function extractRuleMappingFromGroups(groups: RawRecordingRules[]): RuleQ
     {}
   );
 }
-
 /**
  * It creates a matcher string for resource calls
  * @param queries
@@ -913,22 +826,18 @@ export const extractResourceMatcher = (
   }));
   // Extract label filters from the filters we have already
   const labelsMatch = renderLabelsWithoutBrackets(labelFilters);
-
   if (metricMatch.length === 0 && labelsMatch.length === 0) {
     return undefined;
   }
-
   // Create a matcher using metric names and label filters
   return `{${[...metricMatch, ...labelsMatch].join(',')}}`;
 };
-
 export function remapOneOf(filter: AdHocVariableFilter) {
   let { operator, value, values } = filter;
   if (operator === '=|' || operator === '!=|') {
     operator = operator === '=|' ? '=~' : '!~';
     value = values?.map(prometheusRegularEscape).join('|') ?? '';
   }
-
   return {
     ...filter,
     operator,

--- a/packages/grafana-prometheus/src/language_provider.ts
+++ b/packages/grafana-prometheus/src/language_provider.ts
@@ -1,6 +1,6 @@
+import { structLog } from '@grafana/data';
 // Core Grafana history https://github.com/grafana/grafana/blob/v11.0.0-preview/public/app/plugins/datasource/prometheus/language_provider.ts
 import Prism from 'prismjs';
-
 import {
   type AbstractLabelMatcher,
   AbstractLabelOperator,
@@ -13,7 +13,6 @@ import {
   type TimeRange,
 } from '@grafana/data';
 import { type BackendSrvRequest } from '@grafana/runtime';
-
 import { buildCacheHeaders, getDaysToCacheMetadata, getDefaultCacheHeaders } from './caching';
 import { type PrometheusDatasource } from './datasource';
 import { extractLabelMatchers, fixSummariesMetadata, toPromLikeQuery } from './language_utils';
@@ -21,18 +20,14 @@ import { promqlGrammar } from './promql';
 import { buildVisualQueryFromString } from './querybuilder/parsing';
 import { LabelsApiClient, type ResourceApiClient, SeriesApiClient } from './resource_clients';
 import { type PromMetricsMetadata, type PromQuery } from './types';
-
 interface PrometheusBaseLanguageProvider {
   datasource: PrometheusDatasource;
-
   /**
    * When no timeRange provided, we will use the default time range (now/now-6h)
    * @param timeRange
    */
   start: (timeRange?: TimeRange) => Promise<unknown[]>;
-
   request: (url: string, params?: any, options?: Partial<BackendSrvRequest>) => Promise<any>;
-
   fetchSuggestions: (
     timeRange?: TimeRange,
     queries?: PromQuery[],
@@ -43,7 +38,6 @@ interface PrometheusBaseLanguageProvider {
     requestId?: string
   ) => Promise<string[]>;
 }
-
 /**
  * Modern implementation of the Prometheus language provider that abstracts API endpoint selection.
  *
@@ -67,38 +61,32 @@ export interface PrometheusLanguageProviderInterface extends PrometheusBaseLangu
    * Some places still rely on deprecated fields. Until we replace them, we need _backwardCompatibleStart method.
    */
   start: (timeRange?: TimeRange) => Promise<unknown[]>;
-
   /**
    * Returns already cached metrics metadata including type and help information.
    * If there is no cached metadata, it returns an empty object.
    * To get fresh metadata, use queryMetricsMetadata instead.
    */
   retrieveMetricsMetadata: () => PromMetricsMetadata;
-
   /**
    * Returns already cached list of histogram metrics (identified by '_bucket' suffix).
    * If there are no cached histogram metrics, it returns an empty array.
    */
   retrieveHistogramMetrics: () => string[];
-
   /**
    * Returns already cached list of all available metric names.
    * If there are no cached metrics, it returns an empty array.
    */
   retrieveMetrics: () => string[];
-
   /**
    * Returns already cached list of available label keys.
    * If there are no cached label keys, it returns an empty array.
    */
   retrieveLabelKeys: () => string[];
-
   /**
    * Fetches fresh metrics metadata from Prometheus with optional limit.
    * Uses datasource's default limit if not specified.
    */
   queryMetricsMetadata: (limit?: number) => Promise<PromMetricsMetadata>;
-
   /**
    * Queries Prometheus for label keys within time range, optionally filtered by match selector.
    * Automatically selects labels or series endpoint based on datasource configuration.
@@ -106,7 +94,6 @@ export interface PrometheusLanguageProviderInterface extends PrometheusBaseLangu
    * Use zero (0) to fetch all label keys, but this might return huge amounts of data.
    */
   queryLabelKeys: (timeRange: TimeRange, match?: string, limit?: number) => Promise<string[]>;
-
   /**
    * Queries Prometheus for values of a specific label key, optionally filtered by match selector.
    * Automatically selects labels or series endpoint based on datasource configuration.
@@ -115,30 +102,24 @@ export interface PrometheusLanguageProviderInterface extends PrometheusBaseLangu
    */
   queryLabelValues: (timeRange: TimeRange, labelKey: string, match?: string, limit?: number) => Promise<string[]>;
 }
-
 export class PrometheusLanguageProvider implements PrometheusLanguageProviderInterface {
   public datasource: PrometheusDatasource;
-
   private _metricsMetadata?: PromMetricsMetadata;
   private _resourceClient?: ResourceApiClient;
-
   constructor(datasource: PrometheusDatasource) {
     this.datasource = datasource;
   }
-
   request = async (url: string, params = {}, options?: Partial<BackendSrvRequest>) => {
     try {
       const res = await this.datasource.metadataRequest(url, params, options);
       return res.data.data;
     } catch (error) {
       if (!isCancelledError(error)) {
-        console.error(error);
+        structLog('error', error);
       }
     }
-
     return undefined;
   };
-
   /**
    * Lazily initializes and returns the appropriate resource client based on Prometheus version.
    *
@@ -156,10 +137,8 @@ export class PrometheusLanguageProvider implements PrometheusLanguageProviderInt
         ? new LabelsApiClient(this.request, this.datasource)
         : new SeriesApiClient(this.request, this.datasource);
     }
-
     return this._resourceClient;
   }
-
   /**
    * Same start logic but it uses resource clients. Backward compatibility it calls _backwardCompatibleStart.
    * Some places still relies on deprecated fields. Until we replace them we need _backwardCompatibleStart method
@@ -173,7 +152,6 @@ export class PrometheusLanguageProvider implements PrometheusLanguageProviderInt
       this.queryMetricsMetadata(this.datasource.seriesLimit),
     ]);
   };
-
   /**
    * Fetches metadata for metrics from Prometheus.
    * Sets cache headers based on the configured metadata cache duration.
@@ -193,7 +171,6 @@ export class PrometheusLanguageProvider implements PrometheusLanguageProviderInt
     );
     return fixSummariesMetadata(metadata);
   };
-
   /**
    * Retrieves the cached Prometheus metrics metadata.
    * This metadata includes type information (counter, gauge, etc.) and help text for metrics.
@@ -203,7 +180,6 @@ export class PrometheusLanguageProvider implements PrometheusLanguageProviderInt
   public retrieveMetricsMetadata = (): PromMetricsMetadata => {
     return this._metricsMetadata ?? {};
   };
-
   /**
    * Retrieves the list of histogram metrics from the current resource client.
    * Histogram metrics are identified by the '_bucket' suffix and are used for percentile calculations.
@@ -213,7 +189,6 @@ export class PrometheusLanguageProvider implements PrometheusLanguageProviderInt
   public retrieveHistogramMetrics = (): string[] => {
     return this.resourceClient?.histogramMetrics;
   };
-
   /**
    * Retrieves the complete list of available metrics from the current resource client.
    * This includes all metric names regardless of their type (counter, gauge, histogram).
@@ -223,7 +198,6 @@ export class PrometheusLanguageProvider implements PrometheusLanguageProviderInt
   public retrieveMetrics = (): string[] => {
     return this.resourceClient?.metrics;
   };
-
   /**
    * Retrieves the list of available label keys from the current resource client.
    * Label keys are the names of labels that can be used to filter and group metrics.
@@ -233,7 +207,6 @@ export class PrometheusLanguageProvider implements PrometheusLanguageProviderInt
   public retrieveLabelKeys = (): string[] => {
     return this.resourceClient?.labelKeys;
   };
-
   /**
    * Fetches fresh metrics metadata from Prometheus and updates the cache.
    * This includes querying for metric types, help text, and unit information.
@@ -249,7 +222,6 @@ export class PrometheusLanguageProvider implements PrometheusLanguageProviderInt
     }
     return this._metricsMetadata;
   };
-
   /**
    * Fetches all available label keys that match the specified criteria.
    *
@@ -266,7 +238,6 @@ export class PrometheusLanguageProvider implements PrometheusLanguageProviderInt
     const interpolatedMatch = match ? this.datasource.interpolateString(match) : match;
     return await this.resourceClient.queryLabelKeys(timeRange, interpolatedMatch, limit);
   };
-
   /**
    * Fetches all values for a specific label key that match the specified criteria.
    *
@@ -306,7 +277,6 @@ export class PrometheusLanguageProvider implements PrometheusLanguageProviderInt
       limit
     );
   };
-
   /**
    * Fetch labels or values for a label based on the queries, scopes, filters and time range
    */
@@ -322,7 +292,6 @@ export class PrometheusLanguageProvider implements PrometheusLanguageProviderInt
     if (!timeRange) {
       timeRange = getDefaultTimeRange();
     }
-
     const url = '/suggestions';
     const timeParams = this.datasource.getAdjustedInterval(timeRange);
     const value = await this.request(
@@ -339,7 +308,6 @@ export class PrometheusLanguageProvider implements PrometheusLanguageProviderInt
           if (scope.spec.filters) {
             acc.push(...scope.spec.filters);
           }
-
           return acc;
         }, []),
         adhocFilters: adhocFilters?.map((filter) => ({
@@ -360,15 +328,12 @@ export class PrometheusLanguageProvider implements PrometheusLanguageProviderInt
         method: 'POST',
       }
     );
-
     return value ?? [];
   };
 }
-
 export const importFromAbstractQuery = (labelBasedQuery: AbstractQuery): PromQuery => {
   return toPromLikeQuery(labelBasedQuery);
 };
-
 export const exportToAbstractQuery = (query: PromQuery): AbstractQuery => {
   const promQuery = query.expr;
   if (!promQuery || promQuery.length === 0) {
@@ -384,13 +349,11 @@ export const exportToAbstractQuery = (query: PromQuery): AbstractQuery => {
       value: nameLabelValue,
     });
   }
-
   return {
     refId: query.refId,
     labelMatchers,
   };
 };
-
 /**
  * Checks if an error is a cancelled request error.
  * Used to avoid logging cancelled request errors.
@@ -403,10 +366,8 @@ function isCancelledError(error: unknown): error is {
 } {
   return typeof error === 'object' && error !== null && 'cancelled' in error && error.cancelled === true;
 }
-
 function getNameLabelValue(promQuery: string, tokens: Array<string | Prism.Token>): string {
   let nameLabelValue = '';
-
   for (const token of tokens) {
     if (typeof token === 'string') {
       nameLabelValue = token;
@@ -415,7 +376,6 @@ function getNameLabelValue(promQuery: string, tokens: Array<string | Prism.Token
   }
   return nameLabelValue;
 }
-
 /**
  * Extracts metrics from queries and populates match parameters.
  * This is used to filter time series data based on existing queries.
@@ -428,7 +388,6 @@ export const populateMatchParamsFromQueries = (queries?: PromQuery[]): string[] 
   if (!queries) {
     return [];
   }
-
   const metrics = (queries ?? []).reduce<string[]>((params, query) => {
     const visualQuery = buildVisualQueryFromString(query.expr);
     if (visualQuery.query.metric !== '') {
@@ -443,6 +402,5 @@ export const populateMatchParamsFromQueries = (queries?: PromQuery[]): string[] 
     }
     return params;
   }, []);
-
   return metrics.length === 0 ? [] : [`__name__=~"${metrics.join('|')}"`];
 };

--- a/packages/grafana-prometheus/src/querybuilder/components/metrics-modal/MetricsModalContext.tsx
+++ b/packages/grafana-prometheus/src/querybuilder/components/metrics-modal/MetricsModalContext.tsx
@@ -1,3 +1,4 @@
+import { structLog } from '@grafana/data';
 import debounce from 'debounce-promise';
 import {
   createContext,
@@ -10,27 +11,21 @@ import {
   useRef,
   useState,
 } from 'react';
-
 import { type SelectableValue, type TimeRange } from '@grafana/data';
-
 import { METRIC_LABEL, PROMETHEUS_QUERY_BUILDER_MAX_RESULTS } from '../../../constants';
 import { type PrometheusLanguageProviderInterface } from '../../../language_provider';
 import { regexifyLabelValuesQueryString } from '../../parsingUtils';
 import { type QueryBuilderLabelFilter } from '../../shared/types';
 import { formatPrometheusLabelFilters } from '../formatter';
-
 import { generateMetricData } from './helpers';
 import { type MetricData, type MetricsData } from './types';
 import { fuzzySearch } from './uFuzzy';
-
 export const DEFAULT_RESULTS_PER_PAGE = 25;
-
 type Pagination = {
   pageNum: number;
   resultsPerPage: number;
   totalPageNum: number;
 };
-
 type MetricsModalContextValue = {
   isLoading: boolean;
   setIsLoading: (val: boolean) => void;
@@ -47,14 +42,11 @@ type MetricsModalContextValue = {
   searchedText: string;
   setSearchedText: (val: string) => void;
 };
-
 const MetricsModalContext = createContext<MetricsModalContextValue | undefined>(undefined);
-
 type MetricsModalContextProviderProps = {
   languageProvider: PrometheusLanguageProviderInterface;
   timeRange: TimeRange;
 };
-
 export const MetricsModalContextProvider: FC<PropsWithChildren<MetricsModalContextProviderProps>> = ({
   children,
   languageProvider,
@@ -69,12 +61,10 @@ export const MetricsModalContextProvider: FC<PropsWithChildren<MetricsModalConte
   });
   const [selectedTypes, setSelectedTypes] = useState<Array<SelectableValue<string>>>([]);
   const [searchedText, setSearchedText] = useState('');
-
   const filteredMetricsData = useMemo(() => {
     if (selectedTypes.length === 0) {
       return metricsData;
     }
-
     // Filter metrics based on selected types
     return metricsData.filter((metric: MetricData) => {
       return selectedTypes.some((selectedType) => {
@@ -82,37 +72,30 @@ export const MetricsModalContextProvider: FC<PropsWithChildren<MetricsModalConte
         if (metric.type && selectedType.value) {
           return metric.type.includes(selectedType.value);
         }
-
         // Handle metrics without type when "no type" is selected
         if (!metric.type && selectedType.value === 'no type') {
           return true;
         }
-
         return false;
       });
     });
   }, [metricsData, selectedTypes]);
-
   useEffect(() => {
     const totalPageNum =
       filteredMetricsData.length === 0 ? 1 : Math.ceil(filteredMetricsData.length / pagination.resultsPerPage);
     const pageNum = pagination.pageNum > totalPageNum ? 1 : pagination.pageNum;
-
     setPagination((prevPagination) => ({
       ...prevPagination,
       totalPageNum,
       pageNum,
     }));
   }, [filteredMetricsData.length, pagination.resultsPerPage, pagination.pageNum]);
-
   // Track the latest search ID to handle race conditions
   const latestSearchIdRef = useRef<number>(0);
-
   const fetchMetadata = useCallback(async () => {
     try {
       setIsLoading(true);
       const metadata = await languageProvider.queryMetricsMetadata(PROMETHEUS_QUERY_BUILDER_MAX_RESULTS);
-
       // We receive ALERTS metadata in any case
       if (Object.keys(metadata).length <= 1) {
         const fetchedMetrics = await languageProvider.queryLabelValues(
@@ -133,41 +116,33 @@ export const MetricsModalContextProvider: FC<PropsWithChildren<MetricsModalConte
       setIsLoading(false);
     }
   }, [languageProvider, timeRange]);
-
   const debouncedBackendSearch = useMemo(
     () =>
       debounce(async (timeRange: TimeRange, metricText: string, queryLabels?: QueryBuilderLabelFilter[]) => {
         // Generate unique search ID to handle race conditions
         const searchId = ++latestSearchIdRef.current;
-
         try {
           if (metricText === '') {
             await fetchMetadata();
             return;
           }
-
           setIsLoading(true);
-
           const queryString = regexifyLabelValuesQueryString(metricText);
           const filterArray = queryLabels ? formatPrometheusLabelFilters(queryLabels) : [];
           const match = `{__name__=~"(?i).*${queryString}"${filterArray ? filterArray.join('') : ''}}`;
-
           const results = await languageProvider.queryLabelValues(timeRange, METRIC_LABEL, match);
-
           // Check if this is still the most recent search
           if (searchId !== latestSearchIdRef.current) {
             return; // Ignore outdated results
           }
-
           const [fuzzyOrderedMetrics] = fuzzySearch(results, queryString);
           const resultsOptions: MetricsData = fuzzyOrderedMetrics.map((m) => generateMetricData(m, languageProvider));
-
           setMetricsData(resultsOptions);
           setIsLoading(false);
         } catch (error) {
           // Only update state if this is still the latest search
           if (searchId === latestSearchIdRef.current) {
-            console.error('Backend search failed:', error);
+            structLog('error', 'Backend search failed:', error);
             setMetricsData([]); // Clear results on error
             setIsLoading(false);
           }
@@ -175,13 +150,10 @@ export const MetricsModalContextProvider: FC<PropsWithChildren<MetricsModalConte
       }, 300),
     [fetchMetadata, languageProvider]
   );
-
   useEffect(() => {
     fetchMetadata();
-
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
-
   return (
     <MetricsModalContext.Provider
       value={{
@@ -201,7 +173,6 @@ export const MetricsModalContextProvider: FC<PropsWithChildren<MetricsModalConte
     </MetricsModalContext.Provider>
   );
 };
-
 export function useMetricsModal() {
   const context = useContext(MetricsModalContext);
   if (context === undefined) {

--- a/packages/grafana-prometheus/src/querybuilder/parsing.ts
+++ b/packages/grafana-prometheus/src/querybuilder/parsing.ts
@@ -1,3 +1,4 @@
+import { structLog } from '@grafana/data';
 // Core Grafana history https://github.com/grafana/grafana/blob/v11.0.0-preview/public/app/plugins/datasource/prometheus/querybuilder/parsing.ts
 import { type SyntaxNode } from '@lezer/common';
 import {
@@ -25,9 +26,7 @@ import {
   VectorSelector,
   Without,
 } from '@prometheus-io/lezer-promql';
-
 import { t } from '@grafana/i18n';
-
 import { binaryScalarOperatorToOperatorName } from './binaryScalarOperations';
 import {
   ErrorId,
@@ -43,7 +42,6 @@ import {
 } from './parsingUtils';
 import { type QueryBuilderLabelFilter, type QueryBuilderOperation } from './shared/types';
 import { type PromVisualQuery, type PromVisualQueryBinary } from './types';
-
 /**
  * Parses a PromQL query into a visual query model.
  *
@@ -55,7 +53,6 @@ export function buildVisualQueryFromString(expr: string): Omit<Context, 'replace
   const { replacedExpr, replacedVariables } = replaceVariables(expr);
   const tree = parser.parse(replacedExpr);
   const node = tree.topNode;
-
   // This will be modified in the handlers.
   const visQuery: PromVisualQuery = {
     metric: '',
@@ -67,43 +64,36 @@ export function buildVisualQueryFromString(expr: string): Omit<Context, 'replace
     errors: [],
     replacements: replacedVariables,
   };
-
   try {
     handleExpression(replacedExpr, node, context);
   } catch (err) {
     // Not ideal to log it here, but otherwise we would lose the stack trace.
-    console.error(err);
+    structLog('error', err);
     if (err instanceof Error) {
       context.errors.push({
         text: err.message,
       });
     }
   }
-
   // If we have empty query, we want to reset errors
   if (isEmptyQuery(context.query)) {
     context.errors = [];
   }
-
   // No need to return replaced variables
   delete context.replacements;
-
   return context;
 }
-
 interface ParsingError {
   text: string;
   from?: number;
   to?: number;
   parentType?: string;
 }
-
 interface Context {
   query: PromVisualQuery;
   errors: ParsingError[];
   replacements?: Record<string, string>;
 }
-
 /**
  * Handler for default state. It will traverse the tree and call the appropriate handler for each node. The node
  * handled here does not necessarily need to be of type == Expr.
@@ -113,14 +103,12 @@ interface Context {
  */
 function handleExpression(expr: string, node: SyntaxNode, context: Context) {
   const visQuery = context.query;
-
   switch (node.type.id) {
     case Identifier: {
       // Expectation is that there is only one of those per query.
       visQuery.metric = getString(expr, node);
       break;
     }
-
     case QuotedLabelName: {
       // Usually we got the metric name above in the Identifier case.
       // If we didn't get the name that's potentially we have it in curly braces as quoted string.
@@ -133,7 +121,6 @@ function handleExpression(expr: string, node: SyntaxNode, context: Context) {
       }
       break;
     }
-
     case QuotedLabelMatcher: {
       const quotedLabel = getLabel(expr, node, QuotedLabelName);
       quotedLabel.label = quotedLabel.label.slice(1, -1);
@@ -144,7 +131,6 @@ function handleExpression(expr: string, node: SyntaxNode, context: Context) {
       }
       break;
     }
-
     case UnquotedLabelMatcher: {
       // Same as MetricIdentifier should be just one per query.
       visQuery.labels.push(getLabel(expr, node, LabelName));
@@ -154,22 +140,18 @@ function handleExpression(expr: string, node: SyntaxNode, context: Context) {
       }
       break;
     }
-
     case FunctionCall: {
       handleFunction(expr, node, context);
       break;
     }
-
     case AggregateExpr: {
       handleAggregation(expr, node, context);
       break;
     }
-
     case BinaryExpr: {
       handleBinary(expr, node, context);
       break;
     }
-
     case ErrorId: {
       if (isIntervalVariableError(node)) {
         break;
@@ -177,7 +159,6 @@ function handleExpression(expr: string, node: SyntaxNode, context: Context) {
       context.errors.push(makeError(expr, node));
       break;
     }
-
     default: {
       if (node.type.id === ParenExpr) {
         // We don't support parenthesis in the query to group expressions.
@@ -196,12 +177,10 @@ function handleExpression(expr: string, node: SyntaxNode, context: Context) {
     }
   }
 }
-
 // TODO check if we still need this
 function isIntervalVariableError(node: SyntaxNode) {
   return node.prevSibling?.firstChild?.type.id === VectorSelector;
 }
-
 function getLabel(
   expr: string,
   node: SyntaxNode,
@@ -216,9 +195,7 @@ function getLabel(
     value,
   };
 }
-
 const rangeFunctions = ['changes', 'rate', 'irate', 'increase', 'delta'];
-
 /**
  * Handle function call which is usually and identifier and its body > arguments.
  * @param expr
@@ -229,7 +206,6 @@ function handleFunction(expr: string, node: SyntaxNode, context: Context) {
   const visQuery = context.query;
   const nameNode = node.getChild(FunctionIdentifier);
   const funcName = getString(expr, nameNode);
-
   // Visual query builder doesn't support nested queries and so info function.
   if (funcName === 'info') {
     context.errors.push({
@@ -241,11 +217,9 @@ function handleFunction(expr: string, node: SyntaxNode, context: Context) {
       to: node.to,
     });
   }
-
   const body = node.getChild(FunctionCallBody);
   const params = [];
   let interval = '';
-
   // This is a bit of a shortcut to get the interval argument. Reasons are
   // - interval is not part of the function args per promQL grammar but we model it as argument for the function in
   //   the query model.
@@ -259,11 +233,9 @@ function handleFunction(expr: string, node: SyntaxNode, context: Context) {
       params.push(returnBuiltInVariable(match[1]));
     }
   }
-
   const op = { id: funcName, params };
   // We unshift operations to keep the more natural order that we want to have in the visual query editor.
   visQuery.operations.unshift(op);
-
   if (body) {
     if (getString(expr, body) === '([' + interval + '])') {
       // This is a special case where we have a function with a single argument and it is the interval.
@@ -273,7 +245,6 @@ function handleFunction(expr: string, node: SyntaxNode, context: Context) {
     updateFunctionArgs(expr, body, context, op);
   }
 }
-
 /**
  * Handle aggregation as they are distinct type from other functions.
  * @param expr
@@ -284,33 +255,26 @@ function handleAggregation(expr: string, node: SyntaxNode, context: Context) {
   const visQuery = context.query;
   const nameNode = node.getChild(AggregateOp);
   let funcName = getString(expr, nameNode);
-
   const modifier = node.getChild(AggregateModifier);
   const labels = [];
-
   if (modifier) {
     const byModifier = modifier.getChild(`By`);
     if (byModifier && funcName) {
       funcName = `__${funcName}_by`;
     }
-
     const withoutModifier = modifier.getChild(Without);
     if (withoutModifier) {
       funcName = `__${funcName}_without`;
     }
-
     labels.push(...getAllByType(expr, modifier, LabelName), ...getAllByType(expr, modifier, QuotedLabelName));
   }
-
   const body = node.getChild(FunctionCallBody);
-
   const op: QueryBuilderOperation = { id: funcName, params: [] };
   visQuery.operations.unshift(op);
   updateFunctionArgs(expr, body, context, op);
   // We add labels after params in the visual query editor.
   op.params.push(...labels);
 }
-
 /**
  * Handle (probably) all types of arguments that function or aggregation can have.
  *
@@ -329,24 +293,20 @@ function updateFunctionArgs(expr: string, node: SyntaxNode | null, context: Cont
   switch (node.type.id) {
     case FunctionCallBody: {
       let child = node.firstChild;
-
       while (child) {
         updateFunctionArgs(expr, child, context, op);
         child = child.nextSibling;
       }
       break;
     }
-
     case NumberDurationLiteral: {
       op.params.push(parseFloat(getString(expr, node)));
       break;
     }
-
     case StringLiteral: {
       op.params.push(getString(expr, node).replace(/"/g, ''));
       break;
     }
-
     case VectorSelector: {
       // When we replace a custom variable to prevent errors during parsing we receive VectorSelector and Identifier in it.
       // But this is also a normal case for a normal function body. i.e. topk(5, http_requests_total{})
@@ -359,7 +319,6 @@ function updateFunctionArgs(expr: string, node: SyntaxNode | null, context: Cont
         break;
       }
     }
-
     default: {
       // Means we get to something that does not seem like simple function arg and is probably nested query so jump
       // back to main context
@@ -367,7 +326,6 @@ function updateFunctionArgs(expr: string, node: SyntaxNode | null, context: Cont
     }
   }
 }
-
 /**
  * Right now binary expressions can be represented in 2 way in visual query. As additional operation in case it is
  * just operation with scalar or it creates a binaryQuery when it's 2 queries.
@@ -380,16 +338,11 @@ function handleBinary(expr: string, node: SyntaxNode, context: Context, idx = 0)
   const left = node.firstChild!;
   const op = getString(expr, left.nextSibling);
   const binModifier = getBinaryModifier(expr, node.getChild(BoolModifier) ?? node.getChild(MatchingModifierClause));
-
   const right = node.lastChild!;
-
   const opDef = binaryScalarOperatorToOperatorName[op];
-
   const leftNumber = left.type.id === NumberDurationLiteral;
   const rightNumber = right.type.id === NumberDurationLiteral;
-
   const rightBinary = right.type.id === BinaryExpr;
-
   // binary operations that are part of a function argument do not get processed and added to the query until the end, this index helps keep track
   // of where to add the operation in the list rather than just appending it to the end. If the binary operation is just part of a nested binary exp,
   // we append at the end
@@ -408,10 +361,8 @@ function handleBinary(expr: string, node: SyntaxNode, context: Context, idx = 0)
     // we have to traverse a bit deeper to know
     handleExpression(expr, left, context);
   }
-
   // in the case we have an expression like func(...) / 2 or func(...) + 5, the binary expression will be at the top of the tree
   // in which case, the idx will be 0. In this case it means that the binary operation must be added to the end of the array, and
-
   const newIdx = idx === 0 ? visQuery.operations.length : -idx;
   if (rightNumber) {
     visQuery.operations.splice(newIdx, 0, makeBinOp(opDef, expr, right, !!binModifier?.isBool));
@@ -422,7 +373,6 @@ function handleBinary(expr: string, node: SyntaxNode, context: Context, idx = 0)
     if (leftMostChild?.type.id === NumberDurationLiteral) {
       visQuery.operations.splice(newIdx, 0, makeBinOp(opDef, expr, leftMostChild, !!binModifier?.isBool));
     }
-
     // If we added the first number literal as operation here we still can continue and handle the rest as the first
     // number will be just skipped.
     handleExpression(expr, right, context);
@@ -448,14 +398,21 @@ function handleBinary(expr: string, node: SyntaxNode, context: Context, idx = 0)
     });
   }
 }
-
 // TODO revisit this function.
 function getBinaryModifier(
   expr: string,
   node: SyntaxNode | null
 ):
-  | { isBool: true; isMatcher: false }
-  | { isBool: false; isMatcher: true; matches: string; matchType: 'ignoring' | 'on' }
+  | {
+      isBool: true;
+      isMatcher: false;
+    }
+  | {
+      isBool: false;
+      isMatcher: true;
+      matches: string;
+      matchType: 'ignoring' | 'on';
+    }
   | undefined {
   if (!node) {
     return undefined;
@@ -468,7 +425,6 @@ function getBinaryModifier(
     if (groupingLabels) {
       labels = getAllByType(expr, groupingLabels, LabelName).join(', ');
     }
-
     return {
       isMatcher: true,
       isBool: false,
@@ -477,7 +433,6 @@ function getBinaryModifier(
     };
   }
 }
-
 function isEmptyQuery(query: PromVisualQuery) {
   if (query.labels.length === 0 && query.operations.length === 0 && !query.metric) {
     return true;

--- a/packages/grafana-prometheus/src/result_transformer.ts
+++ b/packages/grafana-prometheus/src/result_transformer.ts
@@ -1,6 +1,6 @@
+import { structLog } from '@grafana/data';
 // Core Grafana history https://github.com/grafana/grafana/blob/v11.0.0-preview/public/app/plugins/datasource/prometheus/result_transformer.ts
 import { flatten, forOwn, groupBy, partition } from 'lodash';
-
 import {
   CoreApp,
   type DataFrame,
@@ -20,12 +20,9 @@ import {
   TIME_SERIES_VALUE_FIELD_NAME,
 } from '@grafana/data';
 import { getDataSourceSrv } from '@grafana/runtime';
-
 import { type ExemplarTraceIdDestination, type PromMetric, type PromQuery, type PromValue } from './types';
-
 // handles case-insensitive Inf, +Inf, -Inf (with optional "inity" suffix)
 const INFINITY_SAMPLE_REGEX = /^[+-]?inf(?:inity)?$/i;
-
 const isTableResult = (dataFrame: DataFrame, options: DataQueryRequest<PromQuery>): boolean => {
   // We want to process vector and scalar results in Explore as table
   if (
@@ -34,21 +31,17 @@ const isTableResult = (dataFrame: DataFrame, options: DataQueryRequest<PromQuery
   ) {
     return true;
   }
-
   // We want to process all dataFrames with target.format === 'table' as table
   const target = options.targets.find((target) => target.refId === dataFrame.refId);
   return target?.format === 'table';
 };
-
 const isCumulativeHeatmapResult = (dataFrame: DataFrame, options: DataQueryRequest<PromQuery>): boolean => {
   if (dataFrame.meta?.type === DataFrameType.HeatmapCells) {
     return false;
   }
-
   const target = options.targets.find((target) => target.refId === dataFrame.refId);
   return target?.format === 'heatmap';
 };
-
 // get each frame's (named) field's labels
 function getAllLabels(frames: DataFrame[]): Labels[] {
   // for each frame, take all fields with matching __name__ label in a flat list of labels (instead of Labels[][])
@@ -61,12 +54,13 @@ function getAllLabels(frames: DataFrame[]): Labels[] {
     .flat()
     .filter((labels?: Labels) => labels !== undefined);
 }
-
 // V2 result transformer used to transform query results from queries that were run through prometheus backend
 export function transformV2(
   response: DataQueryResponse,
   request: DataQueryRequest<PromQuery>,
-  options: { exemplarTraceIdDestinations?: ExemplarTraceIdDestination[] }
+  options: {
+    exemplarTraceIdDestinations?: ExemplarTraceIdDestination[];
+  }
 ) {
   // migration for dataplane field name issue
   // update displayNameFromDS in the field config
@@ -86,15 +80,12 @@ export function transformV2(
       });
     }
   });
-
   const [tableFrames, framesWithoutTable] = partition<DataFrame>(response.data, (df) => isTableResult(df, request));
   const processedTableFrames = transformDFToTable(tableFrames);
-
   const [exemplarFrames, framesWithoutTableAndExemplars] = partition<DataFrame>(
     framesWithoutTable,
     (df) => df.meta?.custom?.resultType === 'exemplar'
   );
-
   // EXEMPLAR FRAMES: We enrich exemplar frames with data links and add dataTopic meta info
   const { exemplarTraceIdDestinations: destinations } = options;
   const processedExemplarFrames = exemplarFrames.map((dataFrame) => {
@@ -109,23 +100,18 @@ export function transformV2(
         }
       }
     }
-
     return { ...dataFrame, meta: { ...dataFrame.meta, dataTopic: DataTopic.Annotations } };
   });
-
   const [heatmapResults, framesWithoutTableHeatmapsAndExemplars] = partition<DataFrame>(
     framesWithoutTableAndExemplars,
     (df) => isCumulativeHeatmapResult(df, request)
   );
-
   // this works around the fact that we only get back frame.name with le buckets when legendFormat == {{le}}...which is not the default
   heatmapResults.forEach((df) => {
     if (df.name == null) {
       let f = df.fields.find((f) => f.type === FieldType.number);
-
       if (f) {
         let le = f.labels?.le;
-
         if (le) {
           // this is used for sorting the frames by numeric ascending le labels for de-accum
           df.name = le;
@@ -135,18 +121,14 @@ export function transformV2(
       }
     }
   });
-
   // Group heatmaps by query
   const heatmapResultsGroupedByQuery = groupBy<DataFrame>(heatmapResults, (h) => h.refId);
-
   // Initialize empty array to push grouped histogram frames to
   let processedHeatmapResultsGroupedByQuery: DataFrame[][] = [];
-
   // Iterate through every query in this heatmap
   for (const query in heatmapResultsGroupedByQuery) {
     // Get reference to dataFrames for heatmap
     const heatmapResultsGroup = heatmapResultsGroupedByQuery[query];
-
     // Create a new grouping by iterating through the data frames...
     const heatmapResultsGroupedByValues = groupBy<DataFrame>(heatmapResultsGroup, (dataFrame) => {
       // Each data frame has `Time` and `Value` properties, we want to get the values
@@ -156,11 +138,9 @@ export function transformV2(
         const { le, ...notLE } = values?.labels;
         return Object.values(notLE).join();
       }
-
       // Return a string made from the concatenation of this frame's values to represent a grouping in the query
       return Object.values(values?.labels ?? []).join();
     });
-
     // Then iterate through the resultant object
     forOwn(heatmapResultsGroupedByValues, (dataFrames, key) => {
       // Sort frames within each grouping
@@ -169,7 +149,6 @@ export function transformV2(
       processedHeatmapResultsGroupedByQuery.push(mergeHeatmapFrames(transformToHistogramOverTime(sortedHeatmap)));
     });
   }
-
   // Everything else is processed as time_series result and graph preferredVisualisationType
   const otherFrames = framesWithoutTableHeatmapsAndExemplars.map((dataFrame) => {
     const df: DataFrame = {
@@ -181,39 +160,31 @@ export function transformV2(
     };
     return df;
   });
-
   const flattenedProcessedHeatmapFrames = flatten(processedHeatmapResultsGroupedByQuery);
-
   return {
     ...response,
     data: [...otherFrames, ...processedTableFrames, ...flattenedProcessedHeatmapFrames, ...processedExemplarFrames],
   };
 }
-
 const HISTOGRAM_QUANTILE_LABEL_NAME = 'le';
-
 export function transformDFToTable(dfs: DataFrame[]): DataFrame[] {
   // If no dataFrames or if 1 dataFrames with no values, return original dataFrame
   if (dfs.length === 0 || (dfs.length === 1 && dfs[0].length === 0)) {
     return dfs;
   }
-
   // Group results by refId and process dataFrames with the same refId as 1 dataFrame
   const dataFramesByRefId = groupBy(dfs, 'refId');
   const refIds = Object.keys(dataFramesByRefId);
-
   const frames = refIds.map((refId) => {
     // Create timeField, valueField and labelFields
     const valueText = getValueText(refIds.length, refId);
     const valueField = getValueField({ data: [], valueName: valueText });
     const timeField = getTimeField([]);
     const labelFields: Field[] = [];
-
     // Fill labelsFields with labels from dataFrames
     dataFramesByRefId[refId].forEach((df) => {
       const frameValueField = df.fields[1];
       const promLabels = frameValueField?.labels ?? {};
-
       Object.keys(promLabels)
         .sort()
         .forEach((label) => {
@@ -228,36 +199,27 @@ export function transformDFToTable(dfs: DataFrame[]): DataFrame[] {
           }
         });
     });
-
     let prevTime = -Infinity;
     let needsSort = false;
-
     // Fill valueField, timeField and labelFields with values
     dataFramesByRefId[refId].forEach((df) => {
       timeField.config.interval ??= df.fields[0]?.config.interval;
-
       const timeFields = df.fields[0]?.values ?? [];
       const dataFields = df.fields[1]?.values ?? [];
-
       timeFields.forEach((value) => {
         timeField.values.push(value);
-
         if (value < prevTime) {
           needsSort = true;
         }
-
         prevTime = value;
       });
-
       dataFields.forEach((value) => {
         valueField.values.push(parseSampleValue(value));
         const labelsForField = df.fields[1].labels ?? {};
         labelFields.forEach((field) => field.values.push(getLabelValue(labelsForField, field.name)));
       });
     });
-
     const fields = [timeField, ...labelFields, valueField];
-
     const frame: DataFrame = {
       refId,
       fields,
@@ -268,24 +230,18 @@ export function transformDFToTable(dfs: DataFrame[]): DataFrame[] {
       },
       length: timeField.values.length,
     };
-
     return needsSort ? sortDataFrame(frame, 0) : frame;
   });
-
   return frames;
 }
-
 function getValueText(responseLength: number, refId = '') {
   return responseLength > 1 ? `Value #${refId}` : 'Value';
 }
-
 function getDataLinks(options: ExemplarTraceIdDestination): DataLink[] {
   const dataLinks: DataLink[] = [];
-
   if (options.datasourceUid) {
     const dataSourceSrv = getDataSourceSrv();
     const dsSettings = dataSourceSrv.getInstanceSettings(options.datasourceUid);
-
     // dsSettings is undefined because of the reasons below:
     // - permissions issues (probably most likely)
     // - deleted datasource
@@ -307,7 +263,6 @@ function getDataLinks(options: ExemplarTraceIdDestination): DataLink[] {
       });
     }
   }
-
   if (options.url) {
     dataLinks.push({
       title: options.urlDisplayLabel || `Go to ${options.url}`,
@@ -317,14 +272,12 @@ function getDataLinks(options: ExemplarTraceIdDestination): DataLink[] {
   }
   return dataLinks;
 }
-
 function getLabelValue(metric: PromMetric, label: string): string | number {
   if (metric.hasOwnProperty(label)) {
     return metric[label];
   }
   return '';
 }
-
 function getTimeField(data: PromValue[], isMs = false): Field<number> {
   return {
     name: TIME_SERIES_TIME_FIELD_NAME,
@@ -333,7 +286,6 @@ function getTimeField(data: PromValue[], isMs = false): Field<number> {
     values: data.map((val) => (isMs ? val[0] : val[0] * 1000)),
   };
 }
-
 type ValueFieldOptions = {
   data: PromValue[];
   valueName?: string;
@@ -341,7 +293,6 @@ type ValueFieldOptions = {
   labels?: Labels;
   displayNameFromDS?: string;
 };
-
 function getValueField({
   data,
   valueName = TIME_SERIES_VALUE_FIELD_NAME,
@@ -360,7 +311,6 @@ function getValueField({
     values: data.map((val) => (parseValue ? parseSampleValue(val[1]) : val[1])),
   };
 }
-
 export function getOriginalMetricName(labelData: { [key: string]: string }) {
   const metricName = labelData.__name__ || '';
   delete labelData.__name__;
@@ -369,22 +319,18 @@ export function getOriginalMetricName(labelData: { [key: string]: string }) {
     .join(',');
   return `${metricName}{${labelPart}}`;
 }
-
 function mergeHeatmapFrames(frames: DataFrame[]): DataFrame[] {
   if (frames.length === 0 || (frames.length === 1 && frames[0].length === 0)) {
     return [];
   }
-
   const timeField = frames[0].fields.find((field) => field.type === FieldType.time)!;
   const countFields = frames.map((frame) => {
     let field = frame.fields.find((field) => field.type === FieldType.number)!;
-
     return {
       ...field,
       name: field.config.displayNameFromDS!,
     };
   });
-
   return [
     {
       ...frames[0],
@@ -396,39 +342,32 @@ function mergeHeatmapFrames(frames: DataFrame[]): DataFrame[] {
     },
   ];
 }
-
 /** @internal */
 export function transformToHistogramOverTime(seriesList: DataFrame[]): DataFrame[] {
   /*      t1 = timestamp1, t2 = timestamp2 etc.
-            t1  t2  t3          t1  t2  t3
-    le10    10  10  0     =>    10  10  0
-    le20    20  10  30    =>    10  0   30
-    le30    30  10  35    =>    10  0   5
-    */
-
+              t1  t2  t3          t1  t2  t3
+      le10    10  10  0     =>    10  10  0
+      le20    20  10  30    =>    10  0   30
+      le30    30  10  35    =>    10  0   5
+      */
   for (let i = seriesList.length - 1; i > 0; i--) {
     const topSeries = seriesList[i].fields.find((s) => s.type === FieldType.number);
     const bottomSeries = seriesList[i - 1].fields.find((s) => s.type === FieldType.number);
     if (!topSeries || !bottomSeries) {
       throw new Error('Prometheus heatmap transform error: data should be a time series');
     }
-
     for (let j = 0; j < topSeries.values.length; j++) {
       const bottomPoint = bottomSeries.values[j] || [0];
       topSeries.values[j] -= bottomPoint;
-
       if (topSeries.values[j] < 1e-9) {
         topSeries.values[j] = 0;
       }
     }
   }
-
   return seriesList;
 }
-
 export function sortSeriesByLabel(s1: DataFrame, s2: DataFrame): number {
   let le1, le2;
-
   try {
     // the state.displayName conditions are here because we also use this sorting util fn
     // in panels where isHeatmapResult was false but we still want to sort numerically-named
@@ -437,21 +376,17 @@ export function sortSeriesByLabel(s1: DataFrame, s2: DataFrame): number {
     le2 = parseSampleValue(s2.fields[1].state?.displayName ?? s2.name ?? s2.fields[1].name);
   } catch (err) {
     // fail if not integer. might happen with bad queries
-    console.error(err);
+    structLog('error', err);
     return 0;
   }
-
   if (le1 > le2) {
     return 1;
   }
-
   if (le1 < le2) {
     return -1;
   }
-
   return 0;
 }
-
 /** @internal */
 export function parseSampleValue(value: string): number {
   if (INFINITY_SAMPLE_REGEX.test(value)) {

--- a/packages/grafana-runtime/src/config.ts
+++ b/packages/grafana-runtime/src/config.ts
@@ -1,5 +1,5 @@
+import { structLog } from '@grafana/data';
 import { merge } from 'lodash';
-
 import {
   type AppPluginConfig as AppPluginConfigGrafanaData,
   type AuthSettings,
@@ -27,7 +27,6 @@ import {
   type GrafanaConfig,
   type CurrentUserDTO,
 } from '@grafana/data';
-
 /**
  * @deprecated Use the type from `@grafana/data`
  */
@@ -41,7 +40,6 @@ export interface AzureSettings {
   userIdentityFallbackCredentialsEnabled: boolean;
   azureEntraPasswordCredentialsEnabled: boolean;
 }
-
 /**
  * @deprecated Use the type from `@grafana/data`
  */
@@ -50,7 +48,6 @@ export interface AzureCloudInfo {
   name: string;
   displayName: string;
 }
-
 /**
  * @deprecated Use the type from `@grafana/data`
  */
@@ -66,7 +63,6 @@ export type AppPluginConfig = {
   extensions: PluginExtensions;
   moduleHash?: string;
 };
-
 /**
  * @deprecated Use the type from `@grafana/data`
  */
@@ -75,7 +71,6 @@ export type PreinstalledPlugin = {
   id: string;
   version: string;
 };
-
 /**
  * Use to access Grafana config settings in application code.
  * This takes `window.grafanaBootData.settings` as input and returns a config object.
@@ -84,9 +79,13 @@ export class GrafanaBootConfig {
   publicDashboardAccessToken?: string;
   publicDashboardsEnabled = true;
   snapshotEnabled = true;
-  datasources: { [str: string]: DataSourceInstanceSettings } = {};
+  datasources: {
+    [str: string]: DataSourceInstanceSettings;
+  } = {};
   /** @deprecated it will be removed in a future release, use isPanelPluginInstalled, getPanelPluginVersion or getListedPanelPluginIds instead */
-  panels: { [key: string]: PanelPluginMeta } = {};
+  panels: {
+    [key: string]: PanelPluginMeta;
+  } = {};
   /** @deprecated it will be removed in a future release, use isAppPluginInstalled or getAppPluginVersion instead */
   apps: Record<string, AppPluginConfigGrafanaData> = {};
   auth: AuthSettings = {};
@@ -143,7 +142,9 @@ export class GrafanaBootConfig {
   /** @deprecated Use `theme2` instead. */
   theme: GrafanaTheme;
   theme2: GrafanaTheme2;
-  featureToggles: FeatureToggles & { kubernetesDashboards?: boolean } = {};
+  featureToggles: FeatureToggles & {
+    kubernetesDashboards?: boolean;
+  } = {};
   anonymousEnabled = false;
   anonymousDeviceLimit?: number;
   licenseInfo: LicenseInfo = {} as LicenseInfo;
@@ -203,7 +204,6 @@ export class GrafanaBootConfig {
     },
     recordingRulesEnabled: false,
     defaultRecordingRulesTargetDatasourceUID: undefined,
-
     // Backward compatibility fields - populated by backend
     alertStateHistoryBackend: undefined,
     alertStateHistoryPrimary: undefined,
@@ -256,13 +256,11 @@ export class GrafanaBootConfig {
   quickRanges?: TimeOption[];
   pluginRestrictedAPIsAllowList?: Record<string, string[]>;
   pluginRestrictedAPIsBlockList?: Record<string, string[]>;
-
   /**
    * Language used in Grafana's UI. This is after the user's preference (or deteceted locale) is resolved to one of
    * Grafana's supported language.
    */
   language: string | undefined;
-
   /**
    * regionalFormat used in Grafana's UI. Default to 'es-US' in the backend and overwritten when the user select a different one in SharedPreferences.
    * This is the regionalFormat that is used for date formatting and other locale-specific features.
@@ -270,28 +268,21 @@ export class GrafanaBootConfig {
   regionalFormat: string;
   listDashboardScopesEndpoint = '';
   listScopesEndpoint = '';
-
   openFeatureContext: Record<string, unknown> = {};
-
   constructor(
     options: BootData['settings'] & {
       bootData: BootData;
     }
   ) {
     this.bootData = options.bootData;
-
     merge(this, options);
-
     if (this.dateFormats) {
       systemDateFormats.update(this.dateFormats);
     }
-
     overrideFeatureTogglesFromUrl(this);
     overrideFeatureTogglesFromLocalStorage(this);
-
     this.featureToggles.kubernetesDashboards = true; // Force true
     this.bootData.settings.featureToggles = this.featureToggles;
-
     // Creating theme after applying feature toggle overrides in case we need to toggle anything
     this.theme2 = getThemeById(this.bootData.user.theme);
     this.bootData.user.lightTheme = this.theme2.isLight;
@@ -299,7 +290,6 @@ export class GrafanaBootConfig {
     this.regionalFormat = options.bootData.user.regionalFormat;
   }
 }
-
 // localstorage key: grafana.featureToggles
 // example value: panelEditor=1,panelInspector=1
 function overrideFeatureTogglesFromLocalStorage(config: GrafanaBootConfig) {
@@ -313,48 +303,40 @@ function overrideFeatureTogglesFromLocalStorage(config: GrafanaBootConfig) {
       const toggleState = featureValue === 'true' || featureValue === '1';
       // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
       featureToggles[featureName as keyof FeatureToggles] = toggleState;
-      console.log(`Setting feature toggle ${featureName} = ${toggleState} via localstorage`);
+      structLog('log', `Setting feature toggle ${featureName} = ${toggleState} via localstorage`);
     }
   }
 }
-
 function overrideFeatureTogglesFromUrl(config: GrafanaBootConfig) {
   if (window.location.href.indexOf('__feature') === -1) {
     return;
   }
-
   const isDevelopment = config.buildInfo.env === 'development';
-
   // Although most flags can not be changed from the URL in production,
   // some of them are safe (and useful!) to change dynamically from the browser URL
   const safeRuntimeFeatureFlags = new Set(['queryServiceFromUI']);
-
   const params = new URLSearchParams(window.location.search);
   params.forEach((value, key) => {
     if (key.startsWith('__feature.')) {
       const featureToggles = config.featureToggles as Record<string, boolean>;
       const featureName = key.substring(10);
-
       const toggleState = value === 'true' || value === ''; // browser rewrites true as ''
       if (toggleState !== featureToggles[key]) {
         if (isDevelopment || safeRuntimeFeatureFlags.has(featureName)) {
           featureToggles[featureName] = toggleState;
-          console.log(`Setting feature toggle ${featureName} = ${toggleState} via url`);
+          structLog('log', `Setting feature toggle ${featureName} = ${toggleState} via url`);
         } else {
-          console.log(`Unable to change feature toggle ${featureName} via url in production.`);
+          structLog('log', `Unable to change feature toggle ${featureName} via url in production.`);
         }
       }
     }
   });
 }
-
 let bootData = window.grafanaBootData;
-
 if (!bootData) {
   if (process.env.NODE_ENV !== 'test') {
-    console.error('window.grafanaBootData was not set by the time config was initialized');
+    structLog('error', 'window.grafanaBootData was not set by the time config was initialized');
   }
-
   bootData = {
     assets: {
       dark: '',
@@ -365,7 +347,6 @@ if (!bootData) {
     navTree: [],
   };
 }
-
 /**
  * Use this to access the {@link GrafanaBootConfig} for the current running Grafana instance.
  *

--- a/packages/grafana-runtime/src/internal/openFeature/index.ts
+++ b/packages/grafana-runtime/src/internal/openFeature/index.ts
@@ -1,16 +1,13 @@
+import { structLog } from '@grafana/data';
 import { OFREPWebProvider } from '@openfeature/ofrep-web-provider';
 import { OpenFeature, ProviderEvents, NOOP_PROVIDER, type EventDetails } from '@openfeature/react-sdk';
-
 import { type FeatureToggles } from '@grafana/data';
-
 import { config } from '../../config';
 import { logError } from '../../utils/logging';
-
 function checkDefaultProvider(event?: EventDetails) {
   if (event?.domain) {
     return;
   }
-
   // Warn plugin developers if we've detected OpenFeature's default provider has been changed,
   //  as plugins should always be using a domain when setting a provider to avoid conflicts.
   if (OpenFeature.getProvider() !== NOOP_PROVIDER) {
@@ -18,13 +15,11 @@ function checkDefaultProvider(event?: EventDetails) {
       'OpenFeature default domain provider has been unexpectedly changed. This may be caused by a plugin that is incorrectly using the default domain.',
       { cause: OpenFeature.getProvider() }
     );
-    console.error(err);
+    structLog('error', err);
     logError(err);
   }
 }
-
 export type FeatureFlagName = keyof FeatureToggles;
-
 // The domain creates the unique instance of the OpenFeature client for Grafana core,
 // with its own evaluation context and provider.
 // Plugins should not use this client or domain, and instead create their own client
@@ -33,26 +28,21 @@ export type FeatureFlagName = keyof FeatureToggles;
 // If changing this, you MUST also update the same constant in packages/grafana-test-utils/src/utilities/featureFlags.ts
 // to ensure tests work correctly.
 export const GRAFANA_CORE_OPEN_FEATURE_DOMAIN = 'internal-grafana-core';
-
 export async function initOpenFeature() {
   OpenFeature.addHandler(ProviderEvents.Ready, checkDefaultProvider);
   OpenFeature.addHandler(ProviderEvents.Error, checkDefaultProvider);
-
   const subPath = config.appSubUrl || '';
   const baseUrl = `${subPath}/apis/features.grafana.app/v0alpha1/namespaces/${config.namespace}`;
-
   const ofProvider = new OFREPWebProvider({
     baseUrl: baseUrl,
     pollInterval: -1, // disable polling
-    timeoutMs: 5_000,
+    timeoutMs: 5000,
   });
-
   await OpenFeature.setProviderAndWait(GRAFANA_CORE_OPEN_FEATURE_DOMAIN, ofProvider, {
     targetingKey: config.namespace,
     ...config.openFeatureContext,
   });
 }
-
 /**
  * Get the OpenFeature client for Grafana core.
  * Prefer to instead use the React hooks for evaluating feature flags instead as they remain up to date with the latest flag values.

--- a/packages/grafana-runtime/src/services/pluginMeta/apps.test.ts
+++ b/packages/grafana-runtime/src/services/pluginMeta/apps.test.ts
@@ -98,7 +98,6 @@ describe('when useMTPlugins flag is enabled', () => {
     describe('and initPluginMetas returns an empty result', () => {
       beforeEach(() => {
         initPluginMetasMock.mockResolvedValue({ items: [] });
-        jest.spyOn(console, 'warn').mockImplementation();
       });
 
       it.each([{ func: getAppPluginMetas }])(
@@ -106,10 +105,6 @@ describe('when useMTPlugins flag is enabled', () => {
         async ({ func }) => {
           await func();
 
-          expect(console.warn).toHaveBeenCalledTimes(1);
-          expect(console.warn).toHaveBeenCalledWith(
-            'PluginMeta: plugin meta yielded an empty result so Grafana is falling back to bootdata'
-          );
           expect(logger.logWarning).toHaveBeenCalledTimes(1);
           expect(logger.logWarning).toHaveBeenCalledWith(
             'PluginMeta: plugin meta yielded an empty result so Grafana is falling back to bootdata',
@@ -123,10 +118,6 @@ describe('when useMTPlugins flag is enabled', () => {
         async ({ func }) => {
           await func('');
 
-          expect(console.warn).toHaveBeenCalledTimes(1);
-          expect(console.warn).toHaveBeenCalledWith(
-            'PluginMeta: plugin meta yielded an empty result so Grafana is falling back to bootdata'
-          );
           expect(logger.logWarning).toHaveBeenCalledTimes(1);
           expect(logger.logWarning).toHaveBeenCalledWith(
             'PluginMeta: plugin meta yielded an empty result so Grafana is falling back to bootdata',

--- a/packages/grafana-runtime/src/services/pluginMeta/logging.ts
+++ b/packages/grafana-runtime/src/services/pluginMeta/logging.ts
@@ -1,31 +1,21 @@
 import { type PluginType } from '@grafana/data';
-
 import { createMonitoringLogger, type MonitoringLogger } from '../../utils/logging';
-
 let logger: MonitoringLogger;
-
 function getLogger() {
   if (!logger) {
     logger = createMonitoringLogger('pluginMeta-logs');
   }
-
   return logger;
 }
-
 export function logPluginMetaWarning(message: string, type: PluginType): void {
   getLogger().logWarning(message, { type });
-  console.warn(message);
 }
-
 export function logPluginMetaError(message: string, error: unknown): void {
   getLogger().logError(new Error(message, { cause: error }));
-  console.error(message, error);
 }
-
 export function setPluginMetaLogger(override: MonitoringLogger) {
   if (process.env.NODE_ENV !== 'test') {
     throw new Error('setLogger function can only be called from tests.');
   }
-
   logger = override;
 }

--- a/packages/grafana-runtime/src/services/pluginMeta/panels.test.ts
+++ b/packages/grafana-runtime/src/services/pluginMeta/panels.test.ts
@@ -147,7 +147,6 @@ describe('when useMTPlugins flag is enabled', () => {
       beforeEach(() => {
         initPluginMetasMock.mockResolvedValue({ items: [] });
         refetchPluginMetasMock.mockResolvedValue({ items: [] });
-        jest.spyOn(console, 'warn').mockImplementation();
       });
 
       it.each([
@@ -159,10 +158,6 @@ describe('when useMTPlugins flag is enabled', () => {
       ])(`when func:$func is called then a warning should be logged`, async ({ func }) => {
         await func();
 
-        expect(console.warn).toHaveBeenCalledTimes(1);
-        expect(console.warn).toHaveBeenCalledWith(
-          'PluginMeta: plugin meta yielded an empty result so Grafana is falling back to bootdata'
-        );
         expect(logger.logWarning).toHaveBeenCalledTimes(1);
         expect(logger.logWarning).toHaveBeenCalledWith(
           'PluginMeta: plugin meta yielded an empty result so Grafana is falling back to bootdata',
@@ -175,10 +170,6 @@ describe('when useMTPlugins flag is enabled', () => {
         async ({ func }) => {
           await func('');
 
-          expect(console.warn).toHaveBeenCalledTimes(1);
-          expect(console.warn).toHaveBeenCalledWith(
-            'PluginMeta: plugin meta yielded an empty result so Grafana is falling back to bootdata'
-          );
           expect(logger.logWarning).toHaveBeenCalledTimes(1);
           expect(logger.logWarning).toHaveBeenCalledWith(
             'PluginMeta: plugin meta yielded an empty result so Grafana is falling back to bootdata',

--- a/packages/grafana-runtime/src/utils/chromeHeaderHeight.ts
+++ b/packages/grafana-runtime/src/utils/chromeHeaderHeight.ts
@@ -1,18 +1,15 @@
+import { structLog } from '@grafana/data';
 type ChromeHeaderHeightHook = () => number;
-
 let chromeHeaderHeightHook: ChromeHeaderHeightHook | undefined = undefined;
-
 export const setChromeHeaderHeightHook = (hook: ChromeHeaderHeightHook) => {
   chromeHeaderHeightHook = hook;
 };
-
 export const useChromeHeaderHeight = () => {
   if (!chromeHeaderHeightHook) {
     if (process.env.NODE_ENV !== 'production') {
       throw new Error('useChromeHeaderHeight hook not found in @grafana/runtime');
     }
-    console.error('useChromeHeaderHeight hook not found');
+    structLog('error', 'useChromeHeaderHeight hook not found');
   }
-
   return chromeHeaderHeightHook?.();
 };

--- a/packages/grafana-runtime/src/utils/logging.ts
+++ b/packages/grafana-runtime/src/utils/logging.ts
@@ -1,8 +1,38 @@
 import { faro, type LogContext, LogLevel } from '@grafana/faro-web-sdk';
+import { structLog } from '@grafana/data/structLog';
 
 import { config } from '../config';
 
 export { LogLevel };
+
+function stringifyForContext(v: unknown): string {
+  if (typeof v === 'string') {
+    return v;
+  }
+  if (v instanceof Error) {
+    return v.message;
+  }
+  try {
+    return JSON.stringify(v);
+  } catch {
+    return String(v);
+  }
+}
+
+/**
+ * Coerce a LogContext to Faro's `Record<string, string>` (nested values are JSON-stringified).
+ * @internal
+ */
+function normalizeFaroLogContext(contexts?: LogContext): LogContext | undefined {
+  if (!contexts) {
+    return undefined;
+  }
+  const out: LogContext = {};
+  for (const key of Object.keys(contexts)) {
+    out[key] = stringifyForContext((contexts as Record<string, unknown>)[key]);
+  }
+  return out;
+}
 
 /**
  * Log a message at INFO level
@@ -12,8 +42,10 @@ export function logInfo(message: string, contexts?: LogContext) {
   if (config.grafanaJavascriptAgent.enabled) {
     faro.api.pushLog([message], {
       level: LogLevel.INFO,
-      context: contexts,
+      context: normalizeFaroLogContext(contexts),
     });
+  } else {
+    structLog('log', message, contexts ?? '');
   }
 }
 
@@ -26,8 +58,10 @@ export function logWarning(message: string, contexts?: LogContext) {
   if (config.grafanaJavascriptAgent.enabled) {
     faro.api.pushLog([message], {
       level: LogLevel.WARN,
-      context: contexts,
+      context: normalizeFaroLogContext(contexts),
     });
+  } else {
+    structLog('warn', message, contexts ?? '');
   }
 }
 
@@ -40,8 +74,10 @@ export function logDebug(message: string, contexts?: LogContext) {
   if (config.grafanaJavascriptAgent.enabled) {
     faro.api.pushLog([message], {
       level: LogLevel.DEBUG,
-      context: contexts,
+      context: normalizeFaroLogContext(contexts),
     });
+  } else {
+    structLog('debug', message, contexts ?? '');
   }
 }
 
@@ -53,8 +89,10 @@ export function logDebug(message: string, contexts?: LogContext) {
 export function logError(err: Error, contexts?: LogContext) {
   if (config.grafanaJavascriptAgent.enabled) {
     faro.api.pushError(err, {
-      context: contexts,
+      context: normalizeFaroLogContext(contexts),
     });
+  } else {
+    structLog('error', err, contexts ?? '');
   }
 }
 
@@ -73,6 +111,8 @@ export function logMeasurement(type: string, values: MeasurementValues, context?
       },
       { context: context }
     );
+  } else {
+    structLog('log', 'measurement', { type, values, ...context });
   }
 }
 

--- a/packages/grafana-runtime/src/utils/megaMenuOpen.ts
+++ b/packages/grafana-runtime/src/utils/megaMenuOpen.ts
@@ -1,11 +1,9 @@
+import { structLog } from '@grafana/data';
 type MegaMenuOpenHook = () => Readonly<[boolean, (open: boolean, persist?: boolean) => void]>;
-
 let megaMenuOpenHook: MegaMenuOpenHook | undefined = undefined;
-
 export const setMegaMenuOpenHook = (hook: MegaMenuOpenHook) => {
   megaMenuOpenHook = hook;
 };
-
 /**
  * Guidelines:
  * - Should only be used in very specific circumstances where the mega menu needs to be opened or closed programmatically.
@@ -15,8 +13,7 @@ export const useMegaMenuOpen: MegaMenuOpenHook = () => {
     if (process.env.NODE_ENV !== 'production') {
       throw new Error('useMegaMenuOpen hook not found in @grafana/runtime');
     }
-    return [false, () => console.error('MegaMenuOpen hook not found')];
+    return [false, () => structLog('error', 'MegaMenuOpen hook not found')];
   }
-
   return megaMenuOpenHook();
 };

--- a/packages/grafana-runtime/src/utils/migrationHandler.ts
+++ b/packages/grafana-runtime/src/utils/migrationHandler.ts
@@ -1,11 +1,9 @@
+import { structLog } from '@grafana/data';
 import { type DataQueryRequest } from '@grafana/data';
 import { type DataQuery } from '@grafana/schema';
-
 import { config } from '../config';
 import { getBackendSrv } from '../services';
-
 import { DataSourceWithBackend } from './DataSourceWithBackend';
-
 /**
  * @alpha Experimental: Plugins implementing MigrationHandler interface will automatically have their queries migrated.
  */
@@ -13,17 +11,14 @@ export interface MigrationHandler {
   hasBackendMigration: boolean;
   shouldMigrate(query: DataQuery): boolean;
 }
-
 export function isMigrationHandler(object: unknown): object is MigrationHandler {
   return object instanceof DataSourceWithBackend && 'hasBackendMigration' in object && 'shouldMigrate' in object;
 }
-
 async function postMigrateRequest<TQuery extends DataQuery>(queries: TQuery[]): Promise<TQuery[]> {
   if (!(config.featureToggles.grafanaAPIServerWithExperimentalAPIs || config.featureToggles.datasourceAPIServers)) {
-    console.warn('migrateQuery is only available with the experimental API server');
+    structLog('warn', 'migrateQuery is only available with the experimental API server');
     return queries;
   }
-
   // Obtaining the GroupName from the plugin ID as done in the backend, this is temporary until we have a better way to obtain it
   // https://github.com/grafana/grafana/blob/e013cd427cb0457177e11f19ebd30bc523b36c76/pkg/plugins/apiserver.go#L10
   const dsnameURL = queries[0].datasource?.type?.replace(/^(grafana-)?(.*?)(-datasource)?$/, '$2');
@@ -42,7 +37,6 @@ async function postMigrateRequest<TQuery extends DataQuery>(queries: TQuery[]): 
   const res = await getBackendSrv().post(url, request);
   return res.queries.map((query: { JSON: TQuery }) => query.JSON);
 }
-
 /**
  * @alpha Experimental: Calls migration endpoint with one query. Requires grafanaAPIServerWithExperimentalAPIs or datasourceAPIServers feature toggle.
  */
@@ -56,7 +50,6 @@ export async function migrateQuery<TQuery extends DataQuery>(
   const res = await postMigrateRequest([query]);
   return res[0];
 }
-
 /**
  * @alpha Experimental: Calls migration endpoint with multiple queries. Requires grafanaAPIServerWithExperimentalAPIs or datasourceAPIServers feature toggle.
  */

--- a/packages/grafana-runtime/src/utils/plugin.ts
+++ b/packages/grafana-runtime/src/utils/plugin.ts
@@ -1,7 +1,6 @@
+import { structLog } from '@grafana/data';
 import { type PanelPlugin } from '@grafana/data';
-
 import { config } from '../config';
-
 /**
  * Option to specify a plugin css that should be applied for the dark
  * and the light theme.
@@ -12,7 +11,6 @@ export interface PluginCssOptions {
   light: string;
   dark: string;
 }
-
 /**
  * Use this to load css for a Grafana plugin by specifying a {@link PluginCssOptions}
  * containing styling for the dark and the light theme.
@@ -25,29 +23,23 @@ export async function loadPluginCss(options: PluginCssOptions): Promise<System.M
     const cssPath = config.bootData.user.theme === 'light' ? options.light : options.dark;
     return window.System.import(cssPath);
   } catch (err) {
-    console.error(err);
+    structLog('error', err);
   }
 }
-
 interface PluginImportUtils {
   importPanelPlugin: (id: string) => Promise<PanelPlugin>;
   getPanelPluginFromCache: (id: string) => PanelPlugin | undefined;
 }
-
 let pluginImportUtils: PluginImportUtils | undefined;
-
 export function setPluginImportUtils(utils: PluginImportUtils) {
   if (pluginImportUtils) {
     throw new Error('pluginImportUtils should only be set once, when Grafana is starting.');
   }
-
   pluginImportUtils = utils;
 }
-
 export function getPluginImportUtils(): PluginImportUtils {
   if (!pluginImportUtils) {
     throw new Error('pluginImportUtils can only be used after Grafana instance has started.');
   }
-
   return pluginImportUtils;
 }

--- a/packages/grafana-runtime/src/utils/qscheck.ts
+++ b/packages/grafana-runtime/src/utils/qscheck.ts
@@ -1,12 +1,11 @@
+import { structLog } from '@grafana/data';
 import { type DataSourceInstanceSettings, type DataSourceJsonData } from '@grafana/data';
-
 interface JsonData extends DataSourceJsonData {
   oauthPassThru?: unknown; // we do not assume boolean, to be more robust
   azureCredentials?: {
     authType?: unknown;
   };
 }
-
 function isOauthEnabled(ds: DataSourceInstanceSettings<JsonData>): boolean {
   const oauth = ds.jsonData.oauthPassThru;
   // we are working with json-data here, the content may not necessarily be a boolean,
@@ -14,29 +13,22 @@ function isOauthEnabled(ds: DataSourceInstanceSettings<JsonData>): boolean {
   if (oauth === undefined) {
     return false;
   }
-
   if (oauth === false) {
     return false;
   }
-
   if (oauth === true) {
     return true;
   }
-
   // for us it is safer to assume true when there is some weird value used in the jsondata.
   return true;
 }
-
 type DSSettings = DataSourceInstanceSettings<JsonData>;
-
 function isProblematicAzureAuth(ds: DSSettings): boolean {
   return ds.jsonData.azureCredentials?.authType === 'currentuser';
 }
-
 type AllowedTypes = {
   types: string[];
 };
-
 // TODO: consider using a data-validation library
 function parseAllowedTypes(data: unknown): AllowedTypes {
   // we want to be safe, this should never crash
@@ -44,19 +36,17 @@ function parseAllowedTypes(data: unknown): AllowedTypes {
     // typescript infers the array as any[], not unknown[], we need to correct this to have
     // typescript protect us.
     const types: unknown[] = data.types;
-
     if (types.every((x) => typeof x === 'string')) {
       return { types };
     } else {
-      console.error('qscheck.parseFlags: non-string item in allowed');
+      structLog('error', 'qscheck.parseFlags: non-string item in allowed');
       return { types: [] };
     }
   } else {
-    console.error('qscheck.parseFlags: invalid data');
+    structLog('error', 'qscheck.parseFlags: invalid data');
     return { types: [] };
   }
 }
-
 export function isQueryServiceCompatible(datasources: DSSettings[], allowedTypes: unknown) {
   if (datasources.length === 0) {
     // note: this probably means something went wrong,
@@ -65,24 +55,20 @@ export function isQueryServiceCompatible(datasources: DSSettings[], allowedTypes
     // and say no to query service.
     return false;
   }
-
   const at = parseAllowedTypes(allowedTypes);
   if (!areDataSourceTypesAllowed(datasources, new Set(at.types))) {
     return false;
   }
-
   for (const ds of datasources) {
     if (isOauthEnabled(ds)) {
       return false;
     }
-
     if (isProblematicAzureAuth(ds)) {
       return false;
     }
   }
   return true;
 }
-
 function areDataSourceTypesAllowed(datasources: DSSettings[], allowedTypes: Set<string>): boolean {
   for (const ds of datasources) {
     if (!allowedTypes.has(ds.type)) {

--- a/packages/grafana-runtime/src/utils/returnToPrevious.ts
+++ b/packages/grafana-runtime/src/utils/returnToPrevious.ts
@@ -1,11 +1,9 @@
+import { structLog } from '@grafana/data';
 type ReturnToPreviousHook = () => (title: string, href?: string) => void;
-
 let rtpHook: ReturnToPreviousHook | undefined = undefined;
-
 export const setReturnToPreviousHook = (hook: ReturnToPreviousHook) => {
   rtpHook = hook;
 };
-
 /**
  * Guidelines:
  * - Only use the ‘Return to previous’ functionality when the user is sent to another context, such as from Alerting to a dashboard.
@@ -16,8 +14,7 @@ export const useReturnToPrevious: ReturnToPreviousHook = () => {
     if (process.env.NODE_ENV !== 'production') {
       throw new Error('useReturnToPrevious hook not found in @grafana/runtime');
     }
-    return () => console.error('ReturnToPrevious hook not found');
+    return () => structLog('error', 'ReturnToPrevious hook not found');
   }
-
   return rtpHook();
 };

--- a/packages/grafana-sql/src/datasource/SqlDatasource.ts
+++ b/packages/grafana-sql/src/datasource/SqlDatasource.ts
@@ -1,6 +1,6 @@
+import { structLog } from '@grafana/data';
 import { lastValueFrom, type Observable, throwError } from 'rxjs';
 import { map } from 'rxjs/operators';
-
 import {
   getDefaultTimeRange,
   type DataFrame,
@@ -28,13 +28,11 @@ import {
   type TemplateSrv,
   reportInteraction,
 } from '@grafana/runtime';
-
 import { ResponseParser } from '../ResponseParser';
 import { SqlQueryEditorLazy } from '../components/QueryEditorLazy';
 import { MACRO_NAMES } from '../constants';
 import { type DB, type SQLQuery, type SQLOptions, type SqlQueryModel, QueryFormat, type SQLDialect } from '../types';
 import migrateAnnotation from '../utils/migration';
-
 export abstract class SqlDatasource extends DataSourceWithBackend<SQLQuery, SQLOptions> {
   uid: string;
   responseParser: ResponseParser;
@@ -43,7 +41,6 @@ export abstract class SqlDatasource extends DataSourceWithBackend<SQLQuery, SQLO
   db: DB;
   preconfiguredDatabase: string;
   dialect: SQLDialect = 'other';
-
   constructor(
     public instanceSettings: DataSourceInstanceSettings<SQLOptions>,
     protected readonly templateSrv: TemplateSrv = getTemplateSrv()
@@ -56,24 +53,20 @@ export abstract class SqlDatasource extends DataSourceWithBackend<SQLQuery, SQLO
     this.interval = settingsData.timeInterval || '1m';
     this.db = this.getDB();
     /*
-      The `settingsData.database` will be defined if a default database has been defined in either
-      1) the ConfigurationEditor.tsx, OR 2) the provisioning config file, either under `jsondata.database`, or simply `database`.
-    */
+          The `settingsData.database` will be defined if a default database has been defined in either
+          1) the ConfigurationEditor.tsx, OR 2) the provisioning config file, either under `jsondata.database`, or simply `database`.
+        */
     this.preconfiguredDatabase = settingsData.database ?? '';
     this.annotations = {
       prepareAnnotation: migrateAnnotation,
       QueryEditor: SqlQueryEditorLazy,
     };
   }
-
   abstract getDB(): DB;
-
   abstract getQueryModel(target?: SQLQuery, templateSrv?: TemplateSrv, scopedVars?: ScopedVars): SqlQueryModel;
-
   getResponseParser() {
     return this.responseParser;
   }
-
   interpolateVariable = (value: string | string[] | number, variable: VariableWithMultiSupport) => {
     if (typeof value === 'string') {
       if (variable.multi || variable.includeAll) {
@@ -82,19 +75,15 @@ export abstract class SqlDatasource extends DataSourceWithBackend<SQLQuery, SQLO
         return String(value).replace(/'/g, "''");
       }
     }
-
     if (typeof value === 'number') {
       return value;
     }
-
     if (Array.isArray(value)) {
       const quotedValues = value.map((v) => this.getQueryModel().quoteLiteral(v));
       return quotedValues.join(',');
     }
-
     return value;
   };
-
   interpolateVariablesInQueries(queries: SQLQuery[], scopedVars: ScopedVars): SQLQuery[] {
     let expandedQueries = queries;
     if (queries && queries.length > 0) {
@@ -110,11 +99,9 @@ export abstract class SqlDatasource extends DataSourceWithBackend<SQLQuery, SQLO
     }
     return expandedQueries;
   }
-
   filterQuery(query: SQLQuery): boolean {
     return !query.hide;
   }
-
   applyTemplateVariables(target: SQLQuery, scopedVars: ScopedVars) {
     return {
       refId: target.refId,
@@ -123,21 +110,17 @@ export abstract class SqlDatasource extends DataSourceWithBackend<SQLQuery, SQLO
       format: target.format,
     };
   }
-
   query(request: DataQueryRequest<SQLQuery>): Observable<DataQueryResponse> {
     // This logic reenables the previous SQL behavior regarding what databases are available for the user to query.
     const databaseIssue = this.checkForDatabaseIssue(request);
-
     if (!!databaseIssue) {
       const error = new Error(databaseIssue);
       return throwError(() => error);
     }
-
     request.targets.forEach((target) => {
       if (request.app === CoreApp.Dashboard || request.app === CoreApp.PanelViewer) {
         return;
       }
-
       reportInteraction('grafana_sql_query_executed', {
         datasource: target.datasource?.type,
         editorMode: target.editorMode,
@@ -145,10 +128,8 @@ export abstract class SqlDatasource extends DataSourceWithBackend<SQLQuery, SQLO
         app: request.app,
       });
     });
-
     return super.query(request);
   }
-
   private checkForDatabaseIssue(request: DataQueryRequest<SQLQuery>) {
     // If the datasource is Postgres and there is no default database configured - either never configured or removed - return a database issue.
     if (this.type === 'grafana-postgresql-datasource' && !this.preconfiguredDatabase) {
@@ -156,14 +137,13 @@ export abstract class SqlDatasource extends DataSourceWithBackend<SQLQuery, SQLO
              database with which to connect. Please configure one through the Data Sources Configuration page, or if you
              are using a provisioning file, update that configuration file with a default database.`;
     }
-
     // No need to check for database change/update issues if the datasource is being used in Explore.
     if (request.app !== CoreApp.Explore) {
       /*
-        If a preconfigured datasource database has been added/updated - and the user has built ANY number of queries using a
-        database OTHER than the preconfigured one, return a database issue - since those databases are no longer available.
-        The user will need to update their queries to use the preconfigured database.
-      */
+              If a preconfigured datasource database has been added/updated - and the user has built ANY number of queries using a
+              database OTHER than the preconfigured one, return a database issue - since those databases are no longer available.
+              The user will need to update their queries to use the preconfigured database.
+            */
       if (!!this.preconfiguredDatabase) {
         for (const target of request.targets) {
           // Test for database configuration change only if query was made in `builder` mode.
@@ -179,59 +159,49 @@ export abstract class SqlDatasource extends DataSourceWithBackend<SQLQuery, SQLO
         }
       }
     }
-
     return;
   }
-
   async metricFindQuery(query: string, options?: LegacyMetricFindQueryOptions): Promise<MetricFindValue[]> {
     const range = options?.range;
     if (range == null) {
       // i cannot create a scenario where this happens, we handle it just to be sure.
       return [];
     }
-
     let refId = 'tempvar';
     if (options && options.variable && options.variable.name) {
       refId = options.variable.name;
     }
-
     const scopedVars = {
       ...options?.scopedVars,
       ...getSearchFilterScopedVar({ query, wildcardChar: '%', options }),
     };
-
     const rawSql = this.templateSrv.replace(query, scopedVars, this.interpolateVariable);
-
     const interpolatedQuery: SQLQuery = {
       refId: refId,
       datasource: this.getRef(),
       rawSql,
       format: QueryFormat.Table,
     };
-
     // NOTE: we can remove this try-catch when https://github.com/grafana/grafana/issues/82250
     // is fixed.
     let response;
     try {
       response = await this.runMetaQuery(interpolatedQuery, range);
     } catch (error) {
-      console.error(error);
+      structLog('error', error);
       throw new Error('error when executing the sql query');
     }
     return this.getResponseParser().transformMetricFindResponse(response);
   }
-
   // NOTE: this always runs with the `@grafana/data/getDefaultTimeRange` time range
   async runSql<T extends object>(query: string, options?: RunSQLOptions) {
     const range = getDefaultTimeRange();
     const frame = await this.runMetaQuery({ rawSql: query, format: QueryFormat.Table, refId: options?.refId }, range);
     return new DataFrameView<T>(frame);
   }
-
   private runMetaQuery(request: Partial<SQLQuery>, range: TimeRange): Promise<DataFrame> {
     const refId = request.refId || 'meta';
     const queries: DataQuery[] = [{ ...request, datasource: request.datasource || this.getRef(), refId }];
-
     return lastValueFrom(
       getBackendSrv()
         .fetch<BackendDataSourceResponse>({
@@ -253,7 +223,6 @@ export abstract class SqlDatasource extends DataSourceWithBackend<SQLQuery, SQLO
         )
     );
   }
-
   targetContainsTemplate(target: SQLQuery) {
     let queryWithoutMacros = target.rawSql;
     MACRO_NAMES.forEach((value) => {
@@ -262,7 +231,6 @@ export abstract class SqlDatasource extends DataSourceWithBackend<SQLQuery, SQLO
     return this.templateSrv.containsTemplate(queryWithoutMacros);
   }
 }
-
 interface RunSQLOptions extends LegacyMetricFindQueryOptions {
   refId?: string;
 }

--- a/packages/grafana-ui/src/components/Combobox/storyUtils.ts
+++ b/packages/grafana-ui/src/components/Combobox/storyUtils.ts
@@ -1,43 +1,34 @@
+import { structLog } from '@grafana/data';
 import { type ComboboxOption } from './types';
-
 let fakeApiOptions: Array<ComboboxOption<string>>;
 export async function fakeSearchAPI(urlString: string): Promise<Array<ComboboxOption<string>>> {
   const searchParams = new URL(urlString).searchParams;
-
   const errorOnQuery = searchParams.get('errorOnQuery')?.toLowerCase();
   const searchQuery = searchParams.get('query')?.toLowerCase();
-
   if (errorOnQuery === searchQuery) {
     throw new Error('An error occurred (because it was asked for)');
   }
-
   if (!fakeApiOptions) {
     fakeApiOptions = await generateOptions(1000);
-    console.log('fakeApiOptions', fakeApiOptions);
+    structLog('log', 'fakeApiOptions', fakeApiOptions);
   }
-
   if (!searchQuery || searchQuery.length === 0) {
     return Promise.resolve(fakeApiOptions.slice(0, 24));
   }
-
   const filteredOptions = Promise.resolve(
     fakeApiOptions.filter((opt) => opt.label?.toLowerCase().includes(searchQuery))
   );
-
   const delay = searchQuery.length % 2 === 0 ? 200 : 1000;
-
   return new Promise<Array<ComboboxOption<string>>>((resolve) => {
     setTimeout(() => resolve(filteredOptions), delay);
   });
 }
-
 export async function generateOptions(amount: number): Promise<ComboboxOption[]> {
   return Array.from({ length: amount }, (_, index) => ({
     label: 'Option ' + index,
     value: index.toString(),
   }));
 }
-
 export async function generateGroupingOptions(amount: number): Promise<ComboboxOption[]> {
   return Array.from({ length: amount }, (_, index) => ({
     label: 'Option ' + index,

--- a/packages/grafana-ui/src/components/Combobox/useOptions.ts
+++ b/packages/grafana-ui/src/components/Combobox/useOptions.ts
@@ -1,23 +1,17 @@
+import { structLog } from '@grafana/data';
 /* Spreading unbound arrays can be very slow or even crash the browser if used for arguments */
 /* eslint no-restricted-syntax: ["error", "SpreadElement"] */
-
 import { debounce } from 'lodash';
 import { useState, useCallback, useMemo } from 'react';
-
 import { t } from '@grafana/i18n';
-
 import { fuzzyFind, itemToString } from './filter';
 import { type ComboboxOption } from './types';
 import { StaleResultError, useLatestAsyncCall } from './useLatestAsyncCall';
-
 type AsyncOptions<T extends string | number> =
   | Array<ComboboxOption<T>>
   | ((inputValue: string) => Promise<Array<ComboboxOption<T>>>);
-
 const asyncNoop = () => Promise.resolve([]);
-
 export const DEBOUNCE_TIME_MS = 200;
-
 /**
  * Abstracts away sync/async options for combobox components.
  * It also filters options based on the user's input.
@@ -33,9 +27,7 @@ export function useOptions<T extends string | number>(
   customValueDescription?: string
 ) {
   const isAsync = typeof rawOptions === 'function';
-
   const loadOptions = useLatestAsyncCall(isAsync ? rawOptions : asyncNoop);
-
   const debouncedLoadOptions = useMemo(
     () =>
       debounce((searchTerm: string) => {
@@ -49,24 +41,20 @@ export function useOptions<T extends string | number>(
             if (!(error instanceof StaleResultError)) {
               setAsyncError(true);
               setAsyncLoading(false);
-
               if (error) {
-                console.error('Error loading async options for Combobox', error);
+                structLog('error', 'Error loading async options for Combobox', error);
               }
             }
           });
       }, DEBOUNCE_TIME_MS),
     [loadOptions]
   );
-
   const [asyncOptions, setAsyncOptions] = useState<Array<ComboboxOption<T>>>([]);
   const [asyncLoading, setAsyncLoading] = useState(false);
   const [asyncError, setAsyncError] = useState(false);
-
   // This hook keeps its own inputValue state (rather than accepting it as an arg) because it needs to be
   // told it for async options loading anyway.
   const [userTypedSearch, setUserTypedSearch] = useState('');
-
   const addCustomValue = useCallback(
     (opts: Array<ComboboxOption<T>>) => {
       let currentOptions: Array<ComboboxOption<T>> = opts;
@@ -88,7 +76,6 @@ export function useOptions<T extends string | number>(
     },
     [createCustomValue, customValueDescription, userTypedSearch]
   );
-
   const updateOptions = useCallback(
     (inputValue: string) => {
       setUserTypedSearch(inputValue);
@@ -99,34 +86,26 @@ export function useOptions<T extends string | number>(
     },
     [debouncedLoadOptions, isAsync]
   );
-
   const stringifiedOptions = useMemo(() => {
     return isAsync ? [] : rawOptions.map(itemToString);
   }, [isAsync, rawOptions]);
-
   // Create a list of options filtered by the current search.
   // If async, just returns the async options.
   const filteredOptions = useMemo(() => {
     if (isAsync) {
       return asyncOptions;
     }
-
     return fuzzyFind(rawOptions, stringifiedOptions, userTypedSearch);
   }, [asyncOptions, isAsync, rawOptions, stringifiedOptions, userTypedSearch]);
-
   const [finalOptions, groupStartIndices] = useMemo(() => {
     const { options, groupStartIndices } = sortByGroup(filteredOptions);
-
     return [addCustomValue(options), groupStartIndices];
   }, [filteredOptions, addCustomValue]);
-
   const resetSearch = useCallback(() => {
     setUserTypedSearch('');
   }, []);
-
   return { options: finalOptions, groupStartIndices, updateOptions, asyncLoading, asyncError, resetSearch };
 }
-
 /**
  * Sorts options by group and returns the sorted options and the starting index of each group
  */
@@ -134,7 +113,6 @@ export function sortByGroup<T extends string | number>(options: Array<ComboboxOp
   // Group options by their group
   const groupedOptions = new Map<string | undefined, Array<ComboboxOption<T>>>();
   const groupStartIndices = new Map<string | undefined, number>();
-
   for (const option of options) {
     const group = option.group;
     const existing = groupedOptions.get(group);
@@ -144,24 +122,19 @@ export function sortByGroup<T extends string | number>(options: Array<ComboboxOp
       groupedOptions.set(group, [option]);
     }
   }
-
   // If we only have one group (either the undefined group, or a single group), return the original array
   if (groupedOptions.size <= 1) {
     if (options[0]?.group) {
       groupStartIndices.set(options[0]?.group, 0);
     }
-
     return {
       options,
       groupStartIndices,
     };
   }
-
   // 'Preallocate' result array with same size as input - very minor optimization
   const result: Array<ComboboxOption<T>> = new Array(options.length);
-
   let currentIndex = 0;
-
   // Fill result array with grouped and undefined grouped options
   for (const [group, groupOptions] of groupedOptions) {
     if (group) {
@@ -171,7 +144,6 @@ export function sortByGroup<T extends string | number>(options: Array<ComboboxOp
       result[currentIndex++] = option;
     }
   }
-
   return {
     options: result,
     groupStartIndices,

--- a/packages/grafana-ui/src/components/Combobox/utils.ts
+++ b/packages/grafana-ui/src/components/Combobox/utils.ts
@@ -1,21 +1,16 @@
+import { structLog } from '@grafana/data';
 import { isIconName, type SelectableValue } from '@grafana/data';
-
 import { type ComboboxOption } from './types';
-
 export const isNewGroup = <T extends string | number>(option: ComboboxOption<T>, prevOption?: ComboboxOption<T>) => {
   const currentGroup = option.group;
-
   if (!currentGroup) {
     return prevOption?.group ? true : false;
   }
-
   if (!prevOption) {
     return true;
   }
-
   return prevOption.group !== currentGroup;
 };
-
 /**
  * returns a ComboboxOption from a SelectableValue, or undefined if it could not be converted.
  * @param v - The SelectableValue to convert.
@@ -25,11 +20,11 @@ export const selectableValueToComboboxOption = <T extends string | number>(
   v: SelectableValue<T>
 ): ComboboxOption<T> | undefined => {
   if (v == null || v.value == null) {
-    console.warn('selectableValueToComboboxOption: value is null or undefined', v);
+    structLog('warn', 'selectableValueToComboboxOption: value is null or undefined', v);
     return undefined;
   }
   if (v.icon != null && !isIconName(v.icon)) {
-    console.warn('selectableValueToComboboxOption: icon is not a valid icon name', v.icon);
+    structLog('warn', 'selectableValueToComboboxOption: icon is not a valid icon name', v.icon);
     return undefined;
   }
   return {

--- a/packages/grafana-ui/src/components/DateTimePickers/TimeRangePicker/CalendarBody.tsx
+++ b/packages/grafana-ui/src/components/DateTimePickers/TimeRangePicker/CalendarBody.tsx
@@ -1,29 +1,24 @@
+import { structLog } from '@grafana/data';
 import { css } from '@emotion/css';
 import { useCallback } from 'react';
 import Calendar, { type CalendarType } from 'react-calendar';
-
 import { type GrafanaTheme2, dateTimeParse, type DateTime, type TimeZone } from '@grafana/data';
 import { t } from '@grafana/i18n';
-
 import { useStyles2 } from '../../../themes/ThemeContext';
 import { Icon } from '../../Icon/Icon';
 import { getWeekStart, type WeekStart } from '../WeekStartPicker';
 import { adjustDateForReactCalendar } from '../utils/adjustDateForReactCalendar';
-
 import { type TimePickerCalendarProps } from './TimePickerCalendar';
-
 const weekStartMap: Record<WeekStart, CalendarType> = {
   saturday: 'islamic',
   sunday: 'gregory',
   monday: 'iso8601',
 };
-
 export function Body({ onChange, from, to, timeZone, weekStart }: TimePickerCalendarProps) {
   const value = inputToValue(from, to, new Date(), timeZone);
   const onCalendarChange = useOnCalendarChange(onChange, timeZone);
   const styles = useStyles2(getBodyStyles);
   const weekStartValue = getWeekStart(weekStart);
-
   return (
     <Calendar
       selectRange={true}
@@ -42,9 +37,7 @@ export function Body({ onChange, from, to, timeZone, weekStart }: TimePickerCale
     />
   );
 }
-
 Body.displayName = 'Body';
-
 export function inputToValue(
   from: DateTime,
   to: DateTime,
@@ -53,57 +46,46 @@ export function inputToValue(
 ): [Date, Date] {
   let fromAsDate = from.isValid() ? from.toDate() : invalidDateDefault;
   let toAsDate = to.isValid() ? to.toDate() : invalidDateDefault;
-
   if (timezone) {
     fromAsDate = adjustDateForReactCalendar(fromAsDate, timezone);
     toAsDate = adjustDateForReactCalendar(toAsDate, timezone);
   }
-
   if (fromAsDate > toAsDate) {
     return [toAsDate, fromAsDate];
   }
-
   return [fromAsDate, toAsDate];
 }
-
 function useOnCalendarChange(onChange: (from: DateTime, to: DateTime) => void, timeZone?: TimeZone) {
   return useCallback<NonNullable<React.ComponentProps<typeof Calendar>['onChange']>>(
     (value) => {
       if (!Array.isArray(value)) {
-        return console.error('onCalendarChange: should be run in selectRange={true}');
+        return structLog('error', 'onCalendarChange: should be run in selectRange={true}');
       }
-
       if (value[0] && value[1]) {
         const from = dateTimeParse(dateInfo(value[0]), { timeZone });
         const to = dateTimeParse(dateInfo(value[1]), { timeZone });
-
         onChange(from, to);
       }
     },
     [onChange, timeZone]
   );
 }
-
 function dateInfo(date: Date): number[] {
   return [date.getFullYear(), date.getMonth(), date.getDate(), date.getHours(), date.getMinutes(), date.getSeconds()];
 }
-
 export const getBodyStyles = (theme: GrafanaTheme2) => {
   // If a time range is part of only 1 day but does not encompass the whole day,
   // the class that react-calendar uses is '--hasActive' by itself (without being part of a '--range')
   const hasActiveSelector = `.react-calendar__tile--hasActive:not(.react-calendar__tile--range)`;
-
   return {
     title: css({
       color: theme.colors.text.primary,
       backgroundColor: theme.colors.background.primary,
       fontSize: theme.typography.size.md,
       border: '1px solid transparent',
-
       '&:hover, &:focus': {
         position: 'relative',
       },
-
       '&:disabled': {
         color: theme.colors.action.disabledText,
         cursor: 'not-allowed',
@@ -113,11 +95,9 @@ export const getBodyStyles = (theme: GrafanaTheme2) => {
       zIndex: theme.zIndex.modal,
       backgroundColor: theme.colors.background.elevated,
       width: '268px',
-
       '.react-calendar__navigation': {
         display: 'flex',
       },
-
       '.react-calendar__navigation__label, .react-calendar__navigation__arrow, .react-calendar__navigation': {
         paddingTop: '4px',
         backgroundColor: 'inherit',
@@ -125,12 +105,10 @@ export const getBodyStyles = (theme: GrafanaTheme2) => {
         border: 0,
         fontWeight: theme.typography.fontWeightMedium,
       },
-
       '.react-calendar__month-view__weekdays': {
         backgroundColor: 'inherit',
         textAlign: 'center',
         color: theme.colors.primary.text,
-
         abbr: {
           border: 0,
           textDecoration: 'none',
@@ -139,22 +117,18 @@ export const getBodyStyles = (theme: GrafanaTheme2) => {
           padding: '4px 0 4px 0',
         },
       },
-
       '.react-calendar__month-view__days': {
         backgroundColor: 'inherit',
       },
-
       '.react-calendar__tile, .react-calendar__tile--now': {
         marginBottom: '4px',
         backgroundColor: 'inherit',
         height: '26px',
       },
-
       '.react-calendar__navigation__label, .react-calendar__navigation > button:focus, .time-picker-calendar-tile:focus':
         {
           outline: 0,
         },
-
       // The --hover modifier is active when the user is selecting a range and hovering over a tile - it shows the pending range.
       // It is applied to all dates between the clicked date and the hovered date.
       // The *clicked* date should have primary bg, while *pending* range dates should have hover bg.
@@ -163,36 +137,30 @@ export const getBodyStyles = (theme: GrafanaTheme2) => {
         // eslint-disable-next-line @grafana/no-border-radius-literal
         borderRadius: 0,
       },
-
       '.react-calendar__tile--hoverStart': {
         borderTopLeftRadius: theme.shape.radius.pill,
         borderBottomLeftRadius: theme.shape.radius.pill,
       },
-
       '.react-calendar__tile--hoverEnd': {
         borderTopRightRadius: theme.shape.radius.pill,
         borderBottomRightRadius: theme.shape.radius.pill,
       },
-
       // Addiitonally, when hovering a date before clicking any, it should show the hover bg.
       '.react-calendar__tile:hover:not(.react-calendar__tile--hover):not(.react-calendar__tile--active):not(.react-calendar__tile--hasActive)':
         {
           backgroundColor: theme.colors.action.hover,
           borderRadius: theme.shape.radius.pill,
         },
-
       // When the user is selecting a range (they've clicked one date, tiles have --hover), both --rangeStart and --rangeEnd are on the tile.
       // The --hover classes above  handle the rounding of the tiles so they're contigious with the range
       [`${hasActiveSelector}, .react-calendar__tile--rangeStart:not(.react-calendar__tile--hover)`]: {
         borderTopLeftRadius: theme.shape.radius.pill,
         borderBottomLeftRadius: theme.shape.radius.pill,
       },
-
       [`${hasActiveSelector}, .react-calendar__tile--rangeEnd:not(.react-calendar__tile--hover)`]: {
         borderTopRightRadius: theme.shape.radius.pill,
         borderBottomRightRadius: theme.shape.radius.pill,
       },
-
       [`${hasActiveSelector}, .react-calendar__tile--active, .react-calendar__tile--rangeEnd, .react-calendar__tile--rangeStart`]:
         {
           color: theme.colors.primary.contrastText,

--- a/packages/grafana-ui/src/components/Icon/Icon.tsx
+++ b/packages/grafana-ui/src/components/Icon/Icon.tsx
@@ -1,15 +1,12 @@
+import { structLog } from '@grafana/data';
 import { css, cx } from '@emotion/css';
 import { useCallback, useState, useRef, memo, forwardRef } from 'react';
 import SVG from 'react-inlinesvg';
-
 import { type GrafanaTheme2, isIconName } from '@grafana/data';
-
 import { useStyles2 } from '../../themes/ThemeContext';
 import { type IconName, type IconType, type IconSize } from '../../types/icon';
 import { spin } from '../../utils/keyframes';
-
 import { getIconPath, getSvgSize } from './utils';
-
 export interface IconProps extends Omit<React.SVGProps<SVGElement>, 'onLoad' | 'onError' | 'ref'> {
   name: IconName;
   size?: IconSize;
@@ -19,7 +16,6 @@ export interface IconProps extends Omit<React.SVGProps<SVGElement>, 'onLoad' | '
    */
   title?: string;
 }
-
 const getIconStyles = (theme: GrafanaTheme2) => {
   return {
     icon: css({
@@ -41,7 +37,6 @@ const getIconStyles = (theme: GrafanaTheme2) => {
     }),
   };
 };
-
 // The SVG can become 'stuck' if it's changed quickly before the previous icon finished loading.
 // See https://github.com/gilbarbara/react-inlinesvg/issues/247
 // By using the svgPath as the key, we ensure that the component is re-mounted and the new icon is loaded correctly.
@@ -50,15 +45,12 @@ function useIconWorkaround(name: IconName) {
   // We use refs for state and a forceUpdate state to avoid needing to use the buffered name in the happy path
   // of when the icon changes when its not currently loading.
   // We want to avoid needless state updates to keep track of the lifecycle.
-
   const [, setForceUpdate] = useState(0);
   const isLoadingRef = useRef(false);
   const currentNameRef = useRef(name);
   const bufferedNameRef = useRef<IconName | null>(null);
-
   // Decide which name to render THIS render
   let nameToUse = name;
-
   if (isLoadingRef.current && name !== currentNameRef.current) {
     // Currently loading and name changed - buffer it, keep using current
     nameToUse = currentNameRef.current;
@@ -69,10 +61,8 @@ function useIconWorkaround(name: IconName) {
     bufferedNameRef.current = null;
     isLoadingRef.current = true; // Mark as loading when we accept a new name
   }
-
   const handleLoad = useCallback(() => {
     isLoadingRef.current = false;
-
     // Apply buffered name if one exists
     if (bufferedNameRef.current) {
       currentNameRef.current = bufferedNameRef.current;
@@ -80,10 +70,8 @@ function useIconWorkaround(name: IconName) {
       setForceUpdate((n) => n + 1); // Trigger re-render with buffered name
     }
   }, []);
-
   return { nameToUse, handleLoad };
 }
-
 /**
  * Grafana's icon wrapper component.
  *
@@ -94,19 +82,15 @@ export const Icon = memo(
     ({ size = 'md', type = 'default', name: nameProp, className, style, title = '', ...rest }, ref) => {
       const styles = useStyles2(getIconStyles);
       const { nameToUse: name, handleLoad } = useIconWorkaround(nameProp);
-
       if (!isIconName(name)) {
-        console.warn('Icon component passed an invalid icon name', name);
+        structLog('warn', 'Icon component passed an invalid icon name', name);
       }
-
       // handle the deprecated 'fa fa-spinner'
       const iconName: IconName = name === 'fa fa-spinner' ? 'spinner' : name;
-
       const svgSize = getSvgSize(size);
       const svgHgt = svgSize;
       const svgWid = name.startsWith('gf-bar-align') ? 16 : name.startsWith('gf-interp') ? 30 : svgSize;
       const svgPath = getIconPath(iconName, type);
-
       const composedClassName = cx(
         styles.icon,
         className,
@@ -115,7 +99,6 @@ export const Icon = memo(
           [styles.spin]: iconName === 'spinner',
         }
       );
-
       return (
         <SVG
           data-testid={`icon-${iconName}`}
@@ -155,5 +138,4 @@ export const Icon = memo(
     }
   )
 );
-
 Icon.displayName = 'Icon';

--- a/packages/grafana-ui/src/components/Input/AutoSizeInput.tsx
+++ b/packages/grafana-ui/src/components/Input/AutoSizeInput.tsx
@@ -1,11 +1,9 @@
+import { structLog } from '@grafana/data';
 import { useCallback, useEffect, useMemo, useRef } from 'react';
 import * as React from 'react';
-
 import { measureText } from '../../utils/measureText';
-
 import { AutoSizeInputContext } from './AutoSizeInputContext';
 import { Input, type Props as InputProps } from './Input';
-
 export interface Props extends InputProps {
   /** Sets the min-width to a multiple of 8px. Default value is 10*/
   minWidth?: number;
@@ -15,11 +13,9 @@ export interface Props extends InputProps {
    * @deprecated Use `onChange` instead and manage the value in the parent as a controlled input
    */
   onCommitChange?: (event: React.FormEvent<HTMLInputElement>) => void;
-
   /** @deprecated Use `value` and `onChange` instead to manage the value in the parent as a controlled input */
   defaultValue?: string | number | readonly string[];
 }
-
 /**
  * You can use it or regular text input. When used, AutoSizeInput resizes itself to the current content. For an array of data or tree-structured data, consider using `Combobox` or `Cascader` respectively.
  *
@@ -39,19 +35,15 @@ export const AutoSizeInput = React.forwardRef<HTMLInputElement, Props>((props, r
     ...restProps
   } = props;
   const [inputState, setInputValue] = useControlledState(controlledValue, onChange);
-
   // This must use ?? instead of || so the default value is not used when the value is an empty string
   // typically from the user clearing the input
   const inputValue = inputState ?? defaultValue;
-
   // Update input width when `value`, `minWidth`, or `maxWidth` change
   const inputWidth = useMemo(() => {
     const displayValue = inputValue || placeholder || '';
     const valueString = typeof displayValue === 'string' ? displayValue : displayValue.toString();
-
     return getWidthFor(valueString, minWidth, maxWidth);
   }, [placeholder, inputValue, minWidth, maxWidth]);
-
   return (
     <AutoSizeInputContext.Provider value={true}>
       <Input
@@ -64,7 +56,6 @@ export const AutoSizeInput = React.forwardRef<HTMLInputElement, Props>((props, r
           if (onChange) {
             onChange(event);
           }
-
           setInputValue(event.currentTarget.value);
         }}
         width={inputWidth}
@@ -86,28 +77,21 @@ export const AutoSizeInput = React.forwardRef<HTMLInputElement, Props>((props, r
     </AutoSizeInputContext.Provider>
   );
 });
-
 function getWidthFor(value: string, minWidth: number, maxWidth: number | undefined): number {
   if (!value) {
     return minWidth;
   }
-
   const extraSpace = 3;
   const realWidth = measureText(value.toString(), 14).width / 8 + extraSpace;
-
   if (minWidth && realWidth < minWidth) {
     return minWidth;
   }
-
   if (maxWidth && realWidth > maxWidth) {
     return maxWidth;
   }
-
   return realWidth;
 }
-
 AutoSizeInput.displayName = 'AutoSizeInput';
-
 /**
  * Hook to abstract away state management for controlled and uncontrolled inputs.
  * If the initial value is not undefined, then the value will be controlled by the parent
@@ -116,30 +100,25 @@ AutoSizeInput.displayName = 'AutoSizeInput';
 function useControlledState<T>(controlledValue: T, onChange: Function | undefined): [T, (newValue: T) => void] {
   const isControlledNow = controlledValue !== undefined && onChange !== undefined;
   const isControlledRef = useRef(isControlledNow); // set the initial value - we never change this
-
   const hasLoggedControlledWarning = useRef(false);
   if (isControlledNow !== isControlledRef.current && !hasLoggedControlledWarning.current) {
-    console.warn(
+    structLog(
+      'warn',
       'An AutoSizeInput is changing from an uncontrolled to a controlled input. If you want to control the input, the empty value should be an empty string.'
     );
     hasLoggedControlledWarning.current = true;
   }
-
   const [internalValue, setInternalValue] = React.useState(controlledValue);
-
   useEffect(() => {
     if (!isControlledRef.current) {
       setInternalValue(controlledValue);
     }
   }, [controlledValue]);
-
   const handleChange = useCallback((newValue: T) => {
     if (!isControlledRef.current) {
       setInternalValue(newValue);
     }
   }, []);
-
   const value = isControlledRef.current ? controlledValue : internalValue;
-
   return [value, handleChange];
 }

--- a/packages/grafana-ui/src/components/Monaco/CodeEditor.tsx
+++ b/packages/grafana-ui/src/components/Monaco/CodeEditor.tsx
@@ -1,116 +1,88 @@
+import { structLog } from '@grafana/data';
 import { css, cx } from '@emotion/css';
 import type * as monacoType from 'monaco-editor/esm/vs/editor/editor.api';
 import { PureComponent } from 'react';
-
 import { type GrafanaTheme2, monacoLanguageRegistry } from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';
-
 import { withTheme2 } from '../../themes/ThemeContext';
 import { type Themeable2 } from '../../types/theme';
-
 import { ReactMonacoEditorLazy } from './ReactMonacoEditorLazy';
 import { registerSuggestions } from './suggestions';
 import { type CodeEditorProps, type Monaco, type MonacoEditor as MonacoEditorType, type MonacoOptions } from './types';
-
 type Props = CodeEditorProps & Themeable2;
-
 class UnthemedCodeEditor extends PureComponent<Props> {
   completionCancel?: monacoType.IDisposable;
   monaco?: Monaco;
   modelId?: string;
-
   constructor(props: Props) {
     super(props);
   }
-
   componentWillUnmount() {
     if (this.completionCancel) {
       this.completionCancel.dispose();
     }
-
     this.props.onEditorWillUnmount?.();
   }
-
   componentDidUpdate(oldProps: Props) {
     const { getSuggestions, language } = this.props;
-
     const newLanguage = oldProps.language !== language;
     const newGetSuggestions = oldProps.getSuggestions !== getSuggestions;
-
     if (newGetSuggestions || newLanguage) {
       if (this.completionCancel) {
         this.completionCancel.dispose();
       }
-
       if (!this.monaco) {
-        console.warn('Monaco instance not loaded yet');
+        structLog('warn', 'Monaco instance not loaded yet');
         return;
       }
-
       if (getSuggestions && this.modelId) {
         this.completionCancel = registerSuggestions(this.monaco, language, getSuggestions, this.modelId);
       }
     }
-
     if (newLanguage) {
       this.loadCustomLanguage();
     }
   }
-
   loadCustomLanguage = () => {
     const { language } = this.props;
-
     const customLanguage = monacoLanguageRegistry.getIfExists(language);
-
     if (customLanguage) {
       return customLanguage.init();
     }
-
     return Promise.resolve();
   };
-
   // This is replaced with a real function when the actual editor mounts
   getEditorValue = () => '';
-
   onBlur = () => {
     const { onBlur } = this.props;
     if (onBlur) {
       onBlur(this.getEditorValue());
     }
   };
-
   onFocus = () => {
     const { onFocus } = this.props;
     if (onFocus) {
       onFocus(this.getEditorValue());
     }
   };
-
   onSave = () => {
     const { onSave } = this.props;
     if (onSave) {
       onSave(this.getEditorValue());
     }
   };
-
   handleBeforeMount = (monaco: Monaco) => {
     this.monaco = monaco;
-
     const { onBeforeEditorMount } = this.props;
-
     onBeforeEditorMount?.(monaco);
   };
-
   handleOnMount = (editor: MonacoEditorType, monaco: Monaco) => {
     const { getSuggestions, language, onChange, onEditorDidMount } = this.props;
-
     this.modelId = editor.getModel()?.id;
     this.getEditorValue = () => editor.getValue();
-
     if (getSuggestions && this.modelId) {
       this.completionCancel = registerSuggestions(monaco, language, getSuggestions, this.modelId);
     }
-
     // Save when pressing Ctrl+S or Cmd+S
     editor.onKeyDown((e: monacoType.IKeyboardEvent) => {
       if (e.keyCode === monaco.KeyCode.KeyS && (e.ctrlKey || e.metaKey)) {
@@ -118,26 +90,20 @@ class UnthemedCodeEditor extends PureComponent<Props> {
         this.onSave();
       }
     });
-
     if (onChange) {
       editor.getModel()?.onDidChangeContent(() => onChange(editor.getValue()));
     }
-
     if (onEditorDidMount) {
       onEditorDidMount(editor, monaco);
     }
   };
-
   render() {
     const { theme, language, width, height, showMiniMap, showLineNumbers, readOnly, wordWrap, monacoOptions } =
       this.props;
     const { alwaysConsumeMouseWheel, ...restMonacoOptions } = monacoOptions ?? {};
-
     const value = this.props.value ?? '';
     const longText = value.length > 100;
-
     const containerStyles = cx(getStyles(theme).container, this.props.containerStyles);
-
     const options: MonacoOptions = {
       wordWrap: wordWrap ? 'on' : 'off',
       tabSize: 2,
@@ -147,7 +113,6 @@ class UnthemedCodeEditor extends PureComponent<Props> {
         enabled: longText && showMiniMap,
         renderCharacters: false,
       },
-
       readOnly,
       lineNumbersMinChars: 4,
       lineDecorationsWidth: 1 * theme.spacing.gridSize,
@@ -158,19 +123,16 @@ class UnthemedCodeEditor extends PureComponent<Props> {
         bottom: 0.5 * theme.spacing.gridSize,
       },
       fixedOverflowWidgets: true, // Ensures suggestions menu is drawn on top
-
       scrollbar: {
         alwaysConsumeMouseWheel: alwaysConsumeMouseWheel ?? false,
       },
     };
-
     if (!showLineNumbers) {
       options.glyphMargin = false;
       options.folding = false;
       options.lineNumbers = 'off';
       options.lineNumbersMinChars = 0;
     }
-
     return (
       <div
         className={containerStyles}
@@ -195,14 +157,12 @@ class UnthemedCodeEditor extends PureComponent<Props> {
     );
   }
 }
-
 /**
  * Monaco Code editor.
  *
  * https://developers.grafana.com/ui/latest/index.html?path=/docs/inputs-codeeditor--docs
  */
 export const CodeEditor = withTheme2(UnthemedCodeEditor);
-
 const getStyles = (theme: GrafanaTheme2) => {
   return {
     container: css({

--- a/packages/grafana-ui/src/components/StatsPicker/StatsPicker.tsx
+++ b/packages/grafana-ui/src/components/StatsPicker/StatsPicker.tsx
@@ -1,23 +1,18 @@
+import { structLog } from '@grafana/data';
 import { difference } from 'lodash';
 import { memo, useEffect } from 'react';
-
 import { fieldReducers, type FieldReducerInfo } from '@grafana/data';
 import { t } from '@grafana/i18n';
-
 import { Combobox, type ComboboxProps } from '../Combobox/Combobox';
 import { MultiCombobox, type MultiComboboxProps } from '../Combobox/MultiCombobox';
 import { type ComboboxOption } from '../Combobox/types';
 import { selectableValueToComboboxOption } from '../Combobox/utils';
-
 import { pickComboboxLayout } from './pickComboboxLayout';
-
 /** Props managed by StatsPicker — forwarded combobox props must not replace these. */
 type ComboboxManagedProps = 'value' | 'options' | 'onChange' | 'isClearable' | 'width' | 'minWidth' | 'maxWidth';
-
 /** Forwarded props (managed keys + layout are applied after the spread). */
 type MultiSpread = Omit<MultiComboboxProps<string>, ComboboxManagedProps>;
 type SingleSpread = Omit<ComboboxProps<string>, ComboboxManagedProps>;
-
 interface BaseProps {
   stats: string[];
   onChange: (stats: string[]) => void;
@@ -27,12 +22,13 @@ interface BaseProps {
   maxWidth?: number;
   filterOptions?: (ext: FieldReducerInfo) => boolean;
 }
-
-type MultiProps = MultiSpread & { allowMultiple: true };
-type SingleProps = SingleSpread & { allowMultiple?: false };
-
+type MultiProps = MultiSpread & {
+  allowMultiple: true;
+};
+type SingleProps = SingleSpread & {
+  allowMultiple?: false;
+};
 export type StatsPickerProps = BaseProps & (MultiProps | SingleProps);
-
 export const StatsPicker = memo<StatsPickerProps>(
   ({
     placeholder = t('grafana-ui.stats-picker.placeholder', 'Choose'),
@@ -47,32 +43,27 @@ export const StatsPicker = memo<StatsPickerProps>(
     ...rest
   }) => {
     const layout = pickComboboxLayout(width, minWidth, maxWidth);
-
     useEffect(() => {
       const current = fieldReducers.list(stats);
       if (current.length !== stats.length) {
         const found = current.map((v) => v.id);
         const notFound = difference(stats, found);
-        console.warn('Unknown stats', notFound, stats);
+        structLog('warn', 'Unknown stats', notFound, stats);
         onChange(current.map((stat) => stat.id));
       }
-
       // Make sure there is only one
       if (!allowMultiple && stats.length > 1) {
-        console.warn('Removing extra stat', stats);
+        structLog('warn', 'Removing extra stat', stats);
         onChange([stats[0]]);
       }
-
       // Set the reducer from callback
       if (defaultStat && stats.length < 1) {
         onChange([defaultStat]);
       }
     }, [stats, allowMultiple, defaultStat, onChange]);
-
     const select = fieldReducers.selectOptions(stats, filterOptions);
     const options = select.options.map((v) => selectableValueToComboboxOption(v)).filter((v) => !!v);
     const value = select.current.map((v) => selectableValueToComboboxOption(v)).filter((v) => !!v);
-
     if (allowMultiple) {
       return (
         <MultiCombobox
@@ -86,7 +77,6 @@ export const StatsPicker = memo<StatsPickerProps>(
         />
       );
     }
-
     const commonOptions = {
       ...rest,
       ...layout,
@@ -94,7 +84,6 @@ export const StatsPicker = memo<StatsPickerProps>(
       options,
       placeholder,
     };
-
     return defaultStat ? (
       <Combobox
         {...commonOptions}
@@ -110,5 +99,4 @@ export const StatsPicker = memo<StatsPickerProps>(
     );
   }
 );
-
 StatsPicker.displayName = 'StatsPicker';

--- a/packages/grafana-ui/src/components/Table/TableNG/utils.ts
+++ b/packages/grafana-ui/src/components/Table/TableNG/utils.ts
@@ -1,3 +1,4 @@
+import { structLog } from '@grafana/data';
 import { type Property } from 'csstype';
 import memoize from 'micro-memoize';
 import WKT from 'ol/format/WKT';
@@ -6,7 +7,6 @@ import { type CSSProperties } from 'react';
 import { type SortColumn } from 'react-data-grid';
 import tinycolor from 'tinycolor2';
 import { type Count, varPreLine } from 'uwrap';
-
 import {
   FieldType,
   type Field,
@@ -28,11 +28,9 @@ import {
   TableCellDisplayMode,
   TableCellHeight,
 } from '@grafana/schema';
-
 import { getTextColorForAlphaBackground } from '../../../utils/colors';
 import { TableCellInspectorMode } from '../TableCellInspector';
 import { type TableCellOptions } from '../types';
-
 import { inferPills } from './Cells/PillCell';
 import { AutoCellRenderer, getAutoRendererDisplayMode, getCellRenderer } from './Cells/renderers';
 import { COLUMN, TABLE } from './constants';
@@ -46,10 +44,8 @@ import {
   type MeasureCellHeightEntry,
   type FilterType,
 } from './types';
-
 /* ---------------------------- Cell calculations --------------------------- */
 export type CellNumLinesCalculator = (text: string, cellWidth: number) => number;
-
 /**
  * @internal
  * Returns the default row height based on the theme and cell height setting.
@@ -62,7 +58,6 @@ export function getDefaultRowHeight(
   if (fields?.some((field) => field.config?.custom?.cellOptions?.dynamicHeight)) {
     return 'min-content';
   }
-
   switch (cellHeight) {
     case TableCellHeight.Sm:
       return 36;
@@ -71,10 +66,8 @@ export function getDefaultRowHeight(
     case TableCellHeight.Lg:
       return TABLE.MAX_CELL_HEIGHT;
   }
-
   return TABLE.CELL_PADDING * 2 + theme.typography.fontSize * theme.typography.body.lineHeight;
 }
-
 /**
  * @internal
  * Returns true if cell inspection (hover to see full content) is enabled for the field.
@@ -82,7 +75,6 @@ export function getDefaultRowHeight(
 export function isCellInspectEnabled(field: Field): boolean {
   return field.config?.custom?.inspect ?? false;
 }
-
 /**
  * @internal
  * Returns true if text wrapping should be applied to the cell.
@@ -90,7 +82,6 @@ export function isCellInspectEnabled(field: Field): boolean {
 export function shouldTextWrap(field: Field): boolean {
   return Boolean(field.config.custom?.wrapText);
 }
-
 /**
  * @internal wrap a cell height measurer to clamp its output to the maxHeight defined in the field, if any.
  */
@@ -100,7 +91,6 @@ function clampByMaxHeight(measurer: MeasureCellHeight, maxHeight = Infinity): Me
     return Math.min(rawHeight, maxHeight);
   };
 }
-
 /**
  * @internal creates a typography context based on a font size and family. used to measure text
  * and estimate size of text in cells.
@@ -109,7 +99,6 @@ export function createTypographyContext(fontSize: number, fontFamily: string, le
   const font = `${fontSize}px ${fontFamily}`;
   const canvas = document.createElement('canvas');
   const ctx = canvas.getContext('2d')!;
-
   ctx.letterSpacing = `${letterSpacing}px`;
   ctx.font = font;
   // 1/6 of the characters in this string are capitalized. Since the avgCharWidth is used for estimation, it's
@@ -120,7 +109,6 @@ export function createTypographyContext(fontSize: number, fontFamily: string, le
   const txtWidth = ctx.measureText(txt).width;
   const avgCharWidth = txtWidth / txt.length + letterSpacing;
   const { count } = varPreLine(ctx);
-
   return {
     ctx,
     fontFamily,
@@ -130,7 +118,6 @@ export function createTypographyContext(fontSize: number, fontFamily: string, le
     measureHeight: getTextHeightMeasurerFromUwrapCount(count),
   };
 }
-
 /**
  * @internal wraps the uwrap count function to ensure that it is given a string.
  */
@@ -139,12 +126,10 @@ export function getTextHeightMeasurerFromUwrapCount(count: Count): MeasureCellHe
     if (value == null) {
       return lineHeight;
     }
-
     const lines = count(String(value), width);
     return lines * lineHeight;
   };
 }
-
 /**
  * @internal returns a measurer which guesstimates a number of lines in a text cell based on the typography context's avgCharWidth.
  */
@@ -153,26 +138,22 @@ export function getTextHeightEstimator(avgCharWidth: number): MeasureCellHeight 
     if (!value) {
       return -1;
     }
-
     // we don't have string breaking enabled in the table,
     // so an unbroken string is by definition a single line.
     const strValue = String(value);
     if (!spaceRegex.test(strValue)) {
       return -1;
     }
-
     const charsPerLine = width / avgCharWidth;
     const lines = Math.ceil(strValue.length / charsPerLine);
     return lines * lineHeight;
   };
 }
-
 /**
  * @internal
  */
 export function getDataLinksHeightMeasurer(): MeasureCellHeight {
   const linksCountCache: Record<string, number> = {};
-
   // when we render links, we need to filter out the invalid links. since the call to `getLinks` is expensive,
   // we'll cache the result and reuse it for every row in the table. this cache is cleared when line counts are
   // rebuilt anytime from the `useRowHeight` hook, and that includes adding and removing data links.
@@ -187,31 +168,24 @@ export function getDataLinksHeightMeasurer(): MeasureCellHeight {
       }
       linksCountCache[cacheKey] = count;
     }
-
     return linksCountCache[cacheKey] * lineHeight;
   };
 }
-
 const PILLS_FONT_SIZE = 12;
 const PILLS_SPACING = 12; // 6px horizontal padding on each side
 const PILLS_GAP = 4; // gap between pills
-
 export function getPillCellHeightMeasurer(measureWidth: (value: string) => number): MeasureCellHeight {
   const widthCache: Record<string, number> = {};
-
   return (value, width, _field, _rowIdx, lineHeight) => {
     if (value == null) {
       return 0;
     }
-
     const pillValues = inferPills(String(value));
     if (pillValues.length === 0) {
       return 0;
     }
-
     let lines = 0;
     let currentLineUse = width;
-
     for (const pillValue of pillValues) {
       const strPill = String(pillValue);
       let rawWidth = widthCache[strPill];
@@ -220,7 +194,6 @@ export function getPillCellHeightMeasurer(measureWidth: (value: string) => numbe
         widthCache[strPill] = rawWidth;
       }
       const pillWidth = rawWidth + PILLS_SPACING;
-
       if (currentLineUse + pillWidth + PILLS_GAP > width) {
         lines++;
         currentLineUse = pillWidth;
@@ -228,13 +201,11 @@ export function getPillCellHeightMeasurer(measureWidth: (value: string) => numbe
         currentLineUse += pillWidth + PILLS_GAP;
       }
     }
-
     // default line height happens to be the height of a pill, but maybe we need a custom
     // const here to make sure this doesn't get out of sync with the actual pill height.
     return lines * lineHeight + (lines - 1) * PILLS_GAP;
   };
 }
-
 /**
  * @internal return a text measurer for every field which has wrapHeaderText enabled.
  */
@@ -248,18 +219,14 @@ export function buildHeaderHeightMeasurers(
     }
     return acc;
   }, []);
-
   if (wrappedColIdxs.length === 0) {
     return undefined;
   }
-
   // don't bother with estimating the line counts for the headers, because it's punishing
   // when we get it wrong and there won't be that many compared to how many rows a table might contain.
   return [{ measure: typographyCtx.measureHeight, fieldIdxs: wrappedColIdxs }];
 }
-
 const spaceRegex = /[\s-]/;
-
 /**
  * @internal return a text height measurer for every field which has wrapHeaderText enabled. we do this once as we're rendering
  * the table, and then getRowHeight uses the output of this to caluclate the height of each row.
@@ -271,7 +238,6 @@ export function buildCellHeightMeasurers(
 ): MeasureCellHeightEntry[] | undefined {
   const result: Record<string, MeasureCellHeightEntry> = {};
   let wrappedFields = 0;
-
   const measurerFactory: Record<
     TableCellDisplayMode.Auto | TableCellDisplayMode.DataLinks | TableCellDisplayMode.Pill,
     () => [MeasureCellHeight, MeasureCellHeight?]
@@ -292,7 +258,6 @@ export function buildCellHeightMeasurers(
       ];
     },
   } as const;
-
   const setupMeasurerForIdx = (measurerFactoryKey: keyof typeof measurerFactory, fieldIdx: number) => {
     if (!result[measurerFactoryKey]) {
       const [measure, estimate] = measurerFactory[measurerFactoryKey]();
@@ -304,12 +269,10 @@ export function buildCellHeightMeasurers(
     }
     result[measurerFactoryKey].fieldIdxs.push(fieldIdx);
   };
-
   for (let fieldIdx = 0; fieldIdx < fields.length; fieldIdx++) {
     const field = fields[fieldIdx];
     if (shouldTextWrap(field)) {
       wrappedFields++;
-
       const cellType = getCellOptions(field).type;
       if (cellType === TableCellDisplayMode.DataLinks) {
         setupMeasurerForIdx(TableCellDisplayMode.DataLinks, fieldIdx);
@@ -325,19 +288,15 @@ export function buildCellHeightMeasurers(
       }
     }
   }
-
   if (wrappedFields === 0) {
     return undefined;
   }
-
   return Object.values(result);
 }
-
 // in some cases, the estimator might return a value that is less than 1, but when calculated by the measurer, it actually
 // realizes that it's a multi-line cell. to avoid this, we want to give a little buffer away from 1 before we fully trust
 // the estimator to have told us that a cell is single-line.
 export const SINGLE_LINE_ESTIMATE_THRESHOLD = 18.5;
-
 /**
  * @internal
  * loop through the fields and their values, determine which cell is going to determine the height of the row based
@@ -355,20 +314,17 @@ export function getRowHeight(
   if (!measurers?.length) {
     return defaultHeight;
   }
-
   let maxHeight = -1;
   let maxValue: unknown = '';
   let maxWidth = 0;
   let maxField: Field | undefined;
   let preciseMeasurer: MeasureCellHeight | undefined;
-
   for (const { estimate, measure, fieldIdxs } of measurers) {
     // for some of the cell height measurers, getting the precise height is expensive. those entries set
     // both "estimate" and "measure" functions. if the cell we find to be the max was estimated, we will
     // get the "true" value right before calculating the row height by keeping a reference to the measure fn.
     const measurer = (estimate ?? measure) satisfies MeasureCellHeight;
     const isEstimating = estimate !== undefined;
-
     for (const fieldIdx of fieldIdxs) {
       const field = fields[fieldIdx];
       const displayName = getDisplayName(field);
@@ -394,23 +350,19 @@ export function getRowHeight(
       }
     }
   }
-
   // if the value is -1 or the estimate for the max cell was less than the SINGLE_LINE_ESTIMATE_THRESHOLD, we trust
   // that the estimator correctly identified that no text wrapping is needed for this row, skipping the preciseMeasurer.
   if (maxField === undefined || maxHeight < SINGLE_LINE_ESTIMATE_THRESHOLD) {
     return defaultHeight;
   }
-
   // if we finished this row height loop with an estimate, we need to call
   // the `preciseMeasurer` method to get the exact line count.
   if (preciseMeasurer !== undefined) {
     maxHeight = preciseMeasurer(maxValue, maxWidth, maxField, row.__index, lineHeight);
   }
-
   // adjust for vertical padding, and clamp to a minimum default height
   return Math.max(maxHeight + verticalPadding, defaultHeight);
 }
-
 /**
  * @internal
  * Returns true if text overflow handling should be applied to the cell.
@@ -423,36 +375,29 @@ export function shouldTextOverflow(field: Field): boolean {
     (field.type === FieldType.string && cellOptions.type !== TableCellDisplayMode.Image) ||
     // regardless of the underlying cell type, data links cells have text overflow.
     cellOptions.type === TableCellDisplayMode.DataLinks;
-
   return eligibleCellType && !shouldTextWrap(field) && !isCellInspectEnabled(field);
 }
-
 // we only want to infer justifyContent and textAlign for these cellTypes
 const TEXT_CELL_TYPES = new Set<TableCellDisplayMode>([
   TableCellDisplayMode.Auto,
   TableCellDisplayMode.ColorText,
   TableCellDisplayMode.ColorBackground,
 ]);
-
 export type TextAlign = 'left' | 'right' | 'center';
-
 /**
  * @internal
  * Returns the text-align value for inline-displayed cells for a field based on its type and configuration.
  */
 export function getAlignment(field: Field): TextAlign {
   const align: FieldTextAlignment | undefined = field.config.custom?.align;
-
   if (!align || align === 'auto') {
     if (TEXT_CELL_TYPES.has(getCellOptions(field).type) && field.type === FieldType.number) {
       return 'right';
     }
     return 'left';
   }
-
   return align;
 }
-
 /**
  * @internal
  * Returns the justify-content value for flex-displayed cells for a field based on its type and configuration.
@@ -460,9 +405,7 @@ export function getAlignment(field: Field): TextAlign {
 export function getJustifyContent(textAlign: TextAlign): Property.JustifyContent {
   return textAlign === 'center' ? 'center' : textAlign === 'right' ? 'flex-end' : 'flex-start';
 }
-
 const DEFAULT_CELL_OPTIONS = { type: TableCellDisplayMode.Auto } as const;
-
 /**
  * @internal
  * Returns the cell options for a field, migrating from legacy displayMode if necessary.
@@ -472,10 +415,8 @@ export function getCellOptions(field: Field): TableCellOptions {
   if (field.config.custom?.displayMode) {
     return migrateTableDisplayModeToCellOptions(field.config.custom?.displayMode);
   }
-
   return field.config.custom?.cellOptions ?? DEFAULT_CELL_OPTIONS;
 }
-
 /**
  * @internal
  * Getting gauge or sparkline values to align is very tricky without looking at all values and passing them through display processor.
@@ -489,7 +430,6 @@ export function getAlignmentFactor(
   rowIndex: number
 ): DisplayValueAlignmentFactors {
   let alignmentFactor = field.state?.alignmentFactors;
-
   if (alignmentFactor) {
     // check if current alignmentFactor is still the longest
     if (formattedValueToString(alignmentFactor).length < formattedValueToString(displayValue).length) {
@@ -501,28 +441,23 @@ export function getAlignmentFactor(
     // look at the next 1000 rows
     alignmentFactor = { ...displayValue };
     const maxIndex = Math.min(field.values.length, rowIndex + 1000);
-
     for (let i = rowIndex + 1; i < maxIndex; i++) {
       const nextDisplayValue = field.display?.(field.values[i]) ?? field.values[i];
       if (formattedValueToString(alignmentFactor).length > formattedValueToString(nextDisplayValue).length) {
         alignmentFactor.text = displayValue.text;
       }
     }
-
     if (field.state) {
       field.state.alignmentFactors = alignmentFactor;
     } else {
       field.state = { alignmentFactors: alignmentFactor };
     }
-
     return alignmentFactor;
   }
 }
-
 /* ------------------------- Cell color calculation ------------------------- */
 const CELL_COLOR_DARKENING_MULTIPLIER = 10;
 const CELL_GRADIENT_HUE_ROTATION_DEGREES = 5;
-
 /**
  * @internal
  * Returns the text and background colors for a table cell based on its options and display value.
@@ -551,15 +486,12 @@ export function getCellColorInlineStylesFactory(theme: GrafanaTheme2) {
     },
     { maxSize: 1000 }
   );
-
   return (cellOptions: TableCellOptions, displayValue: DisplayValue, hasApplyToRow: boolean): CSSProperties => {
     const result: CSSProperties = {};
     const displayValueColor = displayValue.color;
-
     if (!displayValueColor) {
       return result;
     }
-
     if (cellOptions.type === TableCellDisplayMode.ColorText) {
       result.color = displayValueColor;
     } else if (cellOptions.type === TableCellDisplayMode.ColorBackground) {
@@ -568,7 +500,6 @@ export function getCellColorInlineStylesFactory(theme: GrafanaTheme2) {
       if (hasApplyToRow && isTransparent(displayValueColor)) {
         return result;
       }
-
       const mode = cellOptions.mode ?? TableCellBackgroundDisplayMode.Gradient;
       result.color = bgCellTextColor(displayValueColor);
       result.background =
@@ -576,11 +507,9 @@ export function getCellColorInlineStylesFactory(theme: GrafanaTheme2) {
           ? `linear-gradient(120deg, ${gradientBg(displayValueColor)}, ${displayValueColor})`
           : displayValueColor;
     }
-
     return result;
   };
 }
-
 /**
  * @internal
  * Extracts numeric pixel value from theme spacing
@@ -588,7 +517,6 @@ export function getCellColorInlineStylesFactory(theme: GrafanaTheme2) {
 export const extractPixelValue = (spacing: string | number): number => {
   return typeof spacing === 'number' ? spacing : parseFloat(spacing) || 0;
 };
-
 /* ------------------------------- Data links ------------------------------- */
 /**
  * @internal
@@ -600,15 +528,12 @@ export const getCellLinks = (field: Field, rowIdx: number) => {
       valueRowIndex: rowIdx,
     });
   }
-
   if (!links) {
     return;
   }
-
   for (let i = 0; i < links?.length; i++) {
     if (links[i].onClick) {
       const origOnClick = links[i].onClick;
-
       links[i].onClick = (event: MouseEvent) => {
         // Allow opening in new tab
         if (!(event.ctrlKey || event.metaKey || event.shiftKey)) {
@@ -621,10 +546,8 @@ export const getCellLinks = (field: Field, rowIdx: number) => {
       };
     }
   }
-
   return links.filter((link) => link.href || link.onClick != null);
 };
-
 /**
  * @internal
  * Processes nested table rows
@@ -638,7 +561,6 @@ export const processNestedTableRows = (
   // Map for childRows: provides O(1) lookup by parent index when reconstructing the result
   const parentRows: TableRow[] = [];
   const childRows: Map<number, TableRow> = new Map();
-
   for (const row of rows) {
     if (row.__depth === 0) {
       parentRows.push(row);
@@ -646,10 +568,8 @@ export const processNestedTableRows = (
       childRows.set(row.__index, row);
     }
   }
-
   // Process parent rows (filter or sort)
   const processedParents = processParents(parentRows);
-
   // Reconstruct the result
   const result: TableRow[] = [];
   for (const row of processedParents) {
@@ -659,10 +579,8 @@ export const processNestedTableRows = (
       result.push(childRow);
     }
   }
-
   return result;
 };
-
 /* ----------------------------- Data grid sorting ---------------------------- */
 /**
  * @internal
@@ -677,49 +595,38 @@ export function applySort(
   if (sortColumns.length === 0) {
     return rows;
   }
-
   const sortNanos = sortColumns.map(
     (c) => fields.find((f) => f.type === FieldType.time && getDisplayName(f) === c.columnKey)?.nanos
   );
-
   const compareRows = (a: TableRow, b: TableRow): number => {
     let result = 0;
-
     for (let i = 0; i < sortColumns.length; i++) {
       const { columnKey, direction } = sortColumns[i];
       const compare = getComparator(columnTypes[columnKey]);
       const sortDir = direction === 'ASC' ? 1 : -1;
-
       result = sortDir * compare(a[columnKey], b[columnKey]);
-
       if (result === 0) {
         const nanos = sortNanos[i];
-
         if (nanos !== undefined) {
           result = sortDir * (nanos[a.__index] - nanos[b.__index]);
         }
       }
-
       if (result !== 0) {
         break;
       }
     }
-
     return result;
   };
-
   return hasNestedFrames
     ? processNestedTableRows(rows, (parents) => parents.sort(compareRows))
     : [...rows].sort(compareRows);
 }
-
 export interface ApplyFilterResult {
   crossFilterOrder: string[];
   crossFilterRows: Record<string, TableRow[]>;
   crossFilterTailRows: TableRow[];
   filteredRows: TableRow[];
 }
-
 /**
  * @internal
  * Applies active filters to `rows` and computes cross-filter metadata for filter popup UIs.
@@ -745,16 +652,13 @@ export function applyFilter(
   // Scope rows to the relevant nesting level
   const isNested = parentIndex !== undefined;
   const scopedRows = !isNested ? rows.filter((r) => r.__depth === 0) : rows;
-
   // Collect filter keys that belong to this scope (preserving JS insertion order)
   const crossFilterOrder = Object.keys(filter).filter((key) => {
     const entry = filter[key];
     return !isNested ? entry.parentIndex == null : entry.parentIndex === parentIndex;
   });
-
   const crossFilterRows: Record<string, TableRow[]> = {};
   let crossFilterTailRows = scopedRows;
-
   for (const filterKey of crossFilterOrder) {
     const filterEntry = filter[filterKey];
     // Store rows available *before* this filter is applied
@@ -769,7 +673,6 @@ export function applyFilter(
       return filterEntry.filteredSet.has(displayedValue);
     });
   }
-
   // For nested frames, wrap with processNestedTableRows so parent rows that have matching
   // children are preserved for the expander UI. Use a Set for O(1) membership checks.
   let filteredRows = crossFilterTailRows;
@@ -777,10 +680,8 @@ export function applyFilter(
     const tailSet = new Set(crossFilterTailRows);
     filteredRows = processNestedTableRows(rows, (parents) => parents.filter((row) => tailSet.has(row)));
   }
-
   return { crossFilterOrder, crossFilterRows, crossFilterTailRows, filteredRows };
 }
-
 /* ----------------------------- Data grid mapping ---------------------------- */
 /**
  * @internal
@@ -814,13 +715,11 @@ export function compileFrameToRecords(frame: DataFrame, nestedFramesFieldName?: 
     }
     return rows;
   `;
-
   // Creates a function that converts a DataFrame into an array of TableRows
   // Uses new Function() for performance as it's faster than creating rows using loops
   // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
   return new Function('frame', 'nestedRowIndex', fnBody) as FrameToRowsConverter;
 }
-
 /* ----------------------------- Data grid comparator ---------------------------- */
 // The numeric: true option is used to sort numbers as strings correctly. It recognizes numeric sequences
 // within strings and sorts numerically instead of lexicographically.
@@ -842,7 +741,6 @@ const frameCompare: Comparator = (a, b) => {
   // @ts-ignore The compared vals are DataFrameWithValue. the value is the rendered stat (first, last, etc.)
   return (a?.value ?? 0) - (b?.value ?? 0);
 };
-
 /**
  * @internal
  */
@@ -861,7 +759,6 @@ export function getComparator(sortColumnType: FieldType): Comparator {
       return strCompare;
   }
 }
-
 type TableCellGaugeDisplayModes =
   | TableCellDisplayMode.BasicGauge
   | TableCellDisplayMode.GradientGauge
@@ -871,7 +768,6 @@ const TABLE_CELL_GAUGE_DISPLAY_MODES_TO_DISPLAY_MODES: Record<TableCellGaugeDisp
   [TableCellDisplayMode.GradientGauge]: BarGaugeDisplayMode.Gradient,
   [TableCellDisplayMode.LcdGauge]: BarGaugeDisplayMode.Lcd,
 };
-
 type TableCellColorBackgroundDisplayModes =
   | TableCellDisplayMode.ColorBackground
   | TableCellDisplayMode.ColorBackgroundSolid;
@@ -882,7 +778,6 @@ const TABLE_CELL_COLOR_BACKGROUND_DISPLAY_MODES_TO_DISPLAY_MODES: Record<
   [TableCellDisplayMode.ColorBackground]: TableCellBackgroundDisplayMode.Gradient,
   [TableCellDisplayMode.ColorBackgroundSolid]: TableCellBackgroundDisplayMode.Basic,
 };
-
 /* ---------------------------- Miscellaneous ---------------------------- */
 /**
  * Migrates table cell display mode to new object format.
@@ -920,7 +815,6 @@ export function migrateTableDisplayModeToCellOptions(displayMode: TableCellDispl
       };
   }
 }
-
 /**
  * @internal
  * Returns unique key for each row
@@ -928,14 +822,12 @@ export function migrateTableDisplayModeToCellOptions(displayMode: TableCellDispl
 export function rowKeyGetter(row: TableRow): string {
   return row.__index + '_' + row.__depth;
 }
-
 /**
  * @internal
  * Returns true if the DataFrame contains nested frames
  */
 export const getIsNestedTable = (fields: Field[]): boolean =>
   fields.some(({ type }) => type === FieldType.nestedFrames);
-
 /**
  * @internal
  * Calculate the footer height based on the maximum reducer count
@@ -945,11 +837,9 @@ export const calculateFooterHeight = (fields: Field[]): number => {
   for (const field of fields) {
     maxReducerCount = Math.max(maxReducerCount, field.config.custom?.footer?.reducers?.length ?? 0);
   }
-
   // Base height (+ padding) + height per reducer
   return maxReducerCount > 0 ? maxReducerCount * TABLE.LINE_HEIGHT + TABLE.CELL_PADDING * 2 : 0;
 };
-
 /**
  * @internal
  * returns the display name of a field
@@ -961,12 +851,10 @@ export const calculateFooterHeight = (fields: Field[]): number => {
 export const getDisplayName = (field: Field): string => {
   return field.state?.displayName ?? field.name;
 };
-
 /**
  * @internal given a field name or display name, returns a predicate function that checks if a field matches that name.
  */
 export const predicateByName = (name: string) => (f: Field) => f.name === name || getDisplayName(f) === name;
-
 /**
  * @internal
  * returns only fields that are not nested tables and not explicitly hidden
@@ -974,7 +862,6 @@ export const predicateByName = (name: string) => (f: Field) => f.name === name |
 export function getVisibleFields(fields: Field[]): Field[] {
   return fields.filter((field) => field.type !== FieldType.nestedFrames && field.config.custom?.hideFrom?.viz !== true);
 }
-
 /**
  * @internal
  * returns a map of column types by display name
@@ -989,7 +876,6 @@ export function getColumnTypes(fields: Field[]): ColumnTypes {
     }
   }, {});
 }
-
 /**
  * @internal
  * calculates the width of each field, with the following logic:
@@ -999,19 +885,16 @@ export function getColumnTypes(fields: Field[]): ColumnTypes {
 export function computeColWidths(fields: Field[], availWidth: number) {
   let autoCount = 0;
   let definedWidth = 0;
-
   return (
     fields
       // first pass to add up how many fields have pre-defined widths and what that width totals to.
       .map((field) => {
         const width: number = field.config.custom?.width ?? 0;
-
         if (width === 0) {
           autoCount++;
         } else {
           definedWidth += width;
         }
-
         return width;
       })
       // second pass once `autoCount` and `definedWidth` are known.
@@ -1022,7 +905,6 @@ export function computeColWidths(fields: Field[], availWidth: number) {
       )
   );
 }
-
 /**
  * @internal
  * if applyToRow is true in any field, return a function that gets the row background color
@@ -1043,7 +925,6 @@ export function getApplyToRowBgFn(
     }
   }
 }
-
 /** @internal */
 export function canFieldBeColorized(
   cellType: TableCellDisplayMode,
@@ -1055,12 +936,10 @@ export function canFieldBeColorized(
     Boolean(applyToRowBgFn)
   );
 }
-
 export const displayJsonValue: (field: Field) => DisplayProcessor = (field: Field, decimals?: DecimalCount) => {
   const origDisplay = field.display!;
   return (value: unknown): DisplayValue => {
     const displayValue = origDisplay(value, decimals);
-
     let jsonText: string;
     if (!Array.isArray(value) && !isPlainObject(value)) {
       const formattedValue = formattedValueToString(displayValue);
@@ -1073,11 +952,9 @@ export const displayJsonValue: (field: Field) => DisplayProcessor = (field: Fiel
     } else {
       jsonText = JSON.stringify(value, null, ' ');
     }
-
     return { ...displayValue, text: jsonText };
   };
 };
-
 export function prepareSparklineValue(value: unknown, field: Field): FieldSparkline | undefined {
   if (Array.isArray(value)) {
     return {
@@ -1089,29 +966,22 @@ export function prepareSparklineValue(value: unknown, field: Field): FieldSparkl
       },
     };
   }
-
   if (isDataFrame(value)) {
     const timeField = value.fields.find((x) => x.type === FieldType.time);
     const numberField = value.fields.find((x) => x.type === FieldType.number);
-
     if (timeField && numberField) {
       return { x: timeField, y: numberField };
     }
   }
-
   return;
 }
-
 function isPlainObject(value: unknown): value is object {
   return typeof value === 'object' && value != null && !Array.isArray(value);
 }
-
 export function buildInspectValue(value: unknown, field: Field): [string, TableCellInspectorMode] {
   const cellOptions = getCellOptions(field);
-
   let inspectValue: string;
   let mode = TableCellInspectorMode.text;
-
   if (field.type === FieldType.geo && value instanceof Geometry) {
     inspectValue = new WKT().writeGeometry(value, {
       featureProjection: 'EPSG:3857',
@@ -1151,10 +1021,8 @@ export function buildInspectValue(value: unknown, field: Field): [string, TableC
   } else {
     inspectValue = String(value ?? '');
   }
-
   return [inspectValue, mode];
 }
-
 export function getSummaryCellTextAlign(textAlign: TextAlign, cellType: TableCellDisplayMode): TextAlign {
   // gauge is weird. left-aligned gauge has the viz on the left and its numbers on the right, and vice-versa.
   // if you center-aligned your gauge... ok.
@@ -1167,10 +1035,8 @@ export function getSummaryCellTextAlign(textAlign: TextAlign, cellType: TableCel
       } as const
     )[textAlign];
   }
-
   return textAlign;
 }
-
 // we keep this set to avoid spamming the heck out of the console, since it's quite likely that if we fail to parse
 // a value once, it'll happen again and again for many rows in a table, and spamming the console is slow.
 let warnedAboutStyleJsonSet = new Set<string>();
@@ -1184,13 +1050,12 @@ export function parseStyleJson(rawValue: unknown): CSSProperties | void {
       }
     } catch (e) {
       if (!warnedAboutStyleJsonSet.has(rawValue)) {
-        console.error(`encountered invalid cell style JSON: ${rawValue}`, e);
+        structLog('error', `encountered invalid cell style JSON: ${rawValue}`, e);
         warnedAboutStyleJsonSet.add(rawValue);
       }
     }
   }
 }
-
 // Safari 26.0 introduced rendering bugs which require us to disable several features of the table.
 // The bugs were later fixed in Safari 26.2.
 export const IS_SAFARI_26 = (() => {

--- a/packages/grafana-ui/src/components/ThemeDemos/EmotionPerfTest.tsx
+++ b/packages/grafana-ui/src/components/ThemeDemos/EmotionPerfTest.tsx
@@ -1,18 +1,15 @@
+import { structLog } from '@grafana/data';
 /* eslint-disable @grafana/i18n/no-untranslated-strings */
 /** @jsxImportSource @emotion/react */
 import { css, cx } from '@emotion/css';
 import classnames from 'classnames';
 import React, { Profiler, type ProfilerOnRenderCallback, useState, type FC } from 'react';
-
 import { type GrafanaTheme2 } from '@grafana/data';
-
 import { useStyles2, useTheme2 } from '../../themes/ThemeContext';
 import { Button } from '../Button/Button';
 import { Stack } from '../Layout/Stack/Stack';
-
 export function EmotionPerfTest() {
-  console.log('process.env.NODE_ENV', process.env.NODE_ENV);
-
+  structLog('log', 'process.env.NODE_ENV', process.env.NODE_ENV);
   return (
     <Stack direction="column">
       <div>Emotion performance tests</div>
@@ -26,10 +23,11 @@ export function EmotionPerfTest() {
     </Stack>
   );
 }
-
-export const TestScenario: FC<{ name: string; Component: FC<TestComponentProps> }> = ({ name, Component }) => {
+export const TestScenario: FC<{
+  name: string;
+  Component: FC<TestComponentProps>;
+}> = ({ name, Component }) => {
   const [render, setRender] = useState(0);
-
   return (
     <div>
       <Button onClick={() => setRender(render > 2 ? 0 : render + 1)}>{name}</Button>
@@ -37,23 +35,17 @@ export const TestScenario: FC<{ name: string; Component: FC<TestComponentProps> 
     </div>
   );
 };
-
 TestScenario.displayName = 'TestScenario';
-
 function renderManyComponents(Component: FC<TestComponentProps>) {
   const elements: React.ReactNode[] = [];
-
   for (let i = 0; i < 5000; i++) {
     elements.push(<Component index={i} key={i.toString()} />);
   }
-
   return <div style={{ display: 'flex', flexWrap: 'wrap' }}>{elements}</div>;
 }
-
 interface TestComponentProps {
   index: number;
 }
-
 function UseStylesNoCX({ index }: TestComponentProps) {
   const styles = useStyles2(getStyles);
   return (
@@ -62,39 +54,32 @@ function UseStylesNoCX({ index }: TestComponentProps) {
     </div>
   );
 }
-
 function UseStylesWithConditionalCX({ index }: TestComponentProps) {
   const styles = useStyles2(getStyles);
   const mainStyles = cx(styles.main, { [styles.large]: index > 10, [styles.disabed]: index % 10 === 0 });
-
   return (
     <div className={mainStyles}>
       <div className={styles.child}>{index}</div>
     </div>
   );
 }
-
 function UseStylesWithConditionalClassNames({ index }: TestComponentProps) {
   const styles = useStyles2(getStyles);
   const mainStyles = classnames(styles.main, { [styles.large]: index > 10, [styles.disabed]: index % 10 === 0 });
-
   return (
     <div className={mainStyles}>
       <div className={styles.child}>{index}</div>
     </div>
   );
 }
-
 function UseStylesWithCSSProp({ index }: TestComponentProps) {
   const styles = useStyles2(getStylesObjects);
-
   return (
     <div css={styles.main}>
       <div css={styles.child}>{index}</div>
     </div>
   );
 }
-
 function UseStylesWithConditionalCSS({ index }: TestComponentProps) {
   const styles = useStyles2(getStylesObjects);
   const mainStyles = [styles.main, index > 10 && styles.large, index % 10 === 0 && styles.disabed];
@@ -104,18 +89,15 @@ function UseStylesWithConditionalCSS({ index }: TestComponentProps) {
     </div>
   );
 }
-
 function InlineEmotionCSS({ index }: TestComponentProps) {
   const theme = useTheme2();
   const styles = getStyles(theme);
-
   return (
     <div className={styles.main}>
       <div className={styles.child}>{index}</div>
     </div>
   );
 }
-
 function NoStyles({ index }: TestComponentProps) {
   return (
     <div className="no-styles-main">
@@ -123,19 +105,16 @@ function NoStyles({ index }: TestComponentProps) {
     </div>
   );
 }
-
 function MeasureRender({ children, id }: { children: React.ReactNode; id: string }) {
   const onRender: ProfilerOnRenderCallback = (id, phase, actualDuration, baseDuration, startTime, commitTime) => {
-    console.log('Profile ' + id, actualDuration);
+    structLog('log', 'Profile ' + id, actualDuration);
   };
-
   return (
     <Profiler id={id} onRender={onRender}>
       {children}
     </Profiler>
   );
 }
-
 const getStyles = (theme: GrafanaTheme2) => {
   return {
     main: css(getStylesObjectMain(theme)),
@@ -150,7 +129,6 @@ const getStyles = (theme: GrafanaTheme2) => {
     child: css(getStylesObjectChild(theme)),
   };
 };
-
 const getStylesObjects = (theme: GrafanaTheme2) => {
   return {
     main: getStylesObjectMain(theme),
@@ -165,7 +143,6 @@ const getStylesObjects = (theme: GrafanaTheme2) => {
     child: getStylesObjectChild(theme),
   };
 };
-
 function getStylesObjectMain(theme: GrafanaTheme2) {
   return {
     background: 'blue',
@@ -178,7 +155,6 @@ function getStylesObjectMain(theme: GrafanaTheme2) {
     },
   };
 }
-
 function getStylesObjectChild(theme: GrafanaTheme2) {
   return {
     padding: '2px',

--- a/packages/grafana-ui/src/components/VizTooltip/VizTooltipRow.tsx
+++ b/packages/grafana-ui/src/components/VizTooltip/VizTooltipRow.tsx
@@ -1,17 +1,14 @@
+import { structLog } from '@grafana/data';
 import { css } from '@emotion/css';
 import clsx from 'clsx';
 import { type CSSProperties, type ReactNode, useEffect, useRef, useState } from 'react';
 import * as React from 'react';
-
 import { type GrafanaTheme2 } from '@grafana/data';
-
 import { useStyles2 } from '../../themes/ThemeContext';
 import { InlineToast } from '../InlineToast/InlineToast';
 import { Tooltip } from '../Tooltip/Tooltip';
-
 import { ColorIndicatorPosition, VizTooltipColorIndicator } from './VizTooltipColorIndicator';
 import { ColorPlacement, type VizTooltipItem } from './types';
-
 interface VizTooltipRowProps extends Omit<VizTooltipItem, 'value'> {
   value: string | number | null | ReactNode;
   justify?: string;
@@ -21,17 +18,14 @@ interface VizTooltipRowProps extends Omit<VizTooltipItem, 'value'> {
   showValueScroll?: boolean;
   isHiddenFromViz?: boolean;
 }
-
 enum LabelValueTypes {
   label = 'label',
   value = 'value',
 }
-
 const SUCCESSFULLY_COPIED_TEXT = 'Copied to clipboard';
 const SHOW_SUCCESS_DURATION = 2 * 1000;
 const HORIZONTAL_PX_PER_CHAR = 7;
 const CAN_COPY = Boolean(navigator.clipboard && window.isSecureContext);
-
 export const VizTooltipRow = ({
   label,
   value,
@@ -47,7 +41,6 @@ export const VizTooltipRow = ({
   isHiddenFromViz,
 }: VizTooltipRowProps) => {
   const styles = useStyles2(getStyles, justify, marginRight);
-
   const innerValueScrollStyle: CSSProperties = showValueScroll
     ? {
         maxHeight: 55,
@@ -60,35 +53,27 @@ export const VizTooltipRow = ({
         wordBreak: 'break-word',
         lineHeight: 1.2,
       };
-
   const [showLabelTooltip, setShowLabelTooltip] = useState(false);
-
   const [copiedText, setCopiedText] = useState<Record<string, string> | null>(null);
   const [showCopySuccess, setShowCopySuccess] = useState(false);
-
   const labelRef = useRef<null | HTMLDivElement>(null);
   const valueRef = useRef<null | HTMLDivElement>(null);
-
   useEffect(() => {
     let timeoutId: ReturnType<typeof setTimeout>;
-
     if (showCopySuccess) {
       timeoutId = setTimeout(() => {
         setShowCopySuccess(false);
       }, SHOW_SUCCESS_DURATION);
     }
-
     return () => {
       window.clearTimeout(timeoutId);
     };
   }, [showCopySuccess]);
-
   const copyToClipboard = async (text: string, type: LabelValueTypes) => {
     if (!CAN_COPY) {
       fallbackCopyToClipboard(text, type);
       return;
     }
-
     try {
       await navigator.clipboard.writeText(text);
       setCopiedText({ [`${type}`]: text });
@@ -97,7 +82,6 @@ export const VizTooltipRow = ({
       setCopiedText(null);
     }
   };
-
   const fallbackCopyToClipboard = (text: string, type: LabelValueTypes) => {
     // Use a fallback method for browsers/contexts that don't support the Clipboard API.
     const textarea = document.createElement('textarea');
@@ -112,25 +96,20 @@ export const VizTooltipRow = ({
         setShowCopySuccess(true);
       }
     } catch (err) {
-      console.error('Unable to copy to clipboard', err);
+      structLog('error', 'Unable to copy to clipboard', err);
     }
-
     textarea.remove();
   };
-
   const onMouseEnterLabel = (event: React.MouseEvent<HTMLDivElement>) => {
     if (event.currentTarget.offsetWidth < event.currentTarget.scrollWidth) {
       setShowLabelTooltip(true);
     }
   };
-
   const onMouseLeaveLabel = () => setShowLabelTooltip(false);
-
   // if label is > 50% window width, try to put label/value pairs on new lines
   if (label.length * HORIZONTAL_PX_PER_CHAR > window.innerWidth / 2) {
     label = label.replaceAll('{', '{\n  ').replaceAll('}', '\n}').replaceAll(', ', ',\n  ');
   }
-
   return (
     <div className={styles.contentWrapper}>
       {color && colorPlacement === ColorPlacement.first && (
@@ -218,7 +197,6 @@ export const VizTooltipRow = ({
     </div>
   );
 };
-
 const getStyles = (theme: GrafanaTheme2, justify = 'start', marginRight?: string) => ({
   contentWrapper: css({
     display: 'flex',

--- a/packages/grafana-ui/src/utils/logOptions.ts
+++ b/packages/grafana-ui/src/utils/logOptions.ts
@@ -1,3 +1,4 @@
+import { structLog } from '@grafana/data';
 /**
  * This function logs a warning if the amount of items exceeds the recommended amount.
  *
@@ -13,7 +14,7 @@ export function logOptions(
 ): void {
   if (amount > recommendedAmount) {
     const msg = `[Combobox] Items exceed the recommended amount ${recommendedAmount}.`;
-    console.warn(msg, {
+    structLog('warn', msg, {
       itemsCount: '' + amount,
       recommendedAmount: '' + recommendedAmount,
       'aria-labelledby': ariaLabelledBy ?? '',

--- a/packages/grafana-ui/src/utils/logger.ts
+++ b/packages/grafana-ui/src/utils/logger.ts
@@ -1,3 +1,4 @@
+import { structLog } from '@grafana/data';
 import { throttle } from 'lodash';
 
 type Args = Parameters<typeof console.log>;
@@ -6,7 +7,7 @@ type Args = Parameters<typeof console.log>;
  * @internal
  * */
 const throttledLog = throttle((...t: Args) => {
-  console.log(...t);
+  structLog('log', ...t);
 }, 500);
 
 /**
@@ -32,7 +33,7 @@ export const createLogger = (name: string): Logger => {
       if (process.env.NODE_ENV === 'production' || process.env.NODE_ENV === 'test' || !loggingEnabled) {
         return;
       }
-      const fn = throttle ? throttledLog : console.log;
+      const fn = throttle ? throttledLog : structLog.bind(null, 'log');
       fn(`[${name}: ${id}]:`, ...t);
     },
     enable: () => (loggingEnabled = true),

--- a/public/app/AppWrapper.tsx
+++ b/public/app/AppWrapper.tsx
@@ -1,3 +1,4 @@
+import { structLog } from '@grafana/data';
 import { OpenFeatureProvider } from '@openfeature/react-sdk';
 import { UNSAFE_PortalProvider } from '@react-aria/overlays';
 import { type Action, KBarProvider } from 'kbar';
@@ -5,13 +6,11 @@ import { Component, type ComponentType, Fragment, type ReactNode } from 'react';
 import CacheProvider from 'react-inlinesvg/provider';
 import { Provider } from 'react-redux';
 import { Route, Routes } from 'react-router-dom-v5-compat';
-
 import { config, navigationLogger, reportInteraction } from '@grafana/runtime';
 import { getFeatureFlagClient } from '@grafana/runtime/internal';
 import { ErrorBoundaryAlert, getPortalContainer, GlobalStyles, PortalContainer, TimeRangeProvider } from '@grafana/ui';
 import { getAppRoutes } from 'app/routes/routes';
 import { store } from 'app/store/store';
-
 import { ExtensionSidebarContextProvider } from './core/components/AppChrome/ExtensionSidebar/ExtensionSidebarProvider';
 import { GrafanaContext, type GrafanaContextType } from './core/context/GrafanaContext';
 import { GrafanaRouteWrapper } from './core/navigation/GrafanaRoute';
@@ -23,46 +22,44 @@ import { getPluginExtensionRegistries } from './features/plugins/extensions/regi
 import { type PluginExtensionRegistries } from './features/plugins/extensions/registry/types';
 import { ScopesContextProvider } from './features/scopes/ScopesContextProvider';
 import { RouterWrapper } from './routes/RoutesWrapper';
-
 interface AppWrapperProps {
   context: GrafanaContextType;
 }
-
 interface AppWrapperState {
   ready?: boolean;
   registries?: PluginExtensionRegistries;
 }
-
 /** Used by enterprise */
 let bodyRenderHooks: ComponentType[] = [];
 let pageBanners: ComponentType[] = [];
-const enterpriseProviders: Array<ComponentType<{ children: ReactNode }>> = [];
-
-export function addEnterpriseProviders(provider: ComponentType<{ children: ReactNode }>) {
+const enterpriseProviders: Array<
+  ComponentType<{
+    children: ReactNode;
+  }>
+> = [];
+export function addEnterpriseProviders(
+  provider: ComponentType<{
+    children: ReactNode;
+  }>
+) {
   enterpriseProviders.push(provider);
 }
-
 export function addBodyRenderHook(fn: ComponentType) {
   bodyRenderHooks.push(fn);
 }
-
 export function addPageBanner(fn: ComponentType) {
   pageBanners.push(fn);
 }
-
 export class AppWrapper extends Component<AppWrapperProps, AppWrapperState> {
   private iconCacheID = `grafana-icon-cache-${config.buildInfo.commit}`;
-
   constructor(props: AppWrapperProps) {
     super(props);
     this.state = {};
   }
-
   async componentDidMount() {
     const registries = await getPluginExtensionRegistries();
     this.setState({ ready: true, registries });
     this.removePreloader();
-
     // clear any old icon caches
     const cacheKeys = (await window.caches?.keys()) ?? [];
     for (const key of cacheKeys) {
@@ -71,16 +68,14 @@ export class AppWrapper extends Component<AppWrapperProps, AppWrapperState> {
       }
     }
   }
-
   removePreloader() {
     const preloader = document.querySelector('.preloader');
     if (preloader) {
       preloader.remove();
     } else {
-      console.warn('Preloader element not found');
+      structLog('warn', 'Preloader element not found');
     }
   }
-
   renderRoute = (route: RouteDescriptor) => {
     return (
       <Route
@@ -91,33 +86,26 @@ export class AppWrapper extends Component<AppWrapperProps, AppWrapperState> {
       />
     );
   };
-
   renderRoutes() {
     return <Routes>{getAppRoutes().map((r) => this.renderRoute(r))}</Routes>;
   }
-
   render() {
     const { context } = this.props;
     const { ready, registries } = this.state;
-
     navigationLogger('AppWrapper', false, 'rendering');
-
     const commandPaletteActionSelected = (action: Action) => {
       reportInteraction('command_palette_action_selected', {
         actionId: action.id,
         actionName: action.name,
       });
     };
-
     const routerWrapperProps = {
       routes: ready && this.renderRoutes(),
       pageBanners,
       bodyRenderHooks,
       providers: enterpriseProviders,
     };
-
     const MaybeTimeRangeProvider = config.featureToggles.timeRangeProvider ? TimeRangeProvider : Fragment;
-
     return (
       <Provider store={store}>
         <ErrorBoundaryAlert boundaryName="app-wrapper" style="page">

--- a/public/app/api/clients/provisioning/utils/createOnCacheEntryAdded.ts
+++ b/public/app/api/clients/provisioning/utils/createOnCacheEntryAdded.ts
@@ -1,9 +1,8 @@
+import { structLog } from '@grafana/data';
 import { type ThunkDispatch, type UnknownAction } from '@reduxjs/toolkit';
 import { type Subscription } from 'rxjs';
-
 import { ScopedResourceClient } from 'app/features/apiserver/client';
 import { type ListOptions, type GeneratedResourceList as ResourceList } from 'app/features/apiserver/types';
-
 interface OnCacheEntryAddedOptions<List = unknown> {
   onError?: (
     error: unknown,
@@ -12,7 +11,6 @@ interface OnCacheEntryAddedOptions<List = unknown> {
     arg: ListOptions | undefined
   ) => (() => void) | undefined | void;
 }
-
 /**
  * Creates a cache entry handler for RTK Query that watches for changes to a resource
  * and updates the cache accordingly.
@@ -30,7 +28,9 @@ export function createOnCacheEntryAdded<Spec, Status>(
       dispatch,
     }: {
       updateCachedData: (fn: (draft: List) => void) => void;
-      cacheDataLoaded: Promise<{ data: List }>;
+      cacheDataLoaded: Promise<{
+        data: List;
+      }>;
       cacheEntryRemoved: Promise<void>;
       dispatch: ThunkDispatch<unknown, unknown, UnknownAction>;
     }
@@ -38,20 +38,19 @@ export function createOnCacheEntryAdded<Spec, Status>(
     if (!arg?.watch) {
       return;
     }
-
     const client = new ScopedResourceClient<Spec, Status>({
       group: 'provisioning.grafana.app',
       version: 'v0alpha1',
       resource: resourceName,
     });
-
     let subscription: Subscription | null = null;
-    const errorCleanup: { fn?: () => void } = {};
+    const errorCleanup: {
+      fn?: () => void;
+    } = {};
     try {
       // Wait for the initial query to resolve before proceeding
       const response = await cacheDataLoaded;
       const resourceVersion = response.data.metadata?.resourceVersion;
-
       subscription = client
         .watch({ resourceVersion, fieldSelector: arg?.fieldSelector, labelSelector: arg?.labelSelector })
         .subscribe({
@@ -62,7 +61,6 @@ export function createOnCacheEntryAdded<Spec, Status>(
               }
               // Find the item with the matching name
               const existingIndex = draft.items.findIndex((item) => item.metadata?.name === event.object.metadata.name);
-
               if (event.type === 'ADDED' && existingIndex === -1) {
                 draft.items.push(event.object);
               } else if (event.type === 'DELETED' && existingIndex !== -1) {
@@ -80,10 +78,9 @@ export function createOnCacheEntryAdded<Spec, Status>(
           },
         });
     } catch (error) {
-      console.error('Error in onCacheEntryAdded:', error);
+      structLog('error', 'Error in onCacheEntryAdded:', error);
       return;
     }
-
     await cacheEntryRemoved;
     subscription?.unsubscribe();
     errorCleanup.fn?.();

--- a/public/app/api/clients/provisioning/v0alpha1/index.ts
+++ b/public/app/api/clients/provisioning/v0alpha1/index.ts
@@ -1,3 +1,4 @@
+import { structLog } from '@grafana/data';
 import {
   generatedAPI,
   type ConnectionSpec,
@@ -14,7 +15,6 @@ import { isFetchError } from '@grafana/runtime';
 import { clearFolders } from 'app/features/browse-dashboards/state/slice';
 import { getState } from 'app/store/store';
 import { type ThunkDispatch } from 'app/types/store';
-
 import {
   createErrorNotification,
   createSuccessNotification,
@@ -25,7 +25,6 @@ import { PAGE_SIZE } from '../../../../features/browse-dashboards/api/services';
 import { refetchChildren } from '../../../../features/browse-dashboards/state/actions';
 import { handleError } from '../../../utils';
 import { createOnCacheEntryAdded } from '../utils/createOnCacheEntryAdded';
-
 const handleProvisioningFormError = (e: unknown, dispatch: ThunkDispatch, title: string) => {
   if (typeof e === 'object' && e && 'error' in e && isFetchError(e.error)) {
     if (e.error.data.kind === 'Status' && e.error.data.status === 'Failure') {
@@ -33,7 +32,6 @@ const handleProvisioningFormError = (e: unknown, dispatch: ThunkDispatch, title:
       dispatch(notifyApp(createErrorNotification(title, new Error(statusError.message || 'Unknown error'))));
       return;
     }
-
     if (Array.isArray(e.error.data.errors) && e.error.data.errors.length) {
       const nonFieldErrors = e.error.data.errors.filter((err: ErrorDetails) => !err.field);
       if (nonFieldErrors.length > 0) {
@@ -42,10 +40,8 @@ const handleProvisioningFormError = (e: unknown, dispatch: ThunkDispatch, title:
       return;
     }
   }
-
   handleError(e, dispatch, title);
 };
-
 export const provisioningAPIv0alpha1 = generatedAPI.enhanceEndpoints({
   endpoints: {
     listJob: {
@@ -253,7 +249,6 @@ export const provisioningAPIv0alpha1 = generatedAPI.enhanceEndpoints({
         try {
           const result = await queryFulfilled;
           const job = result.data;
-
           // Clear folder cache after successful move/delete jobs
           // We use clearFolders here to clear cached data and closes folders (immediate visual feedback)
           // Force a refetch of subfolders if user has opened them, so user see latest data
@@ -261,7 +256,6 @@ export const provisioningAPIv0alpha1 = generatedAPI.enhanceEndpoints({
             const state = getState().browseDashboards;
             const action = job.spec?.action;
             let childrenKeys = Object.keys(state.childrenByParentUID);
-
             if (action === 'delete') {
               // Do not clear deleted resources to avoid 404s when refetching them
               const deletedResourceNames =
@@ -271,7 +265,7 @@ export const provisioningAPIv0alpha1 = generatedAPI.enhanceEndpoints({
             dispatch(clearFolders(childrenKeys));
           }
         } catch (e) {
-          console.error('Error in getRepositoryJobsWithPath:', e);
+          structLog('error', 'Error in getRepositoryJobsWithPath:', e);
         }
       },
     },
@@ -342,6 +336,5 @@ export const provisioningAPIv0alpha1 = generatedAPI.enhanceEndpoints({
     },
   },
 });
-
 // eslint-disable-next-line no-barrel-files/no-barrel-files
 export * from '@grafana/api-clients/rtkq/provisioning/v0alpha1';

--- a/public/app/app.ts
+++ b/public/app/app.ts
@@ -1,13 +1,11 @@
+import { structLog } from '@grafana/data';
 import 'symbol-observable';
 import 'regenerator-runtime/runtime';
-
 import 'whatwg-fetch'; // fetch polyfill needed for PhantomJs rendering
 import 'file-saver';
 import 'jquery';
-
 import { createElement } from 'react';
 import { createRoot } from 'react-dom/client';
-
 import {
   locationUtil,
   monacoLanguageRegistry,
@@ -54,9 +52,7 @@ import {
 import { loadResources as loadScenesResources, sceneUtils } from '@grafana/scenes';
 import config, { updateConfig } from 'app/core/config';
 import { getStandardTransformers } from 'app/features/transformers/standardTransformers';
-
 import getDefaultMonacoLanguages from '../lib/monaco-languages';
-
 import { AppWrapper } from './AppWrapper';
 import { appEvents } from './core/app_events';
 import { AppChromeService } from './core/components/AppChrome/AppChromeService';
@@ -121,39 +117,31 @@ import { createSwitchVariableAdapter } from './features/variables/switch/adapter
 import { createSystemVariableAdapter } from './features/variables/system/adapter';
 import { createTextBoxVariableAdapter } from './features/variables/textbox/adapter';
 import { configureStore } from './store/configureStore';
-
 // import symlinked extensions
 const extensionsIndex = require.context('.', true, /extensions\/index.ts/);
 const extensionsExports = extensionsIndex.keys().map((key) => {
   return extensionsIndex(key);
 });
-
 export class GrafanaApp {
   context!: GrafanaContextType;
-
   async init() {
     try {
       await preInitTasks();
-
       // Let iframe container know grafana has started loading
       window.parent.postMessage('GrafanaAppInit', '*');
-
       initSystemJSHooks();
-
       // Currently the OpenFeature API requires a signed in user. This means feature flags cannot be used
       // on the login page.
       if (contextSrv.user.isSignedIn) {
         try {
           await initOpenFeature();
         } catch (err) {
-          console.error('Failed to initialize OpenFeature provider', err);
+          structLog('error', 'Failed to initialize OpenFeature provider', err);
         }
       }
-
       const regionalFormat = config.featureToggles.localeFormatPreference
         ? config.regionalFormat
         : contextSrv.user.language;
-
       const initI18nPromise = initializeI18n(
         {
           language: contextSrv.user.language,
@@ -162,22 +150,18 @@ export class GrafanaApp {
         },
         regionalFormat
       );
-
       // This is a placeholder so we can put a 'comment' in the message json files.
       // Starts with an underscore so it's sorted to the top of the file. Even though it is in a comment the following line is still extracted
       // t('_comment', 'The code is the source of truth for English phrases. They should be updated in the components directly, and additional plurals specified in this file.');
       initI18nPromise.then(async ({ language }) => {
         updateConfig({ language });
-
         // Initialise scenes translations into the Grafana namespace. Must finish before any scenes UI is rendered.
         return loadNamespacedResources(GRAFANA_NAMESPACE, language ?? DEFAULT_LANGUAGE, [loadScenesResources]);
       });
-
       setBackendSrv(backendSrv);
       await initEchoSrv();
       // This needs to be done after the `initEchoSrv` since it is being used under the hood.
       startMeasure('frontend_app_init');
-
       setLocale(config.regionalFormat);
       setWeekStart(contextSrv.user.weekStart);
       setPanelRenderer(PanelRenderer);
@@ -190,20 +174,15 @@ export class GrafanaApp {
       setTimeZoneResolver(() => contextSrv.user.timezone);
       initGrafanaLive();
       setCurrentUser(contextSrv.user);
-
       // Expose the app-wide eventbus
       setAppEvents(appEvents);
-
       // We must wait for translations to load because some preloaded store state requires translating
       await initI18nPromise;
-
       // Important that extension reducers are initialized before store
       addExtensionReducers();
       configureStore();
       initExtensions();
-
       initAlerting();
-
       standardEditorsRegistry.setInit(getAllOptionEditors);
       standardFieldConfigEditorRegistry.setInit(getAllStandardFieldConfigs);
       standardTransformersRegistry.setInit(getStandardTransformers);
@@ -218,52 +197,41 @@ export class GrafanaApp {
         createSystemVariableAdapter(),
         createSwitchVariableAdapter(),
       ]);
-
       monacoLanguageRegistry.setInit(getDefaultMonacoLanguages);
       setMonacoEnv();
-
       setQueryRunnerFactory(() => new QueryRunner());
       setVariableQueryRunner(new VariableQueryRunner());
-
       // Provide runRequest implementation to packages, @grafana/scenes in particular
       setRunRequest(runRequest);
-
       // Privide plugin import utils to packages, @grafana/scenes in particular
       setPluginImportUtils({
         importPanelPlugin,
         getPanelPluginFromCache: syncGetPanelPlugin,
       });
-
       // Login redirect requires locationUtil to be initialized
       locationUtil.initialize({
         config: window.grafanaBootData.settings,
         getTimeRangeForUrl: getTimeSrv().timeRangeForUrl,
         getVariablesUrlParams: getVariablesUrlParams,
       });
-
       if (config.featureToggles.useSessionStorageForRedirection) {
         handleRedirectTo();
       }
-
       // intercept anchor clicks and forward it to custom history instead of relying on browser's history
       document.addEventListener('click', interceptLinkClicks);
-
       // Init DataSourceSrv
       const dataSourceSrv = new DatasourceSrv();
       dataSourceSrv.init(config.datasources, config.defaultDatasource);
       setDataSourceSrv(dataSourceSrv);
       initWindowRuntime();
-
       // Do not pre-load apps if rendererDisableAppPluginsPreload is true and the request comes from the image renderer
       const skipAppPluginsPreload =
         config.featureToggles.rendererDisableAppPluginsPreload && contextSrv.user.authenticatedBy === 'render';
       if (contextSrv.user.orgRole !== '' && !skipAppPluginsPreload) {
         preloadPlugins(await getAppPluginsToPreload());
       }
-
       getPluginExtensionRegistries();
       await getPanelPluginMetas();
-
       setHelpNavItemHook(useHelpNode);
       setPluginLinksHook(usePluginLinks);
       setPluginComponentHook(usePluginComponent);
@@ -271,24 +239,20 @@ export class GrafanaApp {
       setPluginFunctionsHook(usePluginFunctions);
       setGetObservablePluginLinks(getObservablePluginLinks);
       setGetObservablePluginComponents(getObservablePluginComponents);
-
       // initialize chrome service
       const queryParams = locationService.getSearchObject();
       const chromeService = new AppChromeService();
       const keybindingsService = new KeybindingSrv(locationService, chromeService);
       const newAssetsChecker = new NewFrontendAssetsChecker();
       newAssetsChecker.start();
-
       // Read initial kiosk mode from url at app startup
       chromeService.setKioskModeFromUrl(queryParams.kiosk);
-
       // Clean up old search local storage values
       try {
         cleanupOldExpandedFolders();
       } catch (err) {
-        console.warn('Failed to clean up old expanded folders', err);
+        structLog('warn', 'Failed to clean up old expanded folders', err);
       }
-
       this.context = {
         backend: backendSrv,
         location: locationService,
@@ -297,55 +261,45 @@ export class GrafanaApp {
         newAssetsChecker,
         config,
       };
-
       setReturnToPreviousHook(useReturnToPreviousInternal);
       setMegaMenuOpenHook(useMegaMenuOpenInternal);
       setChromeHeaderHeightHook(useChromeHeaderHeight);
-
       if (config.featureToggles.crashDetection) {
         initializeCrashDetection();
       }
-
       if (config.featureToggles.dashboardLevelTimeMacros) {
         sceneUtils.registerVariableMacro('__from', DashboardLevelTimeMacro, true);
         sceneUtils.registerVariableMacro('__to', DashboardLevelTimeMacro, true);
       }
-
       const root = createRoot(document.getElementById('reactRoot')!);
       root.render(createElement(AppWrapper, { context: this.context }));
-
       await postInitTasks();
     } catch (error) {
-      console.error('Failed to start Grafana', error);
+      structLog('error', 'Failed to start Grafana', error);
       window.__grafana_load_failed();
     } finally {
       stopMeasure('frontend_app_init');
     }
   }
 }
-
 function addExtensionReducers() {
   if (extensionsExports.length > 0) {
     extensionsExports[0].addExtensionReducers();
   }
 }
-
 function initExtensions() {
   if (extensionsExports.length > 0) {
     extensionsExports[0].init();
   }
 }
-
 function handleRedirectTo(): void {
   const queryParams = locationService.getSearch();
   const redirectToParamKey = 'redirectTo';
-
   if (queryParams.has('auth_token')) {
     // URL Login should not be redirected
     window.sessionStorage.removeItem(RedirectToUrlKey);
     return;
   }
-
   if (queryParams.has(redirectToParamKey) && window.location.pathname !== '/') {
     const rawRedirectTo = queryParams.get(redirectToParamKey)!;
     window.sessionStorage.setItem(RedirectToUrlKey, encodeURIComponent(rawRedirectTo));
@@ -353,16 +307,13 @@ function handleRedirectTo(): void {
     window.history.replaceState({}, '', `${window.location.pathname}${queryParams.size > 0 ? `?${queryParams}` : ''}`);
     return;
   }
-
   if (!contextSrv.user.isSignedIn) {
     return;
   }
-
   const redirectTo = window.sessionStorage.getItem(RedirectToUrlKey);
   if (!redirectTo) {
     return;
   }
-
   window.sessionStorage.removeItem(RedirectToUrlKey);
   let decodedRedirectTo = decodeURIComponent(redirectTo);
   if (decodedRedirectTo.startsWith('/goto/')) {
@@ -375,5 +326,4 @@ function handleRedirectTo(): void {
   const stripped = locationUtil.stripBaseFromUrl(decodedRedirectTo);
   locationService.replace(stripped);
 }
-
 export default new GrafanaApp();

--- a/public/app/core/components/AccessControl/Permissions.tsx
+++ b/public/app/core/components/AccessControl/Permissions.tsx
@@ -1,22 +1,19 @@
+import { structLog } from '@grafana/data';
 import { css } from '@emotion/css';
 import { sortBy } from 'lodash';
 import { useEffect, useMemo, useState } from 'react';
 import * as React from 'react';
 import useAsyncFn from 'react-use/lib/useAsyncFn';
-
 import { type GrafanaTheme2 } from '@grafana/data';
 import { Trans, t } from '@grafana/i18n';
 import { Text, Box, Button, useStyles2, LoadingPlaceholder } from '@grafana/ui';
 import { SlideDown } from 'app/core/components/Animations/SlideDown';
 import { getBackendSrv } from 'app/core/services/backend_srv';
 import { DescendantCount } from 'app/features/browse-dashboards/components/BrowseActions/DescendantCount';
-
 import { AddPermission } from './AddPermission';
 import { PermissionList } from './PermissionList';
 import { PermissionTarget, type ResourcePermission, type SetPermission, type Description } from './types';
-
 const EMPTY_PERMISSION = '';
-
 const INITIAL_DESCRIPTION: Description = {
   permissions: [],
   assignments: {
@@ -26,10 +23,8 @@ const INITIAL_DESCRIPTION: Description = {
     builtInRoles: false,
   },
 };
-
 type ResourceId = string | number;
 type Type = 'users' | 'teams' | 'serviceAccounts' | 'builtInRoles';
-
 export type Props = {
   buttonLabel?: string;
   emptyLabel?: string;
@@ -41,7 +36,6 @@ export type Props = {
   epilogue?: (items: ResourcePermission[]) => React.ReactNode;
   queryParams?: Record<string, string>;
 };
-
 export const Permissions = ({
   buttonLabel = t('access-control.permissions.add-label', 'Add a permission'),
   emptyLabel = t('access-control.permissions.no-permissions', 'There are no permissions'),
@@ -56,7 +50,6 @@ export const Permissions = ({
   const styles = useStyles2(getStyles);
   const [isAdding, setIsAdding] = useState(false);
   const [desc, setDesc] = useState(INITIAL_DESCRIPTION);
-
   const [permissions, fetchPermissions] = useAsyncFn(async () => {
     let items = await getPermissions(resource, resourceId, queryParams);
     if (getWarnings) {
@@ -64,14 +57,12 @@ export const Permissions = ({
     }
     return items;
   }, [resource, resourceId, queryParams, getWarnings]);
-
   useEffect(() => {
     getDescription(resource, queryParams).then((r) => {
       setDesc(r);
       return fetchPermissions();
     });
   }, [resource, fetchPermissions, queryParams]);
-
   const onAdd = (state: SetPermission) => {
     let promise: Promise<void> | null = null;
     if (state.target === PermissionTarget.User || state.target === PermissionTarget.ServiceAccount) {
@@ -81,12 +72,10 @@ export const Permissions = ({
     } else if (state.target === PermissionTarget.BuiltInRole) {
       promise = setBuiltInRolePermission(resource, resourceId, state.builtInRole!, state.permission, queryParams);
     }
-
     if (promise !== null) {
       promise.then(fetchPermissions);
     }
   };
-
   const onRemove = (item: ResourcePermission) => {
     let promise: Promise<void> | null = null;
     if (item.userUid) {
@@ -96,12 +85,10 @@ export const Permissions = ({
     } else if (item.builtInRole) {
       promise = setBuiltInRolePermission(resource, resourceId, item.builtInRole, EMPTY_PERMISSION, queryParams);
     }
-
     if (promise !== null) {
       promise.then(fetchPermissions);
     }
   };
-
   const onChange = (item: ResourcePermission, permission: string) => {
     if (item.permission === permission) {
       return;
@@ -114,7 +101,6 @@ export const Permissions = ({
       onAdd({ permission, builtInRole: item.builtInRole, target: PermissionTarget.BuiltInRole });
     }
   };
-
   const teams = useMemo(
     () =>
       sortBy(
@@ -147,16 +133,13 @@ export const Permissions = ({
       ),
     [permissions.value]
   );
-
   const titleRole = t('access-control.permissions.role', 'Role');
   const titleUser = t('access-control.permissions.user', 'User');
   const titleServiceAccount = t('access-control.permissions.serviceaccount', 'Service Account');
   const titleTeam = t('access-control.permissions.team', 'Team');
-
   if (permissions.loading) {
     return <LoadingPlaceholder text={t('access-control.permissions.loading', 'Loading permissions...')} />;
   }
-
   return (
     <>
       <div>
@@ -243,22 +226,19 @@ export const Permissions = ({
     </>
   );
 };
-
 const getDescription = async (resource: string, queryParams?: Record<string, string>): Promise<Description> => {
   try {
     return await getBackendSrv().get(`/api/access-control/${resource}/description`, queryParams);
   } catch (e) {
-    console.error('failed to load resource description: ', e);
+    structLog('error', 'failed to load resource description: ', e);
     return INITIAL_DESCRIPTION;
   }
 };
-
 const getPermissions = (
   resource: string,
   resourceId: ResourceId,
   queryParams?: Record<string, string>
 ): Promise<ResourcePermission[]> => getBackendSrv().get(`/api/access-control/${resource}/${resourceId}`, queryParams);
-
 const setUserPermission = (
   resource: string,
   resourceId: ResourceId,
@@ -266,7 +246,6 @@ const setUserPermission = (
   permission: string,
   queryParams?: Record<string, string>
 ) => setPermission(resource, resourceId, 'users', userUid, permission, queryParams);
-
 const setTeamPermission = (
   resource: string,
   resourceId: ResourceId,
@@ -274,7 +253,6 @@ const setTeamPermission = (
   permission: string,
   queryParams?: Record<string, string>
 ) => setPermission(resource, resourceId, 'teams', teamUid, permission, queryParams);
-
 const setBuiltInRolePermission = (
   resource: string,
   resourceId: ResourceId,
@@ -282,7 +260,6 @@ const setBuiltInRolePermission = (
   permission: string,
   queryParams?: Record<string, string>
 ) => setPermission(resource, resourceId, 'builtInRoles', builtInRole, permission, queryParams);
-
 const setPermission = (
   resource: string,
   resourceId: ResourceId,
@@ -296,7 +273,6 @@ const setPermission = (
     { permission },
     { params: queryParams }
   );
-
 const getStyles = (theme: GrafanaTheme2) => ({
   breakdown: css({
     ...theme.typography.bodySmall,

--- a/public/app/core/components/AppChrome/TopBar/InviteUserButton.tsx
+++ b/public/app/core/components/AppChrome/TopBar/InviteUserButton.tsx
@@ -1,27 +1,22 @@
+import { structLog } from '@grafana/data';
 import { skipToken } from '@reduxjs/toolkit/query';
-
 import { t } from '@grafana/i18n';
 import { ToolbarButton } from '@grafana/ui';
 import { useGetCurrentOrgQuotaQuery } from 'app/api/clients/legacy';
 import { useMediaQueryMinWidth } from 'app/core/hooks/useMediaQueryMinWidth';
-
 import { NavToolbarSeparator } from '../NavToolbar/NavToolbarSeparator';
-
 import {
   performInviteUserClick,
   performUpgradeUserClick,
   shouldRenderInviteUserButton,
   shouldRenderUpgradeUserButton,
 } from './InviteUserButtonUtils';
-
 export function InviteUserButton() {
   const isLargeScreen = useMediaQueryMinWidth('lg');
   const shouldRender = shouldRenderInviteUserButton();
   const shouldCheckQuota = shouldRenderUpgradeUserButton();
-
   // Only fetch quotas when we should check quota (Cloud instance with upgrade URL configured)
   const { data: quotas } = useGetCurrentOrgQuotaQuery(!shouldCheckQuota ? skipToken : undefined);
-
   // Check if org_user quota is reached
   const userQuota = quotas?.find((quota) => quota.target === 'org_user');
   const isQuotaReached =
@@ -30,10 +25,8 @@ export function InviteUserButton() {
     userQuota.limit !== undefined &&
     userQuota.limit >= 0 &&
     userQuota.used >= userQuota.limit;
-
   // Show upgrade button if: should check quota (Cloud + upgrade URL configured) AND quota is reached
   const showUpgrade = shouldCheckQuota && isQuotaReached;
-
   const handleClick = () => {
     try {
       if (showUpgrade) {
@@ -42,17 +35,15 @@ export function InviteUserButton() {
         performInviteUserClick('top_bar_right', 'invite-user-top-bar');
       }
     } catch (error) {
-      console.error('Failed to handle invite/upgrade user click:', error);
+      structLog('error', 'Failed to handle invite/upgrade user click:', error);
     }
   };
-
   const buttonText = showUpgrade
     ? t('navigation.invite-user.upgrade-button', 'Upgrade')
     : t('navigation.invite-user.invite-button', 'Invite');
   const tooltipText = showUpgrade
     ? t('navigation.invite-user.upgrade-tooltip', 'Upgrade to add more users')
     : t('navigation.invite-user.invite-tooltip', 'Invite user');
-
   return (
     shouldRender && (
       <>

--- a/public/app/core/components/Login/LoginCtrl.tsx
+++ b/public/app/core/components/Login/LoginCtrl.tsx
@@ -1,24 +1,19 @@
+import { structLog } from '@grafana/data';
 import { memo, useState, useCallback, type JSX } from 'react';
-
 import { t } from '@grafana/i18n';
 import { type FetchError, getBackendSrv, isFetchError } from '@grafana/runtime';
 import config from 'app/core/config';
-
 import { type LoginDTO } from './types';
-
 const isOauthEnabled = () => {
   return !!config.oauth && Object.keys(config.oauth).length > 0;
 };
-
 export interface FormModel {
   user: string;
   password: string;
   email: string;
 }
-
 interface Props {
   resetCode?: string;
-
   children: (props: {
     isLoggingIn: boolean;
     changePassword: (pw: string) => void;
@@ -34,7 +29,6 @@ interface Props {
     loginErrorMessage: string | undefined;
   }) => JSX.Element;
 }
-
 export const LoginCtrl = memo(({ resetCode, children }: Props) => {
   const [result, setResult] = useState<LoginDTO | undefined>();
   const [isLoggingIn, setIsLoggingIn] = useState(false);
@@ -44,13 +38,11 @@ export const LoginCtrl = memo(({ resetCode, children }: Props) => {
   const [loginErrorMessage, setLoginErrorMessage] = useState<string | undefined>(
     getBootDataErrMessage(config.loginError)
   );
-
   const toGrafana = useCallback(() => {
     if (config.featureToggles.useSessionStorageForRedirection) {
       window.location.assign(config.appSubUrl + '/');
       return;
     }
-
     if (result?.redirectUrl) {
       if (config.appSubUrl !== '' && !result.redirectUrl.startsWith(config.appSubUrl)) {
         window.location.assign(config.appSubUrl + result.redirectUrl);
@@ -61,7 +53,6 @@ export const LoginCtrl = memo(({ resetCode, children }: Props) => {
       window.location.assign(config.appSubUrl + '/');
     }
   }, [result]);
-
   const changePassword = useCallback(
     (password: string) => {
       const pw = {
@@ -69,14 +60,12 @@ export const LoginCtrl = memo(({ resetCode, children }: Props) => {
         confirmNew: password,
         oldPassword: 'admin',
       };
-
       if (resetCode) {
         const resetModel = {
           code: resetCode,
           newPassword: password,
           confirmPassword: password,
         };
-
         getBackendSrv()
           .post('/api/user/password/reset', resetModel)
           .then(() => {
@@ -88,22 +77,19 @@ export const LoginCtrl = memo(({ resetCode, children }: Props) => {
           .then(() => {
             toGrafana();
           })
-          .catch((err) => console.error(err));
+          .catch((err) => structLog('error', err));
       }
     },
     [resetCode, toGrafana]
   );
-
   const changeView = useCallback((showDefaultPasswordWarning: boolean) => {
     setIsChangingPassword(true);
     setShowDefaultPasswordWarning(showDefaultPasswordWarning);
   }, []);
-
   const login = useCallback(
     async (formModel: FormModel) => {
       setLoginErrorMessage(undefined);
       setIsLoggingIn(true);
-
       return getBackendSrv()
         .post<LoginDTO>('/login', formModel, { showErrorAlert: false })
         .then((result) => {
@@ -123,9 +109,7 @@ export const LoginCtrl = memo(({ resetCode, children }: Props) => {
     },
     [toGrafana, changeView]
   );
-
   const { loginHint, passwordHint, disableLoginForm, disableUserSignUp } = config;
-
   return (
     <>
       {children({
@@ -145,12 +129,17 @@ export const LoginCtrl = memo(({ resetCode, children }: Props) => {
     </>
   );
 });
-
 LoginCtrl.displayName = 'LoginCtrl';
-
 export default LoginCtrl;
-
-function getErrorMessage(err: FetchError<undefined | { messageId?: string; message?: string }>): string | undefined {
+function getErrorMessage(
+  err: FetchError<
+    | undefined
+    | {
+        messageId?: string;
+        message?: string;
+      }
+  >
+): string | undefined {
   switch (err.data?.messageId) {
     case 'password-auth.empty':
     case 'password-auth.failed':
@@ -165,7 +154,6 @@ function getErrorMessage(err: FetchError<undefined | { messageId?: string; messa
       return err.data?.message;
   }
 }
-
 function getBootDataErrMessage(str?: string) {
   switch (str) {
     case 'oauth.login.error':

--- a/public/app/core/components/NavLandingPage/NavLandingPage.tsx
+++ b/public/app/core/components/NavLandingPage/NavLandingPage.tsx
@@ -1,53 +1,45 @@
+import { structLog } from '@grafana/data';
 import { css } from '@emotion/css';
 import * as React from 'react';
-
 import { type GrafanaTheme2, type NavModelItem } from '@grafana/data';
 import { usePluginComponents, usePluginLinks } from '@grafana/runtime';
 import { useStyles2 } from '@grafana/ui';
 import { Page } from 'app/core/components/Page/Page';
 import { useNavModel } from 'app/core/hooks/useNavModel';
-
 import { NavLandingPageCard } from './NavLandingPageCard';
-
 interface Props {
   navId: string;
   header?: React.ReactNode;
 }
-
 const EXTENSION_ID = (nodeId: string) => `grafana/dynamic/nav-landing-page/nav-id-${nodeId}/v1`;
 const CARDS_EXTENSION_ID = (nodeId: string) => `grafana/dynamic/nav-landing-page/nav-id-${nodeId}/cards/v1`;
-
 export function NavLandingPage({ navId, header }: Props) {
   const { node } = useNavModel(navId);
   const styles = useStyles2(getStyles);
   const children = node.children?.filter((child) => !child.hideFromTabs);
-
   const { components, isLoading } = usePluginComponents<{
     node: NavModelItem;
   }>({
     extensionPointId: EXTENSION_ID(node.id ?? ''),
   });
-
   const { links: additionalCards, isLoading: isLoadingCards } = usePluginLinks({
     extensionPointId: CARDS_EXTENSION_ID(node.id ?? ''),
     context: { node },
   });
-
   // Warn if both extension points are being used (they are mutually exclusive)
   React.useEffect(() => {
     if (components && components.length > 0 && additionalCards && additionalCards.length > 0) {
-      console.warn(
+      structLog(
+        'warn',
         `[NavLandingPage] Both NavLandingPage and NavLandingPageCards extensions are registered for "${node.id}". ` +
           `The NavLandingPage extension will take precedence and NavLandingPageCards will be ignored. ` +
           `Please use only one extension point.`
       );
     }
   }, [components, additionalCards, node.id]);
-
   if (isLoading || isLoadingCards) {
     return null;
   }
-
   return (
     <Page navId={node.id}>
       <Page.Contents>
@@ -84,7 +76,6 @@ export function NavLandingPage({ navId, header }: Props) {
     </Page>
   );
 }
-
 const getStyles = (theme: GrafanaTheme2) => ({
   content: css({
     display: 'flex',

--- a/public/app/core/components/RolePicker/TeamRolePicker.tsx
+++ b/public/app/core/components/RolePicker/TeamRolePicker.tsx
@@ -1,12 +1,10 @@
+import { structLog } from '@grafana/data';
 import { skipToken } from '@reduxjs/toolkit/query';
 import { useMemo } from 'react';
-
 import { useListTeamRolesQuery, useSetTeamRolesMutation } from 'app/api/clients/roles';
 import { contextSrv } from 'app/core/services/context_srv';
 import { AccessControlAction, type Role } from 'app/types/accessControl';
-
 import { RolePicker } from './RolePicker';
-
 export interface Props {
   teamId: number;
   orgId?: number;
@@ -31,7 +29,6 @@ export interface Props {
   width?: string | number;
   isLoading?: boolean;
 }
-
 export const TeamRolePicker = ({
   teamId,
   orgId,
@@ -46,17 +43,13 @@ export const TeamRolePicker = ({
   isLoading,
 }: Props) => {
   const hasPermission = contextSrv.hasPermission(AccessControlAction.ActionTeamsRolesList) && teamId > 0;
-
   // In non-apply mode, always fetch to ensure we have fresh data after mutations
   // In apply mode, only skip fetch if we have pendingRoles
   const shouldFetch = apply ? !Boolean(pendingRoles?.length) && hasPermission : hasPermission;
-
   const { data: fetchedRoles, isLoading: isFetching } = useListTeamRolesQuery(
     shouldFetch ? { teamId, targetOrgId: orgId } : skipToken
   );
-
   const [updateTeamRoles, { isLoading: isUpdating }] = useSetTeamRolesMutation();
-
   const appliedRoles =
     useMemo(() => {
       if (apply && Boolean(pendingRoles?.length)) {
@@ -66,7 +59,6 @@ export const TeamRolePicker = ({
       // Fall back to roles prop if fetched data is not available yet
       return fetchedRoles || roles || [];
     }, [roles, pendingRoles, fetchedRoles, apply]) || [];
-
   const onRolesChange = async (newRoles: Role[]) => {
     if (!apply) {
       try {
@@ -79,17 +71,15 @@ export const TeamRolePicker = ({
           },
         }).unwrap();
       } catch (error) {
-        console.error('Error updating team roles', error);
+        structLog('error', 'Error updating team roles', error);
       }
     } else if (onApplyRoles) {
       onApplyRoles(newRoles);
     }
   };
-
   const canUpdateRoles =
     contextSrv.hasPermission(AccessControlAction.ActionTeamsRolesAdd) &&
     contextSrv.hasPermission(AccessControlAction.ActionTeamsRolesRemove);
-
   return (
     <RolePicker
       pickerId={`team-picker-${teamId}`}

--- a/public/app/core/components/RolePicker/UserRolePicker.tsx
+++ b/public/app/core/components/RolePicker/UserRolePicker.tsx
@@ -1,13 +1,11 @@
+import { structLog } from '@grafana/data';
 import { skipToken } from '@reduxjs/toolkit/query';
 import { useMemo } from 'react';
-
 import { type OrgRole } from '@grafana/data';
 import { useListUserRolesQuery, useSetUserRolesMutation } from 'app/api/clients/roles';
 import { contextSrv } from 'app/core/services/context_srv';
 import { AccessControlAction, type Role } from 'app/types/accessControl';
-
 import { RolePicker } from './RolePicker';
-
 export interface Props {
   basicRole: OrgRole;
   roles?: Role[];
@@ -36,7 +34,6 @@ export interface Props {
   width?: string | number;
   isLoading?: boolean;
 }
-
 export const UserRolePicker = ({
   basicRole,
   roles,
@@ -55,18 +52,14 @@ export const UserRolePicker = ({
   isLoading,
 }: Props) => {
   const hasPermission = contextSrv.hasPermission(AccessControlAction.ActionUserRolesList) && userId > 0 && orgId;
-
   // Determine when to fetch:
   // - In apply mode: only fetch if we don't have roles prop AND no pendingRoles (prevents flicker)
   // - In non-apply mode: always fetch to get fresh data after mutations
   const shouldFetch = apply ? !roles && !Boolean(pendingRoles?.length) && hasPermission : hasPermission;
-
   const { data: fetchedRoles, isLoading: isFetching } = useListUserRolesQuery(
     shouldFetch ? { userId, includeHidden: true, includeMapped: true, targetOrgId: orgId } : skipToken
   );
-
   const [updateUserRoles, { isLoading: isUpdating }] = useSetUserRolesMutation();
-
   const appliedRoles =
     useMemo(() => {
       // In apply mode: prioritize pendingRoles, then roles prop (never use fetched data to prevent flicker)
@@ -76,7 +69,6 @@ export const UserRolePicker = ({
       // In non-apply mode: prefer fetched data (fresh from cache) over roles prop
       return fetchedRoles || roles || [];
     }, [roles, pendingRoles, fetchedRoles, apply]) || [];
-
   const onRolesChange = async (newRoles: Role[]) => {
     if (!apply) {
       try {
@@ -90,17 +82,15 @@ export const UserRolePicker = ({
           },
         }).unwrap();
       } catch (error) {
-        console.error('Error updating user roles', error);
+        structLog('error', 'Error updating user roles', error);
       }
     } else if (onApplyRoles) {
       onApplyRoles(newRoles, userId, orgId);
     }
   };
-
   const canUpdateRoles =
     contextSrv.hasPermission(AccessControlAction.ActionUserRolesAdd) &&
     contextSrv.hasPermission(AccessControlAction.ActionUserRolesRemove);
-
   return (
     <RolePicker
       pickerId={`user-picker-${userId}-${orgId}`}

--- a/public/app/core/components/SharedPreferences/SharedPreferencesFunctional.tsx
+++ b/public/app/core/components/SharedPreferences/SharedPreferencesFunctional.tsx
@@ -1,6 +1,6 @@
+import { structLog } from '@grafana/data';
 import { useBooleanFlagValue } from '@openfeature/react-sdk';
 import { memo, useMemo, useState, useEffect } from 'react';
-
 import { type PreferencesSpec as UserPreferencesDTO } from '@grafana/api-clients/rtkq/preferences/v1alpha1';
 import { FeatureState } from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';
@@ -25,10 +25,8 @@ import {
 } from '@grafana/ui';
 import { PreferencesService } from 'app/core/services/PreferencesService';
 import { changeTheme } from 'app/core/services/theme';
-
 import { DashboardPicker } from '../Select/DashboardPicker';
 import { getSelectableThemes } from '../ThemeSelector/getSelectableThemes';
-
 import { languageChanged, regionalFormatChanged, saveButtonClicked, themeChanged } from './analytics/main';
 import {
   getLanguageOptions,
@@ -38,7 +36,6 @@ import {
   type Props,
   type State,
 } from './utils';
-
 export const SharedPreferencesFunctional = memo((props: Props) => {
   const isAnalyticsFrameworkEnabled = useBooleanFlagValue('analyticsFramework', true);
   const [state, setState] = useState<UserPreferencesDTO & State>({
@@ -53,12 +50,9 @@ export const SharedPreferencesFunctional = memo((props: Props) => {
     navbar: { bookmarkUrls: [] },
     homeDashboardUID: '',
   });
-
   const themes = getSelectableThemes();
   const styles = useStyles2(getStyles);
-
   const service = useMemo(() => new PreferencesService(props.resourceUri), [props.resourceUri]);
-
   // Options are translated, so must be called after init but call them
   // in constructor to avoid memo-break of array changing every render
   const themeOptions: ComboboxOption[] = themes.map((theme) => ({
@@ -68,10 +62,8 @@ export const SharedPreferencesFunctional = memo((props: Props) => {
   }));
   const languageOptions: ComboboxOption[] = getLanguageOptions();
   const regionalFormatOptions: ComboboxOption[] = getRegionalFormatOptions();
-
   // Add default option
   themeOptions.unshift({ value: '', label: t('shared-preferences.theme.default-label', 'Default') });
-
   useEffect(() => {
     const loadPreferences = async () => {
       setState((prev) => ({ ...prev, isLoading: true }));
@@ -89,15 +81,13 @@ export const SharedPreferencesFunctional = memo((props: Props) => {
           navbar: prefs.navbar ?? prev.navbar,
         }));
       } catch (err) {
-        console.error('Failed to load preferences', err);
+        structLog('error', 'Failed to load preferences', err);
       } finally {
         setState((prev) => ({ ...prev, isLoading: false }));
       }
     };
-
     loadPreferences();
   }, [service]);
-
   const handleSubmitForm = async (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault();
     const confirmationResult = props.onConfirm ? await props.onConfirm() : true;
@@ -115,7 +105,6 @@ export const SharedPreferencesFunctional = memo((props: Props) => {
         language: state.language,
       });
     }
-
     if (!confirmationResult) {
       return;
     }
@@ -136,7 +125,6 @@ export const SharedPreferencesFunctional = memo((props: Props) => {
       });
     window.location.reload();
   };
-
   const handleThemeChanged = (value: ComboboxOption<string>) => {
     setState((prev) => ({ ...prev, theme: value.value }));
     if (isAnalyticsFrameworkEnabled) {
@@ -151,27 +139,22 @@ export const SharedPreferencesFunctional = memo((props: Props) => {
         preferenceType: props.preferenceType,
       });
     }
-
     if (value.value) {
       changeTheme(value.value, true);
     }
   };
-
   const handleTimeZoneChanged = (timezone?: string) => {
     if (typeof timezone !== 'string') {
       return;
     }
     setState((prev) => ({ ...prev, timezone }));
   };
-
   const handleWeekStartChanged = (weekStart?: WeekStart) => {
     weekStart ? setState((prev) => ({ ...prev, weekStart })) : setState((prev) => ({ ...prev, weekStart: '' }));
   };
-
   const handleDashboardChanged = (dashboardUID: string) => {
     setState((prev) => ({ ...prev, homeDashboardUID: dashboardUID }));
   };
-
   const handleLanguageChanged = (language: string) => {
     setState((prev) => ({ ...prev, language }));
     if (isAnalyticsFrameworkEnabled) {
@@ -187,7 +170,6 @@ export const SharedPreferencesFunctional = memo((props: Props) => {
       });
     }
   };
-
   const handleRegionalFormatChanged = (regionalFormat: string) => {
     setState((prev) => ({ ...prev, regionalFormat }));
     if (isAnalyticsFrameworkEnabled) {
@@ -203,9 +185,7 @@ export const SharedPreferencesFunctional = memo((props: Props) => {
       });
     }
   };
-
   const currentThemeOption = themeOptions.find((x) => x.value === state.theme) ?? themeOptions[0];
-
   return (
     <form onSubmit={handleSubmitForm} className={styles.form}>
       <FieldSet label={<Trans i18nKey="shared-preferences.title">Preferences</Trans>} disabled={props.disabled}>
@@ -354,5 +334,4 @@ export const SharedPreferencesFunctional = memo((props: Props) => {
     </form>
   );
 });
-
 SharedPreferencesFunctional.displayName = 'SharedPreferencesFunctional';

--- a/public/app/core/components/TimePicker/TimePickerWithHistory.tsx
+++ b/public/app/core/components/TimePicker/TimePickerWithHistory.tsx
@@ -1,5 +1,5 @@
+import { structLog } from '@grafana/data';
 import { uniqBy } from 'lodash';
-
 import {
   AppEvents,
   type DateTime,
@@ -11,25 +11,20 @@ import {
 import { t } from '@grafana/i18n';
 import { type TimeRangePickerProps, TimeRangePicker } from '@grafana/ui';
 import { appEvents } from 'app/core/app_events';
-
 const LOCAL_STORAGE_KEY = 'grafana.dashboard.timepicker.history';
 const MAX_HISTORY_ITEMS = 4;
-
 interface Props extends Omit<TimeRangePickerProps, 'history' | 'theme'> {}
-
 // Simplified object to store in local storage
 interface TimePickerHistoryItem {
   from: string;
   to: string;
 }
-
 export const TimePickerWithHistory = (props: Props) => {
   return (
     <LocalStorageValueProvider<unknown> storageKey={LOCAL_STORAGE_KEY} defaultValue={[]}>
       {(values, onSaveToStore) => {
         const validHistory = getValidHistory(values);
         const history = deserializeHistory(validHistory);
-
         return (
           <TimeRangePicker
             {...props}
@@ -50,29 +45,23 @@ export const TimePickerWithHistory = (props: Props) => {
     </LocalStorageValueProvider>
   );
 };
-
 function getValidHistory(values: unknown): TimePickerHistoryItem[] {
   const result: TimePickerHistoryItem[] = [];
-
   if (!Array.isArray(values)) {
     return result;
   }
   // Check if the values are already in the correct format
-
   for (let item of values) {
     const parsed = getValidHistoryItem(item);
     if (parsed) {
       result.push(parsed);
     }
   }
-
   return result;
 }
-
 export function deserializeHistory(values: TimePickerHistoryItem[]): TimeRange[] {
   return values.map((item) => rangeUtil.convertRawToRange(item, 'utc', undefined, 'YYYY-MM-DD HH:mm:ss'));
 }
-
 function onAppendToHistory(
   newTimeRange: TimeRange,
   values: TimePickerHistoryItem[],
@@ -82,25 +71,20 @@ function onAppendToHistory(
     // If the time range is not absolute, do not append it to history, ex: last 5 minutes
     return;
   }
-
   // Convert DateTime objects to strings
   const toAppend = {
     from: convertToISOString(newTimeRange.raw.from),
     to: convertToISOString(newTimeRange.raw.to),
   };
-
   const toStore = limit([toAppend, ...values]);
   onSaveToStore(toStore);
 }
-
 function isAbsoluteTimeRange(value: TimeRange): boolean {
   return isDateTime(value.raw.from) || isDateTime(value.raw.to);
 }
-
 function limit(value: TimePickerHistoryItem[]): TimePickerHistoryItem[] {
   return uniqBy(value, (v) => v.from + v.to).slice(0, MAX_HISTORY_ITEMS);
 }
-
 /**
  * Check if the value is a valid TimePickerHistoryItem. If it doesn't match the format exactly, it will return false.
  * @returns true if the value match exactly to TimePickerHistoryItem, false otherwise
@@ -110,34 +94,27 @@ export function getValidHistoryItem(value: unknown): TimePickerHistoryItem | nul
   if (typeof value !== 'object' || value === null) {
     return null;
   }
-
   // Check if it has exactly two properties
   if (Object.keys(value).length !== 2) {
     return null;
   }
-
   // Check if it has the required properties
   if (!('from' in value) || !('to' in value)) {
     return null;
   }
-
   const { from, to } = value;
   // Check if both properties are strings
   if (typeof from === 'string' && typeof to === 'string') {
     return { from, to };
   }
-
   return null;
 }
-
 function convertToISOString(value: DateTime | string): string {
   if (typeof value === 'string') {
     return value;
   }
-
   if (!value?.toISOString) {
-    throw console.error('Invalid DateTime object passed to convertToISOString');
+    throw structLog('error', 'Invalid DateTime object passed to convertToISOString');
   }
-
   return value.toISOString();
 }

--- a/public/app/core/navigation/errorModels.ts
+++ b/public/app/core/navigation/errorModels.ts
@@ -1,14 +1,12 @@
+import { structLog } from '@grafana/data';
 import { type NavModel, type NavModelItem } from '@grafana/data';
-
 export function getExceptionNav(error: unknown): NavModel {
-  console.error(error);
+  structLog('error', error);
   return getWarningNav('Exception thrown', 'See console for details');
 }
-
 export function getNotFoundNav(): NavModel {
   return getWarningNav('Page not found', '404 Error');
 }
-
 export function getWarningNav(text: string, subTitle?: string): NavModel {
   const node: NavModelItem = {
     text,

--- a/public/app/core/reducers/appNotification.ts
+++ b/public/app/core/reducers/appNotification.ts
@@ -1,17 +1,14 @@
+import { structLog } from '@grafana/data';
 import { createSelector, createSlice, type PayloadAction } from '@reduxjs/toolkit';
-
 import { type AppNotification, AppNotificationSeverity, type AppNotificationsState } from 'app/types/appNotifications';
-
 const MAX_STORED_NOTIFICATIONS = 25;
 export const STORAGE_KEY = 'notifications';
 export const NEW_NOTIFS_KEY = `${STORAGE_KEY}/lastRead`;
 type StoredNotification = Omit<AppNotification, 'component'>;
-
 export const initialState: AppNotificationsState = {
   byId: deserializeNotifications(),
   lastRead: Number.parseInt(window.localStorage.getItem(NEW_NOTIFS_KEY) ?? `${Date.now()}`, 10),
 };
-
 /**
  * Reducer and action to show toast notifications of various types (success, warnings, errors etc). Use to show
  * transient info to user, like errors that cannot be otherwise handled or success after an action.
@@ -26,7 +23,6 @@ const appNotificationsSlice = createSlice({
       if (Object.values(state.byId).some((alert) => isSimilar(newAlert, alert) && alert.showing)) {
         return;
       }
-
       state.byId[newAlert.id] = newAlert;
       serializeNotifications(state.byId);
     },
@@ -34,7 +30,6 @@ const appNotificationsSlice = createSlice({
       if (!(alertId in state.byId)) {
         return;
       }
-
       state.byId[alertId].showing = false;
       serializeNotifications(state.byId);
     },
@@ -51,14 +46,10 @@ const appNotificationsSlice = createSlice({
     },
   },
 });
-
 export const { notifyApp, hideAppNotification, clearNotification, clearAllNotifications, readAllNotifications } =
   appNotificationsSlice.actions;
-
 export const appNotificationsReducer = appNotificationsSlice.reducer;
-
 // Selectors
-
 export const selectLastReadTimestamp = (state: AppNotificationsState) => state.lastRead;
 export const selectById = (state: AppNotificationsState) => state.byId;
 export const selectAll = createSelector(selectById, (byId) =>
@@ -66,37 +57,28 @@ export const selectAll = createSelector(selectById, (byId) =>
 );
 export const selectWarningsAndErrors = createSelector(selectAll, (all) => all.filter(isAtLeastWarning));
 export const selectVisible = createSelector(selectById, (byId) => Object.values(byId).filter((n) => n.showing));
-
 // Helper functions
-
 function isSimilar(a: AppNotification, b: AppNotification): boolean {
   return a.icon === b.icon && a.severity === b.severity && a.text === b.text && a.title === b.title;
 }
-
 function isAtLeastWarning(notif: AppNotification) {
   return notif.severity === AppNotificationSeverity.Warning || notif.severity === AppNotificationSeverity.Error;
 }
-
 function isStoredNotification(obj: unknown): obj is StoredNotification {
   return typeof obj === 'object' && obj !== null && 'id' in obj && 'icon' in obj && 'title' in obj && 'text' in obj;
 }
-
 // (De)serialization
-
 export function deserializeNotifications(): Record<string, StoredNotification> {
   const storedNotifsRaw = window.localStorage.getItem(STORAGE_KEY);
   if (!storedNotifsRaw) {
     return {};
   }
-
   const parsed = JSON.parse(storedNotifsRaw);
   if (!Object.values(parsed).every((v) => isStoredNotification(v))) {
     return {};
   }
-
   return parsed;
 }
-
 function serializeNotifications(notifs: Record<string, StoredNotification>) {
   const reducedNotifs = Object.values(notifs)
     .filter(isAtLeastWarning)
@@ -115,14 +97,12 @@ function serializeNotifications(notifs: Record<string, StoredNotification>) {
         // https://github.com/grafana/grafana/issues/71932
         showing: false,
       };
-
       return prev;
     }, {});
-
   try {
     window.localStorage.setItem(STORAGE_KEY, JSON.stringify(reducedNotifs));
   } catch (err) {
-    console.error('Unable to persist notifications to local storage');
-    console.error(err);
+    structLog('error', 'Unable to persist notifications to local storage');
+    structLog('error', err);
   }
 }

--- a/public/app/core/services/FetchQueue.ts
+++ b/public/app/core/services/FetchQueue.ts
@@ -1,97 +1,85 @@
+import { structLog } from '@grafana/data';
 import { type Observable, Subject } from 'rxjs';
-
 import { type BackendSrvRequest } from '@grafana/runtime';
-
-export interface QueueState extends Record<string, { state: FetchStatus; options: BackendSrvRequest }> {}
-
+export interface QueueState
+  extends Record<
+    string,
+    {
+      state: FetchStatus;
+      options: BackendSrvRequest;
+    }
+  > {}
 export enum FetchStatus {
   Pending,
   InProgress,
   Done,
 }
-
 export interface FetchQueueUpdate {
   noOfInProgress: number;
   noOfPending: number;
   state: QueueState;
 }
-
 interface QueueStateEntry {
   id: string;
   options?: BackendSrvRequest;
   state: FetchStatus;
 }
-
 export class FetchQueue {
   private state: QueueState = {}; // internal queue state
   private queue: Subject<QueueStateEntry> = new Subject<QueueStateEntry>(); // internal stream for requests that are to be queued
   private updates: Subject<FetchQueueUpdate> = new Subject<FetchQueueUpdate>(); // external stream with updates to the queue state
-
   constructor(debug = false) {
     // This will create an implicit live subscription for as long as this class lives.
     // But as FetchQueue is used by the singleton backendSrv that also lives for as long as Grafana app lives
     // I think this ok. We could add some disposable pattern later if the need arises.
     this.queue.subscribe((entry) => {
       const { id, state, options } = entry;
-
       if (!this.state[id]) {
         this.state[id] = { state: FetchStatus.Pending, options: { url: '' } };
       }
-
       if (state === FetchStatus.Done) {
         delete this.state[id];
         const update = this.getUpdate(this.state);
         this.publishUpdate(update, debug);
         return;
       }
-
       this.state[id].state = state;
-
       if (options) {
         this.state[id].options = options;
       }
-
       const update = this.getUpdate(this.state);
       this.publishUpdate(update, debug);
     });
   }
-
   add = (id: string, options: BackendSrvRequest): void => this.queue.next({ id, options, state: FetchStatus.Pending });
-
   setInProgress = (id: string): void => this.queue.next({ id, state: FetchStatus.InProgress });
-
   setDone = (id: string): void => this.queue.next({ id, state: FetchStatus.Done });
-
   getUpdates = (): Observable<FetchQueueUpdate> => this.updates.asObservable();
-
   private getUpdate = (state: QueueState): FetchQueueUpdate => {
     const noOfInProgress = Object.keys(state).filter((key) => state[key].state === FetchStatus.InProgress).length;
     const noOfPending = Object.keys(state).filter((key) => state[key].state === FetchStatus.Pending).length;
-
     return { noOfPending, noOfInProgress, state };
   };
-
   private publishUpdate = (update: FetchQueueUpdate, debug: boolean): void => {
     this.printState(update, debug);
     this.updates.next(update);
   };
-
   private printState = (update: FetchQueueUpdate, debug: boolean): void => {
     if (!debug) {
       return;
     }
-
-    const entriesWithoutOptions = Object.keys(update.state).reduce<Array<{ id: string; state: FetchStatus }>>(
-      (all, key) => {
-        const entry = { id: key, state: update.state[key].state };
-        all.push(entry);
-        return all;
-      },
-      []
-    );
-
-    console.log('FetchQueue noOfStarted', update.noOfInProgress);
-    console.log('FetchQueue noOfNotStarted', update.noOfPending);
-    console.log('FetchQueue state', entriesWithoutOptions);
+    const entriesWithoutOptions = Object.keys(update.state).reduce<
+      Array<{
+        id: string;
+        state: FetchStatus;
+      }>
+    >((all, key) => {
+      const entry = { id: key, state: update.state[key].state };
+      all.push(entry);
+      return all;
+    }, []);
+    structLog('log', 'FetchQueue noOfStarted', update.noOfInProgress);
+    structLog('log', 'FetchQueue noOfNotStarted', update.noOfPending);
+    structLog('log', 'FetchQueue state', entriesWithoutOptions);
   };
 }

--- a/public/app/core/services/backend_srv.ts
+++ b/public/app/core/services/backend_srv.ts
@@ -1,3 +1,4 @@
+import { structLog } from '@grafana/data';
 import FingerprintJS from '@fingerprintjs/fingerprintjs';
 import {
   from,
@@ -25,7 +26,6 @@ import {
   throwIfEmpty,
 } from 'rxjs/operators';
 import { v4 as uuidv4 } from 'uuid';
-
 import { AppEvents, DataQueryErrorType, deprecationWarning } from '@grafana/data';
 import {
   type BackendSrv as BackendService,
@@ -43,36 +43,28 @@ import { type DashboardSearchItem } from 'app/features/search/types';
 import { TokenRevokedModal } from 'app/features/users/TokenRevokedModal';
 import { type DashboardDTO } from 'app/types/dashboard';
 import { type FolderDTO } from 'app/types/folders';
-
 import { ShowModalReactEvent } from '../../types/events';
 import { isContentTypeJson, parseInitFromOptions, parseResponseBody, parseUrlFromOptions } from '../utils/fetch';
 import { isDataQuery, isLocalUrl } from '../utils/query';
-
 import { FetchQueue } from './FetchQueue';
 import { FetchQueueWorker } from './FetchQueueWorker';
 import { ResponseQueue } from './ResponseQueue';
 import { type ContextSrv, contextSrv } from './context_srv';
-
 const CANCEL_ALL_REQUESTS_REQUEST_ID = 'cancel_all_requests_request_id';
-
 export interface BackendSrvDependencies {
   fromFetch: (input: string | Request, init?: RequestInit) => Observable<Response>;
   appEvents: typeof appEvents;
   contextSrv: ContextSrv;
   logout: () => void;
 }
-
 export interface FolderRequestOptions {
   withAccessControl?: boolean;
 }
-
 const GRAFANA_TRACEID_HEADER = 'grafana-trace-id';
-
 export interface InspectorStream {
   response: FetchResponse | FetchError;
   requestId?: string;
 }
-
 export class BackendSrv implements BackendService {
   private inFlightRequests: Subject<string> = new Subject<string>();
   private HTTP_REQUEST_CANCELED = -1;
@@ -82,7 +74,6 @@ export class BackendSrv implements BackendService {
   private readonly responseQueue: ResponseQueue;
   private _tokenRotationInProgress?: Observable<FetchResponse> | null = null;
   private deviceID?: string | null = null;
-
   private dependencies: BackendSrvDependencies = {
     fromFetch: fromFetch,
     appEvents: appEvents,
@@ -91,7 +82,6 @@ export class BackendSrv implements BackendService {
       contextSrv.setLoggedOut();
     },
   };
-
   constructor(deps?: BackendSrvDependencies) {
     if (deps) {
       this.dependencies = {
@@ -99,41 +89,33 @@ export class BackendSrv implements BackendService {
         ...deps,
       };
     }
-
     this.noBackendCache = false;
     this.internalFetch = this.internalFetch.bind(this);
     this.fetchQueue = new FetchQueue();
     this.responseQueue = new ResponseQueue(this.fetchQueue, this.internalFetch);
-
     this.initGrafanaDeviceID();
-
     new FetchQueueWorker(this.fetchQueue, this.responseQueue, getConfig());
   }
-
   private async initGrafanaDeviceID() {
     try {
       const fp = await FingerprintJS.load();
       const result = await fp.get();
       this.deviceID = result.visitorId;
     } catch (error) {
-      console.error(error);
+      structLog('error', error);
     }
   }
-
   async request<T = unknown>(options: BackendSrvRequest): Promise<T> {
     return await lastValueFrom(this.fetch<T>(options).pipe(map((response: FetchResponse<T>) => response.data)));
   }
-
   fetch<T>(options: BackendSrvRequest): Observable<FetchResponse<T>> {
     // We need to match an entry added to the queue stream with the entry that is eventually added to the response stream
     const id = uuidv4();
     const fetchQueue = this.fetchQueue;
-
     return new Observable((observer) => {
       // Subscription is an object that is returned whenever you subscribe to an Observable.
       // You can also use it as a container of many subscriptions and when it is unsubscribed all subscriptions within are also unsubscribed.
       const subscriptions: Subscription = new Subscription();
-
       // We're using the subscriptions.add function to add the subscription implicitly returned by this.responseQueue.getResponses<T>(id).subscribe below.
       subscriptions.add(
         this.responseQueue.getResponses<T>(id).subscribe((result) => {
@@ -144,46 +126,37 @@ export class BackendSrv implements BackendService {
           subscriptions.add(result.observable.subscribe(observer));
         })
       );
-
       // Let the fetchQueue know that this id needs to start data fetching.
       this.fetchQueue.add(id, options);
-
       // This returned function will be called whenever the returned Observable from the fetch<T> function is unsubscribed/errored/completed/canceled.
       return function unsubscribe() {
         // Change status to Done moved here from ResponseQueue because this unsubscribe was called before the responseQueue produced a result
         fetchQueue.setDone(id);
-
         // When subscriptions is unsubscribed all the implicitly added subscriptions above are also unsubscribed.
         subscriptions.unsubscribe();
       };
     });
   }
-
   chunkRequestId = 1;
-
   chunked(options: BackendSrvRequest): Observable<FetchResponse<Uint8Array | undefined>> {
     const requestId = options.requestId ?? `chunked-${this.chunkRequestId++}`;
     const controller = new AbortController();
-
     const init = parseInitFromOptions({
       ...options,
       requestId,
       abortSignal: controller.signal,
     });
-
     return new Observable((observer) => {
       // Calling fromFetch explicitly avoids the request queue
       const sub = parseUrlFromOptions(options)
         .pipe(mergeMap((url) => this.dependencies.fromFetch(url, init)))
         .subscribe(this.getChunkedResponseObserver({ controller, observer, options, requestId }));
-
       return function unsubscribe() {
         controller.abort('unsubscribe');
         sub.unsubscribe();
       };
     });
   }
-
   private getChunkedResponseObserver({
     controller,
     observer,
@@ -210,20 +183,16 @@ export class BackendSrv implements BackendService {
           traceId: response.headers.get(GRAFANA_TRACEID_HEADER) ?? undefined,
           data: undefined,
         };
-
         if (!response.body) {
           observer.next(rsp);
           observer.complete();
           return;
         }
-
         const reader = response.body.getReader();
-
         // Setup onabort callback so that we can cancel the reader properly
         controller.signal.onabort = () => {
           reader.cancel(controller.signal.reason);
         };
-
         async function process() {
           while (reader && !done) {
             const chunk = await reader.read();
@@ -241,7 +210,7 @@ export class BackendSrv implements BackendService {
             observer.complete();
           }) // runs in background
           .catch((e) => {
-            console.log(requestId, 'catch', e);
+            structLog('log', requestId, 'catch', e);
             observer.error(e);
           }); // from abort
       },
@@ -250,14 +219,11 @@ export class BackendSrv implements BackendService {
       },
     };
   }
-
   private internalFetch<T>(options: BackendSrvRequest): Observable<FetchResponse<T>> {
     if (options.requestId) {
       this.inFlightRequests.next(options.requestId);
     }
-
     options = this.parseRequestOptions(options);
-
     const token = loadUrlToken();
     if (token !== null && token !== '') {
       if (config.jwtUrlLogin && config.jwtHeaderName) {
@@ -265,12 +231,10 @@ export class BackendSrv implements BackendService {
         options.headers[config.jwtHeaderName] = `${token}`;
       }
     }
-
     if (!!this.deviceID) {
       options.headers = options.headers ?? {};
       options.headers['X-Grafana-Device-Id'] = `${this.deviceID}`;
     }
-
     return parseUrlFromOptions(options).pipe(
       this.getFromFetchStream<T>(options),
       this.handleStreamResponse<T>(options),
@@ -278,66 +242,51 @@ export class BackendSrv implements BackendService {
       this.handleStreamCancellation(options)
     );
   }
-
   resolveCancelerIfExists(requestId: string) {
     this.inFlightRequests.next(requestId);
   }
-
   cancelAllInFlightRequests() {
     this.inFlightRequests.next(CANCEL_ALL_REQUESTS_REQUEST_ID);
   }
-
   async datasourceRequest<T = unknown>(options: BackendSrvRequest) {
     return lastValueFrom(this.fetch<T>(options));
   }
-
   private parseRequestOptions(options: BackendSrvRequest): BackendSrvRequest {
     const orgId = this.dependencies.contextSrv.user?.orgId;
-
     // init retry counter
     options.retry = options.retry ?? 0;
-
     if (isLocalUrl(options.url)) {
       if (orgId) {
         options.headers = options.headers ?? {};
         options.headers['X-Grafana-Org-Id'] = orgId;
       }
-
       if (options.url.startsWith('/')) {
         options.url = options.url.substring(1);
       }
-
       if (options.headers?.Authorization) {
         options.headers['X-DS-Authorization'] = options.headers.Authorization;
         delete options.headers.Authorization;
       }
-
       if (this.noBackendCache) {
         options.headers = options.headers ?? {};
         options.headers['X-Grafana-NoCache'] = 'true';
       }
     }
-
     if (options.hideFromInspector === undefined) {
       // Hide all local non data query calls
       options.hideFromInspector = isLocalUrl(options.url) && !isDataQuery(options.url);
     }
-
     return options;
   }
-
   private getFromFetchStream<T>(options: BackendSrvRequest): OperatorFunction<string, FetchResponse<T>> {
     return (inputStream) =>
       inputStream.pipe(
         mergeMap((url) => {
           const init = parseInitFromOptions(options);
-
           return this.dependencies.fromFetch(url, init).pipe(
             mergeMap(async (response) => {
               const { status, statusText, ok, headers, url, type, redirected } = response;
-
               const responseType = options.responseType ?? (isContentTypeJson(headers) ? 'json' : undefined);
-
               const data = await parseResponseBody<T>(response, responseType);
               const fetchResponse: FetchResponse<T> = {
                 status,
@@ -357,16 +306,12 @@ export class BackendSrv implements BackendService {
         })
       );
   }
-
   showApplicationErrorAlert(err: FetchError) {}
-
   showSuccessAlert<T>(response: FetchResponse<T>) {
     const { config } = response;
-
     if (config.showSuccessAlert === false) {
       return;
     }
-
     // if showSuccessAlert is undefined we only show alerts non GET request, non data query and local api requests
     if (
       config.showSuccessAlert === undefined &&
@@ -374,14 +319,13 @@ export class BackendSrv implements BackendService {
     ) {
       return;
     }
-
-    const data: { message: string } = response.data as any;
-
+    const data: {
+      message: string;
+    } = response.data as any;
     if (data?.message) {
       this.dependencies.appEvents.emit(AppEvents.alertSuccess, [data.message]);
     }
   }
-
   showErrorAlert(config: BackendSrvRequest, err: FetchError) {
     // do not show non-user error alerts for api keys or render tokens, they are used for kiosk mode and reporting and can't react to error pop-ups
     if (
@@ -392,50 +336,47 @@ export class BackendSrv implements BackendService {
     ) {
       return;
     }
-
     if (config.showErrorAlert === false) {
       return;
     }
-
     // is showErrorAlert is undefined we only show alerts non data query and local api requests
     if (config.showErrorAlert === undefined && (isDataQuery(config.url) || !isLocalUrl(config.url))) {
       return;
     }
-
     let description = '';
     let message = err.data.message;
-
     // Sometimes we have a better error message on err.message
     if (message === 'Unexpected error' && err.message) {
       message = err.message;
     }
-
     if (message.length > 80) {
       description = message;
       message = 'Error';
     }
-
     // Validation
     if (err.status === 422) {
       description = err.data.message;
       message = 'Validation failed';
     }
-
     this.dependencies.appEvents.emit(err.status < 500 ? AppEvents.alertWarning : AppEvents.alertError, [
       message,
       description,
       err.data.traceID,
     ]);
   }
-
   /**
    * Processes FetchError to ensure "data" property is an object.
    *
    * @see DataQueryError.data
    */
-  processRequestError(options: BackendSrvRequest, err: FetchError): FetchError<{ message: string; error?: string }> {
+  processRequestError(
+    options: BackendSrvRequest,
+    err: FetchError
+  ): FetchError<{
+    message: string;
+    error?: string;
+  }> {
     err.data = err.data ?? { message: 'Unexpected error' };
-
     if (typeof err.data === 'string') {
       const message = isHtmlResponse(err.data) ? `${err.status} ${err.statusText ?? 'Error'}` : err.data;
       err.data = {
@@ -444,12 +385,10 @@ export class BackendSrv implements BackendService {
         response: err.data,
       };
     }
-
     // If no message but got error string, copy to message prop
     if (err.data && !err.data.message && typeof err.data.error === 'string') {
       err.data.message = err.data.error;
     }
-
     // check if we should show an error alert
     if (err.data.message) {
       setTimeout(() => {
@@ -458,11 +397,9 @@ export class BackendSrv implements BackendService {
         }
       }, 50);
     }
-
     this.inspectorStream.next({ response: err, requestId: options.requestId });
     return err;
   }
-
   private handleStreamResponse<T>(options: BackendSrvRequest): MonoTypeOperatorFunction<FetchResponse<T>> {
     return (inputStream) =>
       inputStream.pipe(
@@ -486,17 +423,14 @@ export class BackendSrv implements BackendService {
         })
       );
   }
-
   private handleStreamError<T>(options: BackendSrvRequest): MonoTypeOperatorFunction<FetchResponse<T>> {
     const { isSignedIn } = this.dependencies.contextSrv.user;
-
     return (inputStream) =>
       inputStream.pipe(
         retryWhen((attempts) =>
           attempts.pipe(
             mergeMap((error, i) => {
               const firstAttempt = i === 0 && options.retry === 0;
-
               if (error.status === 401 && isLocalUrl(options.url) && firstAttempt && isSignedIn) {
                 if (error.data?.error?.id === 'ERR_TOKEN_REVOKED') {
                   this.dependencies.appEvents.publish(
@@ -510,7 +444,6 @@ export class BackendSrv implements BackendService {
                   this.dependencies.contextSrv.setRedirectToUrl();
                   return throwError(() => error);
                 }
-
                 let authChecker = this.loginPing();
                 if (hasSessionExpiry()) {
                   const expired = getSessionExpiry() * 1000 < Date.now();
@@ -518,7 +451,6 @@ export class BackendSrv implements BackendService {
                     authChecker = this.rotateToken();
                   }
                 }
-
                 return from(authChecker).pipe(
                   catchError((err) => {
                     if (err.status === 401) {
@@ -529,7 +461,6 @@ export class BackendSrv implements BackendService {
                   })
                 );
               }
-
               return throwError(error);
             })
           )
@@ -537,7 +468,6 @@ export class BackendSrv implements BackendService {
         catchError((err: FetchError) => throwError(() => this.processRequestError(options, err)))
       );
   }
-
   private handleStreamCancellation(options: BackendSrvRequest): MonoTypeOperatorFunction<FetchResponse> {
     return (inputStream) =>
       inputStream.pipe(
@@ -545,18 +475,15 @@ export class BackendSrv implements BackendService {
           this.inFlightRequests.pipe(
             filter((requestId) => {
               let cancelRequest = false;
-
               if (options && options.requestId && options.requestId === requestId) {
                 // when a new requestId is started it will be published to inFlightRequests
                 // if a previous long running request that hasn't finished yet has the same requestId
                 // we need to cancel that request
                 cancelRequest = true;
               }
-
               if (requestId === CANCEL_ALL_REQUESTS_REQUEST_ID) {
                 cancelRequest = true;
               }
-
               return cancelRequest;
             })
           )
@@ -573,11 +500,9 @@ export class BackendSrv implements BackendService {
         }))
       );
   }
-
   getInspectorStream(): Observable<InspectorStream> {
     return this.inspectorStream;
   }
-
   async get<T = any>(
     url: string,
     params?: BackendSrvRequest['params'],
@@ -586,54 +511,43 @@ export class BackendSrv implements BackendService {
   ) {
     return this.request<T>({ ...options, method: 'GET', url, params, requestId });
   }
-
   async delete<T = unknown>(url: string, data?: unknown, options?: Partial<BackendSrvRequest>) {
     return this.request<T>({ ...options, method: 'DELETE', url, data });
   }
-
   async post<T = any>(url: string, data?: unknown, options?: Partial<BackendSrvRequest>) {
     return this.request<T>({ ...options, method: 'POST', url, data });
   }
-
   async patch<T = any>(url: string, data: unknown, options?: Partial<BackendSrvRequest>) {
     return this.request<T>({ ...options, method: 'PATCH', url, data });
   }
-
   async put<T = any>(url: string, data: unknown, options?: Partial<BackendSrvRequest>): Promise<T> {
     return this.request<T>({ ...options, method: 'PUT', url, data });
   }
-
   withNoBackendCache(callback: () => Promise<void>) {
     this.noBackendCache = true;
     return callback().finally(() => {
       this.noBackendCache = false;
     });
   }
-
   rotateToken() {
     if (this._tokenRotationInProgress) {
       return this._tokenRotationInProgress;
     }
-
     this._tokenRotationInProgress = this.fetch({ url: '/api/user/auth-tokens/rotate', method: 'POST', retry: 1 }).pipe(
       finalize(() => {
         this._tokenRotationInProgress = null;
       }),
       share()
     );
-
     return this._tokenRotationInProgress;
   }
-
   loginPing() {
     return this.fetch({ url: '/api/login/ping', method: 'GET', retry: 1 });
   }
-
   /** @deprecated */
   search(query: Parameters<typeof this.get>[1]): Promise<DashboardSearchItem[]> {
     return this.get('/api/search', query);
   }
-
   /** @deprecated */
   getDashboardByUid(uid: string): Promise<DashboardDTO> {
     // NOTE: When this is removed, we can also remove most instances of:
@@ -641,11 +555,9 @@ export class BackendSrv implements BackendService {
     deprecationWarning('backend_srv', 'getDashboardByUid(uid)', 'getDashboardAPI().getDashboardDTO(uid)');
     return getDashboardAPI('v1').then((api) => api.getDashboardDTO(uid));
   }
-
   getPublicDashboardByUid(uid: string) {
     return this.get<DashboardDTO>(`/api/public/dashboards/${uid}`);
   }
-
   /**
    * @deprecated Use getFolderByUidFacade from app/api/clients/folder/v1beta1/hooks instead
    * or manually handle calling legacy vs app platform API based on feature toggles
@@ -656,18 +568,15 @@ export class BackendSrv implements BackendService {
     if (options.withAccessControl) {
       queryParams.set('accesscontrol', 'true');
     }
-
     return this.get<FolderDTO>(`/api/folders/${uid}?${queryParams.toString()}`, undefined, undefined, {
       showErrorAlert: false,
     });
   }
 }
-
 function isHtmlResponse(value: string): boolean {
   const trimmed = value.trimStart().toLowerCase();
   return trimmed.startsWith('<!doctype') || trimmed.startsWith('<html');
 }
-
 // Used for testing and things that really need BackendSrv
 export const backendSrv = new BackendSrv();
 export const getBackendSrv = (): BackendSrv => backendSrv;

--- a/public/app/core/services/context_srv.ts
+++ b/public/app/core/services/context_srv.ts
@@ -1,5 +1,5 @@
+import { structLog } from '@grafana/data';
 import { extend } from 'lodash';
-
 import {
   type AnalyticsSettings,
   type OrgRole,
@@ -13,14 +13,11 @@ import { featureEnabled, getBackendSrv } from '@grafana/runtime';
 import { getSessionExpiry } from 'app/core/utils/auth';
 import { type UserPermission, AccessControlAction } from 'app/types/accessControl';
 import { type CurrentUserInternal } from 'app/types/config';
-
 import config from '../../core/config';
-
 // When set to auto, the interval will be based on the query range
 // NOTE: this is defined here rather than TimeSrv so we avoid circular dependencies
 export const AutoRefreshInterval = 'auto';
 export const RedirectToUrlKey = 'redirectTo';
-
 export class User implements Omit<CurrentUserInternal, 'lightTheme'> {
   isSignedIn: boolean;
   id: number;
@@ -46,7 +43,6 @@ export class User implements Omit<CurrentUserInternal, 'lightTheme'> {
   analytics: AnalyticsSettings;
   fiscalYearStartMonth: number;
   authenticatedBy: string;
-
   constructor() {
     this.id = 0;
     this.uid = '';
@@ -73,13 +69,11 @@ export class User implements Omit<CurrentUserInternal, 'lightTheme'> {
       identifier: '',
     };
     this.authenticatedBy = '';
-
     if (config.bootData.user) {
       extend(this, config.bootData.user);
     }
   }
 }
-
 export class ContextSrv {
   user: User;
   isSignedIn: boolean;
@@ -88,34 +82,28 @@ export class ContextSrv {
   sidemenuSmallBreakpoint = false;
   hasEditPermissionInFolders: boolean;
   minRefreshInterval: string;
-
   private tokenRotationJobId = 0;
-
   constructor() {
     if (!config.bootData) {
       config.bootData = { user: {}, settings: {}, navTree: [] } as any;
     }
-
     this.user = new User();
     this.isSignedIn = this.user.isSignedIn;
     this.isGrafanaAdmin = this.user.isGrafanaAdmin;
     this.isEditor = this.hasRole('Editor') || this.hasRole('Admin');
     this.hasEditPermissionInFolders = this.user.hasEditPermissionInFolders;
     this.minRefreshInterval = config.minRefreshInterval;
-
     this.scheduleTokenRotationJob();
   }
-
   async fetchUserPermissions() {
     try {
       this.user.permissions = await getBackendSrv().get('/api/access-control/user/actions', {
         reloadcache: true,
       });
     } catch (e) {
-      console.error(e);
+      structLog('error', e);
     }
   }
-
   /**
    * Indicate the user has been logged out
    */
@@ -126,7 +114,6 @@ export class ContextSrv {
     this.isSignedIn = false;
     window.location.reload();
   }
-
   setRedirectToUrl() {
     if (config.featureToggles.useSessionStorageForRedirection) {
       window.sessionStorage.setItem(
@@ -135,7 +122,6 @@ export class ContextSrv {
       );
     }
   }
-
   hasRole(role: string) {
     if (role === 'ServerAdmin') {
       return this.isGrafanaAdmin;
@@ -143,25 +129,20 @@ export class ContextSrv {
       return this.user.orgRole === role;
     }
   }
-
   licensedAccessControlEnabled(): boolean {
     return featureEnabled('accesscontrol');
   }
-
   // Checks whether user has required permission
   hasPermissionInMetadata(action: AccessControlAction | string, object: WithAccessControlMetadata): boolean {
     return userHasPermissionInMetadata(action, object);
   }
-
   // Checks whether user has required permission
   hasPermission(action: AccessControlAction | string): boolean {
     return userHasPermission(action, this.user);
   }
-
   isGrafanaVisible() {
     return document.visibilityState === undefined || document.visibilityState === 'visible';
   }
-
   // checks whether the passed interval is longer than the configured minimum refresh rate
   isAllowedInterval(interval: string) {
     if (!config.minRefreshInterval || interval === AutoRefreshInterval) {
@@ -169,25 +150,21 @@ export class ContextSrv {
     }
     return rangeUtil.intervalToMs(interval) >= rangeUtil.intervalToMs(config.minRefreshInterval);
   }
-
   getValidInterval(interval: string) {
     if (!this.isAllowedInterval(interval)) {
       return config.minRefreshInterval;
     }
     return interval;
   }
-
   getValidIntervals(intervals: string[]): string[] {
     if (this.minRefreshInterval) {
       return intervals.filter((str) => str !== '').filter(this.isAllowedInterval);
     }
     return intervals;
   }
-
   hasAccessToExplore() {
     return this.hasPermission(AccessControlAction.DataSourcesExplore) && config.exploreEnabled;
   }
-
   // evaluates access control permissions, granting access if the user has any of them
   evaluatePermission(actions: string[]) {
     if (userHasAnyPermission(actions, this.user)) {
@@ -196,18 +173,15 @@ export class ContextSrv {
     // Hack to reject when user does not have permission
     return ['Reject'];
   }
-
   // schedules a job to perform token ration in the background
   private scheduleTokenRotationJob() {
     // check if we can schedula the token rotation job
     if (this.canScheduleRotation()) {
       // get the time token is going to expire
       let expires = getSessionExpiry();
-
       // because this job is scheduled for every tab we have open that shares a session we try
       // to distribute the scheduling of the job. For now this can be between 1 and 20 seconds
       const expiresWithDistribution = expires - Math.floor(Math.random() * (20 - 1) + 1);
-
       // nextRun is when the job should be scheduled for in ms. setTimeout ms has a max value of 2147483647.
       let nextRun = Math.min(expiresWithDistribution * 1000 - Date.now(), 2147483647);
       // @ts-ignore
@@ -222,13 +196,11 @@ export class ContextSrv {
       }, nextRun);
     }
   }
-
   private canScheduleRotation() {
     // skip if user is not signed in, this happens on login page or when using anonymous auth
     if (!this.isSignedIn) {
       return false;
     }
-
     // skip if there is no session to rotate
     // if a user has a session but not yet a session expiry cookie, can happen during upgrade
     // from an older version of grafana, we never schedule the job and the fallback logic
@@ -237,16 +209,13 @@ export class ContextSrv {
     if (getSessionExpiry() === 0) {
       return false;
     }
-
     return true;
   }
-
   private cancelTokenRotationJob() {
     if (this.tokenRotationJobId > 0) {
       clearTimeout(this.tokenRotationJobId);
     }
   }
-
   private rotateToken() {
     // We directly use fetch here to bypass the request queue from backendSvc
     return fetch(config.appSubUrl + '/api/user/auth-tokens/rotate', { method: 'POST' })
@@ -255,21 +224,18 @@ export class ContextSrv {
           this.scheduleTokenRotationJob();
           return;
         }
-
         if (res.status === 401) {
           this.setLoggedOut();
           return;
         }
       })
       .catch((e) => {
-        console.error(e);
+        structLog('error', e);
       });
   }
 }
-
 let contextSrv = new ContextSrv();
 export { contextSrv };
-
 export const setContextSrv = (override: ContextSrv) => {
   if (process.env.NODE_ENV !== 'test') {
     throw new Error('contextSrv can be only overridden in test environment');

--- a/public/app/core/services/echo/backends/analytics/BrowseConsoleBackend.ts
+++ b/public/app/core/services/echo/backends/analytics/BrowseConsoleBackend.ts
@@ -1,3 +1,4 @@
+import { structLog } from '@grafana/data';
 /* eslint-disable no-console */
 import {
   type EchoBackend,
@@ -7,22 +8,17 @@ import {
   isPageviewEvent,
   type PageviewEchoEvent,
 } from '@grafana/runtime';
-
 export class BrowserConsoleBackend implements EchoBackend<PageviewEchoEvent, unknown> {
   options = {};
   supportedEvents = [EchoEventType.Pageview, EchoEventType.Interaction, EchoEventType.ExperimentView];
-
   constructor() {}
-
   addEvent = (e: PageviewEchoEvent) => {
     if (isPageviewEvent(e)) {
-      console.log('[EchoSrv:pageview]', e.payload.page);
+      structLog('log', '[EchoSrv:pageview]', e.payload.page);
     }
-
     if (isInteractionEvent(e)) {
       const eventName = e.payload.interactionName;
-      console.log('[EchoSrv:event]', eventName, e.payload.properties);
-
+      structLog('log', '[EchoSrv:event]', eventName, e.payload.properties);
       // Warn for non-scalar property values. We're not yet making this a hard a
       const invalidTypeProperties = Object.entries(e.payload.properties ?? {}).filter(([_, value]) => {
         const valueType = typeof value;
@@ -30,9 +26,9 @@ export class BrowserConsoleBackend implements EchoBackend<PageviewEchoEvent, unk
           valueType === 'string' || valueType === 'number' || valueType === 'boolean' || valueType === 'undefined';
         return !isValidType;
       });
-
       if (invalidTypeProperties.length > 0) {
-        console.warn(
+        structLog(
+          'warn',
           'Event',
           eventName,
           'has invalid property types. Event properties should only be string, number or boolean. Invalid properties:',
@@ -40,11 +36,9 @@ export class BrowserConsoleBackend implements EchoBackend<PageviewEchoEvent, unk
         );
       }
     }
-
     if (isExperimentViewEvent(e)) {
-      console.log('[EchoSrv:experiment]', e.payload);
+      structLog('log', '[EchoSrv:experiment]', e.payload);
     }
   };
-
   flush = () => {};
 }

--- a/public/app/core/services/echo/init.ts
+++ b/public/app/core/services/echo/init.ts
@@ -1,20 +1,16 @@
+import { structLog } from '@grafana/data';
 import { config, registerEchoBackend, setEchoSrv } from '@grafana/runtime';
 import { reportMetricPerformanceMark } from 'app/core/utils/metrics';
-
 import { contextSrv } from '../context_srv';
-
 import { Echo } from './Echo';
-
 // Initialise EchoSrv backends, calls during frontend app startup
 export async function initEchoSrv() {
   setEchoSrv(new Echo({ debug: process.env.NODE_ENV === 'development' }));
-
   window.addEventListener('load', (e) => {
     const loadMetricName = 'frontend_boot_load_time_seconds';
     // Metrics below are marked in public/views/index.html
     const jsLoadMetricName = 'frontend_boot_js_done_time_seconds';
     const cssLoadMetricName = 'frontend_boot_css_time_seconds';
-
     if (performance) {
       performance.mark(loadMetricName);
       reportMetricPerformanceMark('first-paint', 'frontend_boot_', '_time_seconds');
@@ -24,64 +20,53 @@ export async function initEchoSrv() {
       reportMetricPerformanceMark(cssLoadMetricName);
     }
   });
-
   try {
     await initPerformanceBackend();
   } catch (error) {
-    console.error('Error initializing EchoSrv Performance backend', error);
+    structLog('error', 'Error initializing EchoSrv Performance backend', error);
   }
-
   try {
     await initFaroBackend();
   } catch (error) {
-    console.error('Error initializing EchoSrv Faro backend', error);
+    structLog('error', 'Error initializing EchoSrv Faro backend', error);
   }
-
   try {
     await initGoogleAnalyticsBackend();
   } catch (error) {
-    console.error('Error initializing EchoSrv GoogleAnalytics backend', error);
+    structLog('error', 'Error initializing EchoSrv GoogleAnalytics backend', error);
   }
-
   try {
     await initGoogleAnalaytics4Backend();
   } catch (error) {
-    console.error('Error initializing EchoSrv GoogleAnalaytics4 backend', error);
+    structLog('error', 'Error initializing EchoSrv GoogleAnalaytics4 backend', error);
   }
-
   try {
     await initRudderstackBackend();
   } catch (error) {
-    console.error('Error initializing EchoSrv Rudderstack backend', error);
+    structLog('error', 'Error initializing EchoSrv Rudderstack backend', error);
   }
-
   try {
     await initAzureAppInsightsBackend();
   } catch (error) {
-    console.error('Error initializing EchoSrv AzureAppInsights backend', error);
+    structLog('error', 'Error initializing EchoSrv AzureAppInsights backend', error);
   }
-
   try {
     await initConsoleBackend();
   } catch (error) {
-    console.error('Error initializing EchoSrv Console backend', error);
+    structLog('error', 'Error initializing EchoSrv Console backend', error);
   }
 }
-
 async function initPerformanceBackend() {
   if (contextSrv.user.orgRole === '') {
     return;
   }
-
   const { PerformanceBackend } = await import('./backends/PerformanceBackend');
   registerEchoBackend(new PerformanceBackend({}));
 }
-
 async function initFaroBackend() {
   if (!config.grafanaJavascriptAgent.enabled) {
     return;
   }
-
   // Ignore Rudderstack URLs
   const rudderstackUrls = [
     config.rudderstackConfigUrl,
@@ -90,17 +75,14 @@ async function initFaroBackend() {
   ]
     .filter(Boolean)
     .map((url) => new RegExp(`${url}.*.`));
-
   const { GrafanaJavascriptAgentBackend } = await import(
     './backends/grafana-javascript-agent/GrafanaJavascriptAgentBackend'
   );
-
   registerEchoBackend(
     new GrafanaJavascriptAgentBackend({
       buildInfo: config.buildInfo,
       userIdentifier: contextSrv.user.analytics.identifier,
       ignoreUrls: rudderstackUrls,
-
       apiKey: config.grafanaJavascriptAgent.apiKey,
       customEndpoint: config.grafanaJavascriptAgent.customEndpoint,
       consoleInstrumentalizationEnabled: config.grafanaJavascriptAgent.consoleInstrumentalizationEnabled,
@@ -112,12 +94,10 @@ async function initFaroBackend() {
     })
   );
 }
-
 async function initGoogleAnalyticsBackend() {
   if (!config.googleAnalyticsId) {
     return;
   }
-
   const { GAEchoBackend } = await import('./backends/analytics/GABackend');
   registerEchoBackend(
     new GAEchoBackend({
@@ -125,12 +105,10 @@ async function initGoogleAnalyticsBackend() {
     })
   );
 }
-
 async function initGoogleAnalaytics4Backend() {
   if (!config.googleAnalytics4Id) {
     return;
   }
-
   const { GA4EchoBackend } = await import('./backends/analytics/GA4Backend');
   registerEchoBackend(
     new GA4EchoBackend({
@@ -139,26 +117,20 @@ async function initGoogleAnalaytics4Backend() {
     })
   );
 }
-
 async function initRudderstackBackend() {
   if (!(config.rudderstackWriteKey && config.rudderstackDataPlaneUrl)) {
     return;
   }
-
   // Logic: if only one of the sdk urls is provided, use respective code
   // otherwise defer to the feature toggle.
-
   const hasOldSdkUrl = Boolean(config.rudderstackSdkUrl);
   const hasNewSdkUrl = Boolean(config.rudderstackV3SdkUrl);
   const onlyOneSdkUrlSet = hasOldSdkUrl !== hasNewSdkUrl;
   const useNewRudderstack = onlyOneSdkUrlSet ? hasNewSdkUrl : config.featureToggles.rudderstackUpgrade;
-
   const sdkUrl = useNewRudderstack ? config.rudderstackV3SdkUrl : config.rudderstackSdkUrl;
-
   const modulePromise = useNewRudderstack
     ? import('./backends/analytics/RudderstackV3Backend')
     : import('./backends/analytics/RudderstackBackend');
-
   const { RudderstackBackend } = await modulePromise;
   registerEchoBackend(
     new RudderstackBackend({
@@ -172,12 +144,10 @@ async function initRudderstackBackend() {
     })
   );
 }
-
 async function initAzureAppInsightsBackend() {
   if (!config.applicationInsightsConnectionString) {
     return;
   }
-
   const { ApplicationInsightsBackend } = await import('./backends/analytics/ApplicationInsightsBackend');
   registerEchoBackend(
     new ApplicationInsightsBackend({
@@ -187,12 +157,10 @@ async function initAzureAppInsightsBackend() {
     })
   );
 }
-
 async function initConsoleBackend() {
   if (!config.analyticsConsoleReporting) {
     return;
   }
-
   const { BrowserConsoleBackend } = await import('./backends/analytics/BrowseConsoleBackend');
   registerEchoBackend(new BrowserConsoleBackend());
 }

--- a/public/app/core/trustedTypePolicies.ts
+++ b/public/app/core/trustedTypePolicies.ts
@@ -1,14 +1,13 @@
+import { structLog } from '@grafana/data';
 import { textUtil } from '@grafana/data';
 import { config } from '@grafana/runtime';
-
 const CSP_REPORT_ONLY_ENABLED = config.cspReportOnlyEnabled;
-
 export const defaultTrustedTypesPolicy = {
   createHTML: (string: string, source: string, sink: string) => {
     if (!CSP_REPORT_ONLY_ENABLED) {
       return string.replace(/<script/gi, '&lt;script');
     }
-    console.error('[HTML not sanitized with Trusted Types]', string, source, sink);
+    structLog('error', '[HTML not sanitized with Trusted Types]', string, source, sink);
     return string;
   },
   createScript: (string: string) => string,
@@ -16,11 +15,10 @@ export const defaultTrustedTypesPolicy = {
     if (!CSP_REPORT_ONLY_ENABLED) {
       return textUtil.sanitizeUrl(string);
     }
-    console.error('[ScriptURL not sanitized with Trusted Types]', string, source, sink);
+    structLog('error', '[ScriptURL not sanitized with Trusted Types]', string, source, sink);
     return string;
   },
 };
-
 if (config.trustedTypesDefaultPolicyEnabled && window.trustedTypes && window.trustedTypes.createPolicy) {
   // check if browser supports Trusted Types
   window.trustedTypes.createPolicy('default', defaultTrustedTypesPolicy);

--- a/public/app/core/utils/dag.ts
+++ b/public/app/core/utils/dag.ts
@@ -1,110 +1,88 @@
+import { structLog } from '@grafana/data';
 export class Edge {
   inputNode?: Node;
   outputNode?: Node;
-
   _linkTo(node: Node, direction: number) {
     if (direction <= 0) {
       node.inputEdges.push(this);
     }
-
     if (direction >= 0) {
       node.outputEdges.push(this);
     }
-
     node.edges.push(this);
   }
-
   link(inputNode: Node, outputNode: Node) {
     if (!inputNode) {
       throw Error('inputNode is required');
     }
-
     if (!outputNode) {
       throw Error('outputNode is required');
     }
-
     this.unlink();
     this.inputNode = inputNode;
     this.outputNode = outputNode;
-
     this._linkTo(inputNode, 1);
     this._linkTo(outputNode, -1);
     return this;
   }
-
   unlink() {
     let pos;
     const inode = this.inputNode;
     const onode = this.outputNode;
-
     if (!(inode && onode)) {
       return;
     }
-
     pos = inode.edges.indexOf(this);
     if (pos > -1) {
       inode.edges.splice(pos, 1);
     }
-
     pos = onode.edges.indexOf(this);
     if (pos > -1) {
       onode.edges.splice(pos, 1);
     }
-
     pos = inode.outputEdges.indexOf(this);
     if (pos > -1) {
       inode.outputEdges.splice(pos, 1);
     }
-
     pos = onode.inputEdges.indexOf(this);
     if (pos > -1) {
       onode.inputEdges.splice(pos, 1);
     }
   }
 }
-
 export class Node {
   name: string;
   edges: Edge[];
   inputEdges: Edge[];
   outputEdges: Edge[];
-
   constructor(name: string) {
     this.name = name;
     this.edges = [];
     this.inputEdges = [];
     this.outputEdges = [];
   }
-
   getEdgeFrom(from: string | Node): Edge | null | undefined {
     if (!from) {
       return null;
     }
-
     if (typeof from === 'object') {
       return this.inputEdges.find((e) => e.inputNode?.name === from.name);
     }
-
     return this.inputEdges.find((e) => e.inputNode?.name === from);
   }
-
   getEdgeTo(to: string | Node): Edge | null | undefined {
     if (!to) {
       return null;
     }
-
     if (typeof to === 'object') {
       return this.outputEdges.find((e) => e.outputNode?.name === to.name);
     }
-
     return this.outputEdges.find((e) => e.outputNode?.name === to);
   }
-
   getOptimizedInputEdges(): Edge[] {
     const toBeRemoved: Edge[] = [];
     this.inputEdges.forEach((e) => {
       const inputEdgesNodes = e.inputNode?.inputEdges.map((e) => e.inputNode);
-
       inputEdgesNodes?.forEach((n) => {
         const edgeToRemove = n?.getEdgeTo(this.name);
         if (edgeToRemove) {
@@ -112,22 +90,17 @@ export class Node {
         }
       });
     });
-
     return this.inputEdges.filter((e) => toBeRemoved.indexOf(e) === -1);
   }
 }
-
 export class Graph {
   nodes: Record<string, Node> = {};
-
   constructor() {}
-
   createNode(name: string): Node {
     const n = new Node(name);
     this.nodes[name] = n;
     return n;
   }
-
   createNodes(names: string[]): Node[] {
     const nodes: Node[] = [];
     names.forEach((name) => {
@@ -135,25 +108,21 @@ export class Graph {
     });
     return nodes;
   }
-
   link(input: string | string[] | Node | Node[], output: string | string[] | Node | Node[]): Edge[] {
     let inputArr = [];
     let outputArr = [];
     const inputNodes: Node[] = [];
     const outputNodes: Node[] = [];
-
     if (input instanceof Array) {
       inputArr = input;
     } else {
       inputArr = [input];
     }
-
     if (output instanceof Array) {
       outputArr = output;
     } else {
       outputArr = [output];
     }
-
     for (let n = 0; n < inputArr.length; n++) {
       const i = inputArr[n];
       if (typeof i === 'string') {
@@ -166,7 +135,6 @@ export class Graph {
         inputNodes.push(i);
       }
     }
-
     for (let n = 0; n < outputArr.length; n++) {
       const i = outputArr[n];
       if (typeof i === 'string') {
@@ -179,7 +147,6 @@ export class Graph {
         outputNodes.push(i);
       }
     }
-
     const edges: Edge[] = [];
     inputNodes.forEach((input) => {
       outputNodes.forEach((output) => {
@@ -191,19 +158,15 @@ export class Graph {
     });
     return edges;
   }
-
   descendants(nodes: Node[] | string[]): Set<Node> {
     if (!nodes.length) {
       return new Set();
     }
-
     const initialNodes = new Set(
       isStringArray(nodes) ? nodes.map((n) => this.nodes[n]).filter((n) => n !== undefined) : nodes
     );
-
     return this.descendantsRecursive(initialNodes);
   }
-
   private descendantsRecursive(nodes: Set<Node>, descendants = new Set<Node>()): Set<Node> {
     for (const node of nodes) {
       const newDescendants = new Set<Node>();
@@ -213,30 +176,23 @@ export class Graph {
           newDescendants.add(inputNode);
         }
       }
-
       this.descendantsRecursive(newDescendants, descendants);
     }
-
     return descendants;
   }
-
   private willCreateCycle(input: Node, output: Node): boolean {
     if (input === output) {
       return true;
     }
-
     // Perform a DFS to check if the input node is reachable from the output node
     const visited = new Set<Node>();
     const stack = [output];
-
     while (stack.length) {
       const current = stack.pop()!;
       if (current === input) {
         return true;
       }
-
       visited.add(current);
-
       for (const edge of current.outputEdges) {
         const next = edge.outputNode;
         if (next && !visited.has(next)) {
@@ -244,19 +200,15 @@ export class Graph {
         }
       }
     }
-
     return false;
   }
-
   createEdge(): Edge {
     return new Edge();
   }
-
   getNode(name: string): Node | undefined {
     return this.nodes[name];
   }
 }
-
 export const printGraph = (g: Graph) => {
   Object.keys(g.nodes).forEach((name) => {
     const n = g.nodes[name];
@@ -268,10 +220,9 @@ export const printGraph = (g: Graph) => {
     if (!inputEdges) {
       inputEdges = '<none>';
     }
-    console.log(`${n.name}:\n - links to:   ${outputEdges}\n - links from: ${inputEdges}`);
+    structLog('log', `${n.name}:\n - links to:   ${outputEdges}\n - links from: ${inputEdges}`);
   });
 };
-
 function isStringArray(arr: unknown[]): arr is string[] {
   return arr.length > 0 && typeof arr[0] === 'string';
 }

--- a/public/app/core/utils/debugLog.ts
+++ b/public/app/core/utils/debugLog.ts
@@ -1,5 +1,5 @@
+import { structLog } from '@grafana/data';
 import { store } from '@grafana/data';
-
 /**
  * Creates a debug logger gated by a localStorage key.
  *
@@ -8,10 +8,9 @@ import { store } from '@grafana/data';
  */
 export function createDebugLog(key: string, prefix: string) {
   const storageKey = `grafana.debug.${key}`;
-
   return function debugLog(message: string, ...args: unknown[]) {
     if (store.get(storageKey) === 'true') {
-      console.log(`[${prefix}] ${message}`, ...args);
+      structLog('log', `[${prefix}] ${message}`, ...args);
     }
   };
 }

--- a/public/app/core/utils/explore.ts
+++ b/public/app/core/utils/explore.ts
@@ -1,7 +1,7 @@
+import { structLog } from '@grafana/data';
 import { customAlphabet } from 'nanoid';
 import { type Unsubscribable } from 'rxjs';
 import { v4 as uuidv4 } from 'uuid';
-
 import {
   type AdHocVariableFilter,
   CoreApp,
@@ -28,21 +28,17 @@ import { getDataSourceSrv } from '@grafana/runtime';
 import { RefreshPicker } from '@grafana/ui';
 import { ExpressionDatasourceUID } from 'app/features/expressions/types';
 import { type QueryOptions, type QueryTransaction } from 'app/types/explore';
-
 export const DEFAULT_UI_STATE = {
   dedupStrategy: LogsDedupStrategy.none,
 };
-
 export const ID_ALPHABET = '0123456789abcdefghijklmnopqrstuvwxyz';
 const nanoid = customAlphabet(ID_ALPHABET, 3);
-
 const LAST_USED_DATASOURCE_KEY = 'grafana.explore.datasource';
 const lastUsedDatasourceKeyForOrgId = (orgId: number) => `${LAST_USED_DATASOURCE_KEY}.${orgId}`;
 export const getLastUsedDatasourceUID = (orgId: number) =>
   store.getObject<string>(lastUsedDatasourceKeyForOrgId(orgId));
 export const setLastUsedDatasourceUID = (orgId: number, datasourceUID: string) =>
   store.setObject(lastUsedDatasourceKeyForOrgId(orgId), datasourceUID);
-
 export interface GetExploreUrlArguments {
   queries: DataQuery[];
   dsRef: DataSourceRef | null | undefined;
@@ -50,17 +46,14 @@ export interface GetExploreUrlArguments {
   scopedVars: ScopedVars | undefined;
   adhocFilters?: AdHocVariableFilter[];
 }
-
 export function generateExploreId() {
   while (true) {
     const id = nanoid(3);
-
     if (!/^\d+$/.test(id)) {
       return id;
     }
   }
 }
-
 /**
  * Returns an Explore-URL that contains a panel's queries and the dashboard time range.
  */
@@ -75,7 +68,6 @@ export async function getExploreUrl(args: GetExploreUrlArguments): Promise<strin
           // if the query defines a datasource, use that one, otherwise use the one from the panel, which should always be defined.
           // this will rejects if the datasource is not found, or return the default one if dsRef is not provided.
           const queryDs = await getDataSourceSrv().get(q.datasource || dsRef);
-
           return {
             // interpolate the query using its datasource `interpolateVariablesInQueries` method if defined, othewise return the query as-is.
             ...(queryDs.interpolateVariablesInQueries?.([q], scopedVars ?? {}, adhocFilters)[0] || q),
@@ -91,7 +83,6 @@ export async function getExploreUrl(args: GetExploreUrlArguments): Promise<strin
       <T>(promise: PromiseSettledResult<T>): promise is PromiseFulfilledResult<T> => promise.status === 'fulfilled'
     )
     .map((q) => q.value);
-
   const exploreState = JSON.stringify({
     [generateExploreId()]: {
       range: toURLRange(timeRange.raw),
@@ -101,11 +92,9 @@ export async function getExploreUrl(args: GetExploreUrlArguments): Promise<strin
   });
   return locationUtil.assureBaseUrl(urlUtil.renderUrl('/explore', { panes: exploreState, schemaVersion: 1 }));
 }
-
 export function requestIdGenerator(exploreId: string) {
   return `explore_${exploreId}`;
 }
-
 export function buildQueryTransaction(
   exploreId: string,
   queries: DataQuery[],
@@ -117,7 +106,6 @@ export function buildQueryTransaction(
 ): QueryTransaction {
   const panelId = Number.parseInt(exploreId, 36);
   const { interval, intervalMs } = getIntervals(range, queryOptions.minInterval, queryOptions.maxDataPoints);
-
   const request: DataQueryRequest = {
     app: CoreApp.Explore,
     // TODO probably should be taken from preferences but does not seem to be used anyway.
@@ -139,7 +127,6 @@ export function buildQueryTransaction(
     liveStreaming: queryOptions.liveStreaming,
     skipQueryCache: true,
   };
-
   return {
     queries,
     request,
@@ -148,27 +135,21 @@ export function buildQueryTransaction(
     done: false,
   };
 }
-
 export const clearQueryKeys: (query: DataQuery) => DataQuery = ({ key, ...rest }) => rest;
-
 export const safeStringifyValue = (value: unknown, space?: number) => {
   if (value === undefined || value === null) {
     return '';
   }
-
   try {
     return JSON.stringify(value, null, space);
   } catch (error) {
-    console.error(error);
+    structLog('error', error);
   }
-
   return '';
 };
-
 export function generateKey(index = 0): string {
   return `Q-${uuidv4()}-${index}`;
 }
-
 export async function generateEmptyQuery(
   queries: DataQuery[],
   index = 0,
@@ -177,7 +158,6 @@ export async function generateEmptyQuery(
   let datasourceInstance: DataSourceApi | undefined;
   let datasourceRef: DataSourceRef | null | undefined;
   let defaultQuery: Partial<DataQuery> | undefined;
-
   // datasource override is if we have switched datasources with no carry-over - we want to create a new query with a datasource we define
   // it's also used if there's a root datasource and there were no previous queries
   if (dataSourceOverride) {
@@ -190,22 +170,17 @@ export async function generateEmptyQuery(
     defaultQuery = datasourceInstance.getDefaultQuery?.(CoreApp.Explore);
     datasourceRef = datasourceInstance.getRef();
   }
-
   if (!datasourceInstance) {
     datasourceInstance = await getDataSourceSrv().get(datasourceRef);
     defaultQuery = datasourceInstance.getDefaultQuery?.(CoreApp.Explore);
   }
-
   return { ...defaultQuery, refId: getNextRefId(queries), key: generateKey(index), datasource: datasourceRef };
 }
-
 export const generateNewKeyAndAddRefIdIfMissing = (target: DataQuery, queries: DataQuery[], index = 0): DataQuery => {
   const key = generateKey(index);
   const refId = target.refId || getNextRefId(queries);
-
   return { ...target, refId, key };
 };
-
 /**
  * Ensure at least one target exists and that targets have the necessary keys
  *
@@ -224,7 +199,6 @@ export async function ensureQueries(
       if (!refId) {
         refId = getNextRefId(allQueries);
       }
-
       // if a query has a datasource, validate it and only add it if valid
       // if a query doesn't have a datasource, do not worry about it at this step
       let validDS = true;
@@ -232,11 +206,10 @@ export async function ensureQueries(
         try {
           await getDataSourceSrv().get(query.datasource.uid);
         } catch {
-          console.error(`One of the queries has a datasource that is no longer available and was removed.`);
+          structLog('error', `One of the queries has a datasource that is no longer available and was removed.`);
           validDS = false;
         }
       }
-
       if (validDS) {
         allQueries.push({
           ...query,
@@ -258,7 +231,6 @@ export async function ensureQueries(
     return [];
   }
 }
-
 /**
  * A target is non-empty when it has keys (with non-empty values) other than refId, key, context and datasource.
  * FIXME: While this is reasonable for practical use cases, a query without any propery might still be "non-empty"
@@ -277,39 +249,30 @@ export function hasNonEmptyQuery<TQuery extends DataQuery>(queries: TQuery[]): b
     })
   );
 }
-
 export const getQueryKeys = (queries: DataQuery[]): string[] => {
   const queryKeys = queries.reduce<string[]>((newQueryKeys, query, index) => {
     const primaryKey = query.datasource?.uid || query.key;
     return newQueryKeys.concat(`${primaryKey}-${index}`);
   }, []);
-
   return queryKeys;
 };
-
 export const getTimeRange = (timeZone: TimeZone, rawRange: RawTimeRange, fiscalYearStartMonth: number): TimeRange => {
   let range = rangeUtil.convertRawToRange(rawRange, timeZone, fiscalYearStartMonth);
-
   return range;
 };
-
 export const refreshIntervalToSortOrder = (refreshInterval?: string) =>
   RefreshPicker.isLive(refreshInterval) ? LogsSortOrder.Ascending : LogsSortOrder.Descending;
-
 export const stopQueryState = (querySubscription: Unsubscribable | undefined) => {
   if (querySubscription) {
     querySubscription.unsubscribe();
   }
 };
-
 export function getIntervals(range: TimeRange, lowLimit?: string, resolution?: number): IntervalValues {
   if (!resolution) {
     return { interval: '1s', intervalMs: 1000 };
   }
-
   return rangeUtil.calculateInterval(range, resolution, lowLimit);
 }
-
 export const copyStringToClipboard = (string: string) => {
   if (navigator.clipboard && window.isSecureContext) {
     navigator.clipboard.writeText(string);

--- a/public/app/core/utils/fetch.ts
+++ b/public/app/core/utils/fetch.ts
@@ -1,16 +1,14 @@
+import { structLog } from '@grafana/data';
 import { omitBy } from 'lodash';
 import { type Observable, of, throwError } from 'rxjs';
-
 import { deprecationWarning, validatePath } from '@grafana/data';
 import { type BackendSrvRequest } from '@grafana/runtime';
-
 export const parseInitFromOptions = (options: BackendSrvRequest): RequestInit => {
   const method = options.method;
   const headers = parseHeaders(options);
   const isAppJson = isContentTypeJson(headers);
   const body = parseBody(options, isAppJson);
   const credentials = parseCredentials(options);
-
   return {
     method,
     headers,
@@ -19,12 +17,10 @@ export const parseInitFromOptions = (options: BackendSrvRequest): RequestInit =>
     signal: options.abortSignal,
   };
 };
-
 interface HeaderParser {
   canParse: (options: BackendSrvRequest) => boolean;
   parse: (headers: Headers) => Headers;
 }
-
 const defaultHeaderParser: HeaderParser = {
   canParse: () => true,
   parse: (headers) => {
@@ -32,12 +28,10 @@ const defaultHeaderParser: HeaderParser = {
     if (accept) {
       return headers;
     }
-
     headers.set('accept', 'application/json, text/plain, */*');
     return headers;
   },
 };
-
 const parseHeaderByMethodFactory = (methodPredicate: string): HeaderParser => ({
   canParse: (options) => {
     const method = options?.method ? options?.method.toLowerCase() : '';
@@ -48,19 +42,15 @@ const parseHeaderByMethodFactory = (methodPredicate: string): HeaderParser => ({
     if (contentType) {
       return headers;
     }
-
     headers.set('content-type', 'application/json');
     return headers;
   },
 });
-
 const postHeaderParser: HeaderParser = parseHeaderByMethodFactory('post');
 const putHeaderParser: HeaderParser = parseHeaderByMethodFactory('put');
 const patchHeaderParser: HeaderParser = parseHeaderByMethodFactory('patch');
-
 const headerParsers = [postHeaderParser, putHeaderParser, patchHeaderParser, defaultHeaderParser];
 const unsafeCharacters = /[^\u0000-\u00ff]/g;
-
 /**
  * Header values can only contain ISO-8859-1 characters. If a header key or value contains characters outside of this, we will encode the whole value.
  * Since `encodeURI` also encodes spaces, we won't encode if the value doesn't contain any unsafe characters.
@@ -68,7 +58,6 @@ const unsafeCharacters = /[^\u0000-\u00ff]/g;
 function sanitizeHeader(v: string) {
   return unsafeCharacters.test(v) ? encodeURI(v) : v;
 }
-
 export const parseHeaders = (options: BackendSrvRequest) => {
   const safeHeaders: Record<string, string> = {};
   for (let [key, value] of Object.entries(options.headers ?? {})) {
@@ -79,15 +68,12 @@ export const parseHeaders = (options: BackendSrvRequest) => {
   const combinedHeaders = parsers.reduce((prev, parser) => {
     return parser.parse(prev);
   }, headers);
-
   return combinedHeaders;
 };
-
 export const isContentTypeJson = (headers: Headers) => {
   if (!headers) {
     return false;
   }
-
   const contentType = headers.get('content-type');
   if (
     contentType &&
@@ -100,25 +86,20 @@ export const isContentTypeJson = (headers: Headers) => {
   ) {
     return true;
   }
-
   return false;
 };
-
 export const parseBody = (options: BackendSrvRequest, isAppJson: boolean) => {
   if (!options) {
     return options;
   }
-
   if (!options.data || typeof options.data === 'string') {
     return options.data;
   }
   if (options.data instanceof Blob) {
     return options.data;
   }
-
   return isAppJson ? JSON.stringify(options.data) : new URLSearchParams(options.data);
 };
-
 export async function parseResponseBody<T>(
   response: Response,
   responseType?: 'json' | 'text' | 'arraybuffer' | 'blob'
@@ -129,35 +110,30 @@ export async function parseResponseBody<T>(
         // this specifically returns a Promise<ArrayBuffer>
         // TODO refactor this function to remove the type assertions
         return response.arrayBuffer() as Promise<T>;
-
       case 'blob':
         // this specifically returns a Promise<Blob>
         // TODO refactor this function to remove the type assertions
         return response.blob() as Promise<T>;
-
       case 'json':
         // An empty string is not a valid JSON.
         // Sometimes (unfortunately) our APIs declare their Content-Type as JSON, however they return an empty body.
         if (response.headers.get('Content-Length') === '0') {
-          console.warn(`${response.url} returned an invalid JSON`);
+          structLog('warn', `${response.url} returned an invalid JSON`);
           return {} as T;
         }
         return await response.json();
-
       case 'text':
         // this specifically returns a Promise<string>
         // TODO refactor this function to remove the type assertions
         return response.text() as Promise<T>;
     }
   }
-
   const textData = await response.text(); // this could be just a string, prometheus requests for instance
   try {
     return JSON.parse(textData); // majority of the requests this will be something that can be parsed
   } catch {}
   return textData as T;
 }
-
 function serializeParams(data: Record<string, string | number | boolean | Array<string | number | boolean>>): string {
   return Object.keys(data)
     .map((key) => {
@@ -169,7 +145,6 @@ function serializeParams(data: Record<string, string | number | boolean | Array<
     })
     .join('&');
 }
-
 /**
  * Formats and validates the URL.
  * If options.validatePath is true, this will throw an exception if the URL fails validation.
@@ -180,30 +155,24 @@ export const parseUrlFromOptions = (options: BackendSrvRequest): Observable<stri
   try {
     const cleanParams = omitBy(options.params, (v) => v === undefined || (v && v.length === 0));
     const serializedParams = serializeParams(cleanParams);
-
     const url = options.validatePath //
       ? validatePath(options.url)
       : options.url;
-
     return options.params && serializedParams.length ? of(`${url}?${serializedParams}`) : of(url);
   } catch (error) {
     return throwError(() => error);
   }
 };
-
 export const parseCredentials = (options: BackendSrvRequest): RequestCredentials => {
   if (!options) {
     return options;
   }
-
   if (options.credentials) {
     return options.credentials;
   }
-
   if (options.withCredentials) {
     deprecationWarning('BackendSrvRequest', 'withCredentials', 'credentials');
     return 'include';
   }
-
   return 'same-origin';
 };

--- a/public/app/core/utils/metrics.ts
+++ b/public/app/core/utils/metrics.ts
@@ -1,41 +1,35 @@
+import { structLog } from '@grafana/data';
 import { reportPerformance } from '../services/echo/EchoSrv';
-
 export function startMeasure(eventName: string) {
   if (!performance || !performance.mark) {
     return;
   }
-
   try {
     performance.mark(`${eventName}_started`);
   } catch (error) {
-    console.error(`[Metrics] Failed to startMeasure ${eventName}`, error);
+    structLog('error', `[Metrics] Failed to startMeasure ${eventName}`, error);
   }
 }
-
 export function stopMeasure(eventName: string) {
   if (!performance || !performance.mark) {
     return;
   }
-
   try {
     const started = `${eventName}_started`;
     const completed = `${eventName}_completed`;
     const measured = `${eventName}_measured`;
-
     performance.mark(completed);
     const measure = performance.measure(measured, started, completed);
     reportPerformance(`${eventName}_ms`, measure.duration);
-
     performance.clearMarks(started);
     performance.clearMarks(completed);
     performance.clearMeasures(measured);
     return measure;
   } catch (error) {
-    console.error(`[Metrics] Failed to stopMeasure ${eventName}`, error);
+    structLog('error', `[Metrics] Failed to stopMeasure ${eventName}`, error);
     return;
   }
 }
-
 /**
  * Report when a metric of a given name was marked during the document lifecycle. Works for markers with no duration,
  * like PerformanceMark or PerformancePaintTiming (e.g. created with performance.mark, or first-contentful-paint)

--- a/public/app/core/utils/shortLinks.ts
+++ b/public/app/core/utils/shortLinks.ts
@@ -1,5 +1,5 @@
+import { structLog } from '@grafana/data';
 import memoizeOne from 'memoize-one';
-
 import { type AbsoluteTimeRange, type LogRowModel, type UrlQueryMap } from '@grafana/data';
 import { t } from '@grafana/i18n';
 import { getBackendSrv, config, locationService } from '@grafana/runtime';
@@ -9,37 +9,30 @@ import { createErrorNotification, createSuccessNotification } from 'app/core/cop
 import { type DashboardScene } from 'app/features/dashboard-scene/scene/DashboardScene';
 import { getDashboardUrl } from 'app/features/dashboard-scene/utils/getDashboardUrl';
 import { dispatch } from 'app/store/store';
-
 import { type ShortURL } from '../../../../apps/shorturl/plugin/src/generated/shorturl/v1beta1/shorturl_object_gen';
 import { extractErrorMessage } from '../../api/utils';
 import { type ShareLinkConfiguration } from '../../features/dashboard-scene/sharing/ShareButton/utils';
 import { notifyApp } from '../reducers/appNotification';
-
 import { copyStringToClipboard } from './explore';
-
 function buildHostUrl() {
   return `${window.location.protocol}//${window.location.host}${config.appSubUrl}`;
 }
-
 export function buildShortUrl(k8sShortUrl: ShortURL) {
   const key = k8sShortUrl.metadata.name;
   const orgId = k8sShortUrl.metadata.namespace;
   const hostUrl = buildHostUrl();
   return `${hostUrl}/goto/${key}?orgId=${orgId}`;
 }
-
 function getRelativeURLPath(url: string) {
   let path = url.replace(buildHostUrl(), '');
   return path.startsWith('/') ? path.substring(1, path.length) : path;
 }
-
 const createShortLinkLegacy = async (path: string): Promise<string> => {
   const shortLink = await getBackendSrv().post(`/api/short-urls`, {
     path: getRelativeURLPath(path),
   });
   return shortLink.url;
 };
-
 // Memoized API call, to not re-execute the same request multiple times
 // this function creates a shortURL using the legacy or the new k8s api depending on the feature toggle
 export const createShortLink = memoizeOne(async (path: string): Promise<string> => {
@@ -58,28 +51,24 @@ export const createShortLink = memoizeOne(async (path: string): Promise<string> 
           },
         })
       );
-
       if ('data' in result && result.data) {
         return buildShortUrl(result.data);
       }
-
       if ('error' in result) {
         const errorMessage = extractErrorMessage(result.error);
         throw new Error(errorMessage || 'Failed to create short URL');
       }
-
       throw new Error('Failed to create short URL');
     } else {
       return await createShortLinkLegacy(path);
     }
   } catch (err) {
-    console.error('Error when creating shortened link: ', err);
+    structLog('error', 'Error when creating shortened link: ', err);
     dispatch(notifyApp(createErrorNotification('Error generating shortened link')));
     createShortLink.clear();
     throw err; // Re-throw so callers know it failed
   }
 });
-
 /**
  * Creates a ClipboardItem for the shortened link. This is used due to clipboard issues in Safari after making async calls.
  * See https://github.com/grafana/grafana/issues/106889
@@ -91,7 +80,6 @@ export const createShortLinkClipboardItem = (path: string) => {
     'text/plain': createShortLink(path),
   });
 };
-
 export const createAndCopyShortLink = async (path: string) => {
   try {
     if (typeof ClipboardItem !== 'undefined' && navigator.clipboard.write) {
@@ -104,10 +92,9 @@ export const createAndCopyShortLink = async (path: string) => {
     }
   } catch (error) {
     // createShortLink already handles error notifications, just log
-    console.error('Error in createAndCopyShortLink:', error);
+    structLog('error', 'Error in createAndCopyShortLink:', error);
   }
 };
-
 export const createAndCopyShareDashboardLink = async (
   dashboard: DashboardScene,
   opts: ShareLinkConfiguration,
@@ -121,15 +108,11 @@ export const createAndCopyShareDashboardLink = async (
     dispatch(notifyApp(createSuccessNotification(t('link.share.copy-to-clipboard', 'Link copied to clipboard'))));
   }
 };
-
 export const createDashboardShareUrl = (dashboard: DashboardScene, opts: ShareLinkConfiguration, panel?: VizPanel) => {
   const location = locationService.getLocation();
   const timeRange = sceneGraph.getTimeRange(panel ?? dashboard);
-
   const urlParamsUpdate = getShareUrlParams(opts, timeRange, panel);
-
   const isSnapshot = dashboard.state.meta.isSnapshot;
-
   return getDashboardUrl({
     uid: isSnapshot ? (dashboard.state.meta.snapshotKey ?? dashboard.state.uid) : dashboard.state.uid,
     slug: isSnapshot ? undefined : dashboard.state.meta.slug,
@@ -139,46 +122,40 @@ export const createDashboardShareUrl = (dashboard: DashboardScene, opts: ShareLi
     isSnapshot,
   });
 };
-
 export const getShareUrlParams = (
-  opts: { useAbsoluteTimeRange: boolean; theme: string },
+  opts: {
+    useAbsoluteTimeRange: boolean;
+    theme: string;
+  },
   timeRange: SceneTimeRangeLike,
   panel?: VizPanel
 ) => {
   const urlParamsUpdate: UrlQueryMap = {};
-
   if (panel) {
     urlParamsUpdate.viewPanel = panel.getPathId();
   }
-
   if (opts.useAbsoluteTimeRange) {
     urlParamsUpdate.from = timeRange.state.value.from.toISOString();
     urlParamsUpdate.to = timeRange.state.value.to.toISOString();
   }
-
   if (opts.theme !== 'current') {
     urlParamsUpdate.theme = opts.theme;
   }
-
   return urlParamsUpdate;
 };
-
 function getPreviousLog(row: LogRowModel, allLogs: LogRowModel[]): LogRowModel | null {
   for (let i = allLogs.indexOf(row) - 1; i >= 0; i--) {
     if (allLogs[i].timeEpochMs > row.timeEpochMs) {
       return allLogs[i];
     }
   }
-
   return null;
 }
-
 export function getLogsPermalinkRange(row: LogRowModel, rows: LogRowModel[], absoluteRange: AbsoluteTimeRange) {
   // With infinite scrolling, the time range of the log line can be after the absolute range or beyond the request line limit, so we need to adjust
   // Look for the previous sibling log, and use its timestamp
   const allLogs = rows.filter((logRow) => logRow.dataFrame.refId === row.dataFrame.refId);
   const prevLog = getPreviousLog(row, allLogs);
-
   if (row.timeEpochMs > absoluteRange.to && !prevLog) {
     // Because there's no sibling and the current `to` is oldest than the log, we have no reference we can use for the interval
     // This only happens when you scroll into the future and you want to share the first log of the list
@@ -188,7 +165,6 @@ export function getLogsPermalinkRange(row: LogRowModel, rows: LogRowModel[], abs
       to: new Date(row.timeEpochMs + 1).toISOString(),
     };
   }
-
   return {
     from: new Date(absoluteRange.from).toISOString(),
     to: new Date(prevLog ? prevLog.timeEpochMs : absoluteRange.to).toISOString(),

--- a/public/app/core/utils/timeRegions.ts
+++ b/public/app/core/utils/timeRegions.ts
@@ -1,25 +1,18 @@
+import { structLog } from '@grafana/data';
 import { Cron } from 'croner';
-
 import { type AbsoluteTimeRange, type TimeRange, durationToMilliseconds, parseDuration } from '@grafana/data';
-
 export type TimeRegionMode = null | 'cron';
 export interface TimeRegionConfig {
   mode?: TimeRegionMode;
-
   from?: string;
   fromDayOfWeek?: number; // 1-7
-
   to?: string;
   toDayOfWeek?: number; // 1-7
-
   timezone?: string;
-
   cronExpr?: string; // 0 9 * * 1-5
   duration?: string; // 8h
 }
-
 const secsInDay = 24 * 3600;
-
 function getDurationSecs(
   fromDay: number,
   fromHour: number,
@@ -29,17 +22,13 @@ function getDurationSecs(
   toMin: number
 ) {
   let days = toDay - fromDay;
-
   // account for rollover
   if (days < 0) {
     days += 7;
   }
-
   let fromSecs = fromHour * 3600 + fromMin * 60;
   let toSecs = toHour * 3600 + toMin * 60;
-
   let durSecs = 0;
-
   // account for toTime < fromTime on same day
   if (days === 0 && toSecs < fromSecs) {
     durSecs = 7 * secsInDay - (fromSecs - toSecs);
@@ -47,10 +36,8 @@ function getDurationSecs(
     let daysSecs = days * secsInDay;
     durSecs = daysSecs - fromSecs + toSecs;
   }
-
   return durSecs;
 }
-
 export function convertToCron(
   fromDay?: number | null,
   from?: string | null,
@@ -61,59 +48,42 @@ export function convertToCron(
   if (fromDay == null && from == null) {
     return undefined;
   }
-
   const cronCfg = {
     cronExpr: '',
     duration: 0,
   };
-
   const isEveryDay = fromDay == null && toDay == null;
   // if the def contains only days of week, then they become end-day-inclusive
   const toDayEnd = fromDay != null && from == null && to == null;
-
   from ??= '00:00';
-
   // 1. create cron (only requires froms)
   let [fromHour, fromMin] = from.split(':').map((v) => +v);
-
   cronCfg.cronExpr = `${fromMin} ${fromHour} * * ${fromDay ?? '*'}`;
-
   // 2. determine duration
   fromDay ??= 1;
   toDay ??= fromDay;
-
   // e.g. from Wed to Fri (implies inclusive Fri)
   if (toDayEnd) {
     to = '00:00';
     toDay += toDay === 7 ? -6 : 1;
   }
-
   to ??= from;
-
   let [toHour, toMin] = to.split(':').map((v) => +v);
-
   let fromSecs = fromHour * 3600 + fromMin * 60;
   let toSecs = toHour * 3600 + toMin * 60;
-
   // e.g. every day from 22:00 to 02:00 (implied next day)
   // NOTE: the odd wrap-around case of toSecs < fromSecs in same day is handled inside getDurationSecs()
   if (isEveryDay && toSecs < fromSecs) {
     toDay += toDay === 7 ? -6 : 1;
   }
-
   cronCfg.duration = getDurationSecs(fromDay, fromHour, fromMin, toDay, toHour, toMin);
-
   return cronCfg;
 }
-
 export function calculateTimesWithin(cfg: TimeRegionConfig, tRange: TimeRange): AbsoluteTimeRange[] {
   const ranges: AbsoluteTimeRange[] = [];
-
   let cronExpr = '';
   let durationMs = 0;
-
   let { fromDayOfWeek, from, toDayOfWeek, to, duration = '' } = cfg;
-
   if (cfg.mode === 'cron') {
     cronExpr = cfg.cronExpr ?? '';
     durationMs = durationToMilliseconds(parseDuration(duration));
@@ -121,33 +91,24 @@ export function calculateTimesWithin(cfg: TimeRegionConfig, tRange: TimeRange): 
     // remove empty strings
     from = from === '' ? undefined : from;
     to = to === '' ? undefined : to;
-
     const cron = convertToCron(fromDayOfWeek, from, toDayOfWeek, to);
-
     if (cron != null) {
       cronExpr = cron.cronExpr;
       durationMs = cron.duration * 1e3;
     }
   }
-
   if (cronExpr === '') {
     return [];
   }
-
   try {
     let tz = cfg.timezone === 'browser' ? undefined : cfg.timezone === 'utc' ? 'Etc/UTC' : cfg.timezone;
-
     let job = new Cron(cronExpr, { timezone: tz });
-
     // get previous run that may overlap with start of timerange
     let fromDate: Date | null = new Date(tRange.from.valueOf() - durationMs);
-
     let toMs = tRange.to.valueOf();
     let nextDate = job.nextRun(fromDate);
-
     while (nextDate != null) {
       let nextMs = +nextDate;
-
       if (nextMs > toMs) {
         break;
       } else {
@@ -160,8 +121,7 @@ export function calculateTimesWithin(cfg: TimeRegionConfig, tRange: TimeRange): 
     }
   } catch (e) {
     // invalid expression
-    console.error(e);
+    structLog('error', e);
   }
-
   return ranges;
 }

--- a/public/app/features/actions/ConnectionPicker.tsx
+++ b/public/app/features/actions/ConnectionPicker.tsx
@@ -1,12 +1,10 @@
+import { structLog } from '@grafana/data';
 import { useMemo } from 'react';
-
 import { ActionType, type DataSourceInstanceSettings } from '@grafana/data';
 import { t } from '@grafana/i18n';
 import { config, getDataSourceSrv } from '@grafana/runtime';
 import { Select } from '@grafana/ui';
-
 import { INFINITY_DATASOURCE_TYPE } from './utils';
-
 interface ConnectionOption {
   label: string;
   value: string;
@@ -14,23 +12,18 @@ interface ConnectionOption {
   imgUrl?: string;
   icon?: string;
 }
-
 interface ConnectionPickerProps {
   actionType: ActionType;
   datasourceUid?: string;
   onChange: (connectionType: 'direct' | DataSourceInstanceSettings) => void;
 }
-
 const DIRECT_OPTION_VALUE = 'direct';
-
 const getSupportedDataSources = () => {
   const dataSourceSrv = getDataSourceSrv();
-
   return dataSourceSrv.getList({
     filter: (ds) => ds.type === INFINITY_DATASOURCE_TYPE,
   });
 };
-
 export const ConnectionPicker = ({ actionType, datasourceUid, onChange }: ConnectionPickerProps) => {
   const connectionOptions: ConnectionOption[] = useMemo(() => {
     const options: ConnectionOption[] = [
@@ -44,10 +37,8 @@ export const ConnectionPicker = ({ actionType, datasourceUid, onChange }: Connec
         icon: 'adjust-circle',
       },
     ];
-
     if (config.featureToggles.vizActionsAuth) {
       const supportedDataSources = getSupportedDataSources();
-
       supportedDataSources.forEach((ds) => {
         options.push({
           label: ds.name,
@@ -56,10 +47,8 @@ export const ConnectionPicker = ({ actionType, datasourceUid, onChange }: Connec
         });
       });
     }
-
     return options;
   }, []);
-
   const getCurrentValue = () => {
     if (actionType === ActionType.Fetch) {
       return DIRECT_OPTION_VALUE;
@@ -68,7 +57,6 @@ export const ConnectionPicker = ({ actionType, datasourceUid, onChange }: Connec
     }
     return DIRECT_OPTION_VALUE;
   };
-
   const handleConnectionChange = (selectedValue: string) => {
     if (selectedValue === DIRECT_OPTION_VALUE) {
       onChange(DIRECT_OPTION_VALUE);
@@ -78,13 +66,11 @@ export const ConnectionPicker = ({ actionType, datasourceUid, onChange }: Connec
       if (selectedDatasource) {
         onChange(selectedDatasource);
       } else {
-        console.error('ConnectionPicker: Could not find datasource with UID:', selectedValue);
+        structLog('error', 'ConnectionPicker: Could not find datasource with UID:', selectedValue);
       }
     }
   };
-
   const currentValue = getCurrentValue();
-
   return (
     <Select
       value={currentValue}

--- a/public/app/features/actions/utils.ts
+++ b/public/app/features/actions/utils.ts
@@ -1,3 +1,4 @@
+import { structLog } from '@grafana/data';
 import {
   type Action,
   type ActionModel,
@@ -18,19 +19,15 @@ import {
 } from '@grafana/data';
 import { type BackendSrvRequest, config as grafanaConfig, getBackendSrv } from '@grafana/runtime';
 import { appEvents } from 'app/core/app_events';
-
 import { HttpRequestMethod } from '../../plugins/panel/canvas/panelcfg.gen';
 import { createAbsoluteUrl, type RelativeUrl } from '../alerting/unified/utils/url';
 import { getTimeSrv } from '../dashboard/services/TimeSrv';
 import { getNextRequestId } from '../query/state/PanelQueryRunner';
-
 import { reportActionTrigger } from './analytics';
-
 /** @internal */
 export const isInfinityActionWithAuth = (action: Action): boolean => {
   return (grafanaConfig.featureToggles.vizActionsAuth ?? false) && action.type === ActionType.Infinity;
 };
-
 /** @internal */
 export const genReplaceActionVars = (
   boundReplaceVariables: InterpolateFunction,
@@ -41,19 +38,15 @@ export const genReplaceActionVars = (
     if (action.variables && actionVars) {
       value = value.replace(/\$\w+/g, (matched) => {
         const name = matched.slice(1);
-
         if (action.variables!.some((action) => action.key === name) && actionVars[name] != null) {
           return actionVars[name];
         }
-
         return matched;
       });
     }
-
     return boundReplaceVariables(value, scopedVars, format);
   };
 };
-
 /** @internal */
 export const getActions = (
   frame: DataFrame,
@@ -67,7 +60,6 @@ export const getActions = (
   if (!actions || actions.length === 0) {
     return [];
   }
-
   const actionModels = actions
     .filter((action) => {
       return action.type === ActionType.Fetch || isInfinityActionWithAuth(action);
@@ -78,18 +70,15 @@ export const getActions = (
         ...fieldScopedVars,
         __dataContext: dataContext,
       };
-
       const boundReplaceVariables: InterpolateFunction = (value, scopedVars, format) => {
         return replaceVariables(value, { ...actionScopedVars, ...scopedVars }, format);
       };
-
       // We are not displaying reduction result
       if (config.valueRowIndex !== undefined && !isNaN(config.valueRowIndex)) {
         dataContext.value.rowIndex = config.valueRowIndex;
       } else {
         dataContext.value.calculatedValue = config.calculatedValue;
       }
-
       const actionModel: ActionModel<Field> = {
         title: replaceVariables(action.title, actionScopedVars),
         type: action.type,
@@ -103,7 +92,6 @@ export const getActions = (
           if (visualizationType) {
             reportActionTrigger(action.type, action.oneClick ?? false, visualizationType);
           }
-
           // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
           let request = {} as BackendSrvRequest;
           if (isInfinityActionWithAuth(action)) {
@@ -111,7 +99,6 @@ export const getActions = (
           } else if (action.type === ActionType.Fetch) {
             request = buildActionRequest(action, genReplaceActionVars(boundReplaceVariables, action, actionVars));
           }
-
           try {
             getBackendSrv()
               .fetch(request)
@@ -120,7 +107,7 @@ export const getActions = (
                   appEvents.emit(AppEvents.alertError, [
                     'An error has occurred. Check console output for more details.',
                   ]);
-                  console.error(error);
+                  structLog('error', error);
                 },
                 complete: () => {
                   appEvents.emit(AppEvents.alertSuccess, ['API call was successful']);
@@ -128,7 +115,7 @@ export const getActions = (
               });
           } catch (error) {
             appEvents.emit(AppEvents.alertError, ['An error has occurred. Check console output for more details.']);
-            console.error(error);
+            structLog('error', error);
             return;
           }
         },
@@ -138,45 +125,36 @@ export const getActions = (
         },
         variables: action.variables,
       };
-
       return actionModel;
     });
-
   return actionModels.filter((action): action is ActionModel => !!action);
 };
-
 /** @internal */
 const processActionConfig = (action: Action, replaceVariables: InterpolateFunction) => {
   const config = action[action.type];
   if (!config) {
     throw new Error('Action does not have the correct configuration');
   }
-
   const url = new URL(getUrl(replaceVariables(config.url)));
   const data = config.method === HttpRequestMethod.GET ? undefined : config.body ? replaceVariables(config.body) : '{}';
-
   const processedHeaders: Array<[string, string]> = [];
   const processedQueryParams: Array<[string, string]> = [];
   let contentType = 'application/json';
-
   if (config.headers) {
     config.headers.forEach(([name, value]) => {
       const processedName = replaceVariables(name);
       const processedValue = replaceVariables(value);
       processedHeaders.push([processedName, processedValue]);
-
       if (processedName.toLowerCase() === 'content-type') {
         contentType = processedValue;
       }
     });
   }
-
   if (config.queryParams) {
     config.queryParams.forEach(([name, value]) => {
       processedQueryParams.push([replaceVariables(name), replaceVariables(value)]);
     });
   }
-
   return {
     config,
     url,
@@ -186,33 +164,25 @@ const processActionConfig = (action: Action, replaceVariables: InterpolateFuncti
     contentType,
   };
 };
-
 /** @internal */
 export const buildActionRequest = (action: Action, replaceVariables: InterpolateFunction) => {
   const { config, url, data, processedHeaders, processedQueryParams } = processActionConfig(action, replaceVariables);
-
   const requestHeaders: Record<string, string> = {};
-
   processedHeaders.forEach(([name, value]) => {
     requestHeaders[name] = value;
   });
-
   processedQueryParams.forEach(([name, value]) => {
     url.searchParams.append(name, value);
   });
-
   requestHeaders['X-Grafana-Action'] = '1';
-
   const request: BackendSrvRequest = {
     url: url.toString(),
     method: config.method,
     data,
     headers: requestHeaders,
   };
-
   return request;
 };
-
 /** @internal */
 export const getActionsDefaultField = (dataLinks: DataLink[] = [], actions: Action[] = []): Field => {
   return {
@@ -222,7 +192,6 @@ export const getActionsDefaultField = (dataLinks: DataLink[] = [], actions: Acti
     values: [],
   };
 };
-
 /** @internal */
 const getUrl = (endpoint: string) => {
   const isRelativeUrl = endpoint.startsWith('/');
@@ -231,18 +200,14 @@ const getUrl = (endpoint: string) => {
     const sanitizedRelativeURL = textUtil.sanitizeUrl(endpoint) as RelativeUrl;
     endpoint = createAbsoluteUrl(sanitizedRelativeURL, []);
   }
-
   return endpoint;
 };
-
 /** @internal */
 interface KeyValuePair {
   key: string;
   value: string;
 }
-
 export const INFINITY_DATASOURCE_TYPE = 'yesoreyeram-infinity-datasource';
-
 /** @internal */
 class InfinityRequestBuilder {
   buildRequest(
@@ -256,18 +221,15 @@ class InfinityRequestBuilder {
     const requestId = getNextRequestId();
     const infinityUrl = `api/ds/query?ds_type=${INFINITY_DATASOURCE_TYPE}&requestId=${requestId}`;
     const timeRange = getTimeSrv().timeRange();
-
     const requestHeaders: KeyValuePair[] = [];
     headers.forEach(([name, value]) => {
       requestHeaders.push({ key: name, value: value });
     });
-
     // Infinity needs [string, string] to {key: string, value: string}
     const requestQueryParams: KeyValuePair[] = [];
     queryParams.forEach(([name, value]) => {
       requestQueryParams.push({ key: name, value: value });
     });
-
     const infinityUrlOptions = {
       method: proxyConfig.method,
       data,
@@ -276,7 +238,6 @@ class InfinityRequestBuilder {
       body_type: 'raw',
       body_content_type: contentType,
     };
-
     return {
       url: infinityUrl,
       method: HttpRequestMethod.POST,
@@ -301,20 +262,17 @@ class InfinityRequestBuilder {
     };
   }
 }
-
 /** @internal */
 export const buildActionProxyRequest = (action: Action, replaceVariables: InterpolateFunction) => {
   const { config, url, data, processedHeaders, processedQueryParams, contentType } = processActionConfig(
     action,
     replaceVariables
   );
-
   // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
   const infinityConfig = config as InfinityOptions;
   if (!infinityConfig.datasourceUid) {
     throw new Error('Datasource not configured for Infinity action');
   }
-
   const requestBuilder = new InfinityRequestBuilder();
   return requestBuilder.buildRequest(infinityConfig, url, data, processedHeaders, processedQueryParams, contentType);
 };

--- a/public/app/features/admin/UserOrgs.tsx
+++ b/public/app/features/admin/UserOrgs.tsx
@@ -1,6 +1,6 @@
+import { structLog } from '@grafana/data';
 import { css, cx } from '@emotion/css';
 import { memo, type ReactElement, useEffect, useRef, useState } from 'react';
-
 import { type GrafanaTheme2, OrgRole } from '@grafana/data';
 import { Trans, t } from '@grafana/i18n';
 import { Button, ConfirmButton, Field, Icon, Modal, Tooltip, useStyles2, Stack, TextLink } from '@grafana/ui';
@@ -11,34 +11,26 @@ import { contextSrv } from 'app/core/services/context_srv';
 import { AccessControlAction, type Role } from 'app/types/accessControl';
 import { type Organization } from 'app/types/organization';
 import { type UserOrg, type UserDTO } from 'app/types/user';
-
 import { OrgRolePicker } from './OrgRolePicker';
-
 interface Props {
   orgs: UserOrg[];
   user?: UserDTO;
   isExternalUser?: boolean;
-
   onOrgRemove: (orgId: number) => void;
   onOrgRoleChange: (orgId: number, newRole: OrgRole) => void;
   onOrgAdd: (orgId: number, role: OrgRole) => void;
 }
-
 export const UserOrgs = memo(({ user, orgs, isExternalUser, onOrgRoleChange, onOrgRemove, onOrgAdd }: Props) => {
   const [showAddOrgModal, setShowAddOrgModal] = useState(false);
   const addToOrgButtonRef = useRef<HTMLButtonElement>(null);
-
   const showOrgAddModal = () => {
     setShowAddOrgModal(true);
   };
-
   const dismissOrgAddModal = () => {
     setShowAddOrgModal(false);
     addToOrgButtonRef.current?.focus();
   };
-
   const canAddToOrg = contextSrv.hasPermission(AccessControlAction.OrgUsersAdd) && !isExternalUser;
-
   return (
     <div>
       <h3 className="page-heading">
@@ -79,7 +71,6 @@ export const UserOrgs = memo(({ user, orgs, isExternalUser, onOrgRoleChange, onO
   );
 });
 UserOrgs.displayName = 'UserOrgs';
-
 const getOrgRowStyles = (theme: GrafanaTheme2) => {
   return {
     removeButton: css({
@@ -108,7 +99,6 @@ const getOrgRowStyles = (theme: GrafanaTheme2) => {
     }),
   };
 };
-
 interface OrgRowProps {
   user?: UserDTO;
   org: UserOrg;
@@ -116,55 +106,45 @@ interface OrgRowProps {
   onOrgRemove: (orgId: number) => void;
   onOrgRoleChange: (orgId: number, newRole: OrgRole) => void;
 }
-
 const OrgRow = memo(({ user, org, isExternalUser, onOrgRemove, onOrgRoleChange }: OrgRowProps) => {
   const [currentRole, setCurrentRole] = useState(org.role);
   const [isChangingRole, setIsChangingRole] = useState(false);
   const [roleOptions, setRoleOptions] = useState<Role[]>([]);
   const styles = useStyles2(getOrgRowStyles);
-
   useEffect(() => {
     if (contextSrv.licensedAccessControlEnabled()) {
       if (contextSrv.hasPermission(AccessControlAction.ActionRolesList)) {
         fetchRoleOptions(org.orgId)
           .then((roles) => setRoleOptions(roles))
-          .catch((e) => console.error(e));
+          .catch((e) => structLog('error', e));
       }
     }
   }, [org.orgId]);
-
   const handleOrgRemove = async () => {
     onOrgRemove(org.orgId);
   };
-
   const handleChangeRoleClick = () => {
     setIsChangingRole(true);
     setCurrentRole(org.role);
   };
-
   const handleOrgRoleChange = (newRole: OrgRole) => {
     setCurrentRole(newRole);
   };
-
   const handleOrgRoleSave = () => {
     onOrgRoleChange(org.orgId, currentRole);
   };
-
   const handleCancelClick = () => {
     setIsChangingRole(false);
   };
-
   const handleBasicRoleChange = (newRole: OrgRole) => {
     onOrgRoleChange(org.orgId, newRole);
   };
-
   const authSource = user?.authLabels?.length && user?.authLabels[0];
   const lockMessage = authSource ? `Synced via ${authSource}` : '';
   const labelClass = cx('width-16', styles.label);
   const canChangeRole = contextSrv.hasPermission(AccessControlAction.OrgUsersWrite);
   const canRemoveFromOrg = contextSrv.hasPermission(AccessControlAction.OrgUsersRemove) && !isExternalUser;
   const rolePickerDisabled = isExternalUser || !canChangeRole;
-
   const inputId = `${org.name}-input`;
   return (
     <tr>
@@ -227,7 +207,6 @@ const OrgRow = memo(({ user, org, isExternalUser, onOrgRemove, onOrgRoleChange }
   );
 });
 OrgRow.displayName = 'OrgRow';
-
 const getAddToOrgModalStyles = () => ({
   modal: css({
     width: '500px',
@@ -239,16 +218,13 @@ const getAddToOrgModalStyles = () => ({
     overflow: 'visible',
   }),
 });
-
 interface AddToOrgModalProps {
   isOpen: boolean;
   user?: UserDTO;
   userOrgs: UserOrg[];
   onOrgAdd(orgId: number, role: string): void;
-
   onDismiss?(): void;
 }
-
 export const AddToOrgModal = memo(({ isOpen, user, userOrgs, onOrgAdd, onDismiss }: AddToOrgModalProps) => {
   const [selectedOrg, setSelectedOrg] = useState<Organization | null>(null);
   const [role, setRole] = useState<OrgRole>(OrgRole.Viewer);
@@ -257,7 +233,6 @@ export const AddToOrgModal = memo(({ isOpen, user, userOrgs, onOrgAdd, onDismiss
   const [pendingUserId, setPendingUserId] = useState<number | null>(null);
   const [pendingRoles, setPendingRoles] = useState<Role[]>([]);
   const styles = useStyles2(getAddToOrgModalStyles);
-
   const onOrgSelect = (org: OrgSelectItem) => {
     const userOrg = userOrgs.find((userOrg) => userOrg.orgId === org.value?.id);
     setSelectedOrg(org.value!);
@@ -266,15 +241,13 @@ export const AddToOrgModal = memo(({ isOpen, user, userOrgs, onOrgAdd, onDismiss
       if (contextSrv.hasPermission(AccessControlAction.ActionRolesList)) {
         fetchRoleOptions(org.value?.id)
           .then((roles) => setRoleOptions(roles))
-          .catch((e) => console.error(e));
+          .catch((e) => structLog('error', e));
       }
     }
   };
-
   const onOrgRoleChange = (newRole: OrgRole) => {
     setRole(newRole);
   };
-
   const onAddUserToOrg = async () => {
     onOrgAdd(selectedOrg!.id, role);
     // add the stored userRoles also
@@ -290,7 +263,6 @@ export const AddToOrgModal = memo(({ isOpen, user, userOrgs, onOrgAdd, onDismiss
       }
     }
   };
-
   const onCancel = () => {
     // clear selectedOrg when modal is canceled
     setSelectedOrg(null);
@@ -301,14 +273,12 @@ export const AddToOrgModal = memo(({ isOpen, user, userOrgs, onOrgAdd, onDismiss
       onDismiss();
     }
   };
-
   const onRoleUpdate = async (roles: Role[], userId: number, orgId: number | undefined) => {
     // keep the new role assignments for user
     setPendingRoles(roles);
     setPendingOrgId(orgId!);
     setPendingUserId(userId);
   };
-
   return (
     <Modal
       className={styles.modal}
@@ -347,7 +317,6 @@ export const AddToOrgModal = memo(({ isOpen, user, userOrgs, onOrgAdd, onDismiss
   );
 });
 AddToOrgModal.displayName = 'AddToOrgModal';
-
 interface ChangeOrgButtonProps {
   lockMessage?: string;
   isExternalUser?: boolean;
@@ -355,7 +324,6 @@ interface ChangeOrgButtonProps {
   onCancelClick: () => void;
   onOrgRoleSave: () => void;
 }
-
 const getChangeOrgButtonTheme = (theme: GrafanaTheme2) => ({
   disabledTooltip: css({
     display: 'flex',
@@ -372,7 +340,6 @@ const getChangeOrgButtonTheme = (theme: GrafanaTheme2) => ({
     lineHeight: 2,
   }),
 });
-
 export function ChangeOrgButton({
   lockMessage,
   onChangeRoleClick,
@@ -424,10 +391,8 @@ export function ChangeOrgButton({
 interface ExternalUserTooltipProps {
   lockMessage?: string;
 }
-
 export const ExternalUserTooltip = ({ lockMessage }: ExternalUserTooltipProps) => {
   const styles = useStyles2(getTooltipStyles);
-
   return (
     <div className={styles.disabledTooltip}>
       <span className={styles.lockMessageClass}>{lockMessage}</span>
@@ -452,7 +417,6 @@ export const ExternalUserTooltip = ({ lockMessage }: ExternalUserTooltipProps) =
     </div>
   );
 };
-
 const getTooltipStyles = (theme: GrafanaTheme2) => ({
   disabledTooltip: css({
     display: 'flex',

--- a/public/app/features/admin/Users/OrgUsersTable.tsx
+++ b/public/app/features/admin/Users/OrgUsersTable.tsx
@@ -1,5 +1,5 @@
+import { structLog } from '@grafana/data';
 import { useEffect, useMemo, useState } from 'react';
-
 import { type OrgRole } from '@grafana/data';
 import { selectors as e2eSelectors } from '@grafana/e2e-selectors';
 import { Trans, t } from '@grafana/i18n';
@@ -28,21 +28,15 @@ import { TagBadge } from 'app/core/components/TagFilter/TagBadge';
 import { contextSrv } from 'app/core/services/context_srv';
 import { AccessControlAction, type Role } from 'app/types/accessControl';
 import { type OrgUser } from 'app/types/user';
-
 import { OrgRolePicker } from '../OrgRolePicker';
-
 type Cell<T extends keyof OrgUser = keyof OrgUser> = CellProps<OrgUser, OrgUser[T]>;
-
 const disabledRoleMessage = `This user's role is not editable because it is synchronized from your auth provider.
 Refer to the Grafana authentication docs for details.`;
-
 const getBasicRoleDisabled = (user: OrgUser) => {
   const isUserSynced = user?.isExternallySynced;
   return !contextSrv.hasPermissionInMetadata(AccessControlAction.OrgUsersWrite, user) || isUserSynced;
 };
-
 const selectors = e2eSelectors.pages.UserListPage.UsersListPage;
-
 export interface Props {
   users: OrgUser[];
   orgId?: number;
@@ -55,7 +49,6 @@ export interface Props {
   rolesLoading?: boolean;
   onUserRolesChange?: () => void;
 }
-
 export const OrgUsersTable = ({
   users,
   orgId,
@@ -70,7 +63,6 @@ export const OrgUsersTable = ({
 }: Props) => {
   const [userToRemove, setUserToRemove] = useState<OrgUser | null>(null);
   const [roleOptions, setRoleOptions] = useState<Role[]>([]);
-
   useEffect(() => {
     async function fetchOptions() {
       try {
@@ -79,14 +71,13 @@ export const OrgUsersTable = ({
           setRoleOptions(options);
         }
       } catch (e) {
-        console.error('Error loading options');
+        structLog('error', 'Error loading options');
       }
     }
     if (contextSrv.licensedAccessControlEnabled()) {
       fetchOptions();
     }
   }, [orgId]);
-
   const columns: Array<Column<OrgUser>> = useMemo(
     () => [
       {
@@ -148,11 +139,9 @@ export const OrgUsersTable = ({
               onUserRolesChange();
             }
           };
-
           if (config.featureToggles.rolePickerDrawer) {
             return <RolePickerBadges disabled={basicRoleDisabled} user={original} />;
           }
-
           return contextSrv.licensedAccessControlEnabled() ? (
             <UserRolePicker
               userId={original.userId}
@@ -256,7 +245,6 @@ export const OrgUsersTable = ({
     ],
     [rolesLoading, orgId, roleOptions, onUserRolesChange, onRoleChange]
   );
-
   return (
     <Stack direction={'column'} gap={2} data-testid={selectors.container}>
       <InteractiveTable columns={columns} data={users} getRowId={(user) => String(user.userId)} fetchData={fetchData} />

--- a/public/app/features/admin/state/actions.ts
+++ b/public/app/features/admin/state/actions.ts
@@ -1,5 +1,5 @@
+import { structLog } from '@grafana/data';
 import { debounce } from 'lodash';
-
 import { dateTimeFormatTimeAgo } from '@grafana/data';
 import { featureEnabled, getBackendSrv, isFetchError, locationService } from '@grafana/runtime';
 import { type FetchDataArgs } from '@grafana/ui';
@@ -10,7 +10,6 @@ import { AccessControlAction } from 'app/types/accessControl';
 import { type LdapUser } from 'app/types/ldap';
 import { type ThunkResult } from 'app/types/store';
 import { type UserDTO, type UserSession, type UserFilter, type AnonUserFilter } from 'app/types/user';
-
 import {
   userAdminPageLoadedAction,
   userProfileLoadedAction,
@@ -37,7 +36,6 @@ import {
   anonQueryChanged,
 } from './reducers';
 // UserAdminPage
-
 export function loadAdminUserPage(userUid: string): ThunkResult<void> {
   return async (dispatch) => {
     try {
@@ -50,34 +48,29 @@ export function loadAdminUserPage(userUid: string): ThunkResult<void> {
       }
       dispatch(userAdminPageLoadedAction(true));
     } catch (error) {
-      console.error(error);
-
+      structLog('error', error);
       if (isFetchError(error)) {
         const userError = {
           title: error.data.message,
           body: error.data.error,
         };
-
         dispatch(userAdminPageFailedAction(userError));
       }
     }
   };
 }
-
 export function loadUserProfile(userUid: string): ThunkResult<void> {
   return async (dispatch) => {
     const user = await getBackendSrv().get(`/api/users/${userUid}`, accessControlQueryParam());
     dispatch(userProfileLoadedAction(user));
   };
 }
-
 export function updateUser(user: UserDTO): ThunkResult<void> {
   return async (dispatch) => {
     await getBackendSrv().put(`/api/users/${user.uid}`, user);
     dispatch(loadAdminUserPage(user.uid));
   };
 }
-
 export function setUserPassword(userUid: string, password: string): ThunkResult<void> {
   return async (dispatch) => {
     const payload = { password };
@@ -85,28 +78,24 @@ export function setUserPassword(userUid: string, password: string): ThunkResult<
     dispatch(loadAdminUserPage(userUid));
   };
 }
-
 export function disableUser(userUid: string): ThunkResult<void> {
   return async (dispatch) => {
     await getBackendSrv().post(`/api/admin/users/${userUid}/disable`);
     locationService.push('/admin/users');
   };
 }
-
 export function enableUser(userUid: string): ThunkResult<void> {
   return async (dispatch) => {
     await getBackendSrv().post(`/api/admin/users/${userUid}/enable`);
     dispatch(loadAdminUserPage(userUid));
   };
 }
-
 export function deleteUser(userUid: string): ThunkResult<void> {
   return async (dispatch) => {
     await getBackendSrv().delete(`/api/admin/users/${userUid}`);
     locationService.push('/admin/users');
   };
 }
-
 export function updateUserPermissions(userUid: string, isGrafanaAdmin: boolean): ThunkResult<void> {
   return async (dispatch) => {
     const payload = { isGrafanaAdmin };
@@ -114,14 +103,12 @@ export function updateUserPermissions(userUid: string, isGrafanaAdmin: boolean):
     dispatch(loadAdminUserPage(userUid));
   };
 }
-
 export function loadUserOrgs(userUid: string): ThunkResult<void> {
   return async (dispatch) => {
     const orgs = await getBackendSrv().get(`/api/users/${userUid}/orgs`);
     dispatch(userOrgsLoadedAction(orgs));
   };
 }
-
 export function addOrgUser(user: UserDTO, orgId: number, role: string): ThunkResult<void> {
   return async (dispatch) => {
     const payload = {
@@ -132,7 +119,6 @@ export function addOrgUser(user: UserDTO, orgId: number, role: string): ThunkRes
     dispatch(loadAdminUserPage(user.uid));
   };
 }
-
 export function updateOrgUserRole(userUid: string, orgId: number, role: string): ThunkResult<void> {
   return async (dispatch) => {
     const payload = { role };
@@ -140,23 +126,19 @@ export function updateOrgUserRole(userUid: string, orgId: number, role: string):
     dispatch(loadAdminUserPage(userUid));
   };
 }
-
 export function deleteOrgUser(userUid: string, orgId: number): ThunkResult<void> {
   return async (dispatch) => {
     await getBackendSrv().delete(`/api/orgs/${orgId}/users/${userUid}`);
     dispatch(loadAdminUserPage(userUid));
   };
 }
-
 export function loadUserSessions(userUid: string): ThunkResult<void> {
   return async (dispatch) => {
     if (!contextSrv.hasPermission(AccessControlAction.UsersAuthTokenList)) {
       return;
     }
-
     const tokens = await getBackendSrv().get(`/api/admin/users/${userUid}/auth-tokens`);
     tokens.reverse();
-
     const sessions = tokens.map((session: UserSession) => {
       return {
         id: session.id,
@@ -172,11 +154,9 @@ export function loadUserSessions(userUid: string): ThunkResult<void> {
         device: session.device,
       };
     });
-
     dispatch(userSessionsLoadedAction(sessions));
   };
 }
-
 export function revokeSession(tokenId: number, userUid: string): ThunkResult<void> {
   return async (dispatch) => {
     const payload = { authTokenId: tokenId };
@@ -184,16 +164,13 @@ export function revokeSession(tokenId: number, userUid: string): ThunkResult<voi
     dispatch(loadUserSessions(userUid));
   };
 }
-
 export function revokeAllSessions(userUid: string): ThunkResult<void> {
   return async (dispatch) => {
     await getBackendSrv().post(`/api/admin/users/${userUid}/logout`);
     dispatch(loadUserSessions(userUid));
   };
 }
-
 // LDAP user actions
-
 export function loadLdapSyncStatus(): ThunkResult<void> {
   return async (dispatch) => {
     // Available only in enterprise
@@ -204,22 +181,18 @@ export function loadLdapSyncStatus(): ThunkResult<void> {
     }
   };
 }
-
 export function syncLdapUser(userId: number, userUid: string): ThunkResult<void> {
   return async (dispatch) => {
     await getBackendSrv().post(`/api/admin/ldap/sync/${userId}`);
     dispatch(loadAdminUserPage(userUid));
   };
 }
-
 // LDAP debug page
-
 export function loadLdapState(): ThunkResult<void> {
   return async (dispatch) => {
     if (!contextSrv.hasPermission(AccessControlAction.LDAPStatusRead)) {
       return;
     }
-
     try {
       const connectionInfo = await getBackendSrv().get(`/api/admin/ldap/status`);
       dispatch(ldapConnectionInfoLoadedAction(connectionInfo));
@@ -235,7 +208,6 @@ export function loadLdapState(): ThunkResult<void> {
     }
   };
 }
-
 export function loadUserMapping(username: string): ThunkResult<void> {
   return async (dispatch) => {
     try {
@@ -261,22 +233,18 @@ export function loadUserMapping(username: string): ThunkResult<void> {
     }
   };
 }
-
 export function clearUserError(): ThunkResult<void> {
   return (dispatch) => {
     dispatch(clearUserErrorAction());
   };
 }
-
 export function clearUserMappingInfo(): ThunkResult<void> {
   return (dispatch) => {
     dispatch(clearUserErrorAction());
     dispatch(clearUserMappingInfoAction());
   };
 }
-
 // UserListAdminPage
-
 const getFilters = (filters: UserFilter[]) => {
   return filters
     .map((filter) => {
@@ -287,7 +255,6 @@ const getFilters = (filters: UserFilter[]) => {
     })
     .join('&');
 };
-
 export function fetchUsers(): ThunkResult<void> {
   return async (dispatch, getState) => {
     try {
@@ -300,13 +267,11 @@ export function fetchUsers(): ThunkResult<void> {
       dispatch(usersFetched(result));
     } catch (error) {
       usersFetchEnd();
-      console.error(error);
+      structLog('error', error);
     }
   };
 }
-
 const fetchUsersWithDebounce = debounce((dispatch) => dispatch(fetchUsers()), 500);
-
 export function changeQuery(query: string): ThunkResult<void> {
   return async (dispatch) => {
     dispatch(usersFetchBegin());
@@ -314,7 +279,6 @@ export function changeQuery(query: string): ThunkResult<void> {
     fetchUsersWithDebounce(dispatch);
   };
 }
-
 export function changeFilter(filter: UserFilter): ThunkResult<void> {
   return async (dispatch) => {
     dispatch(usersFetchBegin());
@@ -322,7 +286,6 @@ export function changeFilter(filter: UserFilter): ThunkResult<void> {
     fetchUsersWithDebounce(dispatch);
   };
 }
-
 export function changePage(page: number): ThunkResult<void> {
   return async (dispatch) => {
     dispatch(usersFetchBegin());
@@ -330,7 +293,6 @@ export function changePage(page: number): ThunkResult<void> {
     dispatch(fetchUsers());
   };
 }
-
 export function changeSort({ sortBy }: FetchDataArgs<UserDTO>): ThunkResult<void> {
   const sort = sortBy.length ? `${sortBy[0].id}-${sortBy[0].desc ? 'desc' : 'asc'}` : undefined;
   return async (dispatch, getState) => {
@@ -342,7 +304,6 @@ export function changeSort({ sortBy }: FetchDataArgs<UserDTO>): ThunkResult<void
     }
   };
 }
-
 // UserListAnonymousPage
 const getAnonFilters = (filters: AnonUserFilter[]) => {
   return filters
@@ -354,7 +315,6 @@ const getAnonFilters = (filters: AnonUserFilter[]) => {
     })
     .join('&');
 };
-
 export function fetchUsersAnonymousDevices(): ThunkResult<void> {
   return async (dispatch, getState) => {
     try {
@@ -366,13 +326,11 @@ export function fetchUsersAnonymousDevices(): ThunkResult<void> {
       const result = await getBackendSrv().get(url);
       dispatch(usersAnonymousDevicesFetched(result));
     } catch (error) {
-      console.error(error);
+      structLog('error', error);
     }
   };
 }
-
 const fetchAnonUsersWithDebounce = debounce((dispatch) => dispatch(fetchUsersAnonymousDevices()), 500);
-
 export function changeAnonUserSort({ sortBy }: FetchDataArgs<UserDTO>): ThunkResult<void> {
   const sort = sortBy.length ? `${sortBy[0].id}-${sortBy[0].desc ? 'desc' : 'asc'}` : undefined;
   return async (dispatch, getState) => {
@@ -384,7 +342,6 @@ export function changeAnonUserSort({ sortBy }: FetchDataArgs<UserDTO>): ThunkRes
     }
   };
 }
-
 export function changeAnonQuery(query: string): ThunkResult<void> {
   return async (dispatch) => {
     // dispatch(usersFetchBegin());
@@ -392,7 +349,6 @@ export function changeAnonQuery(query: string): ThunkResult<void> {
     fetchAnonUsersWithDebounce(dispatch);
   };
 }
-
 export function changeAnonPage(page: number): ThunkResult<void> {
   return async (dispatch) => {
     // dispatch(usersFetchBegin());
@@ -400,16 +356,3 @@ export function changeAnonPage(page: number): ThunkResult<void> {
     dispatch(fetchUsersAnonymousDevices());
   };
 }
-
-// export function fetchUsersAnonymousDevices(): ThunkResult<void> {
-//   return async (dispatch, getState) => {
-//     try {
-//       let url = `/api/anonymous/devices`;
-//       const result = await getBackendSrv().get(url);
-//       dispatch(usersAnonymousDevicesFetched({ devices: result }));
-//     } catch (error) {
-//       usersFetchEnd();
-//       console.error(error);
-//     }
-//   };
-// }

--- a/public/app/features/admin/state/apis.tsx
+++ b/public/app/features/admin/state/apis.tsx
@@ -1,9 +1,8 @@
+import { structLog } from '@grafana/data';
 import { getBackendSrv } from '@grafana/runtime';
-
 interface AnonServerStat {
   activeDevices?: number;
 }
-
 export interface ServerStat extends AnonServerStat {
   activeAdmins: number;
   activeEditors: number;
@@ -23,12 +22,11 @@ export interface ServerStat extends AnonServerStat {
   users: number;
   viewers: number;
 }
-
 export const getServerStats = async (): Promise<ServerStat | null> => {
   return getBackendSrv()
     .get('api/admin/stats')
     .catch((err) => {
-      console.error(err);
+      structLog('error', err);
       return null;
     });
 };

--- a/public/app/features/alerting/unified/components/receivers/form/fields/OptionField.tsx
+++ b/public/app/features/alerting/unified/components/receivers/form/fields/OptionField.tsx
@@ -1,7 +1,7 @@
+import { structLog } from '@grafana/data';
 import { css } from '@emotion/css';
 import { type FC } from 'react';
 import { Controller, type DeepMap, type FieldError, useFormContext } from 'react-hook-form';
-
 import { type GrafanaTheme2 } from '@grafana/data';
 import { t } from '@grafana/i18n';
 import {
@@ -23,13 +23,11 @@ import {
   type NotificationChannelSecureFields,
   type OptionMeta,
 } from 'app/features/alerting/unified/types/alerting';
-
 import { KeyValueMapInput } from './KeyValueMapInput';
 import { StringArrayInput } from './StringArrayInput';
 import { SubformArrayField } from './SubformArrayField';
 import { SubformField } from './SubformField';
 import { WrapWithTemplateSelection } from './TemplateSelector';
-
 interface Props {
   defaultValue: any;
   option: NotificationChannelOption;
@@ -43,7 +41,6 @@ interface Props {
   onDeleteSubform?: (settingsPath: string, option: NotificationChannelOption) => void;
   secureFields: NotificationChannelSecureFields;
 }
-
 export const OptionField: FC<Props> = ({
   option,
   invalid,
@@ -85,11 +82,8 @@ export const OptionField: FC<Props> = ({
       />
     );
   }
-
   const shouldShowProtectedIndicator = option.protected && getOptionMeta?.(option).readOnly;
-
   const labelText = option.element !== 'checkbox' && option.element !== 'radio' ? option.label : undefined;
-
   const label = shouldShowProtectedIndicator ? (
     <Stack direction="row" alignItems="center" gap={0.5}>
       <Tooltip
@@ -105,7 +99,6 @@ export const OptionField: FC<Props> = ({
   ) : (
     labelText
   );
-
   return (
     <Field
       label={label}
@@ -129,28 +122,28 @@ export const OptionField: FC<Props> = ({
     </Field>
   );
 };
-
 export interface ConfiguredSecureFieldProps {
   id: string;
   readOnly: boolean;
   onReset: () => void;
 }
-
 export function ConfiguredSecretInput({ id, readOnly, onReset }: ConfiguredSecureFieldProps) {
   if (readOnly) {
     return <Input id={id} disabled={true} value="configured" />;
   }
   return <SecretInput id={id} onReset={onReset} isConfigured />;
 }
-
 function ConfiguredSecretTextArea({ id, readOnly, onReset }: ConfiguredSecureFieldProps) {
   if (readOnly) {
     return <TextArea id={id} disabled={true} value="configured" />;
   }
   return <SecretTextArea id={id} onReset={onReset} isConfigured />;
 }
-
-const OptionInput: FC<Props & { id: string }> = ({
+const OptionInput: FC<
+  Props & {
+    id: string;
+  }
+> = ({
   option,
   invalid,
   id,
@@ -163,20 +156,14 @@ const OptionInput: FC<Props & { id: string }> = ({
 }) => {
   const styles = useStyles2(getStyles);
   const { control, register, setValue } = useFormContext();
-
   const optionMeta = getOptionMeta?.(option);
-
   const name = `${pathPrefix}${option.propertyName}`;
-
   const secureFieldKey = option.secure && option.secureFieldKey ? option.secureFieldKey : '';
   const isSecureFieldConfigured = secureFieldKey && secureFields?.[secureFieldKey];
-
   const useTemplates = option.placeholder.includes('{{ template');
-
   function onSelectTemplate(template: string) {
     setValue(name, template);
   }
-
   switch (option.element) {
     case 'checkbox':
       return (
@@ -221,7 +208,6 @@ const OptionInput: FC<Props & { id: string }> = ({
           )}
         </WrapWithTemplateSelection>
       );
-
     case 'select':
       return (
         <Controller
@@ -316,13 +302,11 @@ const OptionInput: FC<Props & { id: string }> = ({
           name={name}
         />
       );
-
     default:
-      console.error('Element not supported', option.element);
+      structLog('error', 'Element not supported', option.element);
       return null;
   }
 };
-
 const getStyles = (theme: GrafanaTheme2) => ({
   checkbox: css({
     height: 'auto', // native checkbox has fixed height which does not take into account description
@@ -331,11 +315,9 @@ const getStyles = (theme: GrafanaTheme2) => ({
     fontSize: theme.typography.h6.fontSize,
   }),
 });
-
 const validateOption = (value: string, validationRule: string, required: boolean) => {
   if (value === '' && !required) {
     return true;
   }
-
   return RegExp(validationRule).test(value) ? true : 'Invalid format';
 };

--- a/public/app/features/alerting/unified/components/rule-editor/labels/LabelsField.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/labels/LabelsField.tsx
@@ -1,12 +1,11 @@
+import { structLog } from '@grafana/data';
 import { css, cx } from '@emotion/css';
 import { type FC, useCallback, useMemo } from 'react';
 import { Controller, FormProvider, useFieldArray, useForm, useFormContext } from 'react-hook-form';
-
 import { AlertLabels } from '@grafana/alerting/unstable';
 import { type GrafanaTheme2, type SelectableValue } from '@grafana/data';
 import { Trans, t } from '@grafana/i18n';
 import { Button, type ComboboxOption, Field, InlineLabel, Input, Space, Stack, Text, useStyles2 } from '@grafana/ui';
-
 import { labelsApi } from '../../../api/labelsApi';
 import { usePluginBridge } from '../../../hooks/usePluginBridge';
 import { SupportedPlugin } from '../../../types/pluginBridges';
@@ -17,19 +16,19 @@ import { isRecordingRuleByType } from '../../../utils/rules';
 import AlertLabelDropdown, { type AsyncOptionsLoader } from '../../AlertLabelDropdown';
 import { NeedHelpInfo } from '../NeedHelpInfo';
 import { useGetLabelsFromDataSourceName } from '../useAlertRuleSuggestions';
-
 import { AddButton, RemoveButton } from './LabelsButtons';
-
 const useGetOpsLabelsKeys = (skip: boolean) => {
   const { currentData, isLoading: isloadingLabels } = labelsApi.endpoints.getLabels.useQuery(undefined, {
     skip,
   });
   return { loading: isloadingLabels, labelsOpsKeys: currentData };
 };
-
 function mapLabelsToOptions(
   items: Iterable<string> = [],
-  labelsInSubForm?: Array<{ key: string; value: string }>
+  labelsInSubForm?: Array<{
+    key: string;
+    value: string;
+  }>
 ): Array<ComboboxOption<string>> {
   const existingKeys = new Set(labelsInSubForm ? labelsInSubForm.map((label) => label.key) : []);
   return Array.from(items, (item) => ({
@@ -38,11 +37,15 @@ function mapLabelsToOptions(
     disabled: existingKeys.has(item),
   }));
 }
-
 export interface LabelsInRuleProps {
-  labels: Array<{ key: string; value: string }> | undefined | null;
+  labels:
+    | Array<{
+        key: string;
+        value: string;
+      }>
+    | undefined
+    | null;
 }
-
 export const LabelsInRule = ({ labels }: LabelsInRuleProps) => {
   const safeLabels = Array.isArray(labels) ? labels : [];
   const labelsObj: Record<string, string> = safeLabels.reduce((acc: Record<string, string>, label) => {
@@ -51,26 +54,26 @@ export const LabelsInRule = ({ labels }: LabelsInRuleProps) => {
     }
     return acc;
   }, {});
-
   return <AlertLabels labels={labelsObj} />;
 };
-
 export type LabelsSubformValues = {
-  labelsInSubform: Array<{ key: string; value: string }>;
+  labelsInSubform: Array<{
+    key: string;
+    value: string;
+  }>;
 };
-
 export interface LabelsSubFormProps {
   dataSourceName: string;
-  initialLabels: Array<{ key: string; value: string }>;
+  initialLabels: Array<{
+    key: string;
+    value: string;
+  }>;
   onClose: (labelsToUodate?: KBObjectArray) => void;
 }
-
 export function LabelsSubForm({ dataSourceName, onClose, initialLabels }: LabelsSubFormProps) {
   const styles = useStyles2(getStyles);
   const { watch } = useFormContext<RuleFormValues>();
-
   const type = watch('type') ?? RuleFormType.grafana;
-
   const onSave = (labels: LabelsSubformValues) => {
     onClose(labels.labelsInSubform);
   };
@@ -81,7 +84,6 @@ export function LabelsSubForm({ dataSourceName, onClose, initialLabels }: Labels
   const defaultValues: LabelsSubformValues = useMemo(() => {
     return { labelsInSubform: initialLabels };
   }, [initialLabels]);
-
   const formAPI = useForm<LabelsSubformValues>({ defaultValues });
   return (
     <FormProvider {...formAPI}>
@@ -112,14 +114,15 @@ export function LabelsSubForm({ dataSourceName, onClose, initialLabels }: Labels
     </FormProvider>
   );
 }
-
 const isKeyAllowed = (labelKey: string) => !isPrivateLabelKey(labelKey);
-
 export function useCombinedLabels(
   dataSourceName: string,
   labelsPluginInstalled: boolean,
   loadingLabelsPlugin: boolean,
-  labelsInSubform: Array<{ key: string; value: string }>
+  labelsInSubform: Array<{
+    key: string;
+    value: string;
+  }>
 ) {
   // ------- Get labels keys and their values from existing alerts
   const { labels: labelsByKeyFromExisingAlerts, isLoading } = useGetLabelsFromDataSourceName(dataSourceName);
@@ -127,25 +130,20 @@ export function useCombinedLabels(
   const { loading: isLoadingLabels, labelsOpsKeys = [] } = useGetOpsLabelsKeys(
     !labelsPluginInstalled || loadingLabelsPlugin
   );
-
   // Lazy query for fetching label values on demand
   const [fetchLabelValues] = labelsApi.endpoints.getLabelValues.useLazyQuery();
-
   //------ Convert the labelsOpsKeys to a Set for quick lookup
   const opsLabelKeysSet = useMemo(() => {
     return new Set(labelsOpsKeys.map((label) => label.name));
   }, [labelsOpsKeys]);
-
   //------- Convert the keys from the ops labels to options for the dropdown
   const keysFromGopsLabels = useMemo(() => {
     return mapLabelsToOptions(Array.from(opsLabelKeysSet).filter(isKeyAllowed), labelsInSubform);
   }, [opsLabelKeysSet, labelsInSubform]);
-
   //------- Convert the keys from the existing alerts to options for the dropdown
   const keysFromExistingAlerts = useMemo(() => {
     return mapLabelsToOptions(Array.from(labelsByKeyFromExisingAlerts.keys()).filter(isKeyAllowed), labelsInSubform);
   }, [labelsByKeyFromExisingAlerts, labelsInSubform]);
-
   // create two groups of labels, one for ops and one for custom
   const groupedOptions = [
     {
@@ -159,7 +157,6 @@ export function useCombinedLabels(
       expanded: true,
     },
   ];
-
   // Create an async options loader for a specific key
   // This is called by Combobox when the dropdown menu opens
   const createAsyncValuesLoader = useCallback(
@@ -168,11 +165,9 @@ export function useCombinedLabels(
         if (!isKeyAllowed(key) || !key) {
           return [];
         }
-
         // Collect values from existing alerts first
         const valuesFromAlerts = labelsByKeyFromExisingAlerts.get(key);
         const existingValues = valuesFromAlerts ? Array.from(valuesFromAlerts) : [];
-
         // Collect values from ops labels (if plugin is installed)
         let opsValues: string[] = [];
         if (labelsPluginInstalled && opsLabelKeysSet.has(key)) {
@@ -183,22 +178,18 @@ export function useCombinedLabels(
               opsValues = result.values.map((value) => value.name);
             }
           } catch (error) {
-            console.error('Failed to fetch label values for key:', key, error);
+            structLog('error', 'Failed to fetch label values for key:', key, error);
           }
         }
-
         // Combine: existing values first, then unique ops values (Set preserves first occurrence)
         const combinedValues = [...new Set([...existingValues, ...opsValues])];
-
         const valueQueryLowerCase = valueQuery.toLowerCase();
         const filteredValues = combinedValues.filter((value) => value.toLowerCase().includes(valueQueryLowerCase));
-
         return mapLabelsToOptions(filteredValues);
       };
     },
     [labelsByKeyFromExisingAlerts, labelsPluginInstalled, opsLabelKeysSet, fetchLabelValues]
   );
-
   return {
     loading: isLoading || isLoadingLabels,
     keysFromExistingAlerts,
@@ -206,7 +197,6 @@ export function useCombinedLabels(
     createAsyncValuesLoader,
   };
 }
-
 /*
   We will suggest labels from two sources: existing alerts and ops labels.
   We only will suggest labels from ops if the grafana-labels-app plugin is installed
@@ -215,7 +205,6 @@ export function useCombinedLabels(
 export interface LabelsWithSuggestionsProps {
   dataSourceName: string;
 }
-
 export function LabelsWithSuggestions({ dataSourceName }: LabelsWithSuggestionsProps) {
   const styles = useStyles2(getStyles);
   const {
@@ -223,25 +212,21 @@ export function LabelsWithSuggestions({ dataSourceName }: LabelsWithSuggestionsP
     watch,
     formState: { errors },
   } = useFormContext<LabelsSubformValues>();
-
   const labelsInSubform = watch('labelsInSubform');
   const { fields, remove, append } = useFieldArray({ control, name: 'labelsInSubform' });
   const appendLabel = useCallback(() => {
     append({ key: '', value: '' });
   }, [append]);
-
   // check if the labels plugin is installed
   const { installed: labelsPluginInstalled = false, loading: loadingLabelsPlugin } = usePluginBridge(
     SupportedPlugin.Labels
   );
-
   const { loading, keysFromExistingAlerts, groupedOptions, createAsyncValuesLoader } = useCombinedLabels(
     dataSourceName,
     labelsPluginInstalled,
     loadingLabelsPlugin,
     labelsInSubform
   );
-
   return (
     <Stack direction="column" gap={2} alignItems="flex-start">
       {fields.map((field, index) => {
@@ -249,7 +234,6 @@ export function LabelsWithSuggestions({ dataSourceName }: LabelsWithSuggestionsP
         // This will be called by Combobox when the dropdown opens
         const currentKey = labelsInSubform[index]?.key || '';
         const asyncValuesLoader = createAsyncValuesLoader(currentKey);
-
         return (
           <div key={field.id} className={cx(styles.flexRow, styles.centerAlignRow)}>
             <Field
@@ -324,7 +308,6 @@ export function LabelsWithSuggestions({ dataSourceName }: LabelsWithSuggestionsP
     </Stack>
   );
 }
-
 export const LabelsWithoutSuggestions: FC = () => {
   const styles = useStyles2(getStyles);
   const {
@@ -333,13 +316,11 @@ export const LabelsWithoutSuggestions: FC = () => {
     watch,
     formState: { errors },
   } = useFormContext<RuleFormValues>();
-
   const labels = watch('labels');
   const { fields, remove, append } = useFieldArray({ control, name: 'labels' });
   const appendLabel = useCallback(() => {
     append({ key: '', value: '' });
   }, [append]);
-
   return (
     <>
       {fields.map((field, index) => {
@@ -392,12 +373,9 @@ export const LabelsWithoutSuggestions: FC = () => {
     </>
   );
 };
-
 function LabelsField() {
   const { watch } = useFormContext<RuleFormValues>();
-
   const type = watch('type') ?? RuleFormType.grafana;
-
   return (
     <div>
       <Stack direction="column" gap={1}>
@@ -421,7 +399,6 @@ function LabelsField() {
     </div>
   );
 }
-
 function getLabelText(type: RuleFormType) {
   const isRecordingRule = type ? isRecordingRuleByType(type) : false;
   const text = isRecordingRule
@@ -432,14 +409,12 @@ function getLabelText(type: RuleFormType) {
       );
   return text;
 }
-
 function getDescriptionText() {
   return t(
     'alerting.labels-sub-form.description',
     'Select a label key/value from the options below, or type a new one and press Enter.'
   );
 }
-
 const getStyles = (theme: GrafanaTheme2) => {
   return {
     flexColumn: css({
@@ -473,5 +448,4 @@ const getStyles = (theme: GrafanaTheme2) => {
     }),
   };
 };
-
 export default LabelsField;

--- a/public/app/features/alerting/unified/components/rule-editor/useDashboardQuery.ts
+++ b/public/app/features/alerting/unified/components/rule-editor/useDashboardQuery.ts
@@ -1,27 +1,21 @@
+import { structLog } from '@grafana/data';
 import memoizeOne from 'memoize-one';
 import { useEffect, useState } from 'react';
-
 import { type Spec as DashboardV2Spec } from '@grafana/schema/apis/dashboard.grafana.app/v2';
 import { getDashboardAPI } from 'app/features/dashboard/api/dashboard_api';
 import { type DashboardWithAccessInfo } from 'app/features/dashboard/api/types';
 import { isDashboardV2Resource } from 'app/features/dashboard/api/utils';
 import { type DashboardDTO } from 'app/types/dashboard';
-
 import { DashboardModel } from '../../../../dashboard/state/DashboardModel';
-
 export type DashboardResponse = DashboardDTO | DashboardWithAccessInfo<DashboardV2Spec>;
-
 const ensureV1PanelsHaveIds = memoizeOne((dashboardDTO: DashboardDTO): DashboardResponse => {
   // RTKQuery freezes all returned objects. DashboardModel constructor runs migrations which might change the internal object
   // Hence we need to add structuredClone to make a deep copy of the API response object
   const dashboardDTOClone = structuredClone(dashboardDTO);
   const model = new DashboardModel(dashboardDTOClone.dashboard, dashboardDTOClone.meta);
-
   dashboardDTOClone.dashboard.panels = model.panels;
-
   return dashboardDTOClone;
 });
-
 export function useDashboardQuery(dashboardUid?: string) {
   const [dashboard, setDashboard] = useState<DashboardResponse>();
   const [isFetching, setIsFetching] = useState(false);
@@ -36,17 +30,16 @@ export function useDashboardQuery(dashboardUid?: string) {
           } else if (isDashboardV2Resource(dashboardDTO)) {
             setDashboard(dashboardDTO);
           } else {
-            console.error('Something went wrong, unexpected dashboard format');
+            structLog('error', 'Something went wrong, unexpected dashboard format');
           }
         })
         .catch((error) => {
-          console.error('Failed to fetch dashboard', error);
+          structLog('error', 'Failed to fetch dashboard', error);
         })
         .finally(() => {
           setIsFetching(false);
         });
     }
   }, [dashboardUid]);
-
   return { dashboard, isFetching };
 }

--- a/public/app/features/alerting/unified/components/rule-editor/util.ts
+++ b/public/app/features/alerting/unified/components/rule-editor/util.ts
@@ -1,5 +1,5 @@
+import { structLog } from '@grafana/data';
 import { xor } from 'lodash';
-
 import {
   type DataFrame,
   LoadingState,
@@ -14,9 +14,7 @@ import { EvalFunction } from 'app/features/alerting/state/alertDef';
 import { isExpressionQuery } from 'app/features/expressions/guards';
 import { type ClassicCondition, ExpressionQueryType } from 'app/features/expressions/types';
 import { type AlertQuery } from 'app/types/unified-alerting-dto';
-
 import { createDagFromQueries, getOriginOfRefId } from './dag';
-
 export function queriesWithUpdatedReferences(
   queries: AlertQuery[],
   previousRefId: string,
@@ -26,17 +24,14 @@ export function queriesWithUpdatedReferences(
     if (previousRefId === newRefId) {
       return query;
     }
-
     if (!isExpressionQuery(query.model)) {
       return query;
     }
-
     const isMathExpression = query.model.type === 'math';
     const isReduceExpression = query.model.type === 'reduce';
     const isResampleExpression = query.model.type === 'resample';
     const isClassicExpression = query.model.type === 'classic_conditions';
     const isThresholdExpression = query.model.type === 'threshold';
-
     if (isMathExpression) {
       return {
         ...query,
@@ -46,10 +41,8 @@ export function queriesWithUpdatedReferences(
         },
       };
     }
-
     if (isResampleExpression || isReduceExpression || isThresholdExpression) {
       const isReferencing = query.model.expression === previousRefId;
-
       return {
         ...query,
         model: {
@@ -58,7 +51,6 @@ export function queriesWithUpdatedReferences(
         },
       };
     }
-
     if (isClassicExpression) {
       const conditions = query.model.conditions?.map((condition) => ({
         ...condition,
@@ -67,130 +59,97 @@ export function queriesWithUpdatedReferences(
           params: condition.query.params.map((param: string) => (param === previousRefId ? newRefId : param)),
         },
       }));
-
       return { ...query, model: { ...query.model, conditions } };
     }
-
     return query;
   });
 }
-
 export function updateMathExpressionRefs(expression: string, previousRefId: string, newRefId: string): string {
   const oldExpression = new RegExp('(\\$' + previousRefId + '\\b)|(\\${' + previousRefId + '})', 'gm');
   const newExpression = '${' + newRefId + '}';
-
   return expression.replace(oldExpression, newExpression);
 }
-
 export function refIdExists(queries: AlertQuery[], refId: string | null): boolean {
   return queries.find((query) => query.refId === refId) !== undefined;
 }
-
 export function containsPathSeparator(value: string): boolean {
   return value.includes('/') || value.includes('\\');
 }
-
 // this function assumes we've already checked if the data passed in to the function is of the alert condition
 export function errorFromCurrentCondition(data: PanelData): Error | undefined {
   if (data.series.length === 0) {
     return;
   }
-
   const isTimeSeriesResults = isTimeSeriesFrames(data.series);
-
   let error;
   if (isTimeSeriesResults) {
     error = new Error('You cannot use time series data as an alert condition, consider adding a reduce expression.');
   }
-
   return error;
 }
-
 export function errorFromPreviewData(data: PanelData): Error | undefined {
   // give preference to QueryErrors
   if (data.errors?.length) {
     return new Error(data.errors[0].message);
   }
-
   return;
 }
-
 export function warningFromSeries(series: DataFrame[]): Error | undefined {
   const notices = series[0]?.meta?.notices ?? [];
   const warning = notices.find((notice) => notice.severity === 'warning')?.text;
-
   return warning ? new Error(warning) : undefined;
 }
-
 export type ThresholdDefinition = {
   config: ThresholdsConfig;
   mode: GraphThresholdsStyleMode;
 };
-
 export type ThresholdDefinitions = Record<string, ThresholdDefinition>;
-
 /**
  * This function will retrieve threshold definitions for the given array of data and expression queries.
  */
 export function getThresholdsForQueries(queries: AlertQuery[], condition: string | null) {
   const thresholds: ThresholdDefinitions = {};
   const SUPPORTED_EXPRESSION_TYPES = [ExpressionQueryType.threshold, ExpressionQueryType.classic];
-
   if (!condition) {
     return thresholds;
   }
-
   for (const query of queries) {
     if (!isExpressionQuery(query.model)) {
       continue;
     }
-
     // currently only supporting "threshold" & "classic_condition" expressions
     if (!SUPPORTED_EXPRESSION_TYPES.includes(query.model.type)) {
       continue;
     }
-
     if (!Array.isArray(query.model.conditions)) {
       continue;
     }
-
     if (query.model.refId !== condition) {
       continue;
     }
-
     // if any of the conditions are a "range" we switch to an "area" threshold view and ignore single threshold values
     // the time series panel does not support both.
     const hasRangeThreshold = query.model.conditions.some(isRangeCondition);
-
     query.model.conditions.forEach((condition) => {
       const threshold = condition.evaluator.params;
-
       // "classic_conditions" use `condition.query.params[]` and "threshold" uses `query.model.expression`
       const refId = condition.query?.params[0] ?? query.model.expression;
-
       // if an expression hasn't been linked to a data query yet, it won't have a refId
       if (!refId) {
         return;
       }
-
       const isRangeThreshold = isRangeCondition(condition);
-
       try {
         // create a DAG so we can find the origin of the current expression
         const graph = createDagFromQueries(queries);
-
         const originRefIDs = getOriginOfRefId(refId, graph);
         const originQueries = queries.filter((query) => originRefIDs.includes(query.refId));
-
         originQueries.forEach((originQuery) => {
           const originRefID = originQuery.refId;
-
           // check if the origin is a data query
           const originIsDataQuery = !isExpressionQuery(originQuery?.model);
-
           // if yes, add threshold config to the refId of the data Query
           const hasValidOrigin = Boolean(originIsDataQuery && originRefID);
-
           // create the initial data structure for this origin refId
           if (originRefID && !thresholds[originRefID]) {
             thresholds[originRefID] = {
@@ -201,7 +160,6 @@ export function getThresholdsForQueries(queries: AlertQuery[], condition: string
               mode: GraphThresholdsStyleMode.Line,
             };
           }
-
           if (originRefID && hasValidOrigin && !isRangeThreshold && !hasRangeThreshold) {
             appendSingleThreshold(originRefID, threshold[0]);
           } else if (originRefID && hasValidOrigin && isRangeThreshold) {
@@ -210,12 +168,11 @@ export function getThresholdsForQueries(queries: AlertQuery[], condition: string
           }
         });
       } catch (err) {
-        console.error('Failed to parse thresholds', err);
+        structLog('error', 'Failed to parse thresholds', err);
         return;
       }
     });
   }
-
   function appendSingleThreshold(refId: string, value: number): void {
     thresholds[refId].config.steps.push(
       ...[
@@ -230,7 +187,6 @@ export function getThresholdsForQueries(queries: AlertQuery[], condition: string
       ]
     );
   }
-
   function appendRangeThreshold(refId: string, values: number[], type: EvalFunction): void {
     if (type === EvalFunction.IsWithinRange) {
       thresholds[refId].config.steps.push(
@@ -254,7 +210,6 @@ export function getThresholdsForQueries(queries: AlertQuery[], condition: string
         ]
       );
     }
-
     if (type === EvalFunction.IsOutsideRange) {
       thresholds[refId].config.steps.push(
         ...[
@@ -278,7 +233,6 @@ export function getThresholdsForQueries(queries: AlertQuery[], condition: string
         ]
       );
     }
-
     if (type === EvalFunction.IsWithinRangeIncluded) {
       thresholds[refId].config.steps.push(
         ...[
@@ -301,7 +255,6 @@ export function getThresholdsForQueries(queries: AlertQuery[], condition: string
         ]
       );
     }
-
     if (type === EvalFunction.IsOutsideRangeIncluded) {
       thresholds[refId].config.steps.push(
         ...[
@@ -325,18 +278,14 @@ export function getThresholdsForQueries(queries: AlertQuery[], condition: string
         ]
       );
     }
-
     // now also sort the threshold values, if we don't then they will look weird in the time series panel
     // TODO this doesn't work for negative values for now, those need to be sorted inverse
     thresholds[refId].config.steps.sort((a, b) => a.value - b.value);
-
     // also make sure we remove any "undefined" values from our steps in case the threshold config is incomplete
     thresholds[refId].config.steps = thresholds[refId].config.steps.filter((step) => step.value !== undefined);
   }
-
   return thresholds;
 }
-
 function isRangeCondition(condition: ClassicCondition) {
   return (
     condition.evaluator.type === EvalFunction.IsWithinRange ||
@@ -345,21 +294,17 @@ function isRangeCondition(condition: ClassicCondition) {
     condition.evaluator.type === EvalFunction.IsWithinRangeIncluded
   );
 }
-
 export function getStatusMessage(data: PanelData): string | undefined {
   const genericErrorMessage = 'Failed to fetch data';
   if (data.state !== LoadingState.Error) {
     return;
   }
-
   const errors = data.errors;
   if (errors?.length) {
     return errors.map((error) => error.message ?? genericErrorMessage).join(', ');
   }
-
   return data.error?.message ?? genericErrorMessage;
 }
-
 /**
  * This function finds what refIds have been updated given the previous Array of queries and an Array of updated data queries.
  * All expression queries are discarded from the arrays, since we have separate handlers for those (see "onUpdateRefId") of the ExpressionEditor
@@ -376,11 +321,9 @@ export function findRenamedDataQueryReferences(
   const previousDataQueries = previousQueries
     .filter((query) => !isExpressionQuery(query.model))
     .map((query) => query.refId);
-
   // given the following two arrays
   // ['A', 'B', 'C'] and ['FOO', 'B' 'C']
   // the "xor" function will return ['A', 'FOO'] because those are not in both arrays
   const [oldRefId, newRefId] = xor(previousDataQueries, updatedDataQueries);
-
   return [oldRefId, newRefId];
 }

--- a/public/app/features/alerting/unified/components/rules/Filter/useRuleFilterAutocomplete.ts
+++ b/public/app/features/alerting/unified/components/rules/Filter/useRuleFilterAutocomplete.ts
@@ -1,25 +1,21 @@
+import { structLog } from '@grafana/data';
 import { chain } from 'lodash';
 import { useCallback } from 'react';
-
 import { type DataSourceInstanceSettings } from '@grafana/data';
 import { t } from '@grafana/i18n';
 import { getDataSourceSrv } from '@grafana/runtime';
 import { type ComboboxOption } from '@grafana/ui';
 import { type GrafanaPromRuleGroupDTO } from 'app/types/unified-alerting-dto';
-
 import { prometheusApi } from '../../../api/prometheusApi';
 import { getRulesDataSources } from '../../../utils/datasource';
-
 // Module-scope utilities
 const collator = new Intl.Collator();
 function getExternalRuleDataSources() {
   return getRulesDataSources().filter((ds: DataSourceInstanceSettings) => !!ds?.url);
 }
-
 const NAMESPACE_THRESHOLD_LIMIT = 500;
 const MIN_GROUP_SEARCH_CHARACTERS = 3;
 const GROUP_SEARCH_LIMIT = 100;
-
 function createInfoOption(message: string): ComboboxOption<string> {
   return {
     label: message,
@@ -27,7 +23,6 @@ function createInfoOption(message: string): ComboboxOption<string> {
     infoOption: true,
   };
 }
-
 export function useNamespaceAndGroupOptions(): {
   namespaceOptions: (inputValue: string) => Promise<Array<ComboboxOption<string>>>;
   groupOptions: (inputValue: string) => Promise<Array<ComboboxOption<string>>>;
@@ -36,7 +31,6 @@ export function useNamespaceAndGroupOptions(): {
 } {
   const [fetchGrafanaGroups] = prometheusApi.useLazyGetGrafanaGroupsQuery();
   const [fetchExternalGroups] = prometheusApi.useLazyGetGroupsQuery();
-
   // Formats a raw namespace string into a user-friendly combobox option.
   const formatNamespaceOption = useCallback((namespaceName: string): ComboboxOption<string> => {
     if (namespaceName.includes('/') && (namespaceName.endsWith('.yml') || namespaceName.endsWith('.yaml'))) {
@@ -48,7 +42,6 @@ export function useNamespaceAndGroupOptions(): {
           : namespaceName;
       return { label: filename, value: namespaceName, description: truncatedDescription };
     }
-
     const maxLength = 50;
     const maxDescriptionLength = 100;
     const truncatedName =
@@ -59,7 +52,6 @@ export function useNamespaceAndGroupOptions(): {
         : namespaceName;
     return { label: truncatedName, value: namespaceName, description: truncatedDescription };
   }, []);
-
   const namespaceOptions = useCallback(
     async (inputValue: string) => {
       // Grafana namespaces - fetch with limit to check threshold
@@ -70,7 +62,6 @@ export function useNamespaceAndGroupOptions(): {
       const grafanaFolderNames = Array.from(
         new Set(grafanaResponse.data.groups.map((g: GrafanaPromRuleGroupDTO) => g.file || 'default'))
       );
-
       // External namespaces
       const namespaceNameSet = new Set<string>();
       const calls = getExternalRuleDataSources().map((ds) =>
@@ -87,9 +78,7 @@ export function useNamespaceAndGroupOptions(): {
           res.value.data.groups.forEach((group: { file?: string }) => namespaceNameSet.add(group.file || 'default'));
         }
       }
-
       const totalNamespaces = grafanaFolderNames.length + namespaceNameSet.size;
-
       // If we have more than NAMESPACE_THRESHOLD_LIMIT unique namespaces, show info message
       if (totalNamespaces > NAMESPACE_THRESHOLD_LIMIT) {
         return [
@@ -101,7 +90,6 @@ export function useNamespaceAndGroupOptions(): {
           ),
         ];
       }
-
       const grafanaFolders: Array<ComboboxOption<string>> = grafanaFolderNames
         .map((name) => ({
           label: name,
@@ -109,18 +97,15 @@ export function useNamespaceAndGroupOptions(): {
           description: t('alerting.rules-filter.grafana-folder', 'Grafana folder'),
         }))
         .sort((a, b) => collator.compare(a.label ?? '', b.label ?? ''));
-
       const externalNamespaces = Array.from(namespaceNameSet)
         .map(formatNamespaceOption)
         .sort((a, b) => collator.compare(a.label ?? '', b.label ?? ''));
-
       const options = [...grafanaFolders, ...externalNamespaces];
       const filtered = filterBySearch(options, inputValue);
       return filtered;
     },
     [fetchGrafanaGroups, fetchExternalGroups, formatNamespaceOption]
   );
-
   const groupOptions = useCallback(
     async (inputValue: string) => {
       // Require minimum characters for search
@@ -132,7 +117,6 @@ export function useNamespaceAndGroupOptions(): {
           ),
         ];
       }
-
       try {
         // Use the backend search with lightweight response
         const grafanaResponse = await fetchGrafanaGroups({
@@ -140,10 +124,8 @@ export function useNamespaceAndGroupOptions(): {
           searchGroupName: trimmedInput, // Backend filtering via search.rule_group parameter
           groupLimit: GROUP_SEARCH_LIMIT, // Reasonable limit for dropdown results
         }).unwrap();
-
         // Deduplicate group names
         const groupNames = chain(grafanaResponse.data.groups).map('name').compact().uniq().value();
-
         // No results found
         if (groupNames.length === 0) {
           return [
@@ -154,32 +136,26 @@ export function useNamespaceAndGroupOptions(): {
             ),
           ];
         }
-
         const options: Array<ComboboxOption<string>> = groupNames
           .map((name) => ({ label: name, value: name }))
           .sort((a, b) => collator.compare(a.label ?? '', b.label ?? ''));
-
         return options;
       } catch (error) {
-        console.error('Error fetching groups:', error);
+        structLog('error', 'Error fetching groups:', error);
         return [createInfoOption(t('alerting.rules-filter.group-search-error', 'Error searching groups'))];
       }
     },
     [fetchGrafanaGroups]
   );
-
   const namespacePlaceholder = t('alerting.rules-filter.filter-options.placeholder-namespace', 'Select namespace');
   const groupPlaceholder = t('alerting.rules-filter.placeholder-group-search', 'Search group');
-
   return { namespaceOptions, groupOptions, namespacePlaceholder, groupPlaceholder };
 }
-
 export function useLabelOptions(): {
   labelOptions: (inputValue: string) => Promise<Array<ComboboxOption<string>>>;
 } {
   // Use lazy queries so we only fetch when the dropdown is opened or the user types
   const [fetchGrafanaGroups] = prometheusApi.useLazyGetGrafanaGroupsQuery();
-
   const createInfoOption = useCallback((): ComboboxOption<string> => {
     return {
       label: t('label-dropdown-info', "Can't find your label? Enter it manually"),
@@ -187,7 +163,6 @@ export function useLabelOptions(): {
       infoOption: true,
     };
   }, []);
-
   const toOptions = useCallback((labelsMap: Map<string, Set<string>>): Array<ComboboxOption<string>> => {
     const selectable: Array<ComboboxOption<string>> = Array.from(labelsMap.entries()).flatMap(([key, values]) =>
       Array.from(values).map<ComboboxOption<string>>((value) => ({
@@ -195,31 +170,25 @@ export function useLabelOptions(): {
         value: `${key}=${value}`,
       }))
     );
-
     selectable.sort((a, b) => collator.compare(a.label ?? '', b.label ?? ''));
     return selectable;
   }, []);
-
   const labelOptions = useCallback(
     async (inputValue: string): Promise<Array<ComboboxOption<string>>> => {
       // Fetch grafana groups and prefer cache when available
       const response = await fetchGrafanaGroups({ limitAlerts: 0, groupLimit: 1000 }, true).unwrap();
       const labelsMap = groupsToLabels(response.data.groups);
-
       const selectable = toOptions(labelsMap);
       if (selectable.length === 0) {
         return [];
       }
-
       const options = [...selectable, createInfoOption()];
       return filterBySearch(options, inputValue, true);
     },
     [fetchGrafanaGroups, toOptions, createInfoOption]
   );
-
   return { labelOptions };
 }
-
 export function useAlertingDataSourceOptions(): (inputValue: string) => Promise<Array<ComboboxOption<string>>> {
   return useCallback(async (inputValue: string) => {
     const options = getDataSourceSrv()
@@ -228,15 +197,18 @@ export function useAlertingDataSourceOptions(): (inputValue: string) => Promise<
     return filterBySearch(options, inputValue);
   }, []);
 }
-
-function groupsToLabels(groups: Array<{ rules: Array<{ labels?: Record<string, string> }> }>) {
+function groupsToLabels(
+  groups: Array<{
+    rules: Array<{
+      labels?: Record<string, string>;
+    }>;
+  }>
+) {
   const rules = groups.flatMap((group) => group.rules);
-
   return rules.reduce((result, rule) => {
     if (!rule.labels) {
       return result;
     }
-
     Object.entries(rule.labels).forEach(([labelKey, labelValue]) => {
       if (!labelKey || !labelValue) {
         return;
@@ -248,13 +220,10 @@ function groupsToLabels(groups: Array<{ rules: Array<{ labels?: Record<string, s
         result.set(labelKey, new Set([labelValue]));
       }
     });
-
     return result;
   }, new Map<string, Set<string>>());
 }
-
 // Removed rulerRulesToLabels since label autocomplete only uses Prometheus namespaces for simplicity
-
 function filterBySearch(options: Array<ComboboxOption<string>>, inputValue: string, keepInfoOption = false) {
   const search = (inputValue ?? '').toLowerCase();
   if (!search) {

--- a/public/app/features/alerting/unified/rule-list/hooks/grafanaFilter.ts
+++ b/public/app/features/alerting/unified/rule-list/hooks/grafanaFilter.ts
@@ -1,12 +1,10 @@
+import { structLog } from '@grafana/data';
 import { attempt, isError } from 'lodash';
-
 import { type PromRuleDTO, type PromRuleGroupDTO } from 'app/types/unified-alerting-dto';
-
 import { type GrafanaPromRulesOptions } from '../../api/prometheusApi';
 import { shouldUseBackendFilters, shouldUseFullyCompatibleBackendFilters } from '../../featureToggles';
 import { type RulesFilter } from '../../search/rulesSearchParser';
 import { parseMatcher } from '../../utils/matchers';
-
 import { buildTitleSearch, normalizeFilterState } from './filterNormalization';
 import {
   type GroupFilterConfig,
@@ -25,13 +23,11 @@ import {
   ruleNameFilter,
   ruleTypeFilter,
 } from './filterPredicates';
-
 /**
  * Determines if client-side filtering is needed for Grafana-managed rules.
  */
 export function hasGrafanaClientSideFilters(filterState: Partial<RulesFilter>): boolean {
   const { ruleFilterConfig, groupFilterConfig } = buildGrafanaFilterConfigs();
-
   // Check each rule filter: if the config has a non-null handler AND the filter state has a value, we need client-side filtering
   const hasActiveRuleFilters =
     (ruleFilterConfig.freeFormWords !== null && Boolean(filterState?.freeFormWords?.length)) ||
@@ -45,15 +41,12 @@ export function hasGrafanaClientSideFilters(filterState: Partial<RulesFilter>): 
     (ruleFilterConfig.plugins !== null && Boolean(filterState?.plugins)) ||
     (ruleFilterConfig.contactPoint !== null && Boolean(filterState?.contactPoint)) ||
     (ruleFilterConfig.policy !== null && Boolean(filterState?.policy));
-
   // Check each group filter: if the config has a non-null handler AND the filter state has a value, we need client-side filtering
   const hasActiveGroupFilters =
     (groupFilterConfig.namespace !== null && Boolean(filterState?.namespace)) ||
     (groupFilterConfig.groupName !== null && Boolean(filterState?.groupName));
-
   return hasActiveRuleFilters || hasActiveGroupFilters;
 }
-
 /**
  * Builds a combined filter configuration for Grafana-managed alert rules.
  *
@@ -63,29 +56,23 @@ export function hasGrafanaClientSideFilters(filterState: Partial<RulesFilter>): 
  */
 export function getGrafanaFilter(filterState: Partial<RulesFilter>) {
   const normalizedFilterState = normalizeFilterState(filterState);
-
   const { ruleFilterConfig, groupFilterConfig } = buildGrafanaFilterConfigs();
-
   // Build title search for backend filtering
   const titleSearch = buildTitleSearch(normalizedFilterState);
-
   // Check if data source names were provided but none are valid.
   let hasInvalidDataSourceNames = false;
   let datasourceUids: string[] | undefined = undefined;
-
   // Only map datasources if data source filter should be applied on backend (when ruleFilterConfig.dataSourceNames is null).
   if (ruleFilterConfig.dataSourceNames === null && normalizedFilterState.dataSourceNames.length > 0) {
     datasourceUids = mapDataSourceNamesToUids(normalizedFilterState.dataSourceNames);
     // If names were provided but no valid UIDs were found, all names are invalid.
     hasInvalidDataSourceNames = datasourceUids.length === 0;
   }
-
   // Convert labels to JSON-encoded matchers for backend filtering
   const ruleMatchersBackendFilter: string[] | undefined =
     ruleFilterConfig.labels || normalizedFilterState.labels.length === 0
       ? undefined
       : labelMatchersToBackendFormat(normalizedFilterState.labels);
-
   const backendFilter: GrafanaPromRulesOptions = {
     state: normalizedFilterState.ruleState ? [normalizedFilterState.ruleState] : [],
     health: normalizedFilterState.ruleHealth ? [normalizedFilterState.ruleHealth] : [],
@@ -100,7 +87,6 @@ export function getGrafanaFilter(filterState: Partial<RulesFilter>) {
     plugins: ruleFilterConfig.plugins ? undefined : normalizedFilterState.plugins,
     searchFolder: groupFilterConfig.namespace ? undefined : normalizedFilterState.namespace,
   };
-
   return {
     backendFilter,
     frontendFilter: {
@@ -110,7 +96,6 @@ export function getGrafanaFilter(filterState: Partial<RulesFilter>) {
     hasInvalidDataSourceNames,
   };
 }
-
 /**
  * Builds filter configurations for Grafana rules and groups.
  *
@@ -121,7 +106,6 @@ export function getGrafanaFilter(filterState: Partial<RulesFilter>) {
 function buildGrafanaFilterConfigs() {
   const useBackendFilters = shouldUseBackendFilters();
   const useFullyCompatibleBackendFilters = shouldUseFullyCompatibleBackendFilters();
-
   const ruleFilterConfig: RuleFilterConfig = {
     // When backend filtering is enabled, these filters are handled by the backend
     freeFormWords: useBackendFilters ? null : freeFormFilter,
@@ -136,15 +120,12 @@ function buildGrafanaFilterConfigs() {
     contactPoint: null,
     policy: policyFilter,
   };
-
   const groupFilterConfig: GroupFilterConfig = {
     namespace: useBackendFilters ? null : namespaceFilter,
     groupName: useBackendFilters ? null : groupNameFilter,
   };
-
   return { ruleFilterConfig, groupFilterConfig };
 }
-
 /**
  * Converts label matchers to JSON-encoded strings for backend filtering.
  * Invalid matchers are logged and filtered out.
@@ -152,13 +133,11 @@ function buildGrafanaFilterConfigs() {
 function labelMatchersToBackendFormat(labels: string[]): string[] {
   return labels.reduce<string[]>((acc, label) => {
     const result = attempt(() => JSON.stringify(parseMatcher(label)));
-
     if (isError(result)) {
-      console.warn('Failed to parse label matcher:', label, result);
+      structLog('warn', 'Failed to parse label matcher:', label, result);
     } else {
       acc.push(result);
     }
-
     return acc;
   }, []);
 }

--- a/public/app/features/alerting/unified/settings/extensions.ts
+++ b/public/app/features/alerting/unified/settings/extensions.ts
@@ -1,36 +1,35 @@
+import { structLog } from '@grafana/data';
 import { useLocation } from 'react-router-dom-v5-compat';
-
 import { type NavModelItem } from '@grafana/data';
 import { useSelector } from 'app/types/store';
-
 type SettingsSectionUrl = `/alerting/admin/${string}`;
 type SettingsSectionNav = Pick<NavModelItem, 'id' | 'text' | 'icon'> & {
   url: SettingsSectionUrl;
 };
-
-const settingsExtensions: Map<SettingsSectionUrl, { nav: SettingsSectionNav }> = new Map();
-
+const settingsExtensions: Map<
+  SettingsSectionUrl,
+  {
+    nav: SettingsSectionNav;
+  }
+> = new Map();
 /**
  * Registers a new settings section that will appear as a tab in the alerting settings page.
  * @param pageNav - The navigation configuration for the settings section
  */
 export function addSettingsSection(pageNav: SettingsSectionNav) {
   if (settingsExtensions.has(pageNav.url)) {
-    console.warn('Unable to add settings page, PageNav must have an unique url');
+    structLog('warn', 'Unable to add settings page, PageNav must have an unique url');
     return;
   }
   settingsExtensions.set(pageNav.url, { nav: pageNav });
 }
-
 /**
  * Returns the navigation configuration for all settings extensions.
  */
 export function useSettingsExtensionsNav(): NavModelItem[] {
   const location = useLocation();
-
   const navIndex = useSelector((state) => state.navIndex);
   const settingsNav = navIndex['alerting-admin'];
-
   // Build extension tabs from settingsExtensions
   const extensionTabs: NavModelItem[] = Array.from(settingsExtensions.entries()).map(([url, { nav }]) => ({
     ...nav,
@@ -38,10 +37,8 @@ export function useSettingsExtensionsNav(): NavModelItem[] {
     url: url,
     parentItem: settingsNav,
   }));
-
   return extensionTabs;
 }
-
 /**
  * ONLY USE FOR TESTING. Clears all settings extensions.
  */

--- a/public/app/features/alerting/unified/state/AlertingQueryRunner.ts
+++ b/public/app/features/alerting/unified/state/AlertingQueryRunner.ts
@@ -1,8 +1,8 @@
+import { structLog } from '@grafana/data';
 import { reject } from 'lodash';
 import { type Observable, type OperatorFunction, ReplaySubject, type Unsubscribable, of } from 'rxjs';
 import { catchError, map, share } from 'rxjs/operators';
 import { v4 as uuidv4 } from 'uuid';
-
 import {
   type DataFrameJSON,
   LoadingState,
@@ -21,16 +21,13 @@ import { isExpressionQuery } from 'app/features/expressions/guards';
 import { cancelNetworkRequestsOnUnsubscribe } from 'app/features/query/state/processing/canceler';
 import { setStructureRevision } from 'app/features/query/state/processing/revision';
 import { type AlertQuery } from 'app/types/unified-alerting-dto';
-
 import { type LinkError, createDAGFromQueriesSafe, getDescendants } from '../components/rule-editor/dag';
 import { getTimeRangeForExpression } from '../utils/timeRange';
-
 export interface AlertingQueryResult {
   error?: string;
   status?: number; // HTTP status error
   frames: DataFrameJSON[];
 }
-
 export interface AlertingQueryResponse {
   results: Record<string, AlertingQueryResult>;
 }
@@ -38,7 +35,6 @@ export class AlertingQueryRunner {
   private subject: ReplaySubject<Record<string, PanelData>>;
   private subscription?: Unsubscribable;
   private lastResult: Record<string, PanelData>;
-
   constructor(
     private backendSrv = getBackendSrv(),
     private dataSourceSrv = getDataSourceSrv()
@@ -46,24 +42,19 @@ export class AlertingQueryRunner {
     this.subject = new ReplaySubject(1);
     this.lastResult = {};
   }
-
   get(): Observable<Record<string, PanelData>> {
     return this.subject.asObservable();
   }
-
   async run(queries: AlertQuery[], condition: string) {
     const queriesToRun = await this.prepareQueries(queries);
-
     // if we don't have any queries to run we just bail
     if (queriesToRun.length === 0) {
       return;
     }
-
     // if the condition isn't part of the queries to run, try to run the alert rule without it.
     // It indicates that the "condition" node points to a non-existent node. We still want to be able to evaluate the other nodes.
     const isConditionAvailable = queriesToRun.some((query) => query.refId === condition);
     const ruleCondition = isConditionAvailable ? condition : '';
-
     this.subscription = runRequest(this.backendSrv, queriesToRun, ruleCondition).subscribe({
       next: (dataPerQuery) => {
         const nextResult = applyChange(dataPerQuery, (refId, data) => {
@@ -71,102 +62,82 @@ export class AlertingQueryRunner {
           const preProcessed = preProcessPanelData(data, previous);
           return setStructureRevision(preProcessed, previous);
         });
-
         // add link errors to the panelData and mark them as errors
         const [_, linkErrors] = createDAGFromQueriesSafe(queries);
         linkErrors.forEach((linkError) => {
           nextResult[linkError.source] = createLinkErrorPanelData(linkError);
         });
-
         this.lastResult = nextResult;
         this.subject.next(this.lastResult);
       },
-
       error: (error: Error) => {
         this.lastResult = mapErrorToPanelData(this.lastResult, error);
         this.subject.next(this.lastResult);
       },
     });
   }
-
   // this function will omit any invalid queries and all of its descendants from the list of queries
   // to do this we will convert the list of queries into a DAG and walk the invalid node's output edges recursively
   async prepareQueries(queries: AlertQuery[]): Promise<AlertQuery[]> {
     const queriesToExclude: string[] = [];
-
     // find all invalid nodes and omit those
     for (const query of queries) {
       const refId = query.model.refId;
-
       // expression queries cannot be excluded / filtered out
       if (isExpressionQuery(query.model)) {
         continue;
       }
-
       const dataSourceInstance = await this.dataSourceSrv.get(query.datasourceUid);
       const skipRunningQuery =
         dataSourceInstance instanceof DataSourceWithBackend &&
         dataSourceInstance.filterQuery &&
         !dataSourceInstance.filterQuery(query.model);
-
       if (skipRunningQuery) {
         queriesToExclude.push(refId);
       }
     }
-
     // exclude nodes that failed to link and their child nodes from the final queries array by trying to parse the graph
     // ⚠️ also make sure all dependent nodes are omitted, otherwise we will be evaluating a broken graph with missing references
     const [cleanGraph] = createDAGFromQueriesSafe(queries);
     const cleanNodes = Object.keys(cleanGraph.nodes);
-
     // find descendant nodes of data queries that have been excluded
     queriesToExclude.forEach((refId) => {
       const descendants = getDescendants(refId, cleanGraph);
       queriesToExclude.push(...descendants);
     });
-
     // also exclude all nodes that aren't in cleanGraph, this means they point to other broken nodes
     const nodesNotInGraph = queries.filter((query) => !cleanNodes.includes(query.refId));
     nodesNotInGraph.forEach((node) => {
       queriesToExclude.push(node.refId);
     });
-
     return reject(queries, (query) => queriesToExclude.includes(query.refId));
   }
-
   cancel() {
     if (!this.subscription) {
       return;
     }
     this.subscription.unsubscribe();
-
     let requestIsRunning = false;
-
     const nextResult = applyChange(this.lastResult, (refId, data) => {
       if (data.state === LoadingState.Loading) {
         requestIsRunning = true;
       }
-
       return {
         ...data,
         state: LoadingState.Done,
       };
     });
-
     if (requestIsRunning) {
       this.subject.next(nextResult);
     }
   }
-
   destroy() {
     if (this.subject) {
       this.subject.complete();
     }
-
     this.cancel();
   }
 }
-
 const runRequest = (
   backendSrv: BackendSrv,
   queries: AlertQuery[],
@@ -179,7 +150,6 @@ const runRequest = (
     method: 'POST',
     requestId: uuidv4(),
   };
-
   return withLoadingIndicator({
     whileLoading: initial,
     source: backendSrv.fetch<AlertingQueryResponse>(request).pipe(
@@ -190,7 +160,6 @@ const runRequest = (
     ),
   });
 };
-
 const initialState = (queries: AlertQuery[], state: LoadingState): Record<string, PanelData> => {
   return queries.reduce((dataByQuery: Record<string, PanelData>, query) => {
     dataByQuery[query.refId] = {
@@ -198,38 +167,30 @@ const initialState = (queries: AlertQuery[], state: LoadingState): Record<string
       series: [],
       timeRange: getTimeRange(query, queries),
     };
-
     return dataByQuery;
   }, {});
 };
-
 const getTimeRange = (query: AlertQuery, queries: AlertQuery[]): TimeRange => {
   if (isExpressionQuery(query.model)) {
     const relative = getTimeRangeForExpression(query.model, queries);
     return rangeUtil.relativeToTimeRange(relative);
   }
-
   if (!query.relativeTimeRange) {
-    console.warn(`Query with refId: ${query.refId} did not have any relative time range, using default.`);
+    structLog('warn', `Query with refId: ${query.refId} did not have any relative time range, using default.`);
     return getDefaultTimeRange();
   }
-
   return rangeUtil.relativeToTimeRange(query.relativeTimeRange);
 };
-
 const mapToPanelData = (
   dataByQuery: Record<string, PanelData>
 ): OperatorFunction<FetchResponse<AlertingQueryResponse>, Record<string, PanelData>> => {
   return map((response) => {
     const { data } = response;
     const results: Record<string, PanelData> = {};
-
     for (const [refId, result] of Object.entries(data.results)) {
       const { error, status, frames = [] } = result;
-
       // extract errors from the /eval results
       const errors = error ? [{ message: error, refId, status }] : [];
-
       results[refId] = {
         errors,
         timeRange: dataByQuery[refId].timeRange,
@@ -237,14 +198,11 @@ const mapToPanelData = (
         series: frames.map(dataFrameFromJSON),
       };
     }
-
     return results;
   });
 };
-
 const mapErrorToPanelData = (lastResult: Record<string, PanelData>, error: Error): Record<string, PanelData> => {
   const queryError = toDataQueryError(error);
-
   return applyChange(lastResult, (_refId, data) => {
     if (data.state === LoadingState.Error) {
       return data;
@@ -256,20 +214,16 @@ const mapErrorToPanelData = (lastResult: Record<string, PanelData>, error: Error
     };
   });
 };
-
 const applyChange = (
   initial: Record<string, PanelData>,
   change: (refId: string, data: PanelData) => PanelData
 ): Record<string, PanelData> => {
   const nextResult: Record<string, PanelData> = {};
-
   for (const [refId, data] of Object.entries(initial)) {
     nextResult[refId] = change(refId, data);
   }
-
   return nextResult;
 };
-
 const createLinkErrorPanelData = (error: LinkError): PanelData => ({
   series: [],
   state: LoadingState.Error,
@@ -280,10 +234,8 @@ const createLinkErrorPanelData = (error: LinkError): PanelData => ({
   ],
   timeRange: getDefaultTimeRange(),
 });
-
 function createLinkErrorMessage(error: LinkError): string {
   const isSelfReference = error.source === error.target;
-
   return isSelfReference
     ? t('alerting.dag.self-reference', "You can't link an expression to itself")
     : t(

--- a/public/app/features/annotations/components/StandardAnnotationQueryEditor.tsx
+++ b/public/app/features/annotations/components/StandardAnnotationQueryEditor.tsx
@@ -1,6 +1,6 @@
+import { structLog } from '@grafana/data';
 import { PureComponent, type ReactElement } from 'react';
 import { lastValueFrom } from 'rxjs';
-
 import {
   type AnnotationEventMappings,
   type AnnotationQuery,
@@ -16,15 +16,12 @@ import { Alert, type AlertVariant, Button, Space, Spinner } from '@grafana/ui';
 import { getDashboardSrv } from 'app/features/dashboard/services/DashboardSrv';
 import { getTimeSrv } from 'app/features/dashboard/services/TimeSrv';
 import { PanelModel } from 'app/features/dashboard/state/PanelModel';
-
 import { executeAnnotationQuery } from '../executeAnnotationQuery';
 import { shouldUseLegacyRunner, shouldUseMappingUI, standardAnnotationSupport } from '../standardAnnotationSupport';
 import { type AnnotationQueryResponse } from '../types';
 import { updateAnnotationFromSavedQuery } from '../utils/savedQueryUtils';
-
 import { AnnotationQueryEditorActionsWrapper } from './AnnotationQueryEditorActionsWrapper';
 import { AnnotationFieldMapper } from './AnnotationResultMapper';
-
 export interface Props {
   datasource: DataSourceApi;
   datasourceInstanceSettings: DataSourceInstanceSettings;
@@ -32,26 +29,21 @@ export interface Props {
   onChange: (annotation: AnnotationQuery<DataQuery>) => void;
   disableSavedQueries?: boolean;
 }
-
 interface State {
   running?: boolean;
   response?: AnnotationQueryResponse;
   skipNextVerification?: boolean;
 }
-
 export default class StandardAnnotationQueryEditor extends PureComponent<Props, State> {
   state: State = {};
-
   componentDidMount() {
     this.verifyDataSource();
   }
-
   componentDidUpdate(oldProps: Props) {
     if (this.props.annotation !== oldProps.annotation && !shouldUseLegacyRunner(this.props.datasource)) {
       this.verifyDataSource();
     }
   }
-
   /**
    * verifyDataSource() prepares the annotation and provides immediate query feedback:
    * 1. Applies datasource-specific preparation (e.g., Prometheus moves expr to target field)
@@ -60,21 +52,18 @@ export default class StandardAnnotationQueryEditor extends PureComponent<Props, 
    */
   verifyDataSource() {
     const { datasource, annotation } = this.props;
-
     // Skip verification if we just did a saved query replacement to avoid double preparation
     if (this.state.skipNextVerification) {
       this.setState({ skipNextVerification: false });
       this.onRunQuery();
       return;
     }
-
     // Always run prepareAnnotation to ensure proper query structure
     // This is essential for datasources like Prometheus that need to format queries correctly
     const processor = {
       ...standardAnnotationSupport,
       ...datasource.annotations,
     };
-
     const fixed = processor.prepareAnnotation!(annotation);
     // if datasource prepared annotation returns a different annotation(e.g., prometheus before had expr in the root level now it's saved in 'target'), update the annotation with that one
     if (fixed !== annotation) {
@@ -83,7 +72,6 @@ export default class StandardAnnotationQueryEditor extends PureComponent<Props, 
       this.onRunQuery();
     }
   }
-
   onRunQuery = async () => {
     const { datasource, annotation } = this.props;
     if (shouldUseLegacyRunner(datasource)) {
@@ -92,12 +80,10 @@ export default class StandardAnnotationQueryEditor extends PureComponent<Props, 
       // right now running a query for data source with legacy runner does not make much sense.
       return;
     }
-
     const dashboard = getDashboardSrv().getCurrent();
     if (!dashboard) {
       return;
     }
-
     this.setState({
       running: true,
     });
@@ -117,7 +103,6 @@ export default class StandardAnnotationQueryEditor extends PureComponent<Props, 
       response,
     });
   };
-
   onQueryChange = (target: DataQuery) => {
     // if dealing with v2 dashboards
     if (this.props.annotation.query && this.props.annotation.query.spec) {
@@ -142,35 +127,27 @@ export default class StandardAnnotationQueryEditor extends PureComponent<Props, 
       ...(this.props.annotation.legacyOptions ? { legacyOptions: this.props.annotation.legacyOptions } : {}),
     });
   };
-
   onMappingChange = (mappings?: AnnotationEventMappings) => {
     this.props.onChange({
       ...this.props.annotation,
       mappings,
     });
   };
-
   getStatusSeverity(response: AnnotationQueryResponse): AlertVariant {
     const { events, panelData } = response;
-
     if (panelData?.errors || panelData?.error) {
       return 'error';
     }
-
     if (!events?.length) {
       return 'warning';
     }
-
     return 'success';
   }
-
   renderStatusText(response: AnnotationQueryResponse, running: boolean | undefined): ReactElement {
     const { events, panelData } = response;
-
     if (running || response?.panelData?.state === LoadingState.Loading || !response) {
       return <p>{'loading...'}</p>;
     }
-
     if (panelData?.errors) {
       return (
         <>
@@ -183,7 +160,6 @@ export default class StandardAnnotationQueryEditor extends PureComponent<Props, 
     if (panelData?.error) {
       return <p>{panelData.error.message ?? 'There was an error fetching data'}</p>;
     }
-
     if (!events?.length) {
       return (
         <p>
@@ -191,7 +167,6 @@ export default class StandardAnnotationQueryEditor extends PureComponent<Props, 
         </p>
       );
     }
-
     const frame = panelData?.series?.[0] ?? panelData?.annotations?.[0];
     const numEvents = events.length;
     const numFields = frame?.fields.length;
@@ -203,14 +178,11 @@ export default class StandardAnnotationQueryEditor extends PureComponent<Props, 
       </p>
     );
   }
-
   renderStatus() {
     const { response, running } = this.state;
-
     if (!response) {
       return null;
     }
-
     return (
       <>
         <Space v={2} />
@@ -241,7 +213,6 @@ export default class StandardAnnotationQueryEditor extends PureComponent<Props, 
       </>
     );
   }
-
   onAnnotationChange = (annotation: AnnotationQuery) => {
     // Also preserve any legacyOptions field that might exist when migrating from V2 to V1
     this.props.onChange({
@@ -250,10 +221,8 @@ export default class StandardAnnotationQueryEditor extends PureComponent<Props, 
       ...(this.props.annotation.legacyOptions ? { legacyOptions: this.props.annotation.legacyOptions } : {}),
     });
   };
-
   onQueryReplace = async (replacedQuery: DataQuery) => {
     const { annotation, onChange } = this.props;
-
     try {
       // Use new async updateAnnotationFromSavedQuery that returns properly prepared annotation
       const preparedAnnotation = await updateAnnotationFromSavedQuery(annotation, replacedQuery);
@@ -261,15 +230,13 @@ export default class StandardAnnotationQueryEditor extends PureComponent<Props, 
       this.setState({ skipNextVerification: true });
       onChange(preparedAnnotation);
     } catch (error) {
-      console.error('Failed to replace annotation query:', error);
+      structLog('error', 'Failed to replace annotation query:', error);
       // On error, reset the replacing state but don't change the annotation
     }
   };
-
   render() {
     const { datasource, annotation, datasourceInstanceSettings } = this.props;
     const { response } = this.state;
-
     // Find the annotation runner
     let QueryEditor = datasource.annotations?.QueryEditor || datasource.components?.QueryEditor;
     if (!QueryEditor) {
@@ -281,30 +248,24 @@ export default class StandardAnnotationQueryEditor extends PureComponent<Props, 
         </div>
       );
     }
-
     // For v2 dashboards, target is not available, only query
     let target = annotation.target;
-
     // For v2 dashboards, use query.spec
     if (annotation.query && annotation.query.spec) {
       target = {
         ...annotation.query.spec,
       };
     }
-
     let query = {
       ...datasource.annotations?.getDefaultQuery?.(),
       ...(target ?? { refId: 'Anno' }),
     };
-
     // Create annotation object that respects annotations API
     let editorAnnotation = annotation;
-
     // For v2 dashboards: propagate legacyOptions to root level for datasource compatibility
     if (annotation.query && annotation.legacyOptions) {
       editorAnnotation = { ...annotation.legacyOptions, ...annotation };
     }
-
     return (
       <>
         <DataSourcePluginContextProvider instanceSettings={datasourceInstanceSettings}>

--- a/public/app/features/annotations/standardAnnotationSupport.ts
+++ b/public/app/features/annotations/standardAnnotationSupport.ts
@@ -1,7 +1,7 @@
+import { structLog } from '@grafana/data';
 import { isString } from 'lodash';
 import { type Observable, of, type OperatorFunction } from 'rxjs';
 import { map, mergeMap } from 'rxjs/operators';
-
 import {
   type AnnotationEvent,
   AnnotationEventFieldSource,
@@ -19,7 +19,6 @@ import {
 } from '@grafana/data';
 import { t } from '@grafana/i18n';
 import { config } from '@grafana/runtime';
-
 export const standardAnnotationSupport: AnnotationSupport = {
   /**
    * Assume the stored value is standard model.
@@ -38,12 +37,10 @@ export const standardAnnotationSupport: AnnotationSupport = {
     }
     return json;
   },
-
   /**
    * Default will just return target from the annotation.
    */
   prepareQuery: (anno: AnnotationQuery) => anno.target,
-
   /**
    * Provides default processing from dataFrame to annotation events.
    */
@@ -51,11 +48,9 @@ export const standardAnnotationSupport: AnnotationSupport = {
     return getAnnotationsFromData(data, anno.mappings);
   },
 };
-
 /**
  * Flatten all frames into a single frame with mergeTransformer.
  */
-
 export function singleFrameFromPanelData(): OperatorFunction<DataFrame[], DataFrame | undefined> {
   return (source) =>
     source.pipe(
@@ -63,15 +58,12 @@ export function singleFrameFromPanelData(): OperatorFunction<DataFrame[], DataFr
         if (!data?.length) {
           return of(undefined);
         }
-
         if (data.length === 1) {
           return of(data[0]);
         }
-
         const ctx: DataTransformContext = {
           interpolate: (v: string) => v,
         };
-
         return of(data).pipe(
           standardTransformers.mergeTransformer.operator({}, ctx),
           map((d) => d[0])
@@ -79,7 +71,6 @@ export function singleFrameFromPanelData(): OperatorFunction<DataFrame[], DataFr
       })
     );
 }
-
 interface AnnotationEventFieldSetter {
   key: keyof AnnotationEvent;
   field?: Field;
@@ -87,7 +78,6 @@ interface AnnotationEventFieldSetter {
   regex?: RegExp;
   split?: string; // for tags
 }
-
 export interface AnnotationFieldInfo {
   key: keyof AnnotationEvent;
   label?: string;
@@ -96,7 +86,6 @@ export interface AnnotationFieldInfo {
   placeholder?: string;
   help?: string;
 }
-
 // These fields get added to the standard UI
 export const getAnnotationEventNames: () => AnnotationFieldInfo[] = () => [
   {
@@ -140,7 +129,6 @@ export const getAnnotationEventNames: () => AnnotationFieldInfo[] = () => [
     key: 'id',
   },
 ];
-
 export const publicDashboardEventNames: AnnotationFieldInfo[] = [
   {
     key: 'color',
@@ -152,7 +140,6 @@ export const publicDashboardEventNames: AnnotationFieldInfo[] = [
     key: 'source',
   },
 ];
-
 // Given legacy infrastructure, alert events are passed though the same annotation
 // pipeline, but include fields that should not be exposed generally
 const alertEventAndAnnotationFields: AnnotationFieldInfo[] = [
@@ -169,7 +156,6 @@ const alertEventAndAnnotationFields: AnnotationFieldInfo[] = [
   { key: 'dashboardId' },
   { key: 'dashboardUID' },
 ];
-
 export function getAnnotationsFromData(
   data: DataFrame[],
   options?: AnnotationEventMappings
@@ -180,42 +166,32 @@ export function getAnnotationsFromData(
       if (!frame?.length) {
         return [];
       }
-
       let hasTime = false;
       let hasText = false;
       const byName: KeyValue<Field> = {};
-
       for (const f of frame.fields) {
         const name = getFieldDisplayName(f, frame);
         byName[name.toLowerCase()] = f;
       }
-
       if (!options) {
         options = {};
       }
-
       const fields: AnnotationEventFieldSetter[] = [];
-
       for (const evts of alertEventAndAnnotationFields) {
         const opt = options[evts.key] || {}; //AnnotationEventFieldMapping
-
         if (opt.source === AnnotationEventFieldSource.Skip) {
           continue;
         }
-
         const setter: AnnotationEventFieldSetter = { key: evts.key, split: evts.split };
-
         if (opt.source === AnnotationEventFieldSource.Text) {
           setter.text = opt.value;
         } else {
           const lower = (opt.value || evts.key).toLowerCase();
           setter.field = byName[lower];
-
           if (!setter.field && evts.field) {
             setter.field = evts.field(frame);
           }
         }
-
         if (setter.field || setter.text) {
           fields.push(setter);
           if (setter.key === 'time') {
@@ -225,24 +201,19 @@ export function getAnnotationsFromData(
           }
         }
       }
-
       if (!hasTime || !hasText) {
-        console.error('Cannot process annotation fields. No time or text present.');
+        structLog('error', 'Cannot process annotation fields. No time or text present.');
         return [];
       }
-
       // Add each value to the string
       const events: AnnotationEvent[] = [];
-
       for (let i = 0; i < frame.length; i++) {
         const anno: AnnotationEvent = {
           type: 'default',
           color: 'red',
         };
-
         for (const f of fields) {
           let v = undefined;
-
           if (f.text) {
             v = f.text; // TODO support templates!
           } else if (f.field) {
@@ -254,7 +225,6 @@ export function getAnnotationsFromData(
               }
             }
           }
-
           if (v !== null && v !== undefined) {
             if (f.split && typeof v === 'string') {
               v = v.split(',');
@@ -262,25 +232,20 @@ export function getAnnotationsFromData(
             anno[f.key] = v;
           }
         }
-
         events.push(anno);
       }
-
       return events;
     })
   );
 }
-
 // These opt outs are here only for quicker and easier migration to react based annotations editors and because
 // annotation support API needs some work to support less "standard" editors like prometheus and here it is not
 // polluting public API.
-
 const legacyRunner = [
   'loki',
   'elasticsearch',
   'grafana-opensearch-datasource', // external
 ];
-
 /**
  * Opt out of using the default mapping functionality on frontend.
  */
@@ -291,7 +256,6 @@ export function shouldUseMappingUI(datasource: DataSourceApi): boolean {
     legacyRunner.includes(type)
   );
 }
-
 /**
  * Use legacy runner. Used only as an escape hatch for easier transition to React based annotation editor.
  */

--- a/public/app/features/annotations/utils/savedQueryUtils.ts
+++ b/public/app/features/annotations/utils/savedQueryUtils.ts
@@ -1,3 +1,4 @@
+import { structLog } from '@grafana/data';
 import {
   type AnnotationQuery,
   CoreApp,
@@ -7,9 +8,7 @@ import {
 } from '@grafana/data';
 import { getDataSourceSrv } from '@grafana/runtime';
 import { type DataQuery } from '@grafana/schema';
-
 import { standardAnnotationSupport } from '../standardAnnotationSupport';
-
 /**
  * Converts an AnnotationQuery to DataQuery format for SavedQueryButtons.
  * Supports both v1 dashboards (uses target field) and v2 dashboards (uses query.spec field).
@@ -23,18 +22,15 @@ export function getDataQueryFromAnnotationForSavedQueries(
   if (annotation.query && annotation.query.spec) {
     querySpec = annotation.query.spec;
   }
-
   const baseQuery = {
     ...datasource.annotations?.getDefaultQuery?.(),
     ...(querySpec ?? { refId: 'Anno' }),
   };
-
   return {
     ...baseQuery,
     datasource: annotation.datasource,
   };
 }
-
 /**
  * Converts DataQuery back to AnnotationQuery format while preserving annotation metadata.
  * Used when replacing an annotation query with a saved query.
@@ -59,20 +55,16 @@ export async function updateAnnotationFromSavedQuery(
     builtIn: annotation.builtIn,
     datasource: replacedQuery.datasource,
   };
-
   // Step 2: Use datasource's export/import to normalize saved query
   try {
     const newDatasource = await getDataSourceSrv().get(replacedQuery.datasource);
-
     // Normalize saved query using export/import approach (strips context, keeps content)
     // This follows the same pattern as updateQueries.ts for datasource transitions
     let normalizedQuery = replacedQuery;
-
     // When datasource supports abstract queries, use export/import to normalize context
     if (hasQueryExportSupport(newDatasource) && hasQueryImportSupport(newDatasource)) {
       const abstractQueries = await newDatasource.exportToAbstractQueries([replacedQuery]);
       const importedQueries = await newDatasource.importFromAbstractQueries(abstractQueries);
-
       if (importedQueries.length > 0) {
         // Apply annotation-specific defaults to the normalized query
         const annotationDefaults = {
@@ -80,7 +72,6 @@ export async function updateAnnotationFromSavedQuery(
           datasource: replacedQuery.datasource,
           refId: 'Anno',
         };
-
         normalizedQuery = {
           ...replacedQuery, // Start with all original properties
           ...annotationDefaults, // Apply annotation defaults for context
@@ -97,26 +88,21 @@ export async function updateAnnotationFromSavedQuery(
         refId: 'Anno',
       };
     }
-
     // Remove datasource property to avoid duplication in target
     const { datasource, ...queryFields } = normalizedQuery;
-
     // Step 3: Create annotation and apply datasource-specific preparation
     const tempAnnotation: AnnotationQuery = {
       ...cleanAnnotation,
       target: queryFields,
     };
-
     const processor = { ...standardAnnotationSupport, ...newDatasource.annotations };
     let preparedAnnotation: AnnotationQuery;
-
     if (processor.prepareAnnotation) {
       // Let the datasource do final preparation/restructuring
       preparedAnnotation = processor.prepareAnnotation(tempAnnotation);
     } else {
       preparedAnnotation = tempAnnotation;
     }
-
     // Step 4: Handle v1 vs v2 dashboard format after preparation
     if (annotation.query?.spec) {
       // v2 dashboard - sync prepared target to query.spec
@@ -125,10 +111,9 @@ export async function updateAnnotationFromSavedQuery(
         spec: { ...preparedAnnotation.target },
       };
     }
-
     return preparedAnnotation;
   } catch (error) {
-    console.warn('Could not prepare annotation with new datasource:', error);
+    structLog('warn', 'Could not prepare annotation with new datasource:', error);
     // Return structurally correct annotation even if preparation fails
     const { datasource, ...queryFields } = replacedQuery;
     return { ...cleanAnnotation, target: queryFields };

--- a/public/app/features/apiserver/client.ts
+++ b/public/app/features/apiserver/client.ts
@@ -1,11 +1,9 @@
+import { structLog } from '@grafana/data';
 import { Observable, from, retry, catchError, filter, map, mergeMap } from 'rxjs';
-
 import { isLiveChannelMessageEvent, isLiveChannelStatusEvent, LiveChannelScope } from '@grafana/data';
 import { config, getBackendSrv, getGrafanaLiveSrv } from '@grafana/runtime';
 import { contextSrv } from 'app/core/services/context_srv';
-
 import { getAPINamespace } from '../../api/utils';
-
 import {
   type ListOptions,
   type ListOptionsFieldSelector,
@@ -23,21 +21,17 @@ import {
   type ResourceClientWriteParams,
   type GroupVersionResource,
 } from './types';
-
 export class ScopedResourceClient<T = object, S = object, K = string> implements ResourceClient<T, S, K> {
   readonly url: string;
   readonly gvr: GroupVersionResource;
-
   constructor(gvr: GroupVersionResource, namespaced = true) {
     const ns = namespaced ? `namespaces/${getAPINamespace()}/` : '';
     this.gvr = gvr;
     this.url = `/apis/${gvr.group}/${gvr.version}/${ns}${gvr.resource}`;
   }
-
   public async get(name: string): Promise<Resource<T, S, K>> {
     return getBackendSrv().get<Resource<T, S, K>>(`${this.url}/${name}`);
   }
-
   public watch(params?: WatchOptions): Observable<ResourceEvent<T, S, K>> {
     const selectors = this.getWatchSelectors(params);
     const requestParams = {
@@ -45,7 +39,6 @@ export class ScopedResourceClient<T = object, S = object, K = string> implements
       labelSelector: this.parseListOptionsSelector(selectors.labelSelector),
       fieldSelector: this.parseListOptionsSelector(selectors.fieldSelector),
     };
-
     // For now, watch over live only supports provisioning
     if (this.gvr.group === 'provisioning.grafana.app') {
       let query = '';
@@ -69,12 +62,11 @@ export class ScopedResourceClient<T = object, S = object, K = string> implements
           filter((event) => isLiveChannelMessageEvent(event)),
           map((event) => event.message),
           catchError((error) => {
-            console.warn('Live channel watch failed, falling back to polling:', error);
+            structLog('warn', 'Live channel watch failed, falling back to polling:', error);
             return this.createPollingFallback(params, error);
           })
         );
     }
-
     const decoder = new TextDecoder();
     return getBackendSrv()
       .chunked({
@@ -100,31 +92,27 @@ export class ScopedResourceClient<T = object, S = object, K = string> implements
           try {
             return JSON.parse(line);
           } catch (e) {
-            console.warn('Invalid JSON in watch stream:', e, line);
+            structLog('warn', 'Invalid JSON in watch stream:', e, line);
             return null;
           }
         }),
         filter((event): event is ResourceEvent<T, S, K> => event !== null),
         retry({ count: 3, delay: 1000 }),
         catchError((error) => {
-          console.error('Watch stream error:', error);
+          structLog('error', 'Watch stream error:', error);
           throw error;
         })
       );
   }
-
   public async subresource<S>(name: string, path: string, params?: Record<string, unknown>): Promise<S> {
     return getBackendSrv().get<S>(`${this.url}/${name}/${path}`, params);
   }
-
   public async list(opts?: ListOptions | undefined): Promise<ResourceList<T, S, K>> {
     const finalOpts = opts || {};
     finalOpts.labelSelector = this.parseListOptionsSelector(finalOpts?.labelSelector);
     finalOpts.fieldSelector = this.parseListOptionsSelector(finalOpts?.fieldSelector);
-
     return getBackendSrv().get<ResourceList<T, S, K>>(this.url, opts);
   }
-
   public async create(obj: ResourceForCreate<T, K>, params?: ResourceClientWriteParams): Promise<Resource<T, S, K>> {
     if (!obj.metadata.name && !obj.metadata.generateName) {
       const login = contextSrv.user.login;
@@ -138,7 +126,6 @@ export class ScopedResourceClient<T = object, S = object, K = string> implements
       params,
     });
   }
-
   public async update(obj: Resource<T, S, K>, params?: ResourceClientWriteParams): Promise<Resource<T, S, K>> {
     setSavedFromUIAnnotation(obj.metadata);
     const url = `${this.url}/${obj.metadata.name}`;
@@ -146,18 +133,14 @@ export class ScopedResourceClient<T = object, S = object, K = string> implements
       params,
     });
   }
-
   public async delete(name: string, showSuccessAlert: boolean): Promise<MetaStatus> {
     return getBackendSrv().delete<MetaStatus>(`${this.url}/${name}`, undefined, {
       showSuccessAlert,
     });
   }
-
   private parseListOptionsSelector = parseListOptionsSelector;
-
   private static POLLING_INTERVAL_MS = 5000;
   private static MAX_CONSECUTIVE_POLL_FAILURES = 5;
-
   /**
    * Convert WatchOptions into the fieldSelector / labelSelector pair
    * used by both the live-channel watch request and the polling fallback.
@@ -176,7 +159,6 @@ export class ScopedResourceClient<T = object, S = object, K = string> implements
     }
     return opts;
   }
-
   /**
    * Polling fallback when the Grafana Live WebSocket Observable errors.
    * Periodically calls list() and diffs against the previous snapshot to emit
@@ -191,7 +173,6 @@ export class ScopedResourceClient<T = object, S = object, K = string> implements
     originalError: unknown
   ): Observable<ResourceEvent<T, S, K>> {
     const listOpts = this.getWatchSelectors(params);
-
     return new Observable<ResourceEvent<T, S, K>>((subscriber) => {
       // NOTE: starting empty means the first poll can't detect items deleted between
       // the initial list() and polling start. Seeding from the RTKQ cache would fix
@@ -201,7 +182,6 @@ export class ScopedResourceClient<T = object, S = object, K = string> implements
       let firstPoll = true;
       let timerId: ReturnType<typeof setTimeout> | null = null;
       let consecutiveFailures = 0;
-
       const poll = async () => {
         if (!active) {
           return;
@@ -211,12 +191,10 @@ export class ScopedResourceClient<T = object, S = object, K = string> implements
           if (!active) {
             return;
           }
-
           const currentItems = new Map<string, Resource<T, S, K>>();
           for (const item of result.items) {
             currentItems.set(item.metadata.name, item);
           }
-
           // Emit ADDED or MODIFIED for items in current result
           for (const [name, item] of currentItems) {
             const prev = previousItems.get(name);
@@ -226,14 +204,12 @@ export class ScopedResourceClient<T = object, S = object, K = string> implements
               subscriber.next({ type: 'MODIFIED', object: item });
             }
           }
-
           // Emit DELETED for items no longer present
           for (const [name, item] of previousItems) {
             if (!currentItems.has(name)) {
               subscriber.next({ type: 'DELETED', object: item });
             }
           }
-
           previousItems = currentItems;
           firstPoll = false;
           consecutiveFailures = 0;
@@ -250,20 +226,18 @@ export class ScopedResourceClient<T = object, S = object, K = string> implements
             return;
           }
           // Transient failure: log and retry next cycle.
-          console.warn(
+          structLog(
+            'warn',
             `Polling fallback error (${consecutiveFailures}/${ScopedResourceClient.MAX_CONSECUTIVE_POLL_FAILURES}):`,
             pollError
           );
         }
-
         if (active) {
           timerId = setTimeout(poll, ScopedResourceClient.POLLING_INTERVAL_MS);
         }
       };
-
       // Start first poll immediately
       poll();
-
       // Teardown: stop polling when unsubscribed
       return () => {
         active = false;
@@ -274,7 +248,6 @@ export class ScopedResourceClient<T = object, S = object, K = string> implements
     });
   }
 }
-
 // add the origin annotations so we know what was set from the UI
 function setSavedFromUIAnnotation(meta: Partial<ObjectMeta>) {
   if (!meta.annotations) {
@@ -282,16 +255,18 @@ function setSavedFromUIAnnotation(meta: Partial<ObjectMeta>) {
   }
   meta.annotations[AnnoKeySavedFromUI] = config.buildInfo.versionString;
 }
-
 export class DatasourceAPIVersions {
-  private apiVersions?: { [pluginID: string]: string };
-
+  private apiVersions?: {
+    [pluginID: string]: string;
+  };
   async get(pluginID: string): Promise<string | undefined> {
     if (this.apiVersions) {
       return this.apiVersions[pluginID];
     }
     const apis = await getBackendSrv().get<K8sAPIGroupList>('/apis');
-    const apiVersions: { [pluginID: string]: string } = {};
+    const apiVersions: {
+      [pluginID: string]: string;
+    } = {};
     apis.groups.forEach((group) => {
       if (group.name.includes('datasource.grafana.app')) {
         const id = group.name.split('.')[0];
@@ -302,30 +277,24 @@ export class DatasourceAPIVersions {
     return apiVersions[pluginID];
   }
 }
-
 export const parseListOptionsSelector = (selector: ListOptionsLabelSelector | ListOptionsFieldSelector | undefined) => {
   if (!Array.isArray(selector)) {
     return selector;
   }
-
   return selector
     .map((label) => {
       const key = String(label.key);
       const operator = label.operator;
-
       switch (operator) {
         case '=':
         case '!=':
           return `${key}${operator}${label.value}`;
-
         case 'in':
         case 'notin':
           return `${key} ${operator} (${label.value.join(',')})`;
-
         case '':
         case '!':
           return `${operator}${key}`;
-
         default:
           return null;
       }

--- a/public/app/features/auth-config/FieldRenderer.tsx
+++ b/public/app/features/auth-config/FieldRenderer.tsx
@@ -1,14 +1,12 @@
+import { structLog } from '@grafana/data';
 import { css } from '@emotion/css';
 import { useEffect, useState } from 'react';
 import { type UseFormReturn, Controller } from 'react-hook-form';
-
 import { type SelectableValue } from '@grafana/data';
 import { Checkbox, Field, Input, SecretInput, Select, Switch, useTheme2 } from '@grafana/ui';
-
 import { fieldMap } from './fields';
 import { type SSOProviderDTO, type SSOSettingsField } from './types';
 import { isSelectableValueArray } from './utils/guards';
-
 interface FieldRendererProps
   extends Pick<
     UseFormReturn<SSOProviderDTO>,
@@ -19,7 +17,6 @@ interface FieldRendererProps
   secretConfigured: boolean;
   provider: string;
 }
-
 export const FieldRenderer = ({
   field,
   register,
@@ -38,12 +35,10 @@ export const FieldRenderer = ({
   const parentValue = isDependantField && field.dependsOn ? watch(field.dependsOn) : null;
   const fieldData = fieldMap(provider)[name];
   const theme = useTheme2();
-
   // Handle disabledWhen configuration
   const disabledWhen = isDependantField ? field.disabledWhen : undefined;
   const disabledWhenValue = disabledWhen ? watch(disabledWhen.field) : undefined;
   const isDisabled = disabledWhen ? disabledWhenValue === disabledWhen.is : false;
-
   // Unregister a field that depends on a toggle to clear its data
   useEffect(() => {
     if (isDependantField && field.dependsOn) {
@@ -52,13 +47,11 @@ export const FieldRenderer = ({
       }
     }
   }, [unregister, name, parentValue, isDependantField, field]);
-
   const isNotEmptySelectableValueArray = (
     current: string | boolean | Record<string, string> | Array<SelectableValue<string>> | undefined
   ): current is Array<SelectableValue<string>> => {
     return Array.isArray(current) && current.length > 0 && 'value' in current[0];
   };
-
   useEffect(() => {
     if (fieldData.defaultValue) {
       const current = getValues(name);
@@ -69,30 +62,25 @@ export const FieldRenderer = ({
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
-
   // Set the value when the field is disabled
   useEffect(() => {
     if (isDisabled && disabledWhen?.disabledValue) {
       setValue(name, disabledWhen.disabledValue.value);
     }
   }, [isDisabled, disabledWhen?.disabledValue, name, setValue]);
-
   if (!field) {
-    console.log('missing field:', name);
+    structLog('log', 'missing field:', name);
     return null;
   }
-
   if (!!fieldData.hidden) {
     return null;
   }
-
   // Dependant field means the field depends on another field's value and shouldn't be rendered if the parent field is false
   if (isDependantField && field.dependsOn) {
     if (!parentValue) {
       return null;
     }
   }
-
   const fieldProps = {
     label: fieldData.label,
     required: !!fieldData.validation?.required,
@@ -101,7 +89,6 @@ export const FieldRenderer = ({
     description: fieldData.description,
     defaultValue: fieldData.defaultValue?.value,
   };
-
   switch (fieldData.type) {
     case 'text':
       return (
@@ -190,7 +177,7 @@ export const FieldRenderer = ({
         </Field>
       );
     default:
-      console.error(`Unknown field type: ${fieldData.type}`);
+      structLog('error', `Unknown field type: ${fieldData.type}`);
       return null;
   }
 };

--- a/public/app/features/auth-config/state/actions.ts
+++ b/public/app/features/auth-config/state/actions.ts
@@ -1,14 +1,12 @@
+import { structLog } from '@grafana/data';
 import { lastValueFrom } from 'rxjs';
-
 import { getBackendSrv, isFetchError } from '@grafana/runtime';
 import { contextSrv } from 'app/core/services/context_srv';
 import { AccessControlAction } from 'app/types/accessControl';
 import { type Settings, type UpdateSettingsQuery } from 'app/types/settings';
 import { type ThunkResult } from 'app/types/store';
-
 import { getAuthProviderStatus, getRegisteredAuthProviders } from '..';
 import { type AuthProviderStatus, type SettingsError, type SSOProvider } from '../types';
-
 import {
   loadingBegin,
   loadingEnd,
@@ -18,7 +16,6 @@ import {
   setError,
   settingsUpdated,
 } from './reducers';
-
 export function loadSettings(showSpinner = true): ThunkResult<Promise<Settings>> {
   return async (dispatch) => {
     if (contextSrv.hasPermission(AccessControlAction.SettingsRead)) {
@@ -36,7 +33,6 @@ export function loadSettings(showSpinner = true): ThunkResult<Promise<Settings>>
     }
   };
 }
-
 export function loadProviders(provider = ''): ThunkResult<Promise<SSOProvider[]>> {
   return async (dispatch) => {
     const result = await getBackendSrv().get(`/api/v1/sso-settings${provider ? `/${provider}` : ''}`);
@@ -44,7 +40,6 @@ export function loadProviders(provider = ''): ThunkResult<Promise<SSOProvider[]>
     return result;
   };
 }
-
 export function loadProviderStatuses(): ThunkResult<void> {
   return async (dispatch) => {
     const registeredProviders = getRegisteredAuthProviders();
@@ -61,7 +56,6 @@ export function loadProviderStatuses(): ThunkResult<void> {
     dispatch(providerStatusesLoaded(providerStatuses));
   };
 }
-
 export function saveSettings(data: UpdateSettingsQuery): ThunkResult<Promise<boolean>> {
   return async (dispatch) => {
     if (contextSrv.hasPermission(AccessControlAction.SettingsWrite)) {
@@ -78,7 +72,7 @@ export function saveSettings(data: UpdateSettingsQuery): ThunkResult<Promise<boo
         dispatch(resetError());
         return true;
       } catch (error) {
-        console.log(error);
+        structLog('log', error);
         if (isFetchError(error)) {
           error.isHandled = true;
           const updateErr: SettingsError = {

--- a/public/app/features/browse-dashboards/api/browseDashboardsAPI.ts
+++ b/public/app/features/browse-dashboards/api/browseDashboardsAPI.ts
@@ -1,5 +1,5 @@
+import { structLog } from '@grafana/data';
 import { createApi } from '@reduxjs/toolkit/query/react';
-
 import { handleRequestError } from '@grafana/api-clients';
 import { generatedAPI as legacyUserAPI } from '@grafana/api-clients/internal/rtkq/legacy/user';
 import { createBaseQuery } from '@grafana/api-clients/rtkq';
@@ -30,66 +30,53 @@ import {
   type FolderDTO,
   type FolderListItemDTO,
 } from 'app/types/folders';
-
 import { getDashboardScenePageStateManager } from '../../dashboard-scene/pages/DashboardScenePageStateManager';
 import { deletedDashboardsCache } from '../../search/service/deletedDashboardsCache';
 import { refetchChildren, refreshParents } from '../state/actions';
-
 import { isProvisionedDashboard } from './isProvisioned';
 import { PAGE_SIZE } from './services';
-
 export interface DeleteFoldersArgs {
   folderUIDs: string[];
 }
-
 interface DeleteDashboardsArgs {
   dashboardUIDs: string[];
 }
-
 interface MoveDashboardsArgs {
   destinationUID: string;
   dashboardUIDs: string[];
 }
-
 export interface MoveFoldersArgs {
   destinationUID: string;
   folderUIDs: string[];
 }
-
 export interface MoveFolderArgs {
   folderUID: string;
   destinationUID: string;
 }
-
 export interface ImportInputs {
   name: string;
   type: string;
   value: string;
   pluginId?: string;
 }
-
 interface ImportOptions {
   dashboard: Dashboard;
   overwrite: boolean;
   inputs: ImportInputs[];
   folderUid: string;
 }
-
 interface RestoreDashboardArgs {
   dashboard: Resource<Dashboard | DashboardV2Spec>;
 }
-
 export interface ListFolderQueryArgs {
   page: number;
   parentUid: string | undefined;
   limit: number;
   permission?: PermissionLevel;
 }
-
 // Don't invalidate individual getFolder tags — the resource no longer exists and refetching would 404
 const invalidateListOnSuccess = (result: unknown, error: unknown) =>
   error ? [] : [{ type: 'getFolder' as const, id: 'LIST' }];
-
 export const browseDashboardsAPI = createApi({
   tagTypes: ['getFolder'],
   reducerPath: 'browseDashboardsAPI',
@@ -108,9 +95,15 @@ export const browseDashboardsAPI = createApi({
         params: { parentUid, limit, page, permission },
       }),
     }),
-
     // get folder info (e.g. title, parents) but *not* children
-    getFolder: builder.query<FolderDTO, { folderUID: string; accesscontrol: boolean; isLegacyCall: boolean }>({
+    getFolder: builder.query<
+      FolderDTO,
+      {
+        folderUID: string;
+        accesscontrol: boolean;
+        isLegacyCall: boolean;
+      }
+    >({
       providesTags: (_result, _error, { folderUID }) => [{ type: 'getFolder', id: folderUID }],
       query: ({ folderUID, accesscontrol, isLegacyCall }) => ({
         url: `/folders/${folderUID}`,
@@ -122,9 +115,14 @@ export const browseDashboardsAPI = createApi({
         },
       }),
     }),
-
     // create a new folder
-    newFolder: builder.mutation<FolderDTO, { title: string; parentUid?: string }>({
+    newFolder: builder.mutation<
+      FolderDTO,
+      {
+        title: string;
+        parentUid?: string;
+      }
+    >({
       invalidatesTags: ['getFolder'],
       query: ({ title, parentUid }) => ({
         method: 'POST',
@@ -150,7 +148,6 @@ export const browseDashboardsAPI = createApi({
         invalidateQuotaUsage(dispatch);
       },
     }),
-
     // save an existing folder (e.g. rename)
     saveFolder: builder.mutation<FolderDTO, Pick<FolderDTO, 'uid' | 'title' | 'version' | 'parentUid'>>({
       // because the getFolder calls contain the parents, renaming a parent/grandparent/etc needs to invalidate all child folders
@@ -176,7 +173,6 @@ export const browseDashboardsAPI = createApi({
         });
       },
     }),
-
     // move an *individual* folder. used in the folder actions menu.
     moveFolder: builder.mutation<void, MoveFolderArgs>({
       invalidatesTags: ['getFolder'],
@@ -197,7 +193,6 @@ export const browseDashboardsAPI = createApi({
         });
       },
     }),
-
     // delete an *individual* folder. used in the folder actions menu.
     deleteFolder: builder.mutation<void, FolderDTO>({
       invalidatesTags: invalidateListOnSuccess,
@@ -222,9 +217,14 @@ export const browseDashboardsAPI = createApi({
         });
       },
     }),
-
     // gets the descendant counts for a folder. used in the move/delete modals.
-    getAffectedItems: builder.query<DescendantCount, { folderUIDs: string[]; dashboardUIDs: string[] }>({
+    getAffectedItems: builder.query<
+      DescendantCount,
+      {
+        folderUIDs: string[];
+        dashboardUIDs: string[];
+      }
+    >({
       // don't cache this data for now, since library panel/alert rule creation isn't done through rtk query
       keepUnusedDataFor: 0,
       queryFn: async ({ folderUIDs, dashboardUIDs }) => {
@@ -233,28 +233,24 @@ export const browseDashboardsAPI = createApi({
             return getBackendSrv().get<DescendantCountDTO>(`/api/folders/${folderUID}/counts`);
           });
           const results = await Promise.all(promises);
-
           const totalCounts: DescendantCount = {
             folders: folderUIDs.length,
             dashboards: dashboardUIDs.length,
             library_elements: 0,
             alertrules: 0,
           };
-
           for (const folderCounts of results) {
             totalCounts.folders += folderCounts.folder;
             totalCounts.dashboards += folderCounts.dashboard;
             totalCounts.alertrules += folderCounts.alertrule;
             totalCounts.library_elements += folderCounts.librarypanel;
           }
-
           return { data: totalCounts };
         } catch (error) {
           return { error };
         }
       },
     }),
-
     // move *multiple* dashboards. used in the move modal.
     moveDashboards: builder.mutation<void, MoveDashboardsArgs>({
       invalidatesTags: ['getFolder'],
@@ -266,7 +262,6 @@ export const browseDashboardsAPI = createApi({
           const fullDash = await api.getDashboardDTO(dashboardUID);
           const dashboard = isDashboardV2Resource(fullDash) ? fullDash.spec : fullDash.dashboard;
           const k8s = isDashboardV2Resource(fullDash) ? fullDash.metadata : undefined;
-
           if (config.featureToggles.provisioning) {
             if (isProvisionedDashboard(fullDash)) {
               appEvents.publish({
@@ -298,7 +293,6 @@ export const browseDashboardsAPI = createApi({
         });
       },
     }),
-
     // move *multiple* folders. used in the move modal.
     moveFolders: builder.mutation<void, MoveFoldersArgs>({
       invalidatesTags: ['getFolder'],
@@ -316,14 +310,12 @@ export const browseDashboardsAPI = createApi({
           ) {
             continue;
           }
-
           await baseQuery({
             url: `/folders/${folderUID}/move`,
             method: 'POST',
             body: { parentUID: destinationUID },
           });
         }
-
         return { data: undefined };
       },
       onQueryStarted: ({ destinationUID, folderUIDs }, { queryFulfilled, dispatch }) => {
@@ -338,7 +330,6 @@ export const browseDashboardsAPI = createApi({
         });
       },
     }),
-
     // delete *multiple* folders. used in the delete modal.
     deleteFolders: builder.mutation<void, DeleteFoldersArgs>({
       invalidatesTags: invalidateListOnSuccess,
@@ -371,7 +362,6 @@ export const browseDashboardsAPI = createApi({
         });
       },
     }),
-
     // delete *multiple* dashboards. used in the delete modal.
     deleteDashboards: builder.mutation<void, DeleteDashboardsArgs>({
       invalidatesTags: invalidateListOnSuccess,
@@ -400,7 +390,6 @@ export const browseDashboardsAPI = createApi({
               }
             }
             await api.deleteDashboard(dashboardUID, !restoreDashboardsEnabled);
-
             deletedCount++;
             deletedDashboardUIDs.push(dashboardUID);
           }
@@ -411,7 +400,6 @@ export const browseDashboardsAPI = createApi({
             for (const uid of deletedDashboardUIDs) {
               pageStateManager.removeSceneCache(uid);
             }
-
             // Show success notification after all deletions
             if (restoreDashboardsEnabled) {
               // Show notification with button to Recently Deleted
@@ -435,7 +423,6 @@ export const browseDashboardsAPI = createApi({
             }
           }
         }
-
         return { data: undefined };
       },
       onQueryStarted: ({ dashboardUIDs }, { queryFulfilled, getState }) => {
@@ -457,7 +444,6 @@ export const browseDashboardsAPI = createApi({
         });
       },
     }),
-
     // save an existing dashboard
     saveDashboard: builder.mutation<SaveDashboardResponseDTO, SaveDashboardCommand<Dashboard | DashboardV2Spec>>({
       queryFn: async (cmd) => {
@@ -467,7 +453,6 @@ export const browseDashboardsAPI = createApi({
             const response = await api.saveDashboard(cmd);
             return { data: response };
           }
-
           if (isV1DashboardCommand(cmd)) {
             const api = await getDashboardAPI('v1');
             const rsp = await api.saveDashboard(cmd);
@@ -478,7 +463,6 @@ export const browseDashboardsAPI = createApi({
           return handleRequestError(error);
         }
       },
-
       onQueryStarted: ({ folderUid }, { queryFulfilled, dispatch }) => {
         dashboardWatcher.ignoreNextSave();
         queryFulfilled.then(async ({ data }) => {
@@ -496,7 +480,6 @@ export const browseDashboardsAPI = createApi({
         });
       },
     }),
-
     importDashboard: builder.mutation<ImportDashboardResponseDTO, ImportOptions>({
       query: ({ dashboard, overwrite, inputs, folderUid }) => ({
         method: 'POST',
@@ -521,7 +504,7 @@ export const browseDashboardsAPI = createApi({
           } catch (error) {
             if (isFetchError(error)) {
               if (error.status !== 404) {
-                console.error('Error fetching dashboard', error);
+                structLog('error', 'Error fetching dashboard', error);
               } else {
                 // Do not show the error alert if the dashboard does not exist
                 // this is expected when importing a new dashboard
@@ -530,7 +513,6 @@ export const browseDashboardsAPI = createApi({
             }
           }
         }
-
         queryFulfilled.then(async (response) => {
           // Refresh destination folder
           dispatch(
@@ -539,7 +521,6 @@ export const browseDashboardsAPI = createApi({
               pageSize: PAGE_SIZE,
             })
           );
-
           // If the dashboard was moved from a different folder, refresh the source folder too
           if (currentFolderUid && currentFolderUid !== folderUid) {
             dispatch(
@@ -549,14 +530,12 @@ export const browseDashboardsAPI = createApi({
               })
             );
           }
-
           const dashboardUrl = locationUtil.stripBaseFromUrl(response.data.importedUrl);
           locationService.push(dashboardUrl);
           invalidateQuotaUsage(dispatch);
         });
       },
     }),
-
     // RTK wrapper for the dashboard API
     listDeletedDashboards: builder.query<ResourceList<Dashboard | DashboardV2Spec>, void>({
       providesTags: ['getFolder'],
@@ -564,16 +543,19 @@ export const browseDashboardsAPI = createApi({
         try {
           const api = await getDashboardAPI();
           const response = await api.listDeletedDashboards({});
-
           return { data: response };
         } catch (error) {
           return handleRequestError(error);
         }
       },
     }),
-
     // restore a dashboard that got deleted
-    restoreDashboard: builder.mutation<{ name: string }, RestoreDashboardArgs>({
+    restoreDashboard: builder.mutation<
+      {
+        name: string;
+      },
+      RestoreDashboardArgs
+    >({
       invalidatesTags: ['getFolder'],
       queryFn: async ({ dashboard }) => {
         try {
@@ -581,7 +563,6 @@ export const browseDashboardsAPI = createApi({
           const response = await api.restoreDashboard(dashboard);
           const name = response.spec.title || '';
           const parentFolder = response.metadata?.annotations?.[AnnoKeyFolder];
-
           // Refresh the contents of the folder a dashboard was restored to
           dispatch(
             refetchChildren({
@@ -590,7 +571,6 @@ export const browseDashboardsAPI = createApi({
             })
           );
           invalidateQuotaUsage(dispatch);
-
           return { data: { name } };
         } catch (error) {
           return handleRequestError(error);
@@ -599,7 +579,6 @@ export const browseDashboardsAPI = createApi({
     }),
   }),
 });
-
 export const {
   endpoints,
   useDeleteFolderMutation,

--- a/public/app/features/browse-dashboards/api/recentlyViewed.ts
+++ b/public/app/features/browse-dashboards/api/recentlyViewed.ts
@@ -1,7 +1,7 @@
+import { structLog } from '@grafana/data';
 import impressionSrv from 'app/core/services/impression_srv';
 import { getGrafanaSearcher } from 'app/features/search/service/searcher';
 import { type DashboardQueryResult } from 'app/features/search/service/types';
-
 /**
  * Returns dashboard search results ordered the same way the user opened them.
  */
@@ -11,13 +11,11 @@ export async function getRecentlyViewedDashboards(maxItems = 5): Promise<Dashboa
     if (!recentlyOpened.length) {
       return [];
     }
-
     const searchResults = await getGrafanaSearcher().search({
       kind: ['dashboard'],
       limit: recentlyOpened.length,
       uid: recentlyOpened,
     });
-
     const dashboards = searchResults.view.toArray();
     // Keep dashboards in the same order the user opened them.
     // When a UID is missing from the search response
@@ -26,11 +24,10 @@ export async function getRecentlyViewedDashboards(maxItems = 5): Promise<Dashboa
       const idx = recentlyOpened.indexOf(uid);
       return idx === -1 ? recentlyOpened.length : idx;
     };
-
     dashboards.sort((a, b) => order(a.uid) - order(b.uid));
     return dashboards;
   } catch (error) {
-    console.error('Failed to load recently viewed dashboards', error);
+    structLog('error', 'Failed to load recently viewed dashboards', error);
     return [];
   }
 }

--- a/public/app/features/browse-dashboards/api/services.ts
+++ b/public/app/features/browse-dashboards/api/services.ts
@@ -1,3 +1,4 @@
+import { structLog } from '@grafana/data';
 import { t } from '@grafana/i18n';
 import { config, getBackendSrv } from '@grafana/runtime';
 import { dashboardAPIv0alpha1 } from 'app/api/clients/dashboard/v0alpha1';
@@ -10,7 +11,6 @@ import { extractManagerKind, queryResultToViewItem } from 'app/features/search/s
 import { type DashboardViewItem } from 'app/features/search/types';
 import { AccessControlAction } from 'app/types/accessControl';
 import { dispatch } from 'app/types/store';
-
 import {
   addTeamFolderPrefix,
   getFolderURL,
@@ -19,9 +19,7 @@ import {
   parseOwnerRef,
   teamOwnerRef,
 } from '../utils/dashboards';
-
 export const PAGE_SIZE = 50;
-
 async function searchOldAPI(parentUID?: string, page = 1, pageSize = PAGE_SIZE) {
   const backendSrv = getBackendSrv();
   return await backendSrv.get<NestedFolderDTO[]>('/api/folders', {
@@ -30,7 +28,6 @@ async function searchOldAPI(parentUID?: string, page = 1, pageSize = PAGE_SIZE) 
     limit: pageSize,
   });
 }
-
 const virtualFolderBase = {
   kind: 'folder',
   url: '',
@@ -41,7 +38,6 @@ const virtualFolderBase = {
   score: 0,
   explain: {},
 };
-
 async function searchNewAPI(parentUID?: string, page = 1, pageSize = PAGE_SIZE) {
   const searcher = getGrafanaSearcher();
   const foldersResults = await searcher.search({
@@ -51,9 +47,7 @@ async function searchNewAPI(parentUID?: string, page = 1, pageSize = PAGE_SIZE) 
     limit: pageSize,
     offset: (page - 1) * pageSize,
   });
-
   let folders: DashboardQueryResult[] = foldersResults.view.toArray();
-
   // Add shared with me item statically to the array as it is not returned from the
   // API anymore. This also means we show it every time, whether it has children or not. This is the same as in folder
   // picker for now. In the future we could to additional request to see if there are any children in it.
@@ -64,7 +58,6 @@ async function searchNewAPI(parentUID?: string, page = 1, pageSize = PAGE_SIZE) 
       name: t('browse-dashboards.shared-with-me', 'Shared with me'),
     });
   }
-
   // Add team folders virtual item only if the user actually has team folders
   if (!parentUID && config.featureToggles.teamFolders) {
     try {
@@ -78,10 +71,9 @@ async function searchNewAPI(parentUID?: string, page = 1, pageSize = PAGE_SIZE) 
         });
       }
     } catch (error) {
-      console.error('Failed to load team folders', error);
+      structLog('error', 'Failed to load team folders', error);
     }
   }
-
   return folders.map<NestedFolderDTO>((item) => {
     return {
       uid: item.uid,
@@ -90,7 +82,6 @@ async function searchNewAPI(parentUID?: string, page = 1, pageSize = PAGE_SIZE) 
     };
   });
 }
-
 export async function listFolders(
   parentUID?: string,
   parentTitle?: string, // TODO: remove this when old UI is gone
@@ -105,7 +96,6 @@ export async function listFolders(
       folders = await searchOldAPI(parentUID, page, pageSize);
     }
   }
-
   return folders.map(({ uid, title, managedBy }) => {
     const noUrl = isSharedWithMe(uid) || isVirtualTeamFolder(uid);
     return {
@@ -122,10 +112,8 @@ export async function listFolders(
     };
   });
 }
-
 export async function listDashboards(parentUID?: string, page = 1, pageSize = PAGE_SIZE): Promise<DashboardViewItem[]> {
   const searcher = getGrafanaSearcher();
-
   const dashboardsResults = await searcher.search({
     kind: ['dashboard'],
     query: '*',
@@ -134,47 +122,45 @@ export async function listDashboards(parentUID?: string, page = 1, pageSize = PA
     limit: pageSize,
     offset: (page - 1) * pageSize,
   });
-
   return dashboardsResults.view.map((item) => {
     const viewItem = queryResultToViewItem(item, dashboardsResults.view);
-
     // TODO: Once we remove nestedFolders feature flag, undo this and prevent the 'general'
     // parentUID from being set in searcher
     if (viewItem.parentUID === GENERAL_FOLDER_UID) {
       viewItem.parentUID = undefined;
     }
-
     return viewItem;
   });
 }
-
 /**
  * Fetches the user's teams and returns actual folder items directly under "Team folders",
  * with team owner info attached to each folder.
  */
 export async function listTeamFolders(): Promise<DashboardViewItem[]> {
   const teams = await dispatch(legacyAPI.endpoints.getSignedInUserTeamList.initiate(undefined)).unwrap();
-
   if (!teams || teams.length === 0) {
     return [];
   }
-
   const ownerReference = teams.map(teamOwnerRef);
-
   const result = await dispatch(
     dashboardAPIv0alpha1.endpoints.searchDashboardsAndFolders.initiate({ ownerReference, type: 'folder' })
   ).unwrap();
-
   const hits = result.hits ?? [];
   if (hits.length === 0) {
     return [];
   }
-
   // Build a map of team UID → team info
   const teamsByUid = new Map(teams.map((team) => [team.uid, { name: team.name, avatarUrl: team.avatarUrl }]));
-
   // Build a map of folder UID → owning team reference
-  const folderOwners = new Map<string, { kind: string; uid: string; title: string; avatarUrl?: string }>();
+  const folderOwners = new Map<
+    string,
+    {
+      kind: string;
+      uid: string;
+      title: string;
+      avatarUrl?: string;
+    }
+  >();
   for (const hit of hits) {
     for (const ref of hit.ownerReferences ?? []) {
       const parsed = parseOwnerRef(ref);
@@ -192,7 +178,6 @@ export async function listTeamFolders(): Promise<DashboardViewItem[]> {
       }
     }
   }
-
   // Return actual folders with owner reference info
   return hits.map((hit) => ({
     kind: 'folder' as const,

--- a/public/app/features/browse-dashboards/api/useRecentlyDeletedStateManager.ts
+++ b/public/app/features/browse-dashboards/api/useRecentlyDeletedStateManager.ts
@@ -1,32 +1,27 @@
+import { structLog } from '@grafana/data';
 import { type SelectableValue, store } from '@grafana/data';
 import { t } from '@grafana/i18n';
 import { type TermCount } from 'app/core/components/TagFilter/TagFilter';
 import { SEARCH_SELECTED_SORT } from 'app/features/search/constants';
 import { type SearchState } from 'app/features/search/types';
-
 import { deletedDashboardsCache } from '../../search/service/deletedDashboardsCache';
 import { initialState, SearchStateManager } from '../../search/state/SearchStateManager';
-
 // Subclass SearchStateManager to customize the setStateAndDoSearch behavior.
 // We want to clear the search results when the user clears any search input
 // to trigger the skeleton state.
 export class TrashStateManager extends SearchStateManager {
   setStateAndDoSearch(state: Partial<SearchState>) {
     const sort = state.sort || this.state.sort || store.get(SEARCH_SELECTED_SORT) || undefined;
-
     const query = state.query ?? this.state.query;
     const tags = state.tag ?? this.state.tag;
-
     // When the user clears the search, and we revert back to list listing all
     const clearResults = query.length === 0 && tags.length === 0;
-
     // Set internal state
     this.setState({
       sort,
       result: clearResults ? undefined : this.state.result,
       ...state,
     });
-
     // Update url state
     this.updateLocation({
       query: this.state.query.length === 0 ? null : this.state.query,
@@ -36,20 +31,17 @@ export class TrashStateManager extends SearchStateManager {
       starred: this.state.starred ? this.state.starred : null,
       sort: this.state.sort,
     });
-
     // Prevent searching when user is only clearing the input.
     // We don't show these results anyway
     if (this.hasSearchFilters()) {
       this.doSearchWithDebounce();
     }
   }
-
   // Get tags from deleted dashboards cache
   getTagOptions = async (): Promise<TermCount[]> => {
     try {
       const deletedHits = await deletedDashboardsCache.get();
       const tagCounts = new Map<string, number>();
-
       deletedHits.forEach((hit) => {
         hit.tags.forEach((tag) => {
           if (tag) {
@@ -57,19 +49,16 @@ export class TrashStateManager extends SearchStateManager {
           }
         });
       });
-
       const termCounts: TermCount[] = Array.from(tagCounts.entries()).map(([term, count]) => ({
         term,
         count,
       }));
-
       return termCounts.sort((a, b) => b.count - a.count);
     } catch (error) {
-      console.error('Failed to get tags from deleted dashboards:', error);
+      structLog('error', 'Failed to get tags from deleted dashboards:', error);
       return [];
     }
   };
-
   getSortOptions = async (): Promise<SelectableValue[]> => {
     return Promise.resolve([
       {
@@ -91,19 +80,15 @@ export class TrashStateManager extends SearchStateManager {
     ]);
   };
 }
-
 let recentlyDeletedStateManager: TrashStateManager;
 function getRecentlyDeletedStateManager() {
   if (!recentlyDeletedStateManager) {
     recentlyDeletedStateManager = new TrashStateManager({ ...initialState, includePanels: false, deleted: true });
   }
-
   return recentlyDeletedStateManager;
 }
-
 export function useRecentlyDeletedStateManager() {
   const stateManager = getRecentlyDeletedStateManager();
   const state = stateManager.useState();
-
   return [state, stateManager] as const;
 }

--- a/public/app/features/browse-dashboards/components/RecentlyDeletedActions.tsx
+++ b/public/app/features/browse-dashboards/components/RecentlyDeletedActions.tsx
@@ -1,5 +1,5 @@
+import { structLog } from '@grafana/data';
 import { useMemo, useState } from 'react';
-
 import { Trans } from '@grafana/i18n';
 import { reportInteraction } from '@grafana/runtime';
 import { Button, Stack } from '@grafana/ui';
@@ -10,16 +10,13 @@ import { notifyApp } from 'app/core/reducers/appNotification';
 import { AnnoKeyFolder } from 'app/features/apiserver/types';
 import { GENERAL_FOLDER_UID } from 'app/features/search/constants';
 import { useDispatch } from 'app/types/store';
-
 import { deletedDashboardsCache } from '../../search/service/deletedDashboardsCache';
 import { useRestoreDashboardMutation } from '../api/browseDashboardsAPI';
 import { useRecentlyDeletedStateManager } from '../api/useRecentlyDeletedStateManager';
 import { useActionSelectionState } from '../state/hooks';
 import { clearFolders, setAllSelection } from '../state/slice';
 import { getRestoreNotificationData } from '../utils/notifications';
-
 import { RestoreModal } from './RestoreModal';
-
 export function RecentlyDeletedActions() {
   const dispatch = useDispatch();
   const selectedItemsState = useActionSelectionState();
@@ -27,22 +24,18 @@ export function RecentlyDeletedActions() {
   const [restoreDashboard] = useRestoreDashboardMutation();
   const [isBulkRestoreLoading, setIsBulkRestoreLoading] = useState(false);
   const [isRestoreModalOpen, setIsRestoreModalOpen] = useState(false);
-
   const selectedDashboards = useMemo(() => {
     return Object.entries(selectedItemsState.dashboard)
       .filter(([_, selected]) => selected)
       .map(([uid]) => uid);
   }, [selectedItemsState.dashboard]);
-
   const selectedDashboardOrigin = useMemo(() => {
     if (!searchState.result) {
       return [];
     }
-
     const origins: string[] = [];
     for (const selectedDashboard of selectedDashboards) {
       const index = searchState.result.view.fields.uid.values.findIndex((e) => e === selectedDashboard);
-
       // SQLSearcher changes the location from empty string to 'general' for items with no parent,
       // but the restore API doesn't work with 'general' folder UID, so we need to convert it back
       // to an empty string
@@ -52,7 +45,6 @@ export function RecentlyDeletedActions() {
     }
     return origins;
   }, [selectedDashboards, searchState.result]);
-
   const getErrorMessage = (error: unknown) => {
     if (error instanceof Error) {
       return error.message;
@@ -68,20 +60,17 @@ export function RecentlyDeletedActions() {
     }
     return '';
   };
-
   const onRestore = async (restoreTarget: string) => {
     const resultsView = stateManager.state.result?.view.toArray();
     if (!resultsView) {
       return;
     }
-
     setIsBulkRestoreLoading(true);
-
     const promises = selectedDashboards.map(async (uid) => {
       const deletedDashboards = await deletedDashboardsCache.getAsResourceList();
       const dashboard = deletedDashboards?.items.find((d) => d.metadata.name === uid);
       if (!dashboard) {
-        console.warn(`Dashboard ${uid} not found in deleted items`);
+        structLog('warn', `Dashboard ${uid} not found in deleted items`);
         return { uid, error: 'not_found' };
       }
       // Clone the dashboard to be able to edit the immutable data from the store
@@ -90,16 +79,15 @@ export function RecentlyDeletedActions() {
         ...copy.metadata,
         annotations: { ...copy.metadata?.annotations, [AnnoKeyFolder]: restoreTarget },
       };
-
       return restoreDashboard({ dashboard: copy });
     });
-
     const results = await Promise.allSettled(promises);
-
     // Separate successful and failed restores
     const successful: string[] = [];
-    const failed: Array<{ uid: string; error: string }> = [];
-
+    const failed: Array<{
+      uid: string;
+      error: string;
+    }> = [];
     results.forEach((result, index) => {
       const dashboardUid = selectedDashboards[index];
       if (result.status === 'rejected') {
@@ -117,7 +105,6 @@ export function RecentlyDeletedActions() {
         successful.push(dashboardUid);
       }
     });
-
     const parentUIDs = new Set<string | undefined>();
     for (const uid of selectedDashboards) {
       const foundItem = resultsView.find((v) => v.uid === uid);
@@ -131,10 +118,8 @@ export function RecentlyDeletedActions() {
     }
     dispatch(clearFolders(Array.from(parentUIDs)));
     dispatch(setAllSelection({ isSelected: false, folderUID: undefined }));
-
     deletedDashboardsCache.clear();
     await stateManager.doSearch();
-
     const notificationData = getRestoreNotificationData(successful, failed, restoreTarget);
     if (notificationData) {
       if (notificationData.kind === 'action') {
@@ -154,7 +139,6 @@ export function RecentlyDeletedActions() {
     setIsBulkRestoreLoading(false);
     setIsRestoreModalOpen(false);
   };
-
   const showRestoreModal = () => {
     reportInteraction('grafana_restore_clicked', {
       item_counts: {
@@ -163,7 +147,6 @@ export function RecentlyDeletedActions() {
     });
     setIsRestoreModalOpen(true);
   };
-
   return (
     <>
       <Stack gap={1}>

--- a/public/app/features/browse-dashboards/state/actions.ts
+++ b/public/app/features/browse-dashboards/state/actions.ts
@@ -1,68 +1,57 @@
+import { structLog } from '@grafana/data';
 import { GENERAL_FOLDER_UID, TEAM_FOLDERS_UID } from 'app/features/search/constants';
 import { type DashboardViewItem, type DashboardViewItemKind } from 'app/features/search/types';
 import { createAsyncThunk } from 'app/types/store';
-
 import { listDashboards, listFolders, listTeamFolders, PAGE_SIZE } from '../api/services';
 import { type DashboardViewItemWithUIItems, type UIDashboardViewItem } from '../types';
 import { addTeamFolderPrefix, removeTeamFolderPrefix } from '../utils/dashboards';
-
 import { findItem } from './utils';
-
 async function listTeamFoldersSafe() {
   try {
     return await listTeamFolders();
   } catch (error) {
-    console.error('Failed to load team folders', error);
+    structLog('error', 'Failed to load team folders', error);
     return [];
   }
 }
-
 interface FetchNextChildrenPageArgs {
   parentUID: string | undefined;
-
   // Allow UI items to be excluded (they're always excluded) for convenience for callers
   excludeKinds?: Array<DashboardViewItemWithUIItems['kind'] | UIDashboardViewItem['uiKind']>;
   pageSize: number;
 }
-
 interface FetchNextChildrenPageResult {
   children: DashboardViewItem[];
   kind: 'folder' | 'dashboard';
   page: number;
   lastPageOfKind: boolean;
 }
-
 interface RefetchChildrenArgs {
   parentUID: string | undefined;
   pageSize: number;
 }
-
 interface RefetchChildrenResult {
   children: DashboardViewItem[];
   kind: 'folder' | 'dashboard';
   page: number;
   lastPageOfKind: boolean;
 }
-
 export const refreshParents = createAsyncThunk(
   'browseDashboards/refreshParents',
   async (uids: string[], { getState, dispatch }) => {
     const { browseDashboards } = getState();
     const { rootItems, childrenByParentUID } = browseDashboards;
     const parentsToRefresh = new Set<string | undefined>();
-
     for (const uid of uids) {
       // find the parent folder uid
       const item = findItem(rootItems?.items ?? [], childrenByParentUID, uid);
       parentsToRefresh.add(item?.parentUID);
     }
-
     for (const parentUID of parentsToRefresh) {
       dispatch(refetchChildren({ parentUID, pageSize: PAGE_SIZE }));
     }
   }
 );
-
 export const refetchChildren = createAsyncThunk(
   'browseDashboards/refetchChildren',
   async ({ parentUID, pageSize }: RefetchChildrenArgs): Promise<RefetchChildrenResult> => {
@@ -70,31 +59,24 @@ export const refetchChildren = createAsyncThunk(
       const children = await listTeamFoldersSafe();
       return { children, kind: 'dashboard', page: 1, lastPageOfKind: true };
     }
-
     const strippedUID = parentUID ? removeTeamFolderPrefix(parentUID) : parentUID;
     const uid = strippedUID === GENERAL_FOLDER_UID ? undefined : strippedUID;
-
     // At the moment this will just clear out all loaded children and refetch the first page.
     // If user has scrolled beyond the first page, then InfiniteLoader will probably trigger
     // an additional page load (via fetchNextChildrenPage)
-
     let page = 1;
     let fetchKind: DashboardViewItemKind | undefined = 'folder';
-
     let children = await listFolders(uid, undefined, page, pageSize);
     let lastPageOfKind = children.length < pageSize;
-
     // If we've loaded all folders, load the first page of dashboards.
     // This ensures dashboards are loaded if a folder contains only dashboards.
     if (fetchKind === 'folder' && lastPageOfKind) {
       fetchKind = 'dashboard';
       page = 1;
-
       const childDashboards = await listDashboards(uid, page, pageSize);
       lastPageOfKind = childDashboards.length < pageSize;
       children = children.concat(childDashboards);
     }
-
     // Propagate prefix to all descendants so they get independent expand/collapse state
     const isTeamFolderChild = parentUID !== strippedUID;
     if (isTeamFolderChild) {
@@ -103,7 +85,6 @@ export const refetchChildren = createAsyncThunk(
         uid: addTeamFolderPrefix(removeTeamFolderPrefix(child.uid)),
       }));
     }
-
     return {
       children,
       lastPageOfKind: lastPageOfKind,
@@ -112,7 +93,6 @@ export const refetchChildren = createAsyncThunk(
     };
   }
 );
-
 export const fetchNextChildrenPage = createAsyncThunk(
   'browseDashboards/fetchNextChildrenPage',
   async (
@@ -128,30 +108,24 @@ export const fetchNextChildrenPage = createAsyncThunk(
       const children = await listTeamFoldersSafe();
       return { children, kind: 'dashboard', page: 1, lastPageOfKind: true };
     }
-
     // TODO: invert prop to `includeKinds`, but also support not loading folders
     const loadDashboards = !excludeKinds.includes('dashboard');
-
     const strippedUID = parentUID ? removeTeamFolderPrefix(parentUID) : parentUID;
     const uid = strippedUID === GENERAL_FOLDER_UID ? undefined : strippedUID;
-
     const state = thunkAPI.getState().browseDashboards;
     const collectionKey = parentUID === GENERAL_FOLDER_UID ? undefined : parentUID;
     const collection = collectionKey ? state.childrenByParentUID[collectionKey] : state.rootItems;
-
     let page = 1;
     let fetchKind: DashboardViewItemKind | undefined = undefined;
-
     // Folder children do not come from a single API, so we need to do a bunch of logic to determine
     // which page of which kind to load
-
     if (!collection) {
       // No previous data in store, fetching first page of folders
       page = 1;
       fetchKind = 'folder';
     } else if (collection.lastFetchedKind === 'dashboard' && !collection.lastKindHasMoreItems) {
       // There's nothing to load at all
-      console.warn(`fetchNextChildrenPage called for ${uid} but that collection is fully loaded`);
+      structLog('warn', `fetchNextChildrenPage called for ${uid} but that collection is fully loaded`);
       // return;
     } else if (collection.lastFetchedKind === 'folder' && collection.lastKindHasMoreItems) {
       // Load additional pages of folders
@@ -163,29 +137,23 @@ export const fetchNextChildrenPage = createAsyncThunk(
       page = collection.lastFetchedKind === 'folder' ? 1 : collection.lastFetchedPage + 1;
       fetchKind = 'dashboard';
     }
-
     if (!fetchKind) {
       return;
     }
-
     let children =
       fetchKind === 'folder'
         ? await listFolders(uid, undefined, page, pageSize)
         : await listDashboards(uid, page, pageSize);
-
     let lastPageOfKind = children.length < pageSize;
-
     // If we've loaded all folders, load the first page of dashboards.
     // This ensures dashboards are loaded if a folder contains only dashboards.
     if (fetchKind === 'folder' && lastPageOfKind && loadDashboards) {
       fetchKind = 'dashboard';
       page = 1;
-
       const childDashboards = await listDashboards(uid, page, pageSize);
       lastPageOfKind = childDashboards.length < pageSize;
       children = children.concat(childDashboards);
     }
-
     // Propagate prefix to all descendants so they get independent expand/collapse state
     const isTeamFolderChild = parentUID !== strippedUID;
     if (isTeamFolderChild) {
@@ -194,7 +162,6 @@ export const fetchNextChildrenPage = createAsyncThunk(
         uid: addTeamFolderPrefix(removeTeamFolderPrefix(child.uid)),
       }));
     }
-
     return {
       children,
       lastPageOfKind,

--- a/public/app/features/canvas/runtime/frame.tsx
+++ b/public/app/features/canvas/runtime/frame.tsx
@@ -1,58 +1,47 @@
+import { structLog } from '@grafana/data';
 import { cloneDeep } from 'lodash';
-
 import { notFoundItem } from 'app/features/canvas/elements/notFound';
 import { type DimensionContext } from 'app/features/dimensions/context';
 import { HorizontalConstraint, type Placement, VerticalConstraint } from 'app/plugins/panel/canvas/panelcfg.gen';
 import { LayerActionID } from 'app/plugins/panel/canvas/types';
-
 import { updateConnectionsForSource } from '../../../plugins/panel/canvas/utils';
 import { type CanvasElementItem } from '../element';
 import { type CanvasFrameOptions } from '../frame';
 import { canvasElementRegistry } from '../registry';
-
 import { ElementState } from './element';
 import { type RootElement } from './root';
 import { type Scene } from './scene';
 import { initMoveable } from './sceneAbleManagement';
-
 const DEFAULT_OFFSET = 10;
 const HORIZONTAL_OFFSET = 50;
-
 export const frameItemDummy: CanvasElementItem = {
   id: 'frame',
   name: 'Frame',
   description: 'Frame',
-
   getNewOptions: () => ({
     config: {},
   }),
-
   display: () => {
     // never shown to end user
     // eslint-disable-next-line @grafana/i18n/no-untranslated-strings
     return <div>FRAME!</div>;
   },
 };
-
 export class FrameState extends ElementState {
   elements: ElementState[] = [];
   scene: Scene;
-
   constructor(
     public options: CanvasFrameOptions,
     scene: Scene,
     public parent?: FrameState
   ) {
     super(frameItemDummy, options, parent);
-
     this.scene = scene;
-
     // mutate options object
     let { elements } = this.options;
     if (!elements) {
       this.options.elements = elements = [];
     }
-
     for (const element of elements) {
       if (element.type === 'frame') {
         // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
@@ -63,41 +52,33 @@ export class FrameState extends ElementState {
       }
     }
   }
-
   isRoot(): this is RootElement {
     return false;
   }
-
   updateData(ctx: DimensionContext) {
     super.updateData(ctx);
     for (const elem of this.elements) {
       elem.updateData(ctx);
     }
   }
-
   // used in the layer editor
   reorder(startIndex: number, endIndex: number) {
     const result = Array.from(this.elements);
     const [removed] = result.splice(startIndex, 1);
     result.splice(endIndex, 0, removed);
     this.elements = result;
-
     this.reinitializeMoveable();
   }
-
   // used for tree view
   reorderTree(src: ElementState, dest: ElementState, firstPosition = false) {
     const result = Array.from(this.elements);
     const srcIndex = this.elements.indexOf(src);
     const destIndex = firstPosition ? this.elements.length - 1 : this.elements.indexOf(dest);
-
     const [removed] = result.splice(srcIndex, 1);
     result.splice(destIndex, 0, removed);
     this.elements = result;
-
     this.reinitializeMoveable();
   }
-
   doMove(child: ElementState, action: LayerActionID) {
     const vals = this.elements.filter((v) => v !== child);
     if (action === LayerActionID.MoveBottom) {
@@ -109,13 +90,11 @@ export class FrameState extends ElementState {
     this.scene.save();
     this.reinitializeMoveable();
   }
-
   reinitializeMoveable() {
     // Need to first clear current selection and then re-init moveable with slight delay
     this.scene.clearCurrentSelection();
     setTimeout(() => initMoveable(true, this.scene.isEditingEnabled, this.scene));
   }
-
   // ??? or should this be on the element directly?
   // are actions scoped to layers?
   doAction = (action: LayerActionID, element: ElementState, updateName = true, shiftItemsOnDuplicate = true) => {
@@ -129,16 +108,14 @@ export class FrameState extends ElementState {
         break;
       case LayerActionID.Duplicate:
         if (element.item.id === 'frame') {
-          console.log('Can not duplicate frames (yet)', action, element);
+          structLog('log', 'Can not duplicate frames (yet)', action, element);
           return;
         }
         const opts = cloneDeep(element.options);
-
         if (shiftItemsOnDuplicate) {
           const { constraint, placement: oldPlacement } = element.options;
           const { vertical, horizontal } = constraint ?? {};
           const placement: Placement = { ...oldPlacement };
-
           switch (vertical) {
             case VerticalConstraint.Top:
               if (placement.top == null) {
@@ -160,7 +137,6 @@ export class FrameState extends ElementState {
               } else {
                 placement.top += DEFAULT_OFFSET;
               }
-
               if (placement.bottom == null) {
                 placement.bottom = 100;
               } else {
@@ -173,7 +149,6 @@ export class FrameState extends ElementState {
               }
               break;
           }
-
           switch (horizontal) {
             case HorizontalConstraint.Left:
               if (placement.left == null) {
@@ -195,7 +170,6 @@ export class FrameState extends ElementState {
               } else {
                 placement.left += DEFAULT_OFFSET;
               }
-
               if (placement.right == null) {
                 placement.right = HORIZONTAL_OFFSET;
               } else {
@@ -208,13 +182,10 @@ export class FrameState extends ElementState {
               }
               break;
           }
-
           opts.placement = placement;
         }
-
         // Clear connections on duplicate
         opts.connections = undefined;
-
         const copy = new ElementState(element.item, opts, this);
         copy.updateData(this.scene.context);
         if (updateName) {
@@ -222,13 +193,10 @@ export class FrameState extends ElementState {
         }
         this.elements.push(copy);
         this.scene.byName.set(copy.options.name, copy);
-
         // Update scene byName map for original element (to avoid stale references (e.g. for connections))
         this.scene.byName.set(element.options.name, element);
-
         this.scene.save();
         this.reinitializeMoveable();
-
         setTimeout(() => {
           this.scene.targetsToSelect.add(copy.div!);
         });
@@ -237,13 +205,11 @@ export class FrameState extends ElementState {
       case LayerActionID.MoveBottom:
         element.parent?.doMove(element, action);
         break;
-
       default:
-        console.log('DO action', action, element);
+        structLog('log', 'DO action', action, element);
         return;
     }
   };
-
   renderElement() {
     return (
       <div key={this.UID} ref={this.initElement}>
@@ -251,7 +217,6 @@ export class FrameState extends ElementState {
       </div>
     );
   }
-
   /** Recursively visit all nodes */
   visit(visitor: (v: ElementState) => void) {
     super.visit(visitor);
@@ -259,7 +224,6 @@ export class FrameState extends ElementState {
       visitor(e);
     }
   }
-
   getSaveModel() {
     return {
       ...this.options,

--- a/public/app/features/commandPalette/actions/useActions.tsx
+++ b/public/app/features/commandPalette/actions/useActions.tsx
@@ -1,35 +1,29 @@
+import { structLog } from '@grafana/data';
 import { useRegisterActions } from 'kbar';
 import { useEffect, useMemo, useState } from 'react';
-
 import { type CommandPaletteAction } from '../types';
-
 import { getRecentDashboardActions } from './dashboardActions';
 import { useStaticActions } from './staticActions';
 import useExtensionActions from './useExtensionActions';
-
 /**
  * Register navigation actions to different parts of grafana or some preferences stuff like themes.
  */
 export function useRegisterStaticActions() {
   const extensionActions = useExtensionActions();
   const staticActions = useStaticActions();
-
   const navTreeActions = useMemo(() => {
     return [...staticActions, ...extensionActions];
   }, [staticActions, extensionActions]);
-
   useRegisterActions(navTreeActions, [navTreeActions]);
 }
-
 export function useRegisterRecentDashboardsActions() {
   const [recentDashboardActions, setRecentDashboardActions] = useState<CommandPaletteAction[]>([]);
   useEffect(() => {
     getRecentDashboardActions()
       .then((recentDashboardActions) => setRecentDashboardActions(recentDashboardActions))
       .catch((err) => {
-        console.error('Error loading recent dashboard actions', err);
+        structLog('error', 'Error loading recent dashboard actions', err);
       });
   }, []);
-
   useRegisterActions(recentDashboardActions, [recentDashboardActions]);
 }

--- a/public/app/features/dashboard-scene/behaviors/DashboardAnalyticsInitializerBehavior.ts
+++ b/public/app/features/dashboard-scene/behaviors/DashboardAnalyticsInitializerBehavior.ts
@@ -1,8 +1,7 @@
+import { structLog } from '@grafana/data';
 import { writePerformanceLog } from '@grafana/scenes';
-
 import { getDashboardAnalyticsAggregator } from '../../dashboard/services/DashboardAnalyticsAggregator';
 import { type DashboardScene } from '../scene/DashboardScene';
-
 /**
  * Scene behavior function that manages the dashboard-specific initialization
  * of the global analytics aggregator for each dashboard session.
@@ -13,25 +12,19 @@ import { type DashboardScene } from '../scene/DashboardScene';
  */
 export function dashboardAnalyticsInitializer(dashboard: DashboardScene) {
   const { uid, title } = dashboard.state;
-
   if (!uid) {
-    console.warn('dashboardAnalyticsInitializer: Dashboard UID is missing');
+    structLog('warn', 'dashboardAnalyticsInitializer: Dashboard UID is missing');
     return;
   }
-
   writePerformanceLog('DAI', 'Setting dashboard context for analytics aggregator');
-
   // Set dashboard context on the global aggregator (observer already registered)
   const aggregator = getDashboardAnalyticsAggregator();
   aggregator.initialize(uid, title || 'Untitled Dashboard');
-
   writePerformanceLog('DAI', 'Dashboard analytics aggregator context set:', { uid, title });
-
   // Return cleanup function
   return () => {
     // Only clear dashboard state, keep observer registered for next dashboard
     aggregator.destroy();
-
     writePerformanceLog('DAI', 'Dashboard analytics aggregator context cleared');
   };
 }

--- a/public/app/features/dashboard-scene/behaviors/DefaultControlsBehavior.ts
+++ b/public/app/features/dashboard-scene/behaviors/DefaultControlsBehavior.ts
@@ -1,58 +1,46 @@
+import { structLog } from '@grafana/data';
 import { type Subscription } from 'rxjs';
-
 import { SceneObjectBase, type SceneObjectState } from '@grafana/scenes';
-
 import { loadDefaultControlsShared$, loadDefaultLinks$, loadDefaultVariables$ } from '../utils/dashboardControls';
 import { getDsRefsFromScene } from '../utils/dashboardDsRefs';
 import { getDashboardSceneFor } from '../utils/utils';
-
 export class DefaultControlsBehavior extends SceneObjectBase<SceneObjectState> {
   private _variablesSub?: Subscription;
   private _linksSub?: Subscription;
-
   constructor() {
     super({});
     this.addActivationHandler(() => this._onActivate());
   }
-
   private _onActivate() {
     const dashboard = getDashboardSceneFor(this);
     const refs = getDsRefsFromScene(dashboard);
-
     if (refs.length === 0) {
       return;
     }
-
     dashboard.setState({ defaultVariablesLoading: true, defaultLinksLoading: true });
-
     this._cleanup();
-
     const shared$ = loadDefaultControlsShared$(refs);
-
     this._variablesSub = loadDefaultVariables$(shared$).subscribe({
       next: (vars) => dashboard.setDefaultVariables(vars),
       error: (err) => {
-        console.warn('Failed to load default variables', err);
+        structLog('warn', 'Failed to load default variables', err);
         dashboard.setState({ defaultVariablesLoading: false });
       },
       complete: () => dashboard.setState({ defaultVariablesLoading: false }),
     });
-
     this._linksSub = loadDefaultLinks$(shared$).subscribe({
       next: (links) => dashboard.setDefaultLinks(links),
       error: (err) => {
-        console.warn('Failed to load default links', err);
+        structLog('warn', 'Failed to load default links', err);
         dashboard.setState({ defaultLinksLoading: false });
       },
       complete: () => dashboard.setState({ defaultLinksLoading: false }),
     });
-
     return () => {
       this._cleanup();
       dashboard.clearDefaultControls();
     };
   }
-
   private _cleanup() {
     this._variablesSub?.unsubscribe();
     this._linksSub?.unsubscribe();

--- a/public/app/features/dashboard-scene/edit-pane/DashboardEditPane.tsx
+++ b/public/app/features/dashboard-scene/edit-pane/DashboardEditPane.tsx
@@ -1,3 +1,4 @@
+import { structLog } from '@grafana/data';
 import { type SceneObject, SceneObjectBase, type SceneObjectState, sceneGraph } from '@grafana/scenes';
 import {
   type ElementSelectionContextItem,
@@ -5,12 +6,10 @@ import {
   type ElementSelectionOnSelectOptions,
 } from '@grafana/ui';
 import { getLayoutType } from 'app/features/dashboard/utils/tracking';
-
 import { TabItem } from '../scene/layout-tabs/TabItem';
 import { getRepeatCloneSourceKey } from '../utils/clone';
 import { DashboardInteractions } from '../utils/interactions';
 import { getDefaultVizPanel, getLayoutForObject, getDashboardSceneFor } from '../utils/utils';
-
 import {
   ConditionalRenderingChangedEvent,
   DashboardEditActionEvent,
@@ -22,10 +21,8 @@ import {
   RepeatsUpdatedEvent,
 } from './shared';
 import { type EditPaneSelectionActions } from './types';
-
 export interface DashboardEditPaneState extends SceneObjectState {
   selectionContext: ElementSelectionContextState;
-
   undoStack: DashboardEditActionEventPayload[];
   redoStack: DashboardEditActionEventPayload[];
   openPane?: DashboardSidebarPaneName;
@@ -37,9 +34,7 @@ export interface DashboardEditPaneState extends SceneObjectState {
   isNewElement: boolean;
   isDocked?: boolean;
 }
-
 export type DashboardSidebarPaneName = 'element' | 'outline' | 'filters' | 'add' | 'code';
-
 export class DashboardEditPane extends SceneObjectBase<DashboardEditPaneState> implements EditPaneSelectionActions {
   public constructor() {
     super({
@@ -53,69 +48,55 @@ export class DashboardEditPane extends SceneObjectBase<DashboardEditPaneState> i
       undoStack: [],
       redoStack: [],
     });
-
     this.addActivationHandler(this.onActivate.bind(this));
   }
-
   private panelEditAction?: DashboardEditActionEvent;
-
   public setPanelEditAction(editAction: DashboardEditActionEvent) {
     this.panelEditAction = editAction;
   }
-
   public clone(withState: Partial<DashboardEditPaneState>): this {
     // Clone without any undo/redo history
     return super.clone({ ...withState, redoStack: [], undoStack: [] });
   }
-
   private onActivate() {
     const dashboard = getDashboardSceneFor(this);
-
     if (dashboard.state.isEditing) {
       this.enableSelection();
     }
-
     this._subs.add(
       dashboard.subscribeToEvent(DashboardEditActionEvent, ({ payload }) => {
         this.handleEditAction(payload);
       })
     );
-
     this._subs.add(
       dashboard.subscribeToEvent(NewObjectAddedToCanvasEvent, ({ payload }) => {
         this.newObjectAddedToCanvas(payload);
       })
     );
-
     this._subs.add(
       dashboard.subscribeToEvent(ObjectRemovedFromCanvasEvent, ({ payload }) => {
         this.clearSelection();
       })
     );
-
     this._subs.add(
       dashboard.subscribeToEvent(ObjectsReorderedOnCanvasEvent, ({ payload }) => {
         this.forceRender();
       })
     );
-
     this._subs.add(
       dashboard.subscribeToEvent(ConditionalRenderingChangedEvent, ({ payload }) => {
         this.forceRender();
       })
     );
-
     this._subs.add(
       dashboard.subscribeToEvent(RepeatsUpdatedEvent, () => {
         this.forceRender();
       })
     );
-
     if (this.panelEditAction) {
       this.performPanelEditAction(this.panelEditAction);
       this.panelEditAction = undefined;
     }
-
     return () => {
       if (this.state.selectionContext.selected.length) {
         this.clearSelection(true);
@@ -123,7 +104,6 @@ export class DashboardEditPane extends SceneObjectBase<DashboardEditPaneState> i
       this.disableSelection();
     };
   }
-
   private performPanelEditAction(action: DashboardEditActionEvent) {
     // Some layout items are not yet active when leaving panel edit, let's wait for them to activate
     if (!action.payload.source.isActive) {
@@ -131,10 +111,8 @@ export class DashboardEditPane extends SceneObjectBase<DashboardEditPaneState> i
       setTimeout(() => this.performPanelEditAction(action));
       return;
     }
-
     action.payload.source.publishEvent(action, true);
   }
-
   /**
    * Handles all edit actions
    * Adds to undo history and selects new object
@@ -146,12 +124,9 @@ export class DashboardEditPane extends SceneObjectBase<DashboardEditPaneState> i
     if (this.state.redoStack.length > 0) {
       this.setState({ redoStack: [] });
     }
-
     this.performAction(action);
-
     this.setState({ undoStack: [...this.state.undoStack, action] });
   }
-
   /**
    * Removes last action from undo stack and adds it to redo stack.
    */
@@ -161,45 +136,35 @@ export class DashboardEditPane extends SceneObjectBase<DashboardEditPaneState> i
     if (!action) {
       return;
     }
-
     action.undo();
     action.source.publishEvent(new DashboardStateChangedEvent({ source: action.source }), true);
-
     if (action.addedObject) {
       this.clearSelection();
     }
-
     if (action.movedObject) {
       this.selectObject(action.movedObject, { force: true });
     }
-
     if (action.removedObject) {
       this.newObjectAddedToCanvas(action.removedObject);
     }
-
     this.setState({ undoStack, redoStack: [...this.state.redoStack, action] });
   }
-
   /**
    * Some edit actions also require clearing selection or selecting new objects
    */
   private performAction(action: DashboardEditActionEventPayload) {
     action.perform();
     action.source.publishEvent(new DashboardStateChangedEvent({ source: action.source }), true);
-
     if (action.addedObject) {
       this.newObjectAddedToCanvas(action.addedObject);
     }
-
     if (action.movedObject) {
       this.selectObject(action.movedObject, { force: true });
     }
-
     if (action.removedObject && !action.addedObject) {
       this.clearSelection();
     }
   }
-
   /**
    * Removes last action from redo stack and adds it to undo stack.
    */
@@ -209,54 +174,43 @@ export class DashboardEditPane extends SceneObjectBase<DashboardEditPaneState> i
     if (!action) {
       return;
     }
-
     this.performAction(action);
-
     this.setState({ redoStack, undoStack: [...this.state.undoStack, action] });
   }
-
   public enableSelection() {
     if (this.state.selectionContext.enabled) {
       return;
     }
-
     this.setState({ selectionContext: { ...this.state.selectionContext, enabled: true } });
   }
-
   public disableSelection() {
     if (!this.state.selectionContext.enabled) {
       return;
     }
-
     this.setState({
       selectionContext: { ...this.state.selectionContext, selected: [], enabled: false },
       openPane: undefined,
     });
   }
-
   private selectElement(element: ElementSelectionContextItem, options: ElementSelectionOnSelectOptions) {
     let obj = sceneGraph.findByKey(this, element.id);
     if (!obj) {
-      console.warn('Cannot find element by key="%s"!', element.id);
+      structLog('warn', 'Cannot find element by key="%s"!', element.id);
       return;
     }
-
     const sourceKey = getRepeatCloneSourceKey(obj);
     if (sourceKey) {
       obj = sceneGraph.findByKey(this, sourceKey);
       if (!obj) {
-        console.warn('Cannot find element by source key="%s"!', sourceKey);
+        structLog('warn', 'Cannot find element by source key="%s"!', sourceKey);
         return;
       }
     }
-
     this.selectObject(obj, options);
   }
-
   public selectObject(obj: SceneObject, { multi, force }: ElementSelectionOnSelectOptions = {}) {
     const id = obj.state.key!;
     const hasItem = this.state.selectionContext.selected.find((i) => i.id === id);
-
     if (obj.getRoot() !== this.getRoot() || obj.parent === this) {
       this.setState({
         openPaneTempHack: obj,
@@ -265,7 +219,6 @@ export class DashboardEditPane extends SceneObjectBase<DashboardEditPaneState> i
       });
       return;
     }
-
     if (multi) {
       if (hasItem) {
         // Remove item unless force is true
@@ -283,14 +236,12 @@ export class DashboardEditPane extends SceneObjectBase<DashboardEditPaneState> i
       }
     }
   }
-
   private updateSelection(selected: ElementSelectionContextItem[]) {
     // onBlur events are not fired on unmount and some edit pane inputs have important onBlur events
     // This make sure they fire before unmounting
     if (document.activeElement instanceof HTMLElement) {
       document.activeElement.blur();
     }
-
     this.setState({
       selectionContext: { ...this.state.selectionContext, selected },
       openPane: selected.length === 0 ? undefined : 'element',
@@ -298,7 +249,6 @@ export class DashboardEditPane extends SceneObjectBase<DashboardEditPaneState> i
       openPaneTempHack: undefined,
     });
   }
-
   /**
    * Look-up selected object by key. If key is not provided, will return object based on current selection.
    * @param key of the object
@@ -309,19 +259,15 @@ export class DashboardEditPane extends SceneObjectBase<DashboardEditPaneState> i
       // Not using findByKey here as it requires try catch in case object is not found
       return sceneGraph.findObject(this, (obj) => obj.state.key === key);
     }
-
     if (this.state.openPaneTempHack) {
       return this.state.openPaneTempHack;
     }
-
     if (this.state.selectionContext.selected.length === 0) {
       return null;
     }
-
     // Not using findByKey here as it requires try catch in case object is not found
     return sceneGraph.findObject(this, (obj) => obj.state.key === this.state.selectionContext.selected[0].id);
   }
-
   /**
    * @param force If force = true it will clear selection even when docked
    * @returns
@@ -330,7 +276,6 @@ export class DashboardEditPane extends SceneObjectBase<DashboardEditPaneState> i
     if (!this.state.selectionContext.selected.length) {
       return;
     }
-
     // If we are docked then clearing selection should select dashboard itself
     // Unless the user explicitly closes pane
     if (this.state.isDocked && !force) {
@@ -340,37 +285,30 @@ export class DashboardEditPane extends SceneObjectBase<DashboardEditPaneState> i
       }
       return;
     }
-
     this.updateSelection([]);
   }
-
   public openPane(openPane: DashboardSidebarPaneName) {
     if (this.state.selectionContext.selected.length) {
       this.clearSelection(true);
     }
-
     if (openPane === this.state.openPane) {
       this.setState({ openPane: undefined });
     } else {
       this.setState({ openPane });
     }
   }
-
   public closePane() {
     if (this.state.selectionContext.selected.length) {
       this.clearSelection(true);
     }
-
     if (this.state.openPane) {
       this.setState({ openPane: undefined });
     }
   }
-
   private newObjectAddedToCanvas(obj: SceneObject) {
     this.selectObject(obj);
     this.setState({ isNewElement: true });
   }
-
   public addNewPanel(targetElement?: SceneObject) {
     const panel = getDefaultVizPanel();
     const dashboard = getDashboardSceneFor(this);
@@ -382,7 +320,6 @@ export class DashboardEditPane extends SceneObjectBase<DashboardEditPaneState> i
     }
     DashboardInteractions.trackAddPanelClick('sidebar', getLayoutType(targetElement));
   }
-
   public pastePanel(targetElement?: SceneObject, source: 'sidebar' | 'editPaneHeader' = 'sidebar') {
     const dashboard = getDashboardSceneFor(this);
     if (targetElement) {
@@ -394,12 +331,10 @@ export class DashboardEditPane extends SceneObjectBase<DashboardEditPaneState> i
     DashboardInteractions.trackPastePanelClick(source, getLayoutType(targetElement), 'click');
   }
 }
-
 function trySwitchingToSourceTab(source: SceneObject) {
   if (source.parent === undefined) {
     return;
   }
-
   if (source.parent instanceof TabItem) {
     const tab = source.parent;
     const tabsLayout = source.parent.getParentLayout();

--- a/public/app/features/dashboard-scene/inspect/HelpWizard/SupportSnapshotService.ts
+++ b/public/app/features/dashboard-scene/inspect/HelpWizard/SupportSnapshotService.ts
@@ -1,15 +1,12 @@
+import { structLog } from '@grafana/data';
 import saveAs from 'file-saver';
-
 import { dateTimeFormat, formattedValueToString, getValueFormat, type SelectableValue } from '@grafana/data';
 import { t } from '@grafana/i18n';
 import { sceneGraph, type SceneObject, type VizPanel } from '@grafana/scenes';
 import { StateManagerBase } from 'app/core/services/StateManagerBase';
-
 import { transformSaveModelToScene } from '../../serialization/transformSaveModelToScene';
-
 import { type Randomize } from './randomizer';
 import { getDebugDashboard, getGithubMarkdown } from './utils';
-
 interface SupportSnapshotState {
   currentTab: SnapshotTab;
   showMessage: ShowMessage;
@@ -25,23 +22,19 @@ interface SupportSnapshotState {
   };
   panel: VizPanel;
   panelTitle: string;
-
   // eslint-disable-next-line
   snapshot?: any;
   snapshotUpdate: number;
   scene?: SceneObject;
 }
-
 export enum SnapshotTab {
   Support,
   Data,
 }
-
 export enum ShowMessage {
   PanelSnapshot,
   GithubComment,
 }
-
 export class SupportSnapshotService extends StateManagerBase<SupportSnapshotState> {
   constructor(panel: VizPanel) {
     super({
@@ -70,39 +63,32 @@ export class SupportSnapshotService extends StateManagerBase<SupportSnapshotStat
       ],
     });
   }
-
   async buildDebugDashboard() {
     const { panel, randomize, snapshotUpdate } = this.state;
     const snapshot = await getDebugDashboard(panel, randomize, sceneGraph.getTimeRange(panel).state.value);
     const snapshotText = JSON.stringify(snapshot, null, 2);
     const markdownText = getGithubMarkdown(panel, snapshotText);
     const snapshotSize = formattedValueToString(getValueFormat('bytes')(snapshotText?.length ?? 0));
-
     let scene: SceneObject | undefined = undefined;
     if (snapshot) {
       try {
         const dash = transformSaveModelToScene({ dashboard: snapshot, meta: { isEmbedded: true } });
         scene = dash.state.body; // skip the wrappers
       } catch (ex) {
-        console.log('Error creating scene:', ex);
+        structLog('log', 'Error creating scene:', ex);
       }
     }
-
     this.setState({ snapshot, snapshotText, markdownText, snapshotSize, snapshotUpdate: snapshotUpdate + 1, scene });
   }
-
   onCurrentTabChange = (value: SnapshotTab) => {
     this.setState({ currentTab: value });
   };
-
   onShowMessageChange = (value: SelectableValue<ShowMessage>) => {
     this.setState({ showMessage: value.value! });
   };
-
   onGetMarkdownForClipboard = () => {
     const { markdownText } = this.state;
     const maxLen = Math.pow(1024, 2) * 1.5; // 1.5MB
-
     if (markdownText.length > maxLen) {
       this.setState({
         error: {
@@ -113,13 +99,10 @@ export class SupportSnapshotService extends StateManagerBase<SupportSnapshotStat
           message: 'Snapshot is too large, consider download and attaching a file instead',
         },
       });
-
       return '';
     }
-
     return markdownText;
   };
-
   onDownloadDashboard = () => {
     const { snapshotText, panelTitle } = this.state;
     const blob = new Blob([snapshotText], {
@@ -128,11 +111,9 @@ export class SupportSnapshotService extends StateManagerBase<SupportSnapshotStat
     const fileName = `debug-${panelTitle}-${dateTimeFormat(new Date())}.json.txt`;
     saveAs(blob, fileName);
   };
-
   onSetSnapshotText = (snapshotText: string) => {
     this.setState({ snapshotText });
   };
-
   onToggleRandomize = (k: keyof Randomize) => {
     const { randomize } = this.state;
     this.setState({ randomize: { ...randomize, [k]: !randomize[k] } });

--- a/public/app/features/dashboard-scene/inspect/InspectJsonTab.tsx
+++ b/public/app/features/dashboard-scene/inspect/InspectJsonTab.tsx
@@ -1,6 +1,6 @@
+import { structLog } from '@grafana/data';
 import { isEqual } from 'lodash';
 import AutoSizer from 'react-virtualized-auto-sizer';
-
 import { type SelectableValue } from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';
 import { Trans, t } from '@grafana/i18n';
@@ -26,7 +26,6 @@ import { getPanelInspectorStyles2 } from 'app/features/inspector/styles';
 import { InspectTab } from 'app/features/inspector/types';
 import { getPrettyJSON } from 'app/features/inspector/utils/utils';
 import { reportPanelInspectInteraction } from 'app/features/search/page/reporting';
-
 import { type DashboardScene } from '../scene/DashboardScene';
 import { DashboardGridItem } from '../scene/layout-default/DashboardGridItem';
 import { gridItemToGridLayoutItemKind } from '../serialization/layoutSerializers/DefaultGridLayoutSerializer';
@@ -43,9 +42,7 @@ import {
   isLibraryPanel,
 } from '../utils/utils';
 import { isGridLayoutItemKind, isPanelKindV2 } from '../v2schema/validation';
-
 export type ShowContent = 'panel-json' | 'panel-data' | 'data-frames' | 'panel-layout';
-
 export interface InspectJsonTabState extends SceneObjectState {
   panelRef: SceneObjectRef<VizPanel>;
   source: ShowContent;
@@ -53,7 +50,6 @@ export interface InspectJsonTabState extends SceneObjectState {
   onClose: () => void;
   error?: string;
 }
-
 export class InspectJsonTab extends SceneObjectBase<InspectJsonTabState> {
   public constructor(state: Omit<InspectJsonTabState, 'source' | 'jsonText'>) {
     super({
@@ -62,21 +58,17 @@ export class InspectJsonTab extends SceneObjectBase<InspectJsonTabState> {
       jsonText: getJsonText('panel-json', state.panelRef.resolve()),
     });
   }
-
   public getTabLabel() {
     return t('dashboard.inspect.json-tab', 'JSON');
   }
-
   public getTabValue() {
     return InspectTab.JSON;
   }
-
   public getOptions(): Array<SelectableValue<ShowContent>> {
     const panel = this.state.panelRef.resolve();
     const dashboard = getDashboardSceneFor(panel);
     const dataProvider = panel.state.$data ?? panel.parent?.state.$data;
     const isV2 = isDashboardV2Spec(dashboard.getSaveModel());
-
     const options: Array<SelectableValue<ShowContent>> = [
       {
         label: isV2
@@ -89,7 +81,6 @@ export class InspectJsonTab extends SceneObjectBase<InspectJsonTabState> {
         value: 'panel-json',
       },
     ];
-
     if (isV2 && panel.parent instanceof DashboardGridItem) {
       options.push({
         label: t('dashboard.inspect-json.panel-layout-label', 'Panel Layout'),
@@ -100,7 +91,6 @@ export class InspectJsonTab extends SceneObjectBase<InspectJsonTabState> {
         value: 'panel-layout',
       });
     }
-
     if (dataProvider) {
       options.push({
         label: t('dashboard.inspect-json.panel-data-label', 'Panel data'),
@@ -119,10 +109,8 @@ export class InspectJsonTab extends SceneObjectBase<InspectJsonTabState> {
         value: 'data-frames',
       });
     }
-
     return options;
   }
-
   public onChangeSource = (value: SelectableValue<ShowContent>) => {
     this.setState({
       source: value.value!,
@@ -130,7 +118,6 @@ export class InspectJsonTab extends SceneObjectBase<InspectJsonTabState> {
       error: undefined,
     });
   };
-
   public onApplyChange = () => {
     let jsonObj: unknown;
     try {
@@ -141,14 +128,12 @@ export class InspectJsonTab extends SceneObjectBase<InspectJsonTabState> {
       });
       return;
     }
-
     if (this.state.source === 'panel-layout') {
       this.applyLayoutChange(jsonObj);
     } else if (this.state.source === 'panel-json') {
       this.applyPanelJsonChange(jsonObj);
     }
   };
-
   private applyLayoutChange(jsonObj: unknown) {
     if (!isGridLayoutItemKind(jsonObj)) {
       this.setState({
@@ -159,16 +144,13 @@ export class InspectJsonTab extends SceneObjectBase<InspectJsonTabState> {
       });
       return;
     }
-
     const panel = this.state.panelRef.resolve();
     const dashboard = getDashboardSceneFor(panel);
     const gridItem = panel.parent;
-
     if (!(gridItem instanceof DashboardGridItem)) {
-      console.error('Cannot update layout: panel parent is not a DashboardGridItem');
+      structLog('error', 'Cannot update layout: panel parent is not a DashboardGridItem');
       return;
     }
-
     const originalElementName = dashboardSceneGraph.getElementIdentifierForVizPanel(panel);
     if (jsonObj.spec.element.name !== originalElementName) {
       this.setState({
@@ -179,11 +161,9 @@ export class InspectJsonTab extends SceneObjectBase<InspectJsonTabState> {
       });
       return;
     }
-
     if (!dashboard.state.isEditing) {
       dashboard.onEnterEditMode();
     }
-
     const oldState = gridItem.state;
     const newLayoutState = {
       x: jsonObj.spec.x,
@@ -191,15 +171,12 @@ export class InspectJsonTab extends SceneObjectBase<InspectJsonTabState> {
       width: jsonObj.spec.width,
       height: jsonObj.spec.height,
     };
-
     gridItem.setState(newLayoutState);
-
     // Force the grid layout to re-render with the new positions
     const layout = sceneGraph.getLayout(panel);
     if (layout instanceof SceneGridLayout) {
       layout.forceRender();
     }
-
     reportPanelInspectInteraction(InspectTab.JSON, 'apply', {
       panel_type_changed: false,
       panel_id_changed: false,
@@ -210,21 +187,17 @@ export class InspectJsonTab extends SceneObjectBase<InspectJsonTabState> {
         oldState.height !== newLayoutState.height,
       panel_targets_changed: false,
     });
-
     this.state.onClose();
   }
-
   private applyPanelJsonChange(jsonObj: unknown) {
     const panel = this.state.panelRef.resolve();
     const dashboard = getDashboardSceneFor(panel);
-
     if (isDashboardV2Spec(dashboard.getSaveModel())) {
       this.applyV2PanelChange(jsonObj, panel, dashboard);
     } else {
       this.applyV1PanelChange(jsonObj, panel, dashboard);
     }
   }
-
   private applyV2PanelChange(jsonObj: unknown, panel: VizPanel, dashboard: DashboardScene) {
     if (!isPanelKindV2(jsonObj)) {
       this.setState({
@@ -235,89 +208,69 @@ export class InspectJsonTab extends SceneObjectBase<InspectJsonTabState> {
       });
       return;
     }
-
     const vizPanel = buildVizPanel(jsonObj, jsonObj.spec.id);
-
     if (!dashboard.state.isEditing) {
       dashboard.onEnterEditMode();
     }
-
     reportPanelInspectInteraction(InspectTab.JSON, 'apply', {
       panel_type_changed: panel.state.pluginId !== jsonObj.spec.vizConfig.group,
       panel_id_changed: getPanelIdForVizPanel(panel) !== jsonObj.spec.id,
       panel_grid_pos_changed: false,
       panel_targets_changed: hasQueriesChanged(getQueryRunnerFor(panel), getQueryRunnerFor(vizPanel.state.$data)),
     });
-
     panel.setState(vizPanel.state);
     this.state.onClose();
   }
-
   private applyV1PanelChange(jsonObj: unknown, panel: VizPanel, dashboard: DashboardScene) {
     const panelModel = new PanelModel(jsonObj);
     const gridItem = buildGridItemForPanel(panelModel);
     const newState = sceneUtils.cloneSceneObjectState(gridItem.state);
-
     if (!(panel.parent instanceof DashboardGridItem)) {
-      console.error('Cannot update state of panel', panel, gridItem);
+      structLog('error', 'Cannot update state of panel', panel, gridItem);
       return;
     }
-
     if (!dashboard.state.isEditing) {
       dashboard.onEnterEditMode();
     }
-
     panel.parent.setState(newState);
-
     // Force the grid layout to re-render with the new positions
     const layout = sceneGraph.getLayout(panel);
     if (layout instanceof SceneGridLayout) {
       layout.forceRender();
     }
-
     reportPanelInspectInteraction(InspectTab.JSON, 'apply', {
       panel_type_changed: panel.state.pluginId !== panelModel.type,
       panel_id_changed: getPanelIdForVizPanel(panel) !== panelModel.id,
       panel_grid_pos_changed: hasGridPosChanged(panel.parent.state, newState),
       panel_targets_changed: hasQueriesChanged(getQueryRunnerFor(panel), getQueryRunnerFor(newState.$data)),
     });
-
     this.state.onClose();
   }
-
   public onCodeEditorBlur = (value: string) => {
     this.setState({ jsonText: value });
   };
-
   public isEditable() {
     if (!['panel-json', 'panel-layout'].includes(this.state.source)) {
       return false;
     }
-
     const panel = this.state.panelRef.resolve();
-
     // Library panels are not editable from the inspect
     if (isLibraryPanel(panel)) {
       return false;
     }
-
     // Only support normal grid items for now and not repeated items
     if (panel.parent instanceof DashboardGridItem && panel.parent.isRepeated()) {
       return false;
     }
-
     const dashboard = getDashboardSceneFor(panel);
     return dashboard.state.meta.canEdit;
   }
-
   static Component = InspectJsonTabComponent;
 }
-
 function InspectJsonTabComponent({ model }: SceneComponentProps<InspectJsonTab>) {
   const { source: show, jsonText, error } = model.useState();
   const styles = useStyles2(getPanelInspectorStyles2);
   const options = model.getOptions();
-
   return (
     <div className={styles.wrap}>
       <div className={styles.toolbar} data-testid={selectors.components.PanelInspector.Json.content}>
@@ -361,22 +314,17 @@ function InspectJsonTabComponent({ model }: SceneComponentProps<InspectJsonTab>)
     </div>
   );
 }
-
 function getJsonText(show: ShowContent, panel: VizPanel): string {
   let objToStringify: object = {};
-
   switch (show) {
     case 'panel-json': {
       reportPanelInspectInteraction(InspectTab.JSON, 'panelData');
-
       const isInspectingLibraryPanel = isLibraryPanel(panel);
       const gridItem = panel.parent;
-
       if (isInspectingLibraryPanel) {
         objToStringify = libraryPanelToLegacyRepresentation(panel);
         break;
       }
-
       if (isDashboardV2Spec(getDashboardSceneFor(panel).getSaveModel())) {
         objToStringify = vizPanelToSchemaV2(panel);
         break;
@@ -385,24 +333,19 @@ function getJsonText(show: ShowContent, panel: VizPanel): string {
           objToStringify = gridItemToPanel(gridItem);
         }
       }
-
       break;
     }
-
     case 'panel-data': {
       reportPanelInspectInteraction(InspectTab.JSON, 'panelJSON');
-
       const dataProvider = sceneGraph.getData(panel);
       if (dataProvider.state.data) {
         objToStringify = panel.applyFieldConfig(dataProvider.state.data);
       }
       break;
     }
-
     case 'data-frames': {
       reportPanelInspectInteraction(InspectTab.JSON, 'dataFrame');
       const dataProvider = sceneGraph.getData(panel);
-
       if (dataProvider.state.data) {
         // Get raw untransformed data
         if (dataProvider instanceof SceneDataTransformer && dataProvider.state.$data?.state.data) {
@@ -413,12 +356,9 @@ function getJsonText(show: ShowContent, panel: VizPanel): string {
       }
       break;
     }
-
     case 'panel-layout': {
       reportPanelInspectInteraction(InspectTab.JSON, 'panelLayout');
-
       const gridItem = panel.parent;
-
       if (gridItem instanceof DashboardGridItem) {
         if (isDashboardV2Spec(getDashboardSceneFor(panel).getSaveModel())) {
           objToStringify = gridItemToGridLayoutItemKind(gridItem);
@@ -427,10 +367,8 @@ function getJsonText(show: ShowContent, panel: VizPanel): string {
       break;
     }
   }
-
   return getPrettyJSON(objToStringify);
 }
-
 /**
  *
  * @param panel Must hold a LibraryPanel behavior
@@ -440,13 +378,10 @@ function libraryPanelToLegacyRepresentation(panel: VizPanel<{}, {}>) {
   if (!isLibraryPanel(panel)) {
     throw 'Panel not a library panel';
   }
-
   const gridItem = panel.parent;
-
   if (!(gridItem instanceof DashboardGridItem)) {
     throw 'LibraryPanel not child of DashboardGridItem';
   }
-
   const gridPos = {
     x: gridItem.state.x || 0,
     y: gridItem.state.y || 0,
@@ -455,35 +390,27 @@ function libraryPanelToLegacyRepresentation(panel: VizPanel<{}, {}>) {
   };
   const libraryPanelObj = vizPanelToLibraryPanel(panel);
   const panelObj = vizPanelToPanel(panel.clone({ $behaviors: undefined }), gridPos, false, gridItem);
-
   return { libraryPanel: { ...libraryPanelObj }, ...panelObj };
 }
-
 function vizPanelToLibraryPanel(panel: VizPanel): LibraryPanel {
   if (!isLibraryPanel(panel)) {
     throw new Error('Panel not a Library panel');
   }
-
   const libraryPanel = getLibraryPanelBehavior(panel);
-
   if (!libraryPanel) {
     throw new Error('Library panel behavior not found');
   }
-
   if (!libraryPanel.state._loadedPanel) {
     throw new Error('Library panel not loaded');
   }
   return libraryPanel.state._loadedPanel;
 }
-
 function hasGridPosChanged(a: SceneGridItemStateLike, b: SceneGridItemStateLike) {
   return a.x !== b.x || a.y !== b.y || a.width !== b.width || a.height !== b.height;
 }
-
 function hasQueriesChanged(a: SceneQueryRunner | undefined, b: SceneQueryRunner | undefined) {
   if (a === undefined || b === undefined) {
     return false;
   }
-
   return !isEqual(a.state.queries, b.state.queries);
 }

--- a/public/app/features/dashboard-scene/pages/DashboardScenePage.tsx
+++ b/public/app/features/dashboard-scene/pages/DashboardScenePage.tsx
@@ -1,7 +1,7 @@
+import { structLog } from '@grafana/data';
 import { useEffect, useRef } from 'react';
 import { type Params, useParams } from 'react-router-dom-v5-compat';
 import { usePrevious } from 'react-use';
-
 import { PageLayoutType } from '@grafana/data';
 import { locationService } from '@grafana/runtime';
 import { UrlSyncContextProvider } from '@grafana/scenes';
@@ -22,18 +22,14 @@ import { getDashboardSceneProfiler } from 'app/features/dashboard/services/Dashb
 import { DashboardPreviewBanner } from 'app/features/provisioning/components/Dashboards/DashboardPreviewBanner';
 import { OrphanedDashboardBanner } from 'app/features/provisioning/components/Dashboards/OrphanedDashboardBanner';
 import { DashboardRoutes } from 'app/types/dashboard';
-
 import { DashboardConversionWarningBanner } from '../components/DashboardConversionWarningBanner';
 import { SuggestedDashboardsBanner } from '../components/SuggestedDashboardsBanner';
 import { DashboardPrompt } from '../saving/DashboardPrompt';
 import { preserveDashboardSceneStateInLocalStorage } from '../utils/dashboardSessionState';
-
 import { getDashboardScenePageStateManager } from './DashboardScenePageStateManager';
 import { shouldHideDashboardKioskFooter } from './utils';
-
 export interface Props
   extends Omit<GrafanaRouteComponentProps<DashboardPageRouteParams, DashboardPageRouteSearchParams>, 'match'> {}
-
 export function DashboardScenePage({ route, queryParams, location }: Props) {
   const params = useParams();
   const { type, slug, uid } = params;
@@ -46,7 +42,6 @@ export function DashboardScenePage({ route, queryParams, location }: Props) {
   // After scene migration is complete and we get rid of old dashboard we should refactor dashboardWatcher so this route reload is not need
   const routeReloadCounter = (location.state as any)?.routeReloadCounter;
   const prevParams = useRef<Params<string>>(params);
-
   useEffect(() => {
     if (route.routeName === DashboardRoutes.Normal && type === 'snapshot') {
       stateManager.loadSnapshot(slug!);
@@ -62,14 +57,12 @@ export function DashboardScenePage({ route, queryParams, location }: Props) {
         urlFolderUid: queryParams.folderUid,
       });
     }
-
     return () => {
       getDashboardSceneProfiler().cancelProfile();
       preserveDashboardSceneStateInLocalStorage(locationService.getSearch(), uid);
       stateManager.clearState();
       stateManager.resetActiveManager();
     };
-
     // removing slug and path (which has slug in it) from dependencies to prevent unmount when data links reference
     //  the same dashboard with no slug in url
     // queryParams.path is used by template dashboards to identify the dashboard file; changing it means a new template was selected
@@ -84,7 +77,6 @@ export function DashboardScenePage({ route, queryParams, location }: Props) {
     queryParams.path,
     queryParams.gnetId,
   ]);
-
   useEffect(() => {
     // This use effect corrects URL without refresh when navigating to the same dashboard
     //  using data link that has no slug in url
@@ -99,18 +91,15 @@ export function DashboardScenePage({ route, queryParams, location }: Props) {
         });
       }
     }
-
     return () => {
       prevParams.current = { uid, slug: !slug ? prevParams.current.slug : slug };
     };
   }, [route, slug, type, uid]);
-
   if (!dashboard) {
     let errorElement;
     if (loadError) {
       errorElement = <DashboardPageError error={loadError} type={type} />;
     }
-
     return (
       errorElement || (
         <Page navId="dashboards/browse" layout={PageLayoutType.Canvas} data-testid={'dashboard-scene-page'}>
@@ -121,19 +110,16 @@ export function DashboardScenePage({ route, queryParams, location }: Props) {
       )
     );
   }
-
   // Do not render anything when transitioning from one dashboard to another
   // A bit tricky for transition to or from Home dashboard that does not have a uid in the url (but could have it in the dashboard model)
   // if prevMatch is undefined we are going from normal route to home route or vice versa
   if (type !== 'snapshot' && (!prevMatch || uid !== prevMatch?.params.uid)) {
-    console.log('skipping rendering');
+    structLog('log', 'skipping rendering');
     return null;
   }
-
   // `locationSearchToObject()` parses `?kiosk` as `true` (boolean param). Some clients can emit `?kiosk=`, which parses as ''.
   const isKioskMode = queryParams.kiosk === '1' || queryParams.kiosk === true || queryParams.kiosk === '';
   const hideFooter = shouldHideDashboardKioskFooter(queryParams.hideLogo);
-
   return (
     <UrlSyncContextProvider scene={dashboard} updateUrlOnInit={true} createBrowserHistorySteps={true}>
       <DashboardPreviewBanner queryParams={queryParams} route={route.routeName} slug={slug} path={path} />
@@ -151,5 +137,4 @@ export function DashboardScenePage({ route, queryParams, location }: Props) {
     </UrlSyncContextProvider>
   );
 }
-
 export default DashboardScenePage;

--- a/public/app/features/dashboard-scene/pages/DashboardScenePageStateManager.ts
+++ b/public/app/features/dashboard-scene/pages/DashboardScenePageStateManager.ts
@@ -1,3 +1,4 @@
+import { structLog } from '@grafana/data';
 import { locationUtil, type UrlQueryMap } from '@grafana/data';
 import { t } from '@grafana/i18n';
 import { config, getBackendSrv, getDataSourceSrv, isFetchError, locationService } from '@grafana/runtime';
@@ -45,7 +46,6 @@ import {
   type HomeDashboardRedirectDTO,
   isRedirectResponse,
 } from 'app/types/dashboard';
-
 import { type PanelEditor } from '../panel-edit/PanelEditor';
 import { type DashboardScene } from '../scene/DashboardScene';
 import { buildNewDashboardSaveModel, buildNewDashboardSaveModelV2 } from '../serialization/buildNewDashboardSaveModel';
@@ -56,9 +56,7 @@ import {
   transformSaveModelToScene,
 } from '../serialization/transformSaveModelToScene';
 import { restoreDashboardStateFromLocalStorage } from '../utils/dashboardSessionState';
-
 import { processQueryParamsForDashboardLoad, updateNavModel } from './utils';
-
 /**
  * Initialize both performance services to ensure they're ready before profiling starts
  */
@@ -66,33 +64,26 @@ function initializeDashboardPerformanceServices(): void {
   initializeScenePerformanceLogger();
   initializeDashboardAnalyticsAggregator();
 }
-
 export interface LoadError {
   status?: number;
   messageId?: string;
   message: string;
 }
-
 export interface DashboardScenePageState {
   dashboard?: DashboardScene;
   panelEditor?: PanelEditor;
   isLoading?: boolean;
   loadError?: LoadError;
 }
-
 export const DASHBOARD_CACHE_TTL = 500;
-
 const LOAD_SCENE_MEASUREMENT = 'loadDashboardScene';
-
 /** Only used by cache in loading home in DashboardPageProxy and initDashboard (Old arch), can remove this after old dashboard arch is gone */
 export const HOME_DASHBOARD_CACHE_KEY = '__grafana_home_uid__';
-
 interface DashboardCacheEntry<T> {
   dashboard: T;
   ts: number;
   cacheKey: string;
 }
-
 export interface LoadDashboardOptions {
   uid: string;
   route: DashboardRoutes;
@@ -102,11 +93,9 @@ export interface LoadDashboardOptions {
   defaultVariables?: VariableKind[];
   defaultLinks?: DashboardLink[];
 }
-
 export type HomeDashboardDTO = DashboardDTO & {
   dashboard: DashboardDataDTO | DashboardV2Spec;
 };
-
 interface DashboardScenePageStateManagerLike<T> {
   fetchDashboard(options: LoadDashboardOptions): Promise<T | null>;
   getDashboardFromCache(cacheKey: string): T | null;
@@ -121,24 +110,23 @@ interface DashboardScenePageStateManagerLike<T> {
   getCache(): Record<string, DashboardScene>;
   useState: () => DashboardScenePageState;
 }
-
 /**
  * Creates scene creation options with appropriate layout creator
  * based on feature flags and dashboard type.
  */
 export function getSceneCreationOptions(
   loadOptions?: LoadDashboardOptions,
-  meta?: { isSnapshot?: boolean }
+  meta?: {
+    isSnapshot?: boolean;
+  }
 ): SceneCreationOptions | undefined {
   const isReport = loadOptions?.route === DashboardRoutes.Report;
   const isTemplate = loadOptions?.route === DashboardRoutes.Template;
   const isSnapshot = meta?.isSnapshot ?? false;
-
   // Don't use v2 layout for reports or snapshots
   if (isReport || isSnapshot || isTemplate) {
     return undefined;
   }
-
   // Use v2 layout creator when v2 API is enabled
   if (shouldForceV2API()) {
     return {
@@ -146,10 +134,8 @@ export function getSceneCreationOptions(
       targetVersion: 'v2',
     };
   }
-
   return undefined;
 }
-
 abstract class DashboardScenePageStateManagerBase<T>
   extends StateManagerBase<DashboardScenePageState>
   implements DashboardScenePageStateManagerLike<T>
@@ -158,25 +144,19 @@ abstract class DashboardScenePageStateManagerBase<T>
   abstract reloadDashboard(queryParams: UrlQueryMap): Promise<void>;
   abstract transformResponseToScene(rsp: T | null, options: LoadDashboardOptions): DashboardScene | null;
   abstract loadSnapshotScene(slug: string): Promise<DashboardScene>;
-
   protected cache: Record<string, DashboardScene> = {};
-
   // This is a simplistic, short-term cache for DashboardDTOs to avoid fetching the same dashboard multiple times across a short time span.
   protected dashboardCache?: DashboardCacheEntry<T>;
-
   getCache(): Record<string, DashboardScene> {
     return this.cache;
   }
-
   protected async fetchHomeDashboard(): Promise<DashboardDTO | null> {
     const rsp = await getBackendSrv().get<HomeDashboardDTO | HomeDashboardRedirectDTO>('/api/dashboards/home');
-
     if (isRedirectResponse(rsp)) {
       const newUrl = locationUtil.processRedirectUri(rsp.redirectUri, locationService.getLocation());
       locationService.replace(newUrl);
       return null;
     }
-
     // If dashboard is on v2 schema convert to v1 schema, there's curently no v2 API for home dashboard
     if (isDashboardV2Spec(rsp.dashboard)) {
       rsp.dashboard = transformDashboardV2SpecToV1(rsp.dashboard, {
@@ -186,35 +166,28 @@ abstract class DashboardScenePageStateManagerBase<T>
         creationTimestamp: '',
       });
     }
-
     if (rsp?.meta) {
       rsp.meta.canSave = false;
       rsp.meta.canShare = false;
       rsp.meta.canStar = false;
     }
-
     return rsp;
   }
-
   private async loadHomeDashboard(): Promise<DashboardScene | null> {
     const rsp = await this.fetchHomeDashboard();
     if (rsp) {
       return transformSaveModelToScene(rsp, undefined, getSceneCreationOptions());
     }
-
     return null;
   }
-
   public async loadSnapshot(slug: string) {
     try {
       const dashboard = await this.loadSnapshotScene(slug);
-
       this.setState({ dashboard: dashboard, isLoading: false });
     } catch (err) {
       const status = getStatusFromError(err);
       const message = getMessageFromError(err);
       const messageId = getMessageIdFromError(err);
-
       this.setState({
         isLoading: false,
         loadError: {
@@ -230,15 +203,15 @@ abstract class DashboardScenePageStateManagerBase<T>
       }
     }
   }
-
   /**
    * Loads the assistant preview dashboard from the user storage
    * @param base64EncodedKey base64 encoded key of the dashboard in the user storage
    * @returns Promise with dashboard data (can be v1 or v2 format) and meta
    */
-  protected async loadAssistantPreviewDashboard(
-    base64EncodedKey: string
-  ): Promise<{ dashboard: DashboardDataDTO | DashboardV2Spec; meta: DashboardDTO['meta'] }> {
+  protected async loadAssistantPreviewDashboard(base64EncodedKey: string): Promise<{
+    dashboard: DashboardDataDTO | DashboardV2Spec;
+    meta: DashboardDTO['meta'];
+  }> {
     const decodedKey = atob(decodeURIComponent(base64EncodedKey));
     const userStorage = new UserStorage('grafana-assistant-app');
     const dashboard = await userStorage.getItem(decodeURIComponent(decodedKey));
@@ -262,11 +235,9 @@ abstract class DashboardScenePageStateManagerBase<T>
       },
     };
   }
-
   protected async loadProvisioningDashboard(repo: string, path: string): Promise<T> {
     const params = new URLSearchParams(window.location.search);
     const ref = params.get('ref') ?? undefined; // commit hash or branch
-
     const loadWithRef = async (refParam: string | undefined) => {
       const result = await dispatch(
         provisioningAPIv0alpha1.endpoints.getRepositoryFilesWithPath.initiate({
@@ -275,29 +246,24 @@ abstract class DashboardScenePageStateManagerBase<T>
           ref: refParam,
         })
       );
-
       if (result && 'error' in result) {
         throw result.error;
       }
-
       const v: GetRepositoryFilesWithPathApiResponse = structuredClone(result.data);
       // Load the results from dryRun
       const dryRun = v.resource.dryRun;
       if (!dryRun) {
         return Promise.reject('failed to read provisioned dashboard');
       }
-
       if (!dryRun.apiVersion.startsWith('dashboard.grafana.app')) {
         return Promise.reject('unexpected resource type: ' + dryRun.apiVersion);
       }
-
       return this.processDashboardFromProvisioning(repo, path, dryRun, {
         file: v.path ?? '',
         ref: refParam,
         repo: repo,
       });
     };
-
     try {
       return await loadWithRef(ref);
     } catch (err) {
@@ -308,7 +274,6 @@ abstract class DashboardScenePageStateManagerBase<T>
       throw err;
     }
   }
-
   private processDashboardFromProvisioning(
     repo: string,
     path: string,
@@ -324,7 +289,6 @@ abstract class DashboardScenePageStateManagerBase<T>
           canStar: false,
           isSnapshot: false,
           canShare: false,
-
           // Should come from the repo settings
           canDelete: true,
           canSave: true,
@@ -332,7 +296,6 @@ abstract class DashboardScenePageStateManagerBase<T>
         },
       };
     }
-
     let anno = dryRun.metadata.annotations;
     if (!anno) {
       dryRun.metadata.annotations = {};
@@ -340,34 +303,28 @@ abstract class DashboardScenePageStateManagerBase<T>
     anno[AnnoKeyManagerKind] = 'repo';
     anno[AnnoKeyManagerIdentity] = repo;
     anno[AnnoKeySourcePath] = provisioningPreview.ref ? path + '#' + provisioningPreview.ref : path;
-
     // Include version information to align with the current dashboard schema
     const specWithVersion = {
       ...dryRun.spec,
       version: dryRun.metadata.generation || 0,
     };
-
     return {
       meta: {
         canStar: false,
         isSnapshot: false,
         canShare: false,
-
         // Should come from the repo settings
         canDelete: true,
         canSave: true,
         canEdit: true,
-
         // Includes additional k8s metadata
         k8s: dryRun.metadata,
-
         // lookup info
         provisioning: provisioningPreview,
       },
       dashboard: specWithVersion,
     };
   }
-
   public async loadDashboard(options: LoadDashboardOptions) {
     try {
       startMeasure(LOAD_SCENE_MEASUREMENT);
@@ -375,17 +332,13 @@ abstract class DashboardScenePageStateManagerBase<T>
       if (!dashboard) {
         return;
       }
-
       if (config.featureToggles.preserveDashboardStateWhenNavigating && Boolean(options.uid)) {
         restoreDashboardStateFromLocalStorage(dashboard);
       }
-
       this.setState({ dashboard: dashboard, isLoading: false });
       const measure = stopMeasure(LOAD_SCENE_MEASUREMENT);
       const queryController = sceneGraph.getQueryController(dashboard);
-
       trackDashboardSceneLoaded(dashboard, measure?.duration);
-
       const isRenderTarget =
         options.route === DashboardRoutes.Report ||
         options.route === DashboardRoutes.Embedded ||
@@ -393,27 +346,22 @@ abstract class DashboardScenePageStateManagerBase<T>
       const enableProfiling =
         config.dashboardPerformanceMetrics.findIndex((uid) => uid === '*' || uid === options.uid) !== -1 ||
         isRenderTarget;
-
       if (enableProfiling) {
         // Initialize both performance services before starting profiling to ensure observers are registered
         initializeDashboardPerformanceServices();
-
         // Force profiling on the query controller — it may have been constructed without it
         // (e.g. render targets where the UID isn't in dashboardPerformanceMetrics)
         if (queryController && !queryController.state.enableProfiling) {
           queryController.setState({ enableProfiling: true });
         }
       }
-
       if (isRenderTarget) {
         // Register the report render readiness observer so the image renderer can detect
         // when the dashboard has fully rendered (queries + transforms + fieldConfig + render)
         initializeReportRenderReadinessObserver();
       }
-
       // Start dashboard_view profiling (both services are now guaranteed to be listening)
       queryController?.startProfile('dashboard_view');
-
       if (options.route !== DashboardRoutes.New) {
         emitDashboardViewEvent({
           meta: dashboard.state.meta,
@@ -425,7 +373,6 @@ abstract class DashboardScenePageStateManagerBase<T>
       const status = getStatusFromError(err);
       const message = getMessageFromError(err);
       const messageId = getMessageIdFromError(err);
-
       this.setState({
         isLoading: false,
         loadError: {
@@ -434,11 +381,9 @@ abstract class DashboardScenePageStateManagerBase<T>
           messageId,
         },
       });
-
       if (!isFetchError(err)) {
-        console.error('Error loading dashboard:', err);
+        structLog('error', 'Error loading dashboard:', err);
       }
-
       // If the error is a DashboardVersionError, we want to throw it so that the error boundary is triggered
       // This enables us to switch to the correct version of the dashboard
       if (err instanceof DashboardVersionError) {
@@ -446,33 +391,24 @@ abstract class DashboardScenePageStateManagerBase<T>
       }
     }
   }
-
   private async loadScene(options: LoadDashboardOptions): Promise<DashboardScene | null> {
     this.setState({ dashboard: undefined, isLoading: true });
-
     // Resolve API versions before synchronous getV1()/getV2() calls downstream.
     await dashboardAPIVersionResolver.resolve();
-
     // Home dashboard is not handled through legacy API and is not versioned.
     // Handling home dashboard flow separately from regular dashboard flow.
     if (options.route === DashboardRoutes.Home) {
       return await this.loadHomeDashboard();
     }
-
     const rsp = await this.fetchDashboard(options);
-
     if (!rsp) {
       return null;
     }
-
     const scene = this.transformResponseToScene(rsp, options);
-
     return scene;
   }
-
   public getDashboardFromCache(cacheKey: string): T | null {
     const cachedDashboard = this.dashboardCache;
-
     if (
       cachedDashboard &&
       cachedDashboard.cacheKey === cacheKey &&
@@ -480,13 +416,10 @@ abstract class DashboardScenePageStateManagerBase<T>
     ) {
       return cachedDashboard.dashboard;
     }
-
     return null;
   }
-
   public clearState() {
     getDashboardSrv().setCurrent(undefined);
-
     this.setState({
       dashboard: undefined,
       loadError: undefined,
@@ -494,36 +427,28 @@ abstract class DashboardScenePageStateManagerBase<T>
       panelEditor: undefined,
     });
   }
-
   public setDashboardCache(cacheKey: string, dashboard: T) {
     this.dashboardCache = { dashboard, ts: Date.now(), cacheKey };
   }
-
   public clearDashboardCache() {
     this.dashboardCache = undefined;
   }
-
   public getSceneFromCache(cacheKey: string) {
     return this.cache[cacheKey];
   }
-
   public setSceneCache(cacheKey: string, scene: DashboardScene) {
     this.cache[cacheKey] = scene;
   }
-
   public removeSceneCache(cacheKey: string) {
     delete this.cache[cacheKey];
   }
-
   public clearSceneCache() {
     this.cache = {};
   }
 }
-
 export class DashboardScenePageStateManager extends DashboardScenePageStateManagerBase<DashboardDTO> {
   transformResponseToScene(rsp: DashboardDTO | null, options: LoadDashboardOptions): DashboardScene | null {
     const fromCache = this.getSceneFromCache(options.uid);
-
     if (
       fromCache &&
       fromCache.state.version === rsp?.dashboard.version &&
@@ -536,11 +461,9 @@ export class DashboardScenePageStateManager extends DashboardScenePageStateManag
       });
       return fromCache;
     }
-
     if (rsp?.dashboard) {
       const sceneCreationOptions = getSceneCreationOptions(options, rsp.meta);
       const scene = transformSaveModelToScene(rsp, options, sceneCreationOptions);
-
       // Special handling for Template route - set up edit mode and dirty state
       if (
         (config.featureToggles.dashboardLibrary ||
@@ -552,36 +475,27 @@ export class DashboardScenePageStateManager extends DashboardScenePageStateManag
         scene.onEnterEditMode();
         scene.setState({ isDirty: true });
       }
-
       // Cache scene only if not coming from Explore, we don't want to cache temporary dashboard
       if (options.uid) {
         this.setSceneCache(options.uid, scene);
       }
-
       return scene;
     }
-
     throw new Error('Dashboard not found');
   }
-
   public async loadSnapshotScene(slug: string): Promise<DashboardScene> {
     const rsp = await dashboardLoaderSrv.loadSnapshot(slug);
-
     if (rsp?.dashboard) {
       if (isDashboardV2Spec(rsp.dashboard)) {
         throw new DashboardVersionError('v2beta1', 'Using legacy snapshot API to get a V2 dashboard');
       }
-
       rsp.meta.snapshotKey = slug;
-
       // Snapshots should use default v1 layout
       const scene = transformSaveModelToScene(rsp, undefined, getSceneCreationOptions(undefined, { isSnapshot: true }));
       return scene;
     }
-
     throw new Error('Snapshot not found');
   }
-
   private buildDashboardDTOFromInterpolated(interpolatedDashboard: DashboardDataDTO): DashboardDTO {
     return {
       dashboard: {
@@ -601,36 +515,29 @@ export class DashboardScenePageStateManager extends DashboardScenePageStateManag
       },
     };
   }
-
   private async loadDashboardLibrary(): Promise<DashboardDTO> {
     // Extract template parameters from URL
     const searchParams = new URLSearchParams(window.location.search);
     const datasource = searchParams.get('datasource');
     const gnetId = searchParams.get('gnetId');
     const pluginId = searchParams.get('pluginId');
-
     const path = searchParams.get('path');
-
     // Check if this is a template dashboard
     if (gnetId && datasource && pluginId) {
       return this.loadTemplateDashboard(gnetId, datasource, pluginId);
     }
-
     // Check if this is a community dashboard (has gnetId) or plugin dashboard
     if (gnetId) {
       return this.loadCommunityTemplateDashboard(gnetId);
     }
-
     // Original plugin dashboard flow
     if (!datasource || !pluginId || !path) {
       throw new Error('Missing required parameters for template dashboard');
     }
-
     const ds = getDataSourceSrv().getInstanceSettings(datasource);
     if (!ds) {
       throw new Error(`Datasource "${datasource}" not found. Please check your datasource configuration.`);
     }
-
     const data = {
       pluginId,
       path,
@@ -644,11 +551,9 @@ export class DashboardScenePageStateManager extends DashboardScenePageStateManag
         },
       ],
     };
-
     const interpolatedDashboard = await getBackendSrv().post('/api/dashboards/interpolate', data);
     return this.buildDashboardDTOFromInterpolated(interpolatedDashboard);
   }
-
   private async loadTemplateDashboard(
     gnetId: string,
     datasource: string | null,
@@ -656,10 +561,8 @@ export class DashboardScenePageStateManager extends DashboardScenePageStateManag
   ): Promise<DashboardDTO> {
     // Fetch the community dashboard from grafana.com
     const gnetDashboard = await getBackendSrv().get(`/api/gnet/dashboards/${gnetId}`);
-
     // The dashboard JSON is in the 'json' property
     const dashboardJson = gnetDashboard.json;
-
     const data = {
       dashboard: dashboardJson,
       overwrite: true,
@@ -672,45 +575,36 @@ export class DashboardScenePageStateManager extends DashboardScenePageStateManag
         },
       ],
     };
-
     const interpolatedDashboard = await getBackendSrv().post('/api/dashboards/interpolate', data);
     return this.buildDashboardDTOFromInterpolated(interpolatedDashboard);
   }
-
   private async loadCommunityTemplateDashboard(gnetId: number | string): Promise<DashboardDTO> {
     // Extract mappings from URL params
     const location = locationService.getLocation();
     const searchParams = new URLSearchParams(location.search);
     const mappingsJson = searchParams.get('mappings');
-
     if (!mappingsJson) {
       throw new Error('Missing mappings parameter for community dashboard');
     }
-
     let mappings;
     try {
       mappings = JSON.parse(mappingsJson);
     } catch (err) {
       throw new Error('Invalid mappings parameter: ' + err);
     }
-
     // Fetch the community dashboard from grafana.com
     const gnetDashboard = await getBackendSrv().get(`/api/gnet/dashboards/${gnetId}`);
-
     // The dashboard JSON is in the 'json' property
     const dashboardJson = gnetDashboard.json;
-
     // Call interpolate endpoint with the dashboard JSON and mappings
     const data = {
       dashboard: dashboardJson,
       overwrite: true,
       inputs: mappings,
     };
-
     const interpolatedDashboard = await getBackendSrv().post('/api/dashboards/interpolate', data);
     return this.buildDashboardDTOFromInterpolated(interpolatedDashboard);
   }
-
   public async fetchDashboard({
     type,
     slug,
@@ -719,26 +613,20 @@ export class DashboardScenePageStateManager extends DashboardScenePageStateManag
     urlFolderUid,
   }: LoadDashboardOptions): Promise<DashboardDTO | null> {
     const cacheKey = route === DashboardRoutes.Home ? HOME_DASHBOARD_CACHE_KEY : uid;
-
     const cachedDashboard = this.getDashboardFromCache(cacheKey);
-
     if (cachedDashboard) {
       return cachedDashboard;
     }
-
     let rsp: DashboardDTO;
-
     try {
       switch (route) {
         case DashboardRoutes.Home:
           // For legacy dashboarding we keep this logic here, as dashboard can be loaded through state manager's fetchDashboard method directly
           // See DashboardPageProxy.
           const homeDashboard = await this.fetchHomeDashboard();
-
           if (!homeDashboard) {
             return null;
           }
-
           rsp = homeDashboard;
           break;
         case DashboardRoutes.New:
@@ -779,33 +667,28 @@ export class DashboardScenePageStateManager extends DashboardScenePageStateManag
           } else {
             rsp = await dashboardLoaderSrv.loadDashboard(type || 'db', slug || '', uid);
           }
-
           if (route === DashboardRoutes.Embedded) {
             rsp.meta.isEmbedded = true;
           }
       }
-
       // Fix outdated URLs (e.g., old slugs from title changes) but skip during playlist navigation
       // Playlists manage their own URL generation and redirects would break the navigation flow
       if (rsp.meta.url && route === DashboardRoutes.Normal && !playlistSrv.state.isPlaying) {
         const dashboardUrl = locationUtil.stripBaseFromUrl(rsp.meta.url);
         const currentPath = locationService.getLocation().pathname;
-
         if (dashboardUrl !== currentPath) {
           // Spread current location to persist search params used for navigation
           locationService.replace({
             ...locationService.getLocation(),
             pathname: dashboardUrl,
           });
-          console.log('not correct url correcting', dashboardUrl, currentPath);
+          structLog('log', 'not correct url correcting', dashboardUrl, currentPath);
         }
       }
-
       // Populate nav model in global store according to the folder
       if (rsp.meta.folderUid) {
         await updateNavModel(rsp.meta.folderUid);
       }
-
       // Do not cache new dashboards
       this.setDashboardCache(cacheKey, rsp);
     } catch (e) {
@@ -813,28 +696,20 @@ export class DashboardScenePageStateManager extends DashboardScenePageStateManag
       if (isFetchError(e) && e.cancelled) {
         return null;
       }
-
       throw e;
     }
-
     return rsp;
   }
-
   public async reloadDashboard(queryParams: UrlQueryMap): Promise<void> {
     const dashboard = this.state.dashboard;
-
     if (!dashboard || !dashboard.state.uid) {
       return;
     }
-
     const uid = dashboard.state.uid;
-
     try {
       this.setState({ isLoading: true });
-
       const rsp = await dashboardLoaderSrv.loadDashboard('db', dashboard.state.meta.slug, uid, queryParams);
       const fromCache = this.getSceneFromCache(uid);
-
       // check if cached db version is same as both
       // response and current db state. There are scenarios where they can differ
       // e.g: when reloadOnParamsChange ff is on the first loaded dashboard could be version 0
@@ -852,7 +727,6 @@ export class DashboardScenePageStateManager extends DashboardScenePageStateManag
         this.setState({ isLoading: false });
         return;
       }
-
       if (!rsp?.dashboard) {
         this.setState({
           isLoading: false,
@@ -866,21 +740,17 @@ export class DashboardScenePageStateManager extends DashboardScenePageStateManag
         });
         return;
       }
-
       const sceneCreationOptions = getSceneCreationOptions(undefined, rsp.meta);
       const scene = transformSaveModelToScene(rsp, undefined, sceneCreationOptions);
-
       // we need to call and restore dashboard state on every reload that pulls a new dashboard version
       if (config.featureToggles.preserveDashboardStateWhenNavigating && Boolean(uid)) {
         restoreDashboardStateFromLocalStorage(scene);
       }
-
       this.setSceneCache(uid, scene);
       this.setState({ dashboard: scene, isLoading: false });
     } catch (err) {
       const status = getStatusFromError(err);
       const message = getMessageFromError(err);
-
       this.setState({
         isLoading: false,
         loadError: {
@@ -888,38 +758,31 @@ export class DashboardScenePageStateManager extends DashboardScenePageStateManag
           status,
         },
       });
-
       if (err instanceof DashboardVersionError) {
         throw err;
       }
     }
   }
 }
-
 export class DashboardScenePageStateManagerV2 extends DashboardScenePageStateManagerBase<
   DashboardWithAccessInfo<DashboardV2Spec>
 > {
   private dashboardLoader = new DashboardLoaderSrvV2();
-
   public async loadSnapshotScene(slug: string): Promise<DashboardScene> {
     const rsp = await this.dashboardLoader.loadSnapshot(slug);
     const v2Response = ensureV2Response(rsp);
-
     if (v2Response.spec) {
       const scene = transformSaveModelSchemaV2ToScene(v2Response);
       scene.setState({ meta: { ...scene.state.meta, snapshotKey: slug } });
       return scene;
     }
-
     throw new Error('Snapshot not found');
   }
-
   transformResponseToScene(
     rsp: DashboardWithAccessInfo<DashboardV2Spec> | null,
     options: LoadDashboardOptions
   ): DashboardScene | null {
     const fromCache = this.getSceneFromCache(options.uid);
-
     if (fromCache && fromCache.state.version === rsp?.metadata.generation) {
       const profiler = getDashboardSceneProfiler();
       profiler.setMetadata({
@@ -928,21 +791,16 @@ export class DashboardScenePageStateManagerV2 extends DashboardScenePageStateMan
       });
       return fromCache;
     }
-
     if (rsp) {
       const scene = transformSaveModelSchemaV2ToScene(rsp, options);
-
       // Cache scene only if not coming from Explore, we don't want to cache temporary dashboard
       if (options.uid) {
         this.setSceneCache(options.uid, scene);
       }
-
       return scene;
     }
-
     throw new Error('Dashboard not found');
   }
-
   public async fetchDashboard({
     type,
     slug,
@@ -951,12 +809,10 @@ export class DashboardScenePageStateManagerV2 extends DashboardScenePageStateMan
     urlFolderUid,
   }: LoadDashboardOptions): Promise<DashboardWithAccessInfo<DashboardV2Spec> | null> {
     const cacheKey = route === DashboardRoutes.Home ? HOME_DASHBOARD_CACHE_KEY : uid;
-
     const cachedDashboard = this.getDashboardFromCache(cacheKey);
     if (cachedDashboard) {
       return cachedDashboard;
     }
-
     let rsp: DashboardWithAccessInfo<DashboardV2Spec>;
     try {
       switch (route) {
@@ -1000,7 +856,6 @@ export class DashboardScenePageStateManagerV2 extends DashboardScenePageStateMan
           } else {
             rsp = await this.dashboardLoader.loadDashboard(type || 'db', slug || '', uid);
           }
-
           if (route === DashboardRoutes.Embedded) {
             rsp.metadata.annotations = rsp.metadata.annotations || {};
             rsp.metadata.annotations[AnnoKeyEmbedded] = 'embedded';
@@ -1017,7 +872,7 @@ export class DashboardScenePageStateManagerV2 extends DashboardScenePageStateMan
             ...locationService.getLocation(),
             pathname: dashboardUrl,
           });
-          console.log('not correct url correcting', dashboardUrl, currentPath);
+          structLog('log', 'not correct url correcting', dashboardUrl, currentPath);
         }
       }
       // Populate nav model in global store according to the folder
@@ -1035,22 +890,16 @@ export class DashboardScenePageStateManagerV2 extends DashboardScenePageStateMan
     }
     return rsp;
   }
-
   public async reloadDashboard(queryParams: UrlQueryMap): Promise<void> {
     const dashboard = this.state.dashboard;
-
     if (!dashboard || !dashboard.state.uid) {
       return;
     }
-
     const uid = dashboard.state.uid;
-
     try {
       this.setState({ isLoading: true });
-
       const rsp = await this.dashboardLoader.loadDashboard('db', dashboard.state.meta.slug, uid, queryParams);
       const fromCache = this.getSceneFromCache(uid);
-
       if (
         fromCache &&
         fromCache.state.version === rsp?.metadata.generation &&
@@ -1059,7 +908,6 @@ export class DashboardScenePageStateManagerV2 extends DashboardScenePageStateMan
         this.setState({ isLoading: false });
         return;
       }
-
       if (!rsp?.spec) {
         this.setState({
           isLoading: false,
@@ -1073,16 +921,12 @@ export class DashboardScenePageStateManagerV2 extends DashboardScenePageStateMan
         });
         return;
       }
-
       const scene = transformSaveModelSchemaV2ToScene(rsp);
-
       // we need to call and restore dashboard state on every reload that pulls a new dashboard version
       if (config.featureToggles.preserveDashboardStateWhenNavigating && Boolean(uid)) {
         restoreDashboardStateFromLocalStorage(scene);
       }
-
       this.setSceneCache(uid, scene);
-
       this.setState({ dashboard: scene, isLoading: false });
     } catch (err) {
       const status = getStatusFromError(err);
@@ -1100,26 +944,21 @@ export class DashboardScenePageStateManagerV2 extends DashboardScenePageStateMan
     }
   }
 }
-
 export function shouldForceV2API(): boolean {
   return Boolean(config.featureToggles.dashboardNewLayouts);
 }
-
 export class UnifiedDashboardScenePageStateManager extends DashboardScenePageStateManagerBase<
   DashboardDTO | DashboardWithAccessInfo<DashboardV2Spec>
 > {
   private v1Manager: DashboardScenePageStateManager;
   private v2Manager: DashboardScenePageStateManagerV2;
   private activeManager: DashboardScenePageStateManager | DashboardScenePageStateManagerV2;
-
   constructor(initialState: Partial<DashboardScenePageState>) {
     super(initialState);
     this.v1Manager = new DashboardScenePageStateManager(initialState);
     this.v2Manager = new DashboardScenePageStateManagerV2(initialState);
-
     this.activeManager = shouldForceV2API() ? this.v2Manager : this.v1Manager;
   }
-
   private syncUnifiedStateToManager(manager: DashboardScenePageStateManager | DashboardScenePageStateManagerV2) {
     manager.setState({
       dashboard: this.state.dashboard,
@@ -1128,7 +967,6 @@ export class UnifiedDashboardScenePageStateManager extends DashboardScenePageSta
       loadError: this.state.loadError,
     });
   }
-
   private async withVersionHandling<T>(
     operation: (manager: DashboardScenePageStateManager | DashboardScenePageStateManagerV2) => Promise<T>
   ): Promise<T> {
@@ -1148,13 +986,11 @@ export class UnifiedDashboardScenePageStateManager extends DashboardScenePageSta
       this.setState(this.activeManager.state);
     }
   }
-
   public async fetchDashboard(options: LoadDashboardOptions) {
     return this.withVersionHandling<DashboardDTO | DashboardWithAccessInfo<DashboardV2Spec> | null>((manager) =>
       manager.fetchDashboard(options)
     );
   }
-
   public async reloadDashboard(queryParams: UrlQueryMap) {
     return this.withVersionHandling((manager) => {
       if (manager instanceof DashboardScenePageStateManagerV2) {
@@ -1162,16 +998,13 @@ export class UnifiedDashboardScenePageStateManager extends DashboardScenePageSta
         this.syncUnifiedStateToManager(manager);
         return manager.reloadDashboard(queryParams);
       }
-
       // preserve existing v1 reload behavior
       return manager.reloadDashboard.call(this, queryParams);
     });
   }
-
   public getDashboardFromCache(uid: string) {
     return this.activeManager.getDashboardFromCache(uid);
   }
-
   transformResponseToScene(
     rsp: DashboardDTO | DashboardWithAccessInfo<DashboardV2Spec> | null,
     options: LoadDashboardOptions
@@ -1183,10 +1016,8 @@ export class UnifiedDashboardScenePageStateManager extends DashboardScenePageSta
       this.activeManager = this.v2Manager;
       return this.v2Manager.transformResponseToScene(rsp, options);
     }
-
     return this.v1Manager.transformResponseToScene(rsp, options);
   }
-
   public async loadSnapshotScene(slug: string): Promise<DashboardScene> {
     try {
       return await this.v1Manager.loadSnapshotScene(slug);
@@ -1197,7 +1028,6 @@ export class UnifiedDashboardScenePageStateManager extends DashboardScenePageSta
       throw new Error('Snapshot not found');
     }
   }
-
   public async loadSnapshot(slug: string) {
     return this.withVersionHandling((manager) => {
       if (manager instanceof DashboardScenePageStateManagerV2) {
@@ -1206,39 +1036,31 @@ export class UnifiedDashboardScenePageStateManager extends DashboardScenePageSta
           this.syncUnifiedStateToManager(manager);
         });
       }
-
       return manager.loadSnapshot.call(this, slug);
     });
   }
-
   public clearDashboardCache() {
     this.v1Manager.clearDashboardCache();
     this.v2Manager.clearDashboardCache();
   }
-
   public clearSceneCache() {
     this.v1Manager.clearSceneCache();
     this.v2Manager.clearSceneCache();
     this.cache = {};
   }
-
   public getSceneFromCache(key: string) {
     return this.activeManager.getSceneFromCache(key);
   }
-
   public setSceneCache(cacheKey: string, scene: DashboardScene): void {
     this.activeManager.setSceneCache(cacheKey, scene);
   }
-
   public removeSceneCache(cacheKey: string): void {
     this.v1Manager.removeSceneCache(cacheKey);
     this.v2Manager.removeSceneCache(cacheKey);
   }
-
   public getCache() {
     return this.activeManager.getCache();
   }
-
   public setDashboardCache(cacheKey: string, dashboard: DashboardDTO | DashboardWithAccessInfo<DashboardV2Spec>) {
     if (isDashboardV2Resource(dashboard)) {
       this.v2Manager.setDashboardCache(cacheKey, dashboard);
@@ -1246,18 +1068,15 @@ export class UnifiedDashboardScenePageStateManager extends DashboardScenePageSta
       this.v1Manager.setDashboardCache(cacheKey, dashboard);
     }
   }
-
   public async loadDashboard(options: LoadDashboardOptions): Promise<void> {
     if (options.route === DashboardRoutes.New) {
       const newDashboardVersion = shouldForceV2API() ? 'v2' : 'v1';
       this.setActiveManager(newDashboardVersion);
     }
-
     // Template dashboards are currently in v1 schema format.
     if (options.route === DashboardRoutes.Template) {
       this.setActiveManager('v1');
     }
-
     return this.withVersionHandling((manager) => {
       if (manager instanceof DashboardScenePageStateManagerV2) {
         // we need to post-sync here before withVersionHandling will sync the state back to the unified manager
@@ -1265,11 +1084,9 @@ export class UnifiedDashboardScenePageStateManager extends DashboardScenePageSta
           this.syncUnifiedStateToManager(manager);
         });
       }
-
       return manager.loadDashboard.call(this, options);
     });
   }
-
   public setActiveManager(manager: 'v1' | 'v2') {
     if (manager === 'v1') {
       this.activeManager = this.v1Manager;
@@ -1281,7 +1098,6 @@ export class UnifiedDashboardScenePageStateManager extends DashboardScenePageSta
     this.activeManager = shouldForceV2API() ? this.v2Manager : this.v1Manager;
   }
 }
-
 const managers: {
   v1?: DashboardScenePageStateManager;
   v2?: DashboardScenePageStateManagerV2;
@@ -1291,11 +1107,9 @@ const managers: {
   v2: undefined,
   unified: undefined,
 };
-
 export function getDashboardScenePageStateManager(): UnifiedDashboardScenePageStateManager;
 export function getDashboardScenePageStateManager(v: 'v1'): DashboardScenePageStateManager;
 export function getDashboardScenePageStateManager(v: 'v2'): DashboardScenePageStateManagerV2;
-
 export function getDashboardScenePageStateManager(v?: 'v1' | 'v2') {
   if (v === 'v1') {
     if (!managers.v1) {
@@ -1303,17 +1117,14 @@ export function getDashboardScenePageStateManager(v?: 'v1' | 'v2') {
     }
     return managers.v1;
   }
-
   if (v === 'v2') {
     if (!managers.v2) {
       managers.v2 = new DashboardScenePageStateManagerV2({});
     }
     return managers.v2;
   }
-
   if (!managers.unified) {
     managers.unified = new UnifiedDashboardScenePageStateManager({});
   }
-
   return managers.unified;
 }

--- a/public/app/features/dashboard-scene/pages/utils.ts
+++ b/public/app/features/dashboard-scene/pages/utils.ts
@@ -1,36 +1,32 @@
+import { structLog } from '@grafana/data';
 import { type UrlQueryMap, getTimeZone, getDefaultTimeRange, dateMath } from '@grafana/data';
 import { locationService } from '@grafana/runtime';
 import { getFolderByUidFacade } from 'app/api/clients/folder/v1beta1/hooks';
 import { updateNavIndex } from 'app/core/reducers/navModel';
 import { buildNavModel } from 'app/features/folders/state/navModel';
 import { store } from 'app/store/store';
-
 export async function updateNavModel(folderUid: string) {
   try {
     const folder = await getFolderByUidFacade(folderUid);
     store.dispatch(updateNavIndex(buildNavModel(folder)));
   } catch (err) {
-    console.warn('Error fetching parent folder', folderUid, 'for dashboard', err);
+    structLog('warn', 'Error fetching parent folder', folderUid, 'for dashboard', err);
   }
 }
-
 /**
  * Processes query parameters for dashboard loading, normalizing time range and filtering allowed parameters
  */
 export function processQueryParamsForDashboardLoad(): UrlQueryMap {
   const queryParams = locationService.getSearch();
   const queryParamsObject = locationService.getSearchObject();
-
   queryParamsObject.timezone = queryParams.get('timezone') ?? undefined;
   const now = Date.now();
   const timeZone = getTimeZone({
     timeZone: queryParams.get('timezone') ?? undefined,
   });
   const defaultTimeRange = getDefaultTimeRange();
-
   const fromQP = queryParams.get('from');
   const toQP = queryParams.get('to');
-
   const to = toQP
     ? dateMath.toDateTime(toQP, {
         roundUp: true,
@@ -38,7 +34,6 @@ export function processQueryParamsForDashboardLoad(): UrlQueryMap {
         now: now,
       })
     : undefined;
-
   const from = fromQP
     ? dateMath.toDateTime(fromQP, {
         roundUp: false,
@@ -46,34 +41,27 @@ export function processQueryParamsForDashboardLoad(): UrlQueryMap {
         now: now,
       })
     : undefined;
-
   queryParamsObject.from = from?.toISOString() ?? defaultTimeRange.from.toISOString();
   queryParamsObject.to = to?.toISOString() ?? defaultTimeRange.to.toISOString();
-
   // Remove all properties that are not from, to, scopes, version or start with var-
   Object.keys(queryParamsObject).forEach((key) => {
     if (key !== 'from' && key !== 'to' && key !== 'scopes' && key !== 'version' && !key.startsWith('var-')) {
       delete queryParamsObject[key];
     }
   });
-
   return queryParamsObject;
 }
-
 export function shouldHideDashboardKioskFooter(hideLogo?: string | true): boolean {
   if (hideLogo === undefined) {
     return false;
   }
-
   if (hideLogo === true || hideLogo === '1') {
     return true;
   }
-
   const normalized = String(hideLogo).trim().toLowerCase();
   if (normalized === '') {
     return true;
   }
-
   // Only treat explicit values as enabling hideLogo. Anything else is treated as "not enabled" for predictability.
   return false;
 }

--- a/public/app/features/dashboard-scene/panel-edit/PanelDataPane/PanelDataQueriesTab.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelDataPane/PanelDataQueriesTab.tsx
@@ -1,5 +1,5 @@
+import { structLog } from '@grafana/data';
 import { useCallback, useMemo } from 'react';
-
 import { CoreApp, type DataSourceApi, type DataSourceInstanceSettings, getDataSourceRef } from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';
 import { t, Trans } from '@grafana/i18n';
@@ -33,7 +33,6 @@ import { updateQueries } from 'app/features/query/state/updateQueries';
 import { isSharedDashboardQuery } from 'app/plugins/datasource/dashboard/runSharedRequest';
 import { AccessControlAction } from 'app/types/accessControl';
 import { type QueryGroupOptions } from 'app/types/query';
-
 import { MIXED_DATASOURCE_NAME } from '../../../../plugins/datasource/mixed/MixedDataSource';
 import { useQueryLibraryContext } from '../../../explore/QueryLibrary/QueryLibraryContext';
 import { ExpressionDatasourceUID } from '../../../expressions/types';
@@ -42,10 +41,8 @@ import { PanelInspectDrawer } from '../../inspect/PanelInspectDrawer';
 import { PanelTimeRange } from '../../scene/panel-timerange/PanelTimeRange';
 import { getDashboardSceneFor, getQueryRunnerFor } from '../../utils/utils';
 import { getUpdatedHoverHeader } from '../getPanelFrameOptions';
-
 import { type PanelDataPaneTab, type PanelDataTabHeaderProps, TabId } from './types';
 import { hasBackendDatasource } from './utils';
-
 interface PanelDataQueriesTabState extends SceneObjectState {
   datasource?: DataSourceApi;
   dsSettings?: DataSourceInstanceSettings;
@@ -54,28 +51,22 @@ interface PanelDataQueriesTabState extends SceneObjectState {
 export class PanelDataQueriesTab extends SceneObjectBase<PanelDataQueriesTabState> implements PanelDataPaneTab {
   static Component = PanelDataQueriesTabRendered;
   tabId = TabId.Queries;
-
   public constructor(state: PanelDataQueriesTabState) {
     super(state);
     this.addActivationHandler(() => this.onActivate());
   }
-
   public getTabLabel() {
     return t('dashboard-scene.panel-data-queries-tab.tab-label', 'Queries');
   }
-
   public getItemsCount() {
     return this.getQueries().length;
   }
-
   public renderTab(props: PanelDataTabHeaderProps) {
     return <QueriesTab key={this.getTabLabel()} model={this} {...props} />;
   }
-
   private onActivate() {
     this.loadDataSource();
   }
-
   /**
    * Returns scoped vars with the panel's scene object so that datasource resolution
    * via templateSrv.replace() can find section-level variables (row/tab scoped)
@@ -85,22 +76,17 @@ export class PanelDataQueriesTab extends SceneObjectBase<PanelDataQueriesTabStat
     const panel = this.state.panelRef.resolve();
     return { __sceneObject: new SafeSerializableSceneObject(panel) };
   }
-
   private async loadDataSource() {
     const panel = this.state.panelRef.resolve();
     const dataObj = panel.state.$data;
-
     if (!dataObj) {
       return;
     }
-
     let datasourceToLoad = this.queryRunner.state.datasource;
     const panelContext = this.getPanelContext();
-
     try {
       let datasource: DataSourceApi | undefined;
       let dsSettings: DataSourceInstanceSettings | undefined;
-
       // If no panel-level datasource (V2 schema non-mixed case), infer from first query
       // This also improves the V1 behavior because it doesn't make sense to rely on last used
       // if underlying queries have different datasources
@@ -111,12 +97,10 @@ export class PanelDataQueriesTab extends SceneObjectBase<PanelDataQueriesTabStat
           datasourceToLoad = firstQueryDs;
         }
       }
-
       if (!datasourceToLoad) {
         const dashboardScene = getDashboardSceneFor(this);
         const dashboardUid = dashboardScene.state.uid ?? '';
         const lastUsedDatasource = getLastUsedDatasourceFromStorage(dashboardUid!);
-
         // do we have a last used datasource for this dashboard
         if (lastUsedDatasource?.datasourceUid !== null) {
           // get datasource from dashbopard uid
@@ -129,7 +113,6 @@ export class PanelDataQueriesTab extends SceneObjectBase<PanelDataQueriesTabStat
               },
               panelContext
             );
-
             this.queryRunner.setState({
               datasource: {
                 ...getDataSourceRef(dsSettings),
@@ -142,7 +125,6 @@ export class PanelDataQueriesTab extends SceneObjectBase<PanelDataQueriesTabStat
         datasource = await getDataSourceSrv().get(datasourceToLoad, panelContext);
         dsSettings = getDataSourceSrv().getInstanceSettings(datasourceToLoad, panelContext);
       }
-
       if (datasource && dsSettings) {
         this.setState({ datasource, dsSettings });
         storeLastUsedDataSourceInLocalStorage(getDataSourceRef(dsSettings) || { default: true });
@@ -151,33 +133,27 @@ export class PanelDataQueriesTab extends SceneObjectBase<PanelDataQueriesTabStat
       //set default datasource if we fail to load the datasource
       const datasource = await getDataSourceSrv().get(config.defaultDatasource);
       const dsSettings = getDataSourceSrv().getInstanceSettings(config.defaultDatasource);
-
       if (datasource && dsSettings) {
         this.setState({
           datasource,
           dsSettings,
         });
-
         this.queryRunner.setState({
           datasource: getDataSourceRef(dsSettings),
         });
       }
-
-      console.error(err);
+      structLog('error', err);
     }
   }
-
   public buildQueryOptions(): QueryGroupOptions {
     const panel = this.state.panelRef.resolve();
     const queryRunner = getQueryRunnerFor(panel)!;
     const timeRangeObj = sceneGraph.getTimeRange(panel);
-
     let timeRangeOpts: QueryGroupOptions['timeRange'] = {
       from: undefined,
       shift: undefined,
       hide: undefined,
     };
-
     if (timeRangeObj instanceof PanelTimeRange) {
       timeRangeOpts = {
         from: timeRangeObj.state.timeFrom,
@@ -185,10 +161,8 @@ export class PanelDataQueriesTab extends SceneObjectBase<PanelDataQueriesTabStat
         hide: timeRangeObj.state.hideTimeOverride,
       };
     }
-
     let queries: QueryGroupOptions['queries'] = queryRunner.state.queries;
     const dsSettings = this.state.dsSettings;
-
     return {
       cacheTimeout: dsSettings?.meta.queryOptions?.cacheTimeout ? queryRunner.state.cacheTimeout : undefined,
       queryCachingTTL: dsSettings?.cachingConfig?.enabled ? queryRunner.state.queryCachingTTL : undefined,
@@ -202,53 +176,39 @@ export class PanelDataQueriesTab extends SceneObjectBase<PanelDataQueriesTabStat
       timeRange: timeRangeOpts,
     };
   }
-
   public onOpenInspector = () => {
     const dashboard = getDashboardSceneFor(this);
     dashboard.showModal(new PanelInspectDrawer({ panelRef: this.state.panelRef, currentTab: InspectTab.Query }));
   };
-
   public onChangeDataSource = async (newSettings: DataSourceInstanceSettings, defaultQueries?: SceneDataQuery[]) => {
     const { dsSettings } = this.state;
     const queryRunner = this.queryRunner;
     const panelContext = this.getPanelContext();
-
     const currentDS = dsSettings ? await getDataSourceSrv().get({ uid: dsSettings.uid }, panelContext) : undefined;
     const nextDS = await getDataSourceSrv().get({ uid: newSettings.uid }, panelContext);
-
     const currentQueries = queryRunner.state.queries;
-
     // We need to pass in newSettings.uid as well here as that can be a variable expression and we want to store that in the query model not the current ds variable value
     const queries = defaultQueries || (await updateQueries(nextDS, newSettings.uid, currentQueries, currentDS));
-
     queryRunner.setState({ datasource: getDataSourceRef(newSettings), queries });
-
     if (defaultQueries) {
       queryRunner.runQueries();
     }
-
     this.loadDataSource();
   };
-
   public onQueryOptionsChange = (options: QueryGroupOptions) => {
     const panel = this.state.panelRef.resolve();
     const dataObj = this.queryRunner;
-
     const dataObjStateUpdate: Partial<SceneQueryRunner['state']> = {};
     const panelStateUpdate: Partial<VizPanel['state']> = {};
-
     if (options.maxDataPoints !== dataObj.state.maxDataPoints) {
       dataObjStateUpdate.maxDataPoints = options.maxDataPoints ?? undefined;
     }
-
     if (options.minInterval !== dataObj.state.minInterval) {
       dataObjStateUpdate.minInterval = options.minInterval ?? undefined;
     }
-
     const timeFrom = options.timeRange?.from ?? undefined;
     const timeShift = options.timeRange?.shift ?? undefined;
     const hideTimeOverride = options.timeRange?.hide;
-
     if (timeFrom !== undefined || timeShift !== undefined) {
       panelStateUpdate.$timeRange = new PanelTimeRange({ timeFrom, timeShift, hideTimeOverride });
       panelStateUpdate.hoverHeader = getUpdatedHoverHeader(panel.state.title, panelStateUpdate.$timeRange);
@@ -256,38 +216,29 @@ export class PanelDataQueriesTab extends SceneObjectBase<PanelDataQueriesTabStat
       panelStateUpdate.$timeRange = undefined;
       panelStateUpdate.hoverHeader = getUpdatedHoverHeader(panel.state.title, undefined);
     }
-
     if (options.cacheTimeout !== dataObj?.state.cacheTimeout) {
       dataObjStateUpdate.cacheTimeout = options.cacheTimeout;
     }
-
     if (options.queryCachingTTL !== dataObj?.state.queryCachingTTL) {
       dataObjStateUpdate.queryCachingTTL = options.queryCachingTTL;
     }
-
     panel.setState(panelStateUpdate);
-
     dataObj.setState(dataObjStateUpdate);
     dataObj.runQueries();
   };
-
   public onQueriesChange = (queries: SceneDataQuery[]) => {
     const runner = this.queryRunner;
     runner.setState({ queries });
   };
-
   public onRunQueries = () => {
     this.queryRunner.runQueries();
   };
-
   public getQueries() {
     return this.queryRunner.state.queries;
   }
-
   public newQuery(): Partial<DataQuery> {
     const { dsSettings, datasource } = this.state;
     let ds;
-
     if (!dsSettings?.meta.mixed) {
       ds = dsSettings; // Use dsSettings if it is not mixed
     } else if (!datasource?.meta.mixed) {
@@ -296,31 +247,25 @@ export class PanelDataQueriesTab extends SceneObjectBase<PanelDataQueriesTabStat
       // Use default datasource if both are mixed or just datasource is mixed
       ds = getDataSourceSrv().getInstanceSettings(config.defaultDatasource);
     }
-
     return {
       ...datasource?.getDefaultQuery?.(CoreApp.PanelEditor),
       datasource: { uid: ds?.uid, type: ds?.type },
     };
   }
-
   public addQueryClick = () => {
     const queries = this.getQueries();
     this.onQueriesChange(addQuery(queries, this.newQuery()));
   };
-
   public onAddQuery = (query: Partial<DataQuery>) => {
     const queries = this.getQueries();
     const dsSettings = this.state.dsSettings;
-
     this.onQueriesChange(
       addQuery(queries, query, dsSettings ? getDataSourceRef(dsSettings) : { type: undefined, uid: undefined })
     );
   };
-
   public isExpressionsSupported(dsSettings: DataSourceInstanceSettings): boolean {
     return (dsSettings.meta.backend || dsSettings.meta.alerting || dsSettings.meta.mixed) === true;
   }
-
   public onAddExpressionOfType = (type: ExpressionQueryType) => {
     const queries = this.getQueries();
     // Create base expression query with the specified type
@@ -328,10 +273,8 @@ export class PanelDataQueriesTab extends SceneObjectBase<PanelDataQueriesTabStat
     const queryWithType = { ...baseQuery, type };
     // Apply defaults specific to the expression type
     const queryWithDefaults = getDefaults(queryWithType);
-
     this.onQueriesChange(addQuery(queries, queryWithDefaults));
   };
-
   public renderExtraActions() {
     return GroupActionComponents.getAllExtraRenderAction()
       .map((action, index) =>
@@ -343,11 +286,9 @@ export class PanelDataQueriesTab extends SceneObjectBase<PanelDataQueriesTabStat
       )
       .filter(Boolean);
   }
-
   public get queryRunner(): SceneQueryRunner {
     return getQueryRunnerFor(this.state.panelRef.resolve())!;
   }
-
   /**
    * Updates panel datasource when saved queries from different datasources are used.
    * Handles transition between single and mixed datasource modes.
@@ -363,7 +304,6 @@ export class PanelDataQueriesTab extends SceneObjectBase<PanelDataQueriesTabStat
     }
   };
 }
-
 export function PanelDataQueriesTabRendered({ model }: SceneComponentProps<PanelDataQueriesTab>) {
   const { datasource, dsSettings } = model.useState();
   const { data, queries, datasource: datasourceState } = model.queryRunner.useState();
@@ -371,7 +311,6 @@ export function PanelDataQueriesTabRendered({ model }: SceneComponentProps<Panel
   const canReadQueries = config.featureToggles.savedQueriesRBAC
     ? contextSrv.hasPermission(AccessControlAction.QueriesRead)
     : contextSrv.isSignedIn;
-
   const handleAddExpression = useCallback(
     (type: ExpressionQueryType) => {
       reportInteraction('dashboards_expression_interaction', {
@@ -383,7 +322,6 @@ export function PanelDataQueriesTabRendered({ model }: SceneComponentProps<Panel
     },
     [model]
   );
-
   // Determine which expressions should be disabled (for frontend-only datasources)
   const disabledExpressions = useMemo(() => {
     const hasBackendDs = hasBackendDatasource({ datasourceUid: datasourceState?.uid ?? dsSettings?.uid, queries });
@@ -395,13 +333,10 @@ export function PanelDataQueriesTabRendered({ model }: SceneComponentProps<Panel
     }
     return {};
   }, [datasourceState?.uid, dsSettings?.uid, queries]);
-
   if (!datasource || !dsSettings || !data) {
     return null;
   }
-
   const showAddButton = !isSharedDashboardQuery(dsSettings.name);
-
   const onSelectQueryFromLibrary = async (query: DataQuery) => {
     // ensure all queries explicitly define a datasource
     const enrichedQueries = queries.map((q) =>
@@ -414,7 +349,6 @@ export function PanelDataQueriesTabRendered({ model }: SceneComponentProps<Panel
     );
     const newQueries = addQuery(enrichedQueries, query);
     model.onQueriesChange(newQueries);
-
     if (query.datasource?.uid) {
       const uniqueDatasources = new Set(
         newQueries.map((q) => q.datasource?.uid).filter((uid) => uid !== ExpressionDatasourceUID)
@@ -426,7 +360,6 @@ export function PanelDataQueriesTabRendered({ model }: SceneComponentProps<Panel
       await model.updateDatasourceIfNeeded(newDatasourceRef);
     }
   };
-
   return (
     <div data-testid={selectors.components.QueryTab.content}>
       <QueryGroupTopSection
@@ -494,16 +427,12 @@ export function PanelDataQueriesTabRendered({ model }: SceneComponentProps<Panel
     </div>
   );
 }
-
 interface QueriesTabProps extends PanelDataTabHeaderProps {
   model: PanelDataQueriesTab;
 }
-
 function QueriesTab(props: QueriesTabProps) {
   const { model } = props;
-
   const queryRunnerState = model.queryRunner.useState();
-
   return (
     <Tab
       label={model.getTabLabel()}

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/PanelDataPaneNext.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/PanelDataPaneNext.tsx
@@ -1,5 +1,5 @@
+import { structLog } from '@grafana/data';
 import { throttle } from 'lodash';
-
 import {
   CoreApp,
   type DataSourceApi,
@@ -23,15 +23,12 @@ import { getLastUsedDatasourceFromStorage } from 'app/features/dashboard/utils/d
 import { storeLastUsedDataSourceInLocalStorage } from 'app/features/datasources/components/picker/utils';
 import { MIXED_DATASOURCE_NAME } from 'app/plugins/datasource/mixed/MixedDataSource';
 import { type QueryGroupOptions } from 'app/types/query';
-
 import { PanelTimeRange } from '../../scene/panel-timerange/PanelTimeRange';
 import { getDashboardSceneFor, getQueryRunnerFor } from '../../utils/utils';
 import { getUpdatedHoverHeader } from '../getPanelFrameOptions';
-
 import { QueryEditorContent } from './QueryEditor/QueryEditorContent';
 import { filterDataTransformerConfigs } from './QueryEditor/utils';
 import { TRANSFORMATION_EDIT_INTERACTION_THROTTLE_TIME } from './constants';
-
 const reportTransformationEditInteraction = throttle((context: string, type: string) => {
   reportInteraction('grafana_panel_transformations_clicked', {
     context,
@@ -39,7 +36,6 @@ const reportTransformationEditInteraction = throttle((context: string, type: str
     action: 'edit',
   });
 }, TRANSFORMATION_EDIT_INTERACTION_THROTTLE_TIME);
-
 /**
  * Resolve the datasource ref to assign to a new query.
  */
@@ -51,11 +47,9 @@ function resolveNewQueryDatasource(
   if (callerDs) {
     return callerDs;
   }
-
   if (!panelDsSettings) {
     return undefined;
   }
-
   // "Mixed" isn't meaningful on a per-query basis; use the configured default.
   // If missing a default datasource (unexpected), leave `undefined`
   // so the query inherits the panel datasource at render time.
@@ -63,10 +57,8 @@ function resolveNewQueryDatasource(
     const defaultDs = getDataSourceSrv().getInstanceSettings(config.defaultDatasource);
     return defaultDs ? getDataSourceRef(defaultDs) : undefined;
   }
-
   return getDataSourceRef(panelDsSettings);
 }
-
 /**
  * When in Mixed mode, checks if all non-expression queries share the same datasource.
  * Returns that common datasource ref if they do, or undefined if queries are heterogeneous.
@@ -76,23 +68,19 @@ function getUniformDatasource(queries: DataQuery[]): DataSourceRef | undefined {
   if (regularQueries.length === 0) {
     return undefined;
   }
-
   const firstDs = regularQueries[0].datasource;
   if (!firstDs?.uid) {
     return undefined;
   }
-
   const allSame = regularQueries.every((q) => q.datasource?.uid === firstDs.uid);
   return allSame ? { ...firstDs } : undefined;
 }
-
 export interface PanelDataPaneNextState extends SceneObjectState {
   panelRef: SceneObjectRef<VizPanel>;
   datasource?: DataSourceApi;
   dsSettings?: DataSourceInstanceSettings;
   dsError?: Error;
 }
-
 /**
  * Scene wrapper for the next generation query editor.
  * Handles datasource loading and provides methods for interacting with Scene state.
@@ -100,16 +88,13 @@ export interface PanelDataPaneNextState extends SceneObjectState {
  */
 export class PanelDataPaneNext extends SceneObjectBase<PanelDataPaneNextState> {
   static Component = QueryEditorContent;
-
   public constructor(state: PanelDataPaneNextState) {
     super(state);
     this.addActivationHandler(() => this.onActivate());
   }
-
   private onActivate() {
     const resolvedRef = this.resolveDatasourceRef();
     this.loadDatasource(resolvedRef);
-
     // Subscribe to datasource changes on the queryRunner
     const queryRunner = getQueryRunnerFor(this.state.panelRef.resolve());
     if (queryRunner) {
@@ -122,7 +107,6 @@ export class PanelDataPaneNext extends SceneObjectBase<PanelDataPaneNextState> {
       );
     }
   }
-
   /**
    * Synchronously resolves a datasource ref to use when queryRunner has no explicit datasource set.
    * Returns the resolved ref without mutating queryRunner — the caller passes it to loadDatasource.
@@ -151,12 +135,10 @@ export class PanelDataPaneNext extends SceneObjectBase<PanelDataPaneNextState> {
     if (!queryRunner) {
       return undefined;
     }
-
     // Already have an explicit ref on the runner or the first query — loadDatasource handles it.
     if (queryRunner.state.datasource ?? queryRunner.state.queries?.[0]?.datasource) {
       return undefined;
     }
-
     // Try the last-used datasource for this dashboard from localStorage.
     const dashboard = getDashboardSceneFor(this);
     const dashboardUid = dashboard.state.uid ?? '';
@@ -167,19 +149,16 @@ export class PanelDataPaneNext extends SceneObjectBase<PanelDataPaneNextState> {
         return getDataSourceRef(dsSettings);
       }
     }
-
     // Fall back to the Grafana-configured default datasource.
     const defaultDsSettings = getDataSourceSrv().getInstanceSettings(config.defaultDatasource);
     return defaultDsSettings ? getDataSourceRef(defaultDsSettings) : undefined;
   }
-
   private async loadDatasource(resolvedRef?: DataSourceRef) {
     const queryRunner = getQueryRunnerFor(this.state.panelRef.resolve());
     if (!queryRunner) {
       this.setState({ datasource: undefined, dsSettings: undefined, dsError: undefined });
       return;
     }
-
     try {
       // queryRunner.state.datasource takes precedence; resolvedRef is the fallback computed by
       // resolveDatasourceRef() for panels that have no explicit datasource in their model.
@@ -191,26 +170,21 @@ export class PanelDataPaneNext extends SceneObjectBase<PanelDataPaneNextState> {
         this.setState({ datasource: undefined, dsSettings: undefined, dsError: undefined });
         return;
       }
-
       const datasource = await getDataSourceSrv().get(datasourceToLoad);
       const dsSettings = getDataSourceSrv().getInstanceSettings(datasourceToLoad);
-
       // Treat a missing dsSettings as a load failure so the catch block can attempt the
       // default fallback — same recovery path as a rejected get() call.
       if (!datasource || !dsSettings) {
         throw new Error(`Datasource settings not found for uid: ${JSON.stringify(datasourceToLoad)}`);
       }
-
       this.setState({ datasource, dsSettings, dsError: undefined });
       storeLastUsedDataSourceInLocalStorage(getDataSourceRef(dsSettings) || { default: true });
     } catch (err) {
-      console.error('Failed to load datasource:', err);
-
+      structLog('error', 'Failed to load datasource:', err);
       // Fallback to default datasource (parity with PanelDataQueriesTab)
       try {
         const datasource = await getDataSourceSrv().get(config.defaultDatasource);
         const dsSettings = getDataSourceSrv().getInstanceSettings(config.defaultDatasource);
-
         if (datasource && dsSettings) {
           this.setState({ datasource, dsSettings, dsError: undefined });
           // Intentionally not calling queryRunner.setState here — doing so would fire the
@@ -218,7 +192,7 @@ export class PanelDataPaneNext extends SceneObjectBase<PanelDataPaneNextState> {
           // resolveDatasourceRef() handles the stale-ref case on the next activation.
         }
       } catch (fallbackErr) {
-        console.error('Failed to load default datasource:', fallbackErr);
+        structLog('error', 'Failed to load default datasource:', fallbackErr);
         this.setState({
           datasource: undefined,
           dsSettings: undefined,
@@ -227,7 +201,6 @@ export class PanelDataPaneNext extends SceneObjectBase<PanelDataPaneNextState> {
       }
     }
   }
-
   /**
    * When in Mixed mode, checks if all non-expression queries now use the same datasource.
    * If so, switches back from Mixed to that single datasource so that
@@ -238,13 +211,11 @@ export class PanelDataPaneNext extends SceneObjectBase<PanelDataPaneNextState> {
     if (!queryRunner || queryRunner.state.datasource?.uid !== MIXED_DATASOURCE_NAME) {
       return;
     }
-
     const commonDs = getUniformDatasource(queryRunner.state.queries);
     if (commonDs) {
       queryRunner.setState({ datasource: commonDs });
     }
   }
-
   /**
    * Helper for operations that find and mutate a single query by refId.
    * Handles cloning, finding index, and updating state.
@@ -254,17 +225,14 @@ export class PanelDataPaneNext extends SceneObjectBase<PanelDataPaneNextState> {
     if (!queryRunner) {
       return;
     }
-
     const queries = [...queryRunner.state.queries];
     const index = queries.findIndex((q) => q.refId === refId);
     if (index === -1) {
       return;
     }
-
     const updatedQueries = mutator(queries[index], index, queries);
     queryRunner.setState({ queries: updatedQueries });
   }
-
   // Query Operations
   public updateQueries = (queries: DataQuery[]) => {
     const queryRunner = getQueryRunnerFor(this.state.panelRef.resolve());
@@ -273,38 +241,30 @@ export class PanelDataPaneNext extends SceneObjectBase<PanelDataPaneNextState> {
       this.resolveUniformDatasource();
     }
   };
-
   public updateSelectedQuery = (updatedQuery: DataQuery, originalRefId: string) => {
     this.mutateQuery(originalRefId, (_query, index, queries) => {
       queries[index] = updatedQuery;
       return queries;
     });
   };
-
   public addQuery = (query?: Partial<DataQuery>, afterRefId?: string): string | undefined => {
     const queryRunner = getQueryRunnerFor(this.state.panelRef.resolve());
     if (!queryRunner) {
       return;
     }
-
     const { datasource, dsSettings } = this.state;
     const currentQueries = queryRunner.state.queries;
-
     // Build new query with defaults.
     const newQuery: Partial<DataQuery> = {
       ...datasource?.getDefaultQuery?.(CoreApp.PanelEditor),
       ...query,
     };
-
     newQuery.datasource = resolveNewQueryDatasource(newQuery.datasource ?? undefined, dsSettings);
-
     const updatedQueries = addQuery(currentQueries, newQuery);
-
     // Identify the newly added query by refId rather than position, so this
     // is resilient to future changes in how addQuery orders the array.
     const existingRefIds = new Set(currentQueries.map((q) => q.refId));
     const newItem = updatedQueries.find((q) => !existingRefIds.has(q.refId));
-
     // If afterRefId is specified, move the new query to just after it
     if (afterRefId && newItem) {
       const newItemIndex = updatedQueries.indexOf(newItem);
@@ -318,12 +278,9 @@ export class PanelDataPaneNext extends SceneObjectBase<PanelDataPaneNextState> {
         updatedQueries.push(newItem); // fallback to append if not found
       }
     }
-
     queryRunner.setState({ queries: updatedQueries });
-
     return newItem?.refId;
   };
-
   public deleteQuery = (refId: string) => {
     this.mutateQuery(refId, (_query, index, queries) => {
       queries.splice(index, 1);
@@ -332,7 +289,6 @@ export class PanelDataPaneNext extends SceneObjectBase<PanelDataPaneNextState> {
     this.resolveUniformDatasource();
     this.runQueries();
   };
-
   public duplicateQuery = (refId: string) => {
     this.mutateQuery(refId, (query, index, queries) => {
       const duplicated = {
@@ -344,7 +300,6 @@ export class PanelDataPaneNext extends SceneObjectBase<PanelDataPaneNextState> {
     });
     this.runQueries();
   };
-
   public toggleQueryHide = (refId: string) => {
     this.mutateQuery(refId, (query, index, queries) => {
       queries[index] = { ...query, hide: !query.hide };
@@ -352,14 +307,12 @@ export class PanelDataPaneNext extends SceneObjectBase<PanelDataPaneNextState> {
     });
     this.runQueries();
   };
-
   public runQueries = () => {
     const queryRunner = getQueryRunnerFor(this.state.panelRef.resolve());
     if (queryRunner) {
       queryRunner.runQueries();
     }
   };
-
   // Transformation Operations
   private getSceneDataTransformer(): SceneDataTransformer | undefined {
     const panel = this.state.panelRef.resolve();
@@ -368,36 +321,29 @@ export class PanelDataPaneNext extends SceneObjectBase<PanelDataPaneNextState> {
     }
     return undefined;
   }
-
   private getTransformations(index: number): {
     transformations: DataTransformerConfig[] | undefined;
     transformer: SceneDataTransformer | undefined;
   } {
     const transformer = this.getSceneDataTransformer();
-
     if (transformer) {
       const transformations = filterDataTransformerConfigs([...transformer.state.transformations]);
-
       if (index >= 0 && index < transformations.length) {
         return { transformations, transformer };
       }
     }
-
     return { transformations: undefined, transformer: undefined };
   }
-
   public addTransformation = (transformationId: string, afterIndex?: number): number | undefined => {
     const transformer = this.getSceneDataTransformer();
     if (!transformer) {
       return;
     }
-
     reportInteraction('grafana_panel_transformations_clicked', {
       context: 'query_editor_next',
       type: transformationId,
       action: 'add',
     });
-
     const transformations = filterDataTransformerConfigs([...transformer.state.transformations]);
     const newConfig: DataTransformerConfig = { id: transformationId, options: {} };
     const insertAt = afterIndex !== undefined ? afterIndex + 1 : transformations.length;
@@ -406,7 +352,6 @@ export class PanelDataPaneNext extends SceneObjectBase<PanelDataPaneNextState> {
     transformer.reprocessTransformations();
     return insertAt;
   };
-
   public reorderTransformations = (transformations: DataTransformerConfig[]) => {
     const transformer = this.getSceneDataTransformer();
     if (transformer) {
@@ -414,13 +359,11 @@ export class PanelDataPaneNext extends SceneObjectBase<PanelDataPaneNextState> {
       transformer.reprocessTransformations();
     }
   };
-
   public deleteTransformation = (index: number) => {
     const { transformations, transformer } = this.getTransformations(index);
     if (!transformations || !transformer) {
       return;
     }
-
     const removed = transformations[index];
     if (removed?.id) {
       reportInteraction('grafana_panel_transformations_clicked', {
@@ -430,24 +373,20 @@ export class PanelDataPaneNext extends SceneObjectBase<PanelDataPaneNextState> {
         total_transformations: transformations.length - 1,
       });
     }
-
     transformations.splice(index, 1);
     transformer.setState({ transformations });
     this.runQueries();
   };
-
   public toggleTransformationDisabled = (index: number) => {
     const { transformations, transformer } = this.getTransformations(index);
     if (!transformations || !transformer) {
       return;
     }
-
     const transformation = transformations[index];
     transformations[index] = { ...transformation, disabled: !transformation.disabled };
     transformer.setState({ transformations });
     this.runQueries();
   };
-
   /**
    * Changes the datasource for a specific query.
    *
@@ -471,7 +410,6 @@ export class PanelDataPaneNext extends SceneObjectBase<PanelDataPaneNextState> {
     if (!queryRunner) {
       return;
     }
-
     const newDataSource = getDataSourceSrv().getInstanceSettings(dsRef);
     if (!newDataSource) {
       // Surface the failure in the editor rather than throwing — the caller (sidebar DS picker)
@@ -479,20 +417,16 @@ export class PanelDataPaneNext extends SceneObjectBase<PanelDataPaneNextState> {
       this.setState({ dsError: new Error(`Datasource not found: ${dsRef.uid ?? dsRef.type}`) });
       return;
     }
-
     const queries = [...queryRunner.state.queries];
     const targetIndex = queries.findIndex(({ refId }) => refId === queryRefId);
     if (targetIndex === -1) {
       return;
     }
-
     const targetQuery = queries[targetIndex];
     const previousDataSource = targetQuery.datasource
       ? getDataSourceSrv().getInstanceSettings(targetQuery.datasource)
       : undefined;
-
     const shouldUseDefaultQuery = !previousDataSource || previousDataSource.type !== newDataSource.type;
-
     let updatedQuery: DataQuery;
     if (shouldUseDefaultQuery) {
       try {
@@ -505,9 +439,7 @@ export class PanelDataPaneNext extends SceneObjectBase<PanelDataPaneNextState> {
     } else {
       updatedQuery = { ...targetQuery, datasource: dsRef };
     }
-
     queries[targetIndex] = updatedQuery;
-
     // Transition to Mixed mode if not already there.
     // Mixed mode is required when queries use different datasources, ensuring each query's
     // datasource is respected during execution.
@@ -520,14 +452,12 @@ export class PanelDataPaneNext extends SceneObjectBase<PanelDataPaneNextState> {
       const currentPanelDsRef = queryRunner.state.datasource;
       const defaultDsSettings = getDataSourceSrv().getInstanceSettings(config.defaultDatasource);
       const fallbackDsRef = currentPanelDsRef ?? (defaultDsSettings ? getDataSourceRef(defaultDsSettings) : undefined);
-
       const queriesWithExplicitDs = queries.map((query) => {
         if (query.datasource) {
           return query; // Already has explicit datasource
         }
         return { ...query, datasource: fallbackDsRef }; // Set inherited datasource explicitly
       });
-
       queryRunner.setState({
         queries: queriesWithExplicitDs,
         datasource: { type: 'mixed', uid: MIXED_DATASOURCE_NAME },
@@ -539,35 +469,27 @@ export class PanelDataPaneNext extends SceneObjectBase<PanelDataPaneNextState> {
       // useSelectedQueryDatasource on the next render.
       queryRunner.setState({ queries });
     }
-
     this.resolveUniformDatasource();
     queryRunner.runQueries();
   };
-
   // Query Options Operations
   public onQueryOptionsChange = (options: QueryGroupOptions) => {
     const panel = this.state.panelRef.resolve();
     const queryRunner = getQueryRunnerFor(panel);
-
     if (!queryRunner) {
       return;
     }
-
     const dataObjStateUpdate: Partial<SceneQueryRunner['state']> = {};
     const panelStateUpdate: Partial<VizPanel['state']> = {};
-
     if (options.maxDataPoints !== queryRunner.state.maxDataPoints) {
       dataObjStateUpdate.maxDataPoints = options.maxDataPoints ?? undefined;
     }
-
     if (options.minInterval !== queryRunner.state.minInterval) {
       dataObjStateUpdate.minInterval = options.minInterval ?? undefined;
     }
-
     const timeFrom = options.timeRange?.from ?? undefined;
     const timeShift = options.timeRange?.shift ?? undefined;
     const hideTimeOverride = options.timeRange?.hide;
-
     if (timeFrom !== undefined || timeShift !== undefined) {
       panelStateUpdate.$timeRange = new PanelTimeRange({ timeFrom, timeShift, hideTimeOverride });
       panelStateUpdate.hoverHeader = getUpdatedHoverHeader(panel.state.title, panelStateUpdate.$timeRange);
@@ -575,46 +497,35 @@ export class PanelDataPaneNext extends SceneObjectBase<PanelDataPaneNextState> {
       panelStateUpdate.$timeRange = undefined;
       panelStateUpdate.hoverHeader = getUpdatedHoverHeader(panel.state.title, undefined);
     }
-
     if (options.cacheTimeout !== queryRunner.state.cacheTimeout) {
       dataObjStateUpdate.cacheTimeout = options.cacheTimeout;
     }
-
     if (options.queryCachingTTL !== queryRunner.state.queryCachingTTL) {
       dataObjStateUpdate.queryCachingTTL = options.queryCachingTTL;
     }
-
     panel.setState(panelStateUpdate);
     queryRunner.setState(dataObjStateUpdate);
     queryRunner.runQueries();
   };
-
   public updateTransformation = (oldConfig: DataTransformerConfig, newConfig: DataTransformerConfig) => {
     const panel = this.state.panelRef.resolve();
     const queryRunner = getQueryRunnerFor(panel);
     const dataTransformer = panel.state.$data;
-
     if (!(dataTransformer instanceof SceneDataTransformer)) {
       return;
     }
-
     const transformations = [...dataTransformer.state.transformations];
     // Find by object reference - same reference from useTransformations hook
     const index = transformations.findIndex((t) => t === oldConfig);
-
     if (index === -1) {
       return;
     }
-
     reportTransformationEditInteraction('query_editor_next', newConfig.id);
-
     transformations[index] = newConfig;
     dataTransformer.setState({ transformations });
-
     if (!queryRunner) {
       return;
     }
-
     queryRunner.runQueries();
   };
 }

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Header/PluginActions.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Header/PluginActions.tsx
@@ -1,5 +1,5 @@
+import { structLog } from '@grafana/data';
 import { useMemo } from 'react';
-
 import {
   type CoreApp,
   PluginExtensionPoints,
@@ -9,14 +9,11 @@ import { renderLimitedComponents, usePluginComponents } from '@grafana/runtime';
 import { type DataQuery } from '@grafana/schema';
 import { Stack } from '@grafana/ui';
 import { type QueryActionComponent, RowActionComponents } from 'app/features/query/components/QueryActionComponent';
-
 import { QueryEditorType } from '../../constants';
 import { useActionsContext, useQueryEditorUIContext, useQueryRunnerContext } from '../QueryEditorContext';
-
 interface PluginActionsProps {
   app?: CoreApp;
 }
-
 /**
  * Renders plugin-provided icon buttons (extra actions + adaptive telemetry)
  * directly in the header, outside of the actions dropdown menu.
@@ -28,19 +25,15 @@ export function PluginActions({ app }: PluginActionsProps) {
   const { queries, data } = useQueryRunnerContext();
   const { addQuery } = useActionsContext();
   const { selectedQuery, selectedQueryDsData, cardType } = useQueryEditorUIContext();
-
   const extraActions = useMemo(() => {
     if (!selectedQuery) {
       return [];
     }
-
     const unscopedActions = RowActionComponents.getAllExtraRenderAction();
-
     let scopedActions: QueryActionComponent[] = [];
     if (app !== undefined) {
       scopedActions = RowActionComponents.getScopedExtraRenderAction(app);
     }
-
     return [...unscopedActions, ...scopedActions]
       .map((action, index) =>
         action({
@@ -54,17 +47,13 @@ export function PluginActions({ app }: PluginActionsProps) {
       )
       .filter(Boolean);
   }, [selectedQuery, app, queries, data?.timeRange, addQuery, selectedQueryDsData?.dsSettings]);
-
   const telemetryComponents = useAdaptiveTelemetryComponents(selectedQuery);
-
   if (!selectedQuery || cardType === QueryEditorType.Expression) {
     return null;
   }
-
   if (extraActions.length === 0 && !telemetryComponents) {
     return null;
   }
-
   return (
     <Stack gap={0.5} alignItems="center">
       {extraActions}
@@ -72,7 +61,6 @@ export function PluginActions({ app }: PluginActionsProps) {
     </Stack>
   );
 }
-
 /**
  * Hook to render adaptive telemetry plugin extensions.
  * Matches legacy AdaptiveTelemetryQueryActions component behavior.
@@ -81,11 +69,9 @@ function useAdaptiveTelemetryComponents(query: DataQuery | null) {
   const { isLoading, components } = usePluginComponents<PluginExtensionQueryEditorRowAdaptiveTelemetryV1Context>({
     extensionPointId: PluginExtensionPoints.QueryEditorRowAdaptiveTelemetryV1,
   });
-
   if (isLoading || !components.length || !query) {
     return null;
   }
-
   try {
     return renderLimitedComponents({
       props: { query, contextHints: ['queryeditorrow', 'header'] },
@@ -94,7 +80,7 @@ function useAdaptiveTelemetryComponents(query: DataQuery | null) {
       pluginId: /grafana-adaptive.*/,
     });
   } catch (error) {
-    console.error('Failed to render adaptive telemetry components:', error);
+    structLog('error', 'Failed to render adaptive telemetry components:', error);
     return null;
   }
 }

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/hooks/useSelectedQueryDatasource.ts
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/hooks/useSelectedQueryDatasource.ts
@@ -1,9 +1,8 @@
+import { structLog } from '@grafana/data';
 import { useAsync } from 'react-use';
-
 import { type DataSourceInstanceSettings, getDataSourceRef } from '@grafana/data';
 import { config, getDataSourceSrv } from '@grafana/runtime';
 import { type DataQuery } from '@grafana/schema';
-
 /**
  * Hook to load the datasource for the currently selected query.
  * Falls back to the panel's datasource if the query doesn't specify one.
@@ -16,11 +15,9 @@ export function useSelectedQueryDatasource(
     if (!selectedQuery) {
       return undefined;
     }
-
     try {
       // If query has explicit datasource, use it; otherwise fall back to panel datasource
       let dsRef = selectedQuery.datasource;
-
       if (!dsRef && panelDsSettings) {
         // Special handling for Mixed datasource:
         // Mixed is a meta-datasource that delegates to per-query datasources. It has no QueryEditor component.
@@ -34,21 +31,18 @@ export function useSelectedQueryDatasource(
           dsRef = getDataSourceRef(panelDsSettings);
         }
       }
-
       if (!dsRef) {
         return undefined;
       }
-
       const queryDsSettings = getDataSourceSrv().getInstanceSettings(dsRef);
       if (!queryDsSettings) {
-        console.error('Datasource settings not found for', dsRef);
+        structLog('error', 'Datasource settings not found for', dsRef);
         return undefined;
       }
-
       const queryDatasource = await getDataSourceSrv().get(dsRef);
       return { datasource: queryDatasource, dsSettings: queryDsSettings };
     } catch (err) {
-      console.error('Failed to load datasource for selected query:', err);
+      structLog('error', 'Failed to load datasource for selected query:', err);
       return undefined;
     }
   }, [
@@ -58,7 +52,6 @@ export function useSelectedQueryDatasource(
     panelDsSettings?.uid,
     panelDsSettings?.meta.mixed,
   ]);
-
   return {
     selectedQueryDsData: selectedQueryDsData ?? null,
     selectedQueryDsLoading,

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/localStorageWithTTL.ts
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/localStorageWithTTL.ts
@@ -1,29 +1,24 @@
+import { structLog } from '@grafana/data';
 import { store } from '@grafana/data';
-
 interface StoredValueWithTTL<T> {
   value: T;
   timestamp: number;
 }
-
 const ONE_WEEK_MS = 7 * 24 * 60 * 60 * 1000;
-
 function isExpired<T>(item: StoredValueWithTTL<T>, ttlMs: number): boolean {
   return Date.now() - item.timestamp > ttlMs;
 }
-
 export const setLocalStorageWithTTL = <T>(key: string, value: T) => {
   const item: StoredValueWithTTL<T> = {
     value,
     timestamp: Date.now(),
   };
-
   try {
     store.setObject(key, item);
   } catch (error) {
-    console.error('Failed to persist value with TTL', error);
+    structLog('error', 'Failed to persist value with TTL', error);
   }
 };
-
 export function getLocalStorageWithTTL<T>(key: string, ttlMs: number = ONE_WEEK_MS): T | null {
   const item = store.getObject<StoredValueWithTTL<T>>(key);
   if (!item) {

--- a/public/app/features/dashboard-scene/saving/getDashboardChanges.ts
+++ b/public/app/features/dashboard-scene/saving/getDashboardChanges.ts
@@ -1,3 +1,4 @@
+import { structLog } from '@grafana/data';
 import type { AdHocVariableModel, TextBoxVariableModel, TypedVariableModel } from '@grafana/data';
 import { config } from '@grafana/runtime';
 import { type Dashboard, type VariableOption } from '@grafana/schema';
@@ -9,10 +10,8 @@ import {
 import { ResponseTransformers } from 'app/features/dashboard/api/ResponseTransformers';
 import { isDashboardV2Spec } from 'app/features/dashboard/api/utils';
 import { type DashboardDataDTO, type DashboardDTO } from 'app/types/dashboard';
-
 import { validateFiltersOrigin } from '../serialization/sceneVariablesSetToVariables';
 import { jsonDiff } from '../settings/version-history/utils';
-
 export function deepEqual(a: string | string[], b: string | string[]) {
   return (
     typeof a === typeof b &&
@@ -20,11 +19,9 @@ export function deepEqual(a: string | string[], b: string | string[]) {
       (Array.isArray(a) && a.length === b.length && a.every((val, i) => val === b[i])))
   );
 }
-
 export function isEqual(a: VariableOption | undefined, b: VariableOption | undefined) {
   return a === b || (a && b && a.selected === b.selected && deepEqual(a.text, b.text) && deepEqual(a.value, b.value));
 }
-
 export function getRawDashboardV2Changes(
   initial: DashboardV2Spec | Dashboard,
   changed: DashboardV2Spec,
@@ -46,20 +43,16 @@ export function getRawDashboardV2Changes(
   );
   const hasVariableValueChanges = hasTopLevelVariableChanges || hasSectionVariableChanges;
   const hasRefreshChanged = changedSaveModel.timeSettings.autoRefresh !== initialSaveModel.timeSettings.autoRefresh;
-
   if (!saveTimeRange) {
     changedSaveModel.timeSettings.from = initialSaveModel.timeSettings.from;
     changedSaveModel.timeSettings.to = initialSaveModel.timeSettings.to;
   }
-
   if (!saveRefresh) {
     changedSaveModel.timeSettings.autoRefresh = initialSaveModel.timeSettings.autoRefresh;
   }
-
   // Calculate differences using the non-transformed to v2 spec values to be able to compare the initial and changed dashboard values
   const diff = jsonDiff(initial, changedSaveModel);
   const diffCount = Object.values(diff).reduce((acc, cur) => acc + cur.length, 0);
-
   return {
     changedSaveModel,
     initialSaveModel,
@@ -72,12 +65,10 @@ export function getRawDashboardV2Changes(
     hasMigratedToV2: !isDashboardV2Spec(initial),
   };
 }
-
 function convertToV2SpecIfNeeded(initial: DashboardV2Spec | Dashboard): DashboardV2Spec {
   if (isDashboardV2Spec(initial)) {
     return initial;
   }
-
   const dto: DashboardDTO = {
     // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
     dashboard: initial as DashboardDataDTO,
@@ -85,7 +76,6 @@ function convertToV2SpecIfNeeded(initial: DashboardV2Spec | Dashboard): Dashboar
   };
   return ResponseTransformers.ensureV2Response(dto).spec;
 }
-
 export function getRawDashboardChanges(
   initial: Dashboard,
   changed: Dashboard,
@@ -98,18 +88,14 @@ export function getRawDashboardChanges(
   const hasTimeChanged = getHasTimeChanged(changedSaveModel.time, initialSaveModel.time);
   const hasVariableValueChanges = applyVariableChanges(changedSaveModel, initialSaveModel, saveVariables);
   const hasRefreshChanged = changedSaveModel.refresh !== initialSaveModel.refresh;
-
   if (!saveTimeRange) {
     changedSaveModel.time = initialSaveModel.time;
   }
-
   if (!saveRefresh) {
     changedSaveModel.refresh = initialSaveModel.refresh;
   }
-
   const diff = jsonDiff(initialSaveModel, changedSaveModel);
   const diffCount = Object.values(diff).reduce((acc, cur) => acc + cur.length, 0);
-
   return {
     changedSaveModel,
     initialSaveModel,
@@ -122,7 +108,6 @@ export function getRawDashboardChanges(
     hasRefreshChange: hasRefreshChanged,
   };
 }
-
 interface DefaultPersistedTimeValue {
   from?: string;
   to?: string;
@@ -133,22 +118,18 @@ export function getHasTimeChanged(
 ) {
   return newRange.from !== previousRange.from || newRange.to !== previousRange.to;
 }
-
 export function adHocVariableFiltersEqual(filtersA?: AdHocFilterWithLabels[], filtersB?: AdHocFilterWithLabels[]) {
   if (filtersA === undefined && filtersB === undefined) {
-    console.warn('Adhoc variable filter property is undefined');
+    structLog('warn', 'Adhoc variable filter property is undefined');
     return true;
   }
-
   if ((filtersA === undefined && filtersB !== undefined) || (filtersB === undefined && filtersA !== undefined)) {
-    console.warn('Adhoc variable filter property is undefined');
+    structLog('warn', 'Adhoc variable filter property is undefined');
     return false;
   }
-
   if (filtersA?.length !== filtersB?.length) {
     return false;
   }
-
   for (let i = 0; i < (filtersA?.length ?? 0); i++) {
     const aFilter = filtersA?.[i];
     const bFilter = filtersB?.[i];
@@ -158,7 +139,6 @@ export function adHocVariableFiltersEqual(filtersA?: AdHocFilterWithLabels[], fi
   }
   return true;
 }
-
 export function applyVariableChangesV2(
   saveModel: DashboardV2Spec,
   originalSaveModel: DashboardV2Spec,
@@ -166,7 +146,6 @@ export function applyVariableChangesV2(
 ) {
   return applyVariableKindListChanges(saveModel.variables, originalSaveModel.variables, saveVariables);
 }
-
 function hasCurrentValueToSave(v: VariableKind) {
   return (
     v.kind === 'QueryVariable' ||
@@ -178,7 +157,6 @@ function hasCurrentValueToSave(v: VariableKind) {
     v.kind === 'GroupByVariable'
   );
 }
-
 function hasOptionsToSave(v: VariableKind) {
   return (
     v.kind === 'QueryVariable' ||
@@ -188,7 +166,6 @@ function hasOptionsToSave(v: VariableKind) {
     v.kind === 'GroupByVariable'
   );
 }
-
 /**
  * Shared merge/detect logic for a VariableKind[] pair.
  * Returns true when at least one variable value differs from the original.
@@ -200,16 +177,13 @@ function applyVariableKindListChanges(
   saveVariables?: boolean
 ): boolean {
   let hasChanges = false;
-
   for (const variable of variablesToSave) {
     const original = originalVariables.find(
       ({ spec, kind }) => spec.name === variable.spec.name && kind === variable.kind
     );
-
     if (!original) {
       continue;
     }
-
     if (
       hasCurrentValueToSave(variable) &&
       hasCurrentValueToSave(original) &&
@@ -230,7 +204,6 @@ function applyVariableKindListChanges(
     ) {
       hasChanges = true;
     }
-
     if (!saveVariables) {
       if (variable.kind === 'AdhocVariable' && original.kind === 'AdhocVariable') {
         if (config.featureToggles.adHocFilterDefaultValues || config.featureToggles.dashboardUnifiedDrilldownControls) {
@@ -243,7 +216,6 @@ function applyVariableKindListChanges(
       } else if (variable.kind === 'TextVariable' && original.kind === 'TextVariable') {
         variable.spec.query = original.spec.query;
       }
-
       if (variable.kind !== 'AdhocVariable') {
         if (hasCurrentValueToSave(variable) && hasCurrentValueToSave(original)) {
           variable.spec.current = original.spec.current;
@@ -254,10 +226,8 @@ function applyVariableKindListChanges(
       }
     }
   }
-
   return hasChanges;
 }
-
 /**
  * Recursively walk RowsLayout / TabsLayout and apply variable merge/detection
  * for section variables embedded under row.spec.variables / tab.spec.variables.
@@ -270,9 +240,7 @@ export function applySectionVariableChangesV2(
   if (!changedLayout || !originalLayout || changedLayout.kind !== originalLayout.kind) {
     return false;
   }
-
   let hasChanges = false;
-
   if (changedLayout.kind === 'RowsLayout' && originalLayout.kind === 'RowsLayout') {
     changedLayout.spec.rows.forEach((row, index) => {
       const originalRow = originalLayout.spec.rows[index];
@@ -284,7 +252,6 @@ export function applySectionVariableChangesV2(
       hasChanges = applySectionVariableChangesV2(row.spec.layout, originalRow.spec.layout, saveVariables) || hasChanges;
     });
   }
-
   if (changedLayout.kind === 'TabsLayout' && originalLayout.kind === 'TabsLayout') {
     changedLayout.spec.tabs.forEach((tab, index) => {
       const originalTab = originalLayout.spec.tabs[index];
@@ -296,27 +263,21 @@ export function applySectionVariableChangesV2(
       hasChanges = applySectionVariableChangesV2(tab.spec.layout, originalTab.spec.layout, saveVariables) || hasChanges;
     });
   }
-
   return hasChanges;
 }
-
 export function applyVariableChanges(saveModel: Dashboard, originalSaveModel: Dashboard, saveVariables?: boolean) {
   const originalVariables = originalSaveModel.templating?.list ?? [];
   const variablesToSave = saveModel.templating?.list ?? [];
   let hasVariableValueChanges = false;
-
   for (const variable of variablesToSave) {
     const original = originalVariables.find(({ name, type }) => name === variable.name && type === variable.type);
-
     if (!original) {
       continue;
     }
-
     // Old schema property that never should be in persisted model
     if (original.current) {
       delete original.current.selected;
     }
-
     if (!isEqual(variable.current, original.current)) {
       hasVariableValueChanges = true;
     } else if (variable.type === 'adhoc') {
@@ -324,7 +285,6 @@ export function applyVariableChanges(saveModel: Dashboard, originalSaveModel: Da
       const variableFilters = validateFiltersOrigin((variable as AdHocVariableModel).filters);
       // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
       const originalFilters = validateFiltersOrigin((original as AdHocVariableModel).filters);
-
       if (
         !adHocVariableFiltersEqual(
           variableFilters?.filter((f) => !f.origin),
@@ -334,11 +294,9 @@ export function applyVariableChanges(saveModel: Dashboard, originalSaveModel: Da
         hasVariableValueChanges = true;
       }
     }
-
     if (!saveVariables) {
       // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
       const typed = variable as TypedVariableModel;
-
       if (typed.type === 'adhoc') {
         if (config.featureToggles.adHocFilterDefaultValues || config.featureToggles.dashboardUnifiedDrilldownControls) {
           // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
@@ -357,13 +315,11 @@ export function applyVariableChanges(saveModel: Dashboard, originalSaveModel: Da
         // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
         typed.query = (original as TextBoxVariableModel).query;
       }
-
       if (typed.type !== 'adhoc') {
         variable.current = original.current;
         variable.options = original.options;
       }
     }
   }
-
   return hasVariableValueChanges;
 }

--- a/public/app/features/dashboard-scene/scene/DashboardLayoutOrchestrator.tsx
+++ b/public/app/features/dashboard-scene/scene/DashboardLayoutOrchestrator.tsx
@@ -1,7 +1,7 @@
+import { structLog } from '@grafana/data';
 import { css } from '@emotion/css';
 import { type PointerEvent as ReactPointerEvent } from 'react';
 import { createPortal } from 'react-dom';
-
 import { type GrafanaTheme2 } from '@grafana/data';
 import { logWarning } from '@grafana/runtime';
 import {
@@ -15,11 +15,9 @@ import {
 } from '@grafana/scenes';
 import { useStyles2 } from '@grafana/ui';
 import { getLayoutType } from 'app/features/dashboard/utils/tracking';
-
 import { dashboardEditActions, DashboardStateChangedEvent, ObjectsReorderedOnCanvasEvent } from '../edit-pane/shared';
 import { DashboardInteractions } from '../utils/interactions';
 import { getDefaultVizPanel, getLayoutForObject } from '../utils/utils';
-
 import { DashboardScene } from './DashboardScene';
 import { AutoGridLayoutManager } from './layout-auto-grid/AutoGridLayoutManager';
 import { type DefaultGridLayoutManager } from './layout-default/DefaultGridLayoutManager';
@@ -33,9 +31,7 @@ import {
   type DashboardDropTarget,
   isDashboardDropTarget,
 } from './types/DashboardDropTarget';
-
 const TAB_ACTIVATION_DELAY_MS = 600;
-
 interface DashboardLayoutOrchestratorState extends SceneObjectState {
   /** Grid item currently being dragged */
   draggingGridItem?: SceneObjectRef<SceneGridItemLike>;
@@ -58,7 +54,6 @@ interface DashboardLayoutOrchestratorState extends SceneObjectState {
     type: 'panel' | 'row';
   };
 }
-
 export type TabDragState = {
   tab: TabItem;
   /** Width of the dragged tab header in pixels (for cross-manager placeholder sizing) */
@@ -67,10 +62,8 @@ export type TabDragState = {
   height: number;
   index: number;
 };
-
 export class DashboardLayoutOrchestrator extends SceneObjectBase<DashboardLayoutOrchestratorState> {
   public static Component = DragPreviewRenderer;
-
   private _sourceDropTarget: DashboardDropTarget | null = null;
   private _lastDropTarget: DashboardDropTarget | null = null;
   private _tabActivationTimer: ReturnType<typeof setTimeout> | null = null;
@@ -103,19 +96,14 @@ export class DashboardLayoutOrchestrator extends SceneObjectBase<DashboardLayout
   private _tabDragState: TabDragState | undefined;
   /** Stored pointerup handler for new-panel drag so we can remove it */
   private _dropNewItemPointerUpHandler: ((evt: PointerEvent) => void) | null = null;
-
   public constructor() {
     super({});
-
     this._onPointerMove = this._onPointerMove.bind(this);
     this._stopDraggingSync = this._stopDraggingSync.bind(this);
-
     this._onTabDragPointerMove = this._onTabDragPointerMove.bind(this);
     this._onTabDragPointerUp = this._onTabDragPointerUp.bind(this);
-
     this.addActivationHandler(() => this._activationHandler());
   }
-
   private _activationHandler() {
     return () => {
       document.body.removeEventListener('pointermove', this._onPointerMove);
@@ -129,7 +117,6 @@ export class DashboardLayoutOrchestrator extends SceneObjectBase<DashboardLayout
       this._cleanupDragState();
     };
   }
-
   /**
    * Returns true if the current drag operation will drop the item to a different layout
    * than where it started. Used by AutoGridLayout to know whether to clear draggingKey.
@@ -137,36 +124,28 @@ export class DashboardLayoutOrchestrator extends SceneObjectBase<DashboardLayout
   public isDroppedElsewhere(): boolean {
     return this._lastDropTarget !== null && this._lastDropTarget !== this._sourceDropTarget;
   }
-
   public startDraggingSync(evt: ReactPointerEvent, gridItem: SceneGridItemLike): void {
     const dropTarget = sceneGraph.findObject(gridItem, isDashboardDropTarget);
-
     if (!dropTarget || !isDashboardDropTarget(dropTarget)) {
       return;
     }
-
     this._sourceDropTarget = dropTarget;
     this._lastDropTarget = dropTarget;
     this._sourceOriginalIndex = this._getGridItemIndex(gridItem);
-
     // Capture the offset from cursor to item's top-left corner
     this._captureDragOffset(evt.clientX, evt.clientY, gridItem);
-
     document.body.addEventListener('pointermove', this._onPointerMove);
     // Use capture phase to ensure we receive the event even if something calls stopPropagation
     // (e.g., tab headers call stopPropagation on pointerup)
     document.body.addEventListener('pointerup', this._stopDraggingSync, true);
-
     const sourceTabKey = this._findParentTabKey(gridItem);
     this.setState({ draggingGridItem: gridItem.getRef(), sourceTabKey });
   }
-
   public startDraggingNewPanel(action: 'newPanel' | 'paste'): void {
     this._dropNewItemPointerUpHandler = (evt: PointerEvent) => this._dropNew(evt, action);
     document.body.addEventListener('pointermove', this._onNewPanelPointerMove, true);
     document.body.addEventListener('pointerup', this._dropNewItemPointerUpHandler, true);
   }
-
   private _stopDraggingSync(evt: PointerEvent) {
     const gridItem = this.state.draggingGridItem?.resolve();
     const wasDetached = this._itemDetachedFromSource;
@@ -175,12 +154,10 @@ export class DashboardLayoutOrchestrator extends SceneObjectBase<DashboardLayout
     const lastDropTarget = this._lastDropTarget;
     const dropPosition = this._currentDropPosition;
     const sourceOriginalIndex = this._sourceOriginalIndex;
-
     // Fresh target under the pointer at drop time takes priority over
     // lastDropTarget which may be stale if pointermove events were coalesced.
     const validDropTargetUnderMouse = this._getDropTargetUnderMouse(evt);
     const effectiveDropTarget = validDropTargetUnderMouse ?? lastDropTarget;
-
     // When effectiveDropTarget differs from lastDropTarget (e.g. due to coalesced
     // pointermove), clear stale visual drop state on the previous target so it
     // doesn't keep showing a placeholder/highlight after the drop.
@@ -190,14 +167,12 @@ export class DashboardLayoutOrchestrator extends SceneObjectBase<DashboardLayout
       this._currentDropPosition = null;
       this._lastHoveredAutoGridItemKey = null;
     }
-
     // TabsLayoutManager is not a valid panel drop target — it represents the
     // tab bar area between tab headers. Cancel the drop so the panel either
     // stays in place or returns to its source layout.
     if (effectiveDropTarget instanceof TabsLayoutManager) {
       this._clearDropPosition();
       this._lastDropTarget?.setIsDropTarget?.(false);
-
       if (wasDetached && gridItem) {
         setTimeout(() => {
           sourceDropTarget?.draggedGridItemInside?.(gridItem, sourceOriginalIndex ?? undefined);
@@ -217,7 +192,6 @@ export class DashboardLayoutOrchestrator extends SceneObjectBase<DashboardLayout
       });
     } else {
       const isCrossLayoutDrop = sourceDropTarget !== effectiveDropTarget || wasDetached;
-
       // Handle cross-layout or cross-tab drop
       if (isCrossLayoutDrop) {
         // Wrapped in setTimeout to ensure that any event handlers are called
@@ -231,7 +205,6 @@ export class DashboardLayoutOrchestrator extends SceneObjectBase<DashboardLayout
             // Pass drop position for precise placement (AutoGrid uses this)
             // Note: draggedGridItemInside also clears isDropTarget and dropPosition
             effectiveDropTarget?.draggedGridItemInside?.(gridItem, dropPosition ?? undefined);
-
             // Clean up source grid's drag state (CSS variables and draggingKey) after item is moved.
             // This is done here (after movement) to prevent flickering where the item
             // would momentarily appear at wrong position (CSS vars cleared but draggingKey set
@@ -241,7 +214,7 @@ export class DashboardLayoutOrchestrator extends SceneObjectBase<DashboardLayout
             }
           } else {
             const warningMessage = 'No grid item to drag';
-            console.warn(warningMessage);
+            structLog('warn', warningMessage);
             logWarning(warningMessage);
           }
         });
@@ -251,13 +224,10 @@ export class DashboardLayoutOrchestrator extends SceneObjectBase<DashboardLayout
         this._lastDropTarget?.setIsDropTarget?.(false);
       }
     }
-
     document.body.removeEventListener('pointermove', this._onPointerMove);
     document.body.removeEventListener('pointerup', this._stopDraggingSync, true);
-
     this._clearTabActivationTimer();
     this._clearDragPreview();
-
     // Clear internal tracking state (but not the visual state on the target for cross-layout drops)
     this._currentDropPosition = null;
     this._lastHoveredAutoGridItemKey = null;
@@ -267,45 +237,36 @@ export class DashboardLayoutOrchestrator extends SceneObjectBase<DashboardLayout
     this._sourceOriginalIndex = null;
     this.setState({ draggingGridItem: undefined, sourceTabKey: undefined, hoverTabKey: undefined });
   }
-
   /**
    * Called when a row drag starts (from RowsLayoutManagerRenderer)
    */
   public startRowDrag(row: RowItem): void {
     const sourceTabKey = this._findParentTabKey(row);
-
     // Store source layout info for removal before tab switch
     const parent = row.parent;
     if (parent instanceof RowsLayoutManager) {
       this._sourceRowsLayout = parent;
     }
-
     // Capture row dimensions
     this._captureRowDimensions(row);
-
     // Offset will be captured on first pointermove
     this._rowOffsetCaptured = false;
-
     this.setState({
       draggingRow: row.getRef(),
       sourceTabKey,
     });
-
     // Add pointer move listener for tab hover detection during row drag
     document.body.addEventListener('pointermove', this._onRowDragPointerMove);
     // Add pointerup listener to handle drop after cross-tab switch
     // Use capture phase to ensure we receive the event even if something calls stopPropagation
     document.body.addEventListener('pointerup', this._onRowDragPointerUp, true);
   }
-
   public startTabDrag(sourceTabsManagerId: string, draggedTabId: string): void {
     this._sourceDropTarget = this._findDropTargetByKey(sourceTabsManagerId);
-
     const draggedTab = sceneGraph.findByKeyAndType(this._getDashboard(), draggedTabId, TabItem);
     if (this._sourceDropTarget instanceof TabsLayoutManager) {
       this._sourceDropTarget.forceSelectTab(draggedTabId);
     }
-
     // Calculate dimensions of the dragged tab header and cache for cross-manager placeholder sizing
     const draggedHeaderEl = draggedTab?.containerRef?.current ?? undefined;
     if (draggedHeaderEl) {
@@ -317,19 +278,15 @@ export class DashboardLayoutOrchestrator extends SceneObjectBase<DashboardLayout
         index: 0,
       };
     }
-
     document.body.addEventListener('pointerup', this._onTabDragPointerUp, true);
     document.body.addEventListener('pointermove', this._onTabDragPointerMove);
   }
-
   private _onTabDragPointerMove(evt: PointerEvent) {
     // Note this will never be the same as source - _getDropTargetUnderMouse prevents it.
     const dropTarget = this._getDropTargetUnderMouse(evt);
-
     if (!this._tabDragState) {
       return;
     }
-
     // Tabs can be dropped only to TabsLayoutManager
     if (dropTarget instanceof TabsLayoutManager) {
       this._lastDropTarget = dropTarget;
@@ -337,7 +294,6 @@ export class DashboardLayoutOrchestrator extends SceneObjectBase<DashboardLayout
       this.cleanUpTabDropTarget();
       return;
     }
-
     dropTarget.setIsDropTarget(true);
     const tabUnderMouse = this._getTabUnderMouse(evt.clientX, evt.clientY, this._tabDragState.tab.state.key);
     const targetTabIndex = dropTarget?.getTabsIncludingRepeats().findIndex((t) => t.state.key === tabUnderMouse);
@@ -347,7 +303,6 @@ export class DashboardLayoutOrchestrator extends SceneObjectBase<DashboardLayout
       dropTarget.setPlaceholder(this._tabDragState);
     }
   }
-
   private _onTabDragPointerUp() {
     document.body.removeEventListener('pointermove', this._onTabDragPointerMove);
     document.body.removeEventListener('pointerup', this._onTabDragPointerUp, true);
@@ -355,7 +310,6 @@ export class DashboardLayoutOrchestrator extends SceneObjectBase<DashboardLayout
     // Finishing dropping in here would remove elements from dom causing pangea to think the element is still being
     // dragged and won't fire onDragEnd until container is re-rendered or removed (e.g. when row is collapsed).
   }
-
   /**
    * Single entry point for handling tab drag end. If the tab was dropped from a different manager we use values
    * calculated by layout orchestrator.
@@ -364,14 +318,11 @@ export class DashboardLayoutOrchestrator extends SceneObjectBase<DashboardLayout
     if (this._sourceDropTarget === null || !(this._sourceDropTarget instanceof TabsLayoutManager)) {
       return;
     }
-
     if (!this._tabDragState?.tab) {
       return;
     }
-
     const sourceManager = this._sourceDropTarget;
     const sourceIndex = sourceManager.getTabsIncludingRepeats().findIndex((t) => t === this._tabDragState?.tab);
-
     // targetIndex !== undefined => dropped in the same manager, target index provided by hello-pangea
     if (targetIndex !== undefined) {
       if (sourceIndex !== targetIndex) {
@@ -380,31 +331,26 @@ export class DashboardLayoutOrchestrator extends SceneObjectBase<DashboardLayout
       this.cleanUpTabDrag();
       return;
     }
-
     // dropped in a different manager => handled by the orchestrator
     if (this._lastDropTarget instanceof TabsLayoutManager) {
       const destinationManager = this._lastDropTarget;
       targetIndex = this._tabDragState.index ?? destinationManager.getTabsIncludingRepeats().length;
-
       const realDestinationIndex = destinationManager.mapTabInsertIndex(targetIndex);
       // When moving a tab into a new tab group, make it the active tab.
       this._moveTabBetweenManagers(this._tabDragState.tab, sourceManager, destinationManager, realDestinationIndex);
       this.cleanUpTabDrag();
     }
   }
-
   private cleanUpTabDropTarget() {
     if (this._lastDropTarget && this._lastDropTarget instanceof TabsLayoutManager) {
       this._lastDropTarget.setIsDropTarget?.(false);
     }
     this._lastDropTarget = null;
   }
-
   private cleanUpTabDrag() {
     this.cleanUpTabDropTarget();
     this._tabDragState = undefined;
   }
-
   private _moveTabBetweenManagers(
     tab: TabItem,
     source: TabsLayoutManager,
@@ -415,31 +361,25 @@ export class DashboardLayoutOrchestrator extends SceneObjectBase<DashboardLayout
     const prevSourceSlug = source.state.currentTabSlug;
     const prevDestinationTabs = [...destination.state.tabs];
     const prevDestinationSlug = destination.state.currentTabSlug;
-
     dashboardEditActions.moveElement({
       source,
       movedObject: tab,
       perform: () => {
         const sourceTabs = [...prevSourceTabs];
         const destTabs = [...prevDestinationTabs];
-
         const fromIndex = sourceTabs.findIndex((t) => t === tab);
         if (fromIndex < 0) {
           return;
         }
-
         sourceTabs.splice(fromIndex, 1);
-
         const clampedDestinationIndex = Math.max(0, Math.min(destinationIndex, destTabs.length));
         destTabs.splice(clampedDestinationIndex, 0, tab);
-
         // If the moved tab was active in source, pick a sensible new active tab.
         let nextSourceSlug = prevSourceSlug;
         if (prevSourceSlug === tab.getSlug()) {
           const newIndex = fromIndex > 0 ? fromIndex - 1 : 0;
           nextSourceSlug = sourceTabs[newIndex]?.getSlug();
         }
-
         // Important: avoid briefly parenting the same SceneObject in two places.
         // Remove from source first, then clear parent, then add to destination.
         source.setState({ tabs: sourceTabs, currentTabSlug: nextSourceSlug });
@@ -448,11 +388,9 @@ export class DashboardLayoutOrchestrator extends SceneObjectBase<DashboardLayout
           tabs: destTabs,
           currentTabSlug: tab.getSlug(),
         });
-
         // Make sure outline is refreshed in DashboardEditPane
         source.publishEvent(new ObjectsReorderedOnCanvasEvent(source), true);
         destination.publishEvent(new ObjectsReorderedOnCanvasEvent(destination), true);
-
         // Make sure repeated rows are refreshed - triggers performRowRepeats in RowItemRepeater
         source.publishEvent(new DashboardStateChangedEvent({ source }), true);
         destination.publishEvent(new DashboardStateChangedEvent({ source: destination }), true);
@@ -462,18 +400,15 @@ export class DashboardLayoutOrchestrator extends SceneObjectBase<DashboardLayout
         destination.setState({ tabs: prevDestinationTabs, currentTabSlug: prevDestinationSlug });
         tab.clearParent();
         source.setState({ tabs: prevSourceTabs, currentTabSlug: prevSourceSlug });
-
         // Make sure outline is refreshed in DashboardEditPane
         source.publishEvent(new ObjectsReorderedOnCanvasEvent(source), true);
         destination.publishEvent(new ObjectsReorderedOnCanvasEvent(destination), true);
-
         // Make sure repeated rows are refreshed - triggers performRowRepeats in RowItemRepeater
         source.publishEvent(new DashboardStateChangedEvent({ source }), true);
         destination.publishEvent(new DashboardStateChangedEvent({ source: destination }), true);
       },
     });
   }
-
   private _onRowDragPointerMove = (evt: PointerEvent): void => {
     // Capture row offset on first move (we don't have cursor position at drag start)
     if (!this._rowOffsetCaptured) {
@@ -483,20 +418,16 @@ export class DashboardLayoutOrchestrator extends SceneObjectBase<DashboardLayout
         this._rowOffsetCaptured = true;
       }
     }
-
     // Store cursor position early so it's available for immediate preview on tab switch
     this._lastCursorX = evt.clientX;
     this._lastCursorY = evt.clientY;
-
     this._checkTabHover(evt.clientX, evt.clientY);
     this._updateDragPreview(evt.clientX, evt.clientY);
   };
-
   private _onRowDragPointerUp = (_evt: PointerEvent): void => {
     // Always clear the tab activation timer on pointerup to prevent
     // the tab from switching after the user has released the mouse
     this._clearTabActivationTimer();
-
     // Handle drop after cross-tab row drag
     if (this._itemDetachedFromSource) {
       const row = this.state.draggingRow?.resolve();
@@ -511,7 +442,6 @@ export class DashboardLayoutOrchestrator extends SceneObjectBase<DashboardLayout
     }
     // If not detached, stopRowDrag from hello-pangea/dnd will handle cleanup
   };
-
   private _cleanupDragState() {
     document.body.removeEventListener('pointermove', this._onNewPanelPointerMove, true);
     if (this._dropNewItemPointerUpHandler) {
@@ -520,14 +450,11 @@ export class DashboardLayoutOrchestrator extends SceneObjectBase<DashboardLayout
     }
     this._lastDropTarget = null;
   }
-
   private _dropNew = (evt: PointerEvent, action: 'newPanel' | 'paste'): void => {
     const lastDropTarget = this._lastDropTarget;
     const elementsUnderPoint = document.elementsFromPoint(evt.clientX, evt.clientY);
-
     // if the cursor is in the sidebar, don't add panel
     const isInSidebar = elementsUnderPoint.some((el) => el.getAttribute('id') === 'sidebar-container');
-
     if (isInSidebar) {
       this._cleanupDragState();
       return;
@@ -543,27 +470,23 @@ export class DashboardLayoutOrchestrator extends SceneObjectBase<DashboardLayout
     });
     return;
   };
-
   private _getLayoutForDropTarget = (
     dropTarget: DashboardDropTarget | null
   ): DashboardScene | AutoGridLayoutManager | DefaultGridLayoutManager => {
     const dashboard = this._getDashboard();
     return getLayoutForObject(dropTarget ?? dashboard) ?? dashboard;
   };
-
   private _addNewPanelToLayout = (dropTarget: DashboardDropTarget | null) => {
     const panel = getDefaultVizPanel();
     this._getLayoutForDropTarget(dropTarget).addPanel(panel);
     DashboardInteractions.trackAddPanelClick('sidebar', dropTarget ? getLayoutType(dropTarget) : 'dashboard', 'drop');
   };
-
   private _pastePanelToLayout = (dropTarget: DashboardDropTarget | null) => {
     const layout = this._getLayoutForDropTarget(dropTarget);
     // shouldn't be undefined
     layout.pastePanel();
     DashboardInteractions.trackPastePanelClick('sidebar', dropTarget ? getLayoutType(dropTarget) : 'dashboard', 'drop');
   };
-
   /**
    * Called when a row drag ends (from RowsLayoutManagerRenderer)
    * This is called by hello-pangea/dnd when drag ends normally (within same layout)
@@ -575,10 +498,8 @@ export class DashboardLayoutOrchestrator extends SceneObjectBase<DashboardLayout
     if (this._itemDetachedFromSource) {
       return;
     }
-
     this._finalizeRowDrag();
   }
-
   private _finalizeRowDrag(): void {
     document.body.removeEventListener('pointermove', this._onRowDragPointerMove);
     document.body.removeEventListener('pointerup', this._onRowDragPointerUp, true);
@@ -596,19 +517,16 @@ export class DashboardLayoutOrchestrator extends SceneObjectBase<DashboardLayout
       hoverTabKey: undefined,
     });
   }
-
   private _clearTabActivationTimer(): void {
     if (this._tabActivationTimer) {
       clearTimeout(this._tabActivationTimer);
       this._tabActivationTimer = null;
     }
   }
-
   private _updateDragPreview(x: number, y: number): void {
     // Store cursor position for immediate preview on tab switch
     this._lastCursorX = x;
     this._lastCursorY = y;
-
     if (this._itemDetachedFromSource) {
       this.setState({
         dragPreview: {
@@ -624,12 +542,10 @@ export class DashboardLayoutOrchestrator extends SceneObjectBase<DashboardLayout
       });
     }
   }
-
   private _showDragPreview(): void {
     // Prevent text selection and set move cursor during cross-tab drag
     document.body.classList.add('dashboard-draggable-transparent-selection');
     document.body.classList.add('dragging-active');
-
     this.setState({
       dragPreview: {
         x: this._lastCursorX,
@@ -643,7 +559,6 @@ export class DashboardLayoutOrchestrator extends SceneObjectBase<DashboardLayout
       },
     });
   }
-
   private _captureDragOffset(cursorX: number, cursorY: number, gridItem: SceneGridItemLike): void {
     // Both DashboardGridItem and AutoGridItem have containerRef
     if ('containerRef' in gridItem) {
@@ -661,12 +576,10 @@ export class DashboardLayoutOrchestrator extends SceneObjectBase<DashboardLayout
         return;
       }
     }
-
     // Fallback: center the preview on cursor
     this._dragOffsetX = 0;
     this._dragOffsetY = 0;
   }
-
   private _captureItemDimensions(gridItem: SceneGridItemLike): void {
     // Both DashboardGridItem and AutoGridItem have containerRef
     if ('containerRef' in gridItem) {
@@ -683,12 +596,10 @@ export class DashboardLayoutOrchestrator extends SceneObjectBase<DashboardLayout
         return;
       }
     }
-
     // Fallback to reasonable default
     this._previewWidth = 400;
     this._previewHeight = 300;
   }
-
   private _captureRowDimensions(row: RowItem): void {
     // Try to find the DOM element for the row using DASHBOARD_DROP_TARGET_KEY_ATTR
     const element = document.querySelector(`[${DASHBOARD_DROP_TARGET_KEY_ATTR}="${row.state.key}"]`);
@@ -698,12 +609,10 @@ export class DashboardLayoutOrchestrator extends SceneObjectBase<DashboardLayout
       this._previewHeight = rect.height;
       return;
     }
-
     // Fallback to reasonable default for rows
     this._previewWidth = 800;
     this._previewHeight = 48;
   }
-
   private _captureRowDragOffset(cursorX: number, cursorY: number, row: RowItem): void {
     // Try to find the DOM element for the row
     const element = document.querySelector(`[${DASHBOARD_DROP_TARGET_KEY_ATTR}="${row.state.key}"]`);
@@ -713,54 +622,44 @@ export class DashboardLayoutOrchestrator extends SceneObjectBase<DashboardLayout
       this._dragOffsetY = cursorY - rect.top;
       return;
     }
-
     // Fallback: use small offset
     this._dragOffsetX = 20;
     this._dragOffsetY = 20;
   }
-
   private _clearDragPreview(): void {
     // Re-enable text selection and reset cursor
     document.body.classList.remove('dashboard-draggable-transparent-selection');
     document.body.classList.remove('dragging-active');
     window.getSelection()?.removeAllRanges();
-
     if (this.state.dragPreview) {
       this.setState({ dragPreview: undefined });
     }
   }
-
   private _checkTabHover(clientX: number, clientY: number): void {
     const tabKey = this._getTabUnderMouse(clientX, clientY);
-
     if (tabKey !== this._lastHoveredTabKey) {
       // Cursor moved to a different tab or left all tabs
       this._clearTabActivationTimer();
       this._lastHoveredTabKey = tabKey;
-
       if (tabKey) {
         // Check if this tab is already active - no need to switch
         if (this._isTabAlreadyActive(tabKey)) {
           this.setState({ hoverTabKey: undefined });
           return;
         }
-
         // Start new timer for the new tab
         this._tabActivationTimer = setTimeout(() => {
           this._activateTab(tabKey);
         }, TAB_ACTIVATION_DELAY_MS);
-
         this.setState({ hoverTabKey: tabKey });
       } else {
         this.setState({ hoverTabKey: undefined });
       }
     }
   }
-
   private _isTabAlreadyActive(tabKey: string): boolean {
     const dashboard = this._getDashboard();
     const tabItem = sceneGraph.findByKey(dashboard, tabKey);
-
     if (tabItem instanceof TabItem) {
       const tabsManager = tabItem.getParentLayout();
       if (tabsManager instanceof TabsLayoutManager) {
@@ -770,11 +669,9 @@ export class DashboardLayoutOrchestrator extends SceneObjectBase<DashboardLayout
     }
     return false;
   }
-
   private _activateTab(tabKey: string): void {
     const dashboard = this._getDashboard();
     const tabItem = sceneGraph.findByKey(dashboard, tabKey);
-
     if (tabItem instanceof TabItem) {
       const tabsManager = tabItem.getParentLayout();
       if (tabsManager instanceof TabsLayoutManager) {
@@ -786,31 +683,24 @@ export class DashboardLayoutOrchestrator extends SceneObjectBase<DashboardLayout
           this._previewLabel = this._getItemLabel(gridItem);
           this._previewType = 'panel';
           this._captureItemDimensions(gridItem);
-
           this._sourceDropTarget.draggedGridItemOutside?.(gridItem);
           this._itemDetachedFromSource = true;
-
           // Show preview immediately using last known cursor position
           this._showDragPreview();
         }
-
         // For rows: remove from source layout and show preview
         const row = this.state.draggingRow?.resolve();
         if (row && !this._itemDetachedFromSource && this._sourceRowsLayout) {
           // Get label for preview (dimensions already captured in startRowDrag)
           this._previewLabel = row.state.title || 'Row';
           this._previewType = 'row';
-
           // Remove row from source layout (skip undo as this is part of drag operation)
           this._sourceRowsLayout.removeRow(row, true);
           this._itemDetachedFromSource = true;
-
           // Show preview immediately
           this._showDragPreview();
         }
-
         tabsManager.switchToTab(tabItem);
-
         // Update last drop target to the new tab
         // This ensures drop works even if user releases immediately after tab switch
         if (isDashboardDropTarget(tabItem)) {
@@ -819,7 +709,6 @@ export class DashboardLayoutOrchestrator extends SceneObjectBase<DashboardLayout
       }
     }
   }
-
   private _getGridItemIndex(gridItem: SceneGridItemLike): number | null {
     if (this._sourceDropTarget instanceof AutoGridLayoutManager) {
       const children = this._sourceDropTarget.state.layout.state.children;
@@ -828,17 +717,14 @@ export class DashboardLayoutOrchestrator extends SceneObjectBase<DashboardLayout
     }
     return null;
   }
-
   private _getItemLabel(gridItem: SceneGridItemLike): string {
     if ('state' in gridItem && 'body' in gridItem.state && gridItem.state.body instanceof VizPanel) {
       return gridItem.state.body.state.title || 'Panel';
     }
     return 'Panel';
   }
-
   private _getTabUnderMouse(clientX: number, clientY: number, excludeKey?: string): string | null {
     const elementsUnderPoint = document.elementsFromPoint(clientX, clientY);
-
     const tabKey = elementsUnderPoint
       ?.find(
         (element) =>
@@ -846,10 +732,8 @@ export class DashboardLayoutOrchestrator extends SceneObjectBase<DashboardLayout
           (!excludeKey || element.getAttribute('data-tab-activation-key') !== excludeKey)
       )
       ?.getAttribute('data-tab-activation-key');
-
     return tabKey || null;
   }
-
   private _findParentTabKey(item: RowItem | SceneGridItemLike): string | undefined {
     let parent = item.parent;
     while (parent) {
@@ -860,76 +744,59 @@ export class DashboardLayoutOrchestrator extends SceneObjectBase<DashboardLayout
     }
     return undefined;
   }
-
   private _onNewPanelPointerMove = (evt: PointerEvent): void => {
     const dropTarget = this._getDropTargetUnderMouse(evt) ?? this._sourceDropTarget;
-
     if (!dropTarget) {
       return;
     }
-
     if (dropTarget !== this._lastDropTarget) {
       this._lastDropTarget?.setIsDropTarget?.(false);
       this._lastDropTarget = dropTarget;
-
       if (dropTarget !== this._sourceDropTarget) {
         dropTarget.setIsDropTarget?.(true);
       }
     }
   };
-
   private _onPointerMove(evt: PointerEvent) {
     // Store cursor position early so it's available for immediate preview on tab switch
     this._lastCursorX = evt.clientX;
     this._lastCursorY = evt.clientY;
-
     // Check for tab hover to enable tab switching during drag
     this._checkTabHover(evt.clientX, evt.clientY);
-
     // Update drag preview position if item is detached
     this._updateDragPreview(evt.clientX, evt.clientY);
-
     const dropTarget = this._getDropTargetUnderMouse(evt) ?? this._sourceDropTarget;
-
     if (!dropTarget) {
       this._clearDropPosition();
       return;
     }
-
     if (dropTarget !== this._lastDropTarget) {
       // Clear drop position from previous target
       this._clearDropPosition();
       this._lastDropTarget?.setIsDropTarget?.(false);
       this._lastDropTarget = dropTarget;
-
       if (dropTarget !== this._sourceDropTarget) {
         dropTarget.setIsDropTarget?.(true);
       }
     }
-
     // Update drop position for AutoGrid targets
     this._updateDropPosition(evt.clientX, evt.clientY, dropTarget);
   }
-
   private _updateDropPosition(clientX: number, clientY: number, dropTarget: DashboardDropTarget): void {
     // Only update position for AutoGridLayoutManager targets
     if (!(dropTarget instanceof AutoGridLayoutManager)) {
       return;
     }
-
     // Don't show external placeholder when dragging within the same grid
     // (AutoGrid has its own internal drag placeholder)
     if (dropTarget === this._sourceDropTarget) {
       return;
     }
-
     // Find which AutoGridItem we're hovering over
     const elementsUnderPoint = document.elementsFromPoint(clientX, clientY);
     const targetElement = elementsUnderPoint?.find((el) => el.getAttribute(AUTO_GRID_ITEM_DROP_TARGET_ATTR));
     const targetKey = targetElement?.getAttribute(AUTO_GRID_ITEM_DROP_TARGET_ATTR);
-
     const children = dropTarget.state.layout.state.children;
-
     // If not hovering over any item
     if (!targetKey || !targetElement) {
       // Only set initial position when first entering the grid
@@ -940,36 +807,28 @@ export class DashboardLayoutOrchestrator extends SceneObjectBase<DashboardLayout
       // Otherwise keep the current position (prevents flickering when over placeholder)
       return;
     }
-
     // Determine if we should insert before or after the hovered item
     // by checking if cursor is in left half or right half
     const rect = targetElement.getBoundingClientRect();
     const isRightHalf = clientX > rect.left + rect.width / 2;
-
     // Create a composite key that includes both item key and side
     const compositeKey = `${targetKey}-${isRightHalf ? 'after' : 'before'}`;
-
     // Only update if we're hovering over a different position than before
     // This prevents flickering when the placeholder shifts items around
     if (compositeKey === this._lastHoveredAutoGridItemKey) {
       return;
     }
-
     this._lastHoveredAutoGridItemKey = compositeKey;
-
     // Find the index of the hovered item
     const hoveredIndex = children.findIndex((child) => child.state.key === targetKey);
     if (hoveredIndex < 0) {
       return;
     }
-
     // Insert after if in right half, before if in left half
     const newPosition = isRightHalf ? hoveredIndex + 1 : hoveredIndex;
-
     this._currentDropPosition = newPosition;
     dropTarget.setDropPosition?.(newPosition);
   }
-
   private _clearDropPosition(): void {
     if (this._currentDropPosition !== null && this._lastDropTarget) {
       this._lastDropTarget.setDropPosition?.(null);
@@ -977,62 +836,48 @@ export class DashboardLayoutOrchestrator extends SceneObjectBase<DashboardLayout
     }
     this._lastHoveredAutoGridItemKey = null;
   }
-
   private _getDashboard(): DashboardScene {
     if (!(this.parent instanceof DashboardScene)) {
       throw new Error('Parent is not a DashboardScene');
     }
-
     return this.parent;
   }
-
   private _getDropTargetUnderMouse(evt: MouseEvent): DashboardDropTarget | null {
     const elementsUnderPoint = document.elementsFromPoint(evt.clientX, evt.clientY);
     const cursorIsInSourceTarget = elementsUnderPoint.some(
       (el) => el.getAttribute(DASHBOARD_DROP_TARGET_KEY_ATTR) === this._sourceDropTarget?.state.key
     );
-
     if (cursorIsInSourceTarget) {
       return null;
     }
-
     const key = elementsUnderPoint
       ?.find((element) => element.getAttribute(DASHBOARD_DROP_TARGET_KEY_ATTR))
       ?.getAttribute(DASHBOARD_DROP_TARGET_KEY_ATTR);
-
     if (!key) {
       return null;
     }
-
     return this._findDropTargetByKey(key);
   }
-
   private _findDropTargetByKey(key: string): DashboardDropTarget | null {
     const sceneObject = sceneGraph.findByKey(this._getDashboard(), key);
-
     if (!sceneObject || !isDashboardDropTarget(sceneObject)) {
       return null;
     }
-
     return sceneObject;
   }
 }
-
 /**
  * Renders a floating drag preview when an item is detached during cross-tab drag
  */
 function DragPreviewRenderer({ model }: SceneComponentProps<DashboardLayoutOrchestrator>) {
   const { dragPreview } = model.useState();
   const styles = useStyles2(getPreviewStyles);
-
   if (!dragPreview) {
     return null;
   }
-
   // Position preview so cursor maintains same relative position as when drag started
   const previewLeft = dragPreview.x - dragPreview.offsetX;
   const previewTop = dragPreview.y - dragPreview.offsetY;
-
   const preview = (
     <div
       className={styles.preview}
@@ -1046,10 +891,8 @@ function DragPreviewRenderer({ model }: SceneComponentProps<DashboardLayoutOrche
       <span className={styles.label}>{dragPreview.label}</span>
     </div>
   );
-
   return createPortal(preview, document.body);
 }
-
 const getPreviewStyles = (theme: GrafanaTheme2) => ({
   preview: css({
     position: 'fixed',

--- a/public/app/features/dashboard-scene/scene/DashboardMacro.ts
+++ b/public/app/features/dashboard-scene/scene/DashboardMacro.ts
@@ -1,20 +1,20 @@
+import { structLog } from '@grafana/data';
 import { type FormatVariable, type SceneObject, sceneUtils } from '@grafana/scenes';
-
 import { getDashboardSceneFor } from '../utils/utils';
-
 /**
  * Handles expressions like ${__dashboard.uid}
  */
 class DashboardMacro implements FormatVariable {
-  public state: { name: string; type: string };
-
+  public state: {
+    name: string;
+    type: string;
+  };
   public constructor(
     name: string,
     private _sceneObject: SceneObject
   ) {
     this.state = { name: name, type: 'dashboard_macro' };
   }
-
   public getValue(fieldPath?: string): string {
     const dashboard = getDashboardSceneFor(this._sceneObject);
     switch (fieldPath) {
@@ -27,19 +27,16 @@ class DashboardMacro implements FormatVariable {
         return dashboard.state.title;
     }
   }
-
   public getValueText?(): string {
     return '';
   }
 }
-
 export function registerDashboardMacro() {
   try {
     const unregister = sceneUtils.registerVariableMacro('__dashboard', DashboardMacro);
-
     return () => unregister();
   } catch (e) {
-    console.error('Error registering dashboard macro', e);
+    structLog('error', 'Error registering dashboard macro', e);
     return () => {};
   }
 }

--- a/public/app/features/dashboard-scene/scene/DashboardMutationClientSetter.ts
+++ b/public/app/features/dashboard-scene/scene/DashboardMutationClientSetter.ts
@@ -1,3 +1,4 @@
+import { structLog } from '@grafana/data';
 /**
  * Bridge between DashboardScene and the mutation-api module.
  *
@@ -8,18 +9,15 @@
  * dashboardMutationApi.ts provides the implementation at app init,
  * and DashboardScene calls it on activation without knowing the details.
  */
-
 type CreateMutationClient = (scene: unknown) => () => void;
-
 let _create: CreateMutationClient | null = null;
-
 export function provideMutationClientFactory(create: CreateMutationClient): void {
   _create = create;
 }
-
 export function createMutationClient(scene: unknown): () => void {
   if (!_create) {
-    console.warn(
+    structLog(
+      'warn',
       'createMutationClient called before provideMutationClientFactory. Mutation API will not be available.'
     );
     return () => {};

--- a/public/app/features/dashboard-scene/scene/DashboardScene.tsx
+++ b/public/app/features/dashboard-scene/scene/DashboardScene.tsx
@@ -1,5 +1,5 @@
+import { structLog } from '@grafana/data';
 import type * as H from 'history';
-
 import {
   CoreApp,
   type DataQueryRequest,
@@ -51,7 +51,6 @@ import { type DashboardJson } from 'app/features/manage-dashboards/types';
 import { VariablesChanged } from 'app/features/variables/types';
 import { type DashboardDTO, type DashboardMeta, type SaveDashboardResponseDTO } from 'app/types/dashboard';
 import { DashboardDiscardedEvent, ShowConfirmModalEvent } from 'app/types/events';
-
 import {
   AnnoKeyManagerAllowsEdits,
   AnnoKeyManagerIdentity,
@@ -99,7 +98,6 @@ import {
   getPanelIdForVizPanel,
   hasActualSaveChanges,
 } from '../utils/utils';
-
 import { AddLibraryPanelDrawer } from './AddLibraryPanelDrawer';
 import { type DashboardControls } from './DashboardControls';
 import { DashboardLayoutOrchestrator } from './DashboardLayoutOrchestrator';
@@ -115,21 +113,19 @@ import { addNewRowTo } from './layouts-shared/addNew';
 import { clearClipboard } from './layouts-shared/paste';
 import { type DashboardLayoutManager } from './types/DashboardLayoutManager';
 import { type LayoutParent } from './types/LayoutParent';
-
 export const PERSISTED_PROPS = ['title', 'description', 'tags', 'editable', 'graphTooltip', 'links', 'meta', 'preload'];
 export const PANEL_SEARCH_VAR = 'systemPanelFilterVar';
 export const PANELS_PER_ROW_VAR = 'systemDynamicRowSizeVar';
-
 type PanelStyles = {
-  fieldConfig?: { defaults: Partial<FieldConfig> };
+  fieldConfig?: {
+    defaults: Partial<FieldConfig>;
+  };
   options?: Record<string, unknown>;
 };
-
 type CopiedPanelStyles = {
   panelType: string;
   styles: PanelStyles;
 };
-
 function copyFieldConfigPropIfDefined<K extends keyof FieldConfig>(
   source: FieldConfig,
   target: Partial<FieldConfig>,
@@ -140,7 +136,6 @@ function copyFieldConfigPropIfDefined<K extends keyof FieldConfig>(
     target[key] = value;
   }
 }
-
 function extractOptionProps(source: Record<string, unknown>, props: readonly string[]): Record<string, unknown> {
   const result: Record<string, unknown> = {};
   for (const [key, value] of Object.entries(source)) {
@@ -150,15 +145,12 @@ function extractOptionProps(source: Record<string, unknown>, props: readonly str
   }
   return result;
 }
-
 export interface DashboardScenePreferences {
   defaultLayoutTemplate?: DashboardLayoutManager;
 }
-
 export interface DashboardSceneState extends SceneObjectState {
   /** Dashboard-specific preferences **/
   preferences?: DashboardScenePreferences;
-
   /** The title */
   title: string;
   /** The description */
@@ -214,10 +206,8 @@ export interface DashboardSceneState extends SceneObjectState {
   /** True while default links from datasources are being loaded */
   defaultLinksLoading?: boolean;
 }
-
 export class DashboardScene extends SceneObjectBase<DashboardSceneState> implements LayoutParent {
   static Component = DashboardSceneRenderer;
-
   /**
    * Handles url sync
    */
@@ -226,7 +216,6 @@ export class DashboardScene extends SceneObjectBase<DashboardSceneState> impleme
    * Get notified when variables change
    */
   protected _variableDependency = new DashboardVariableDependency(this);
-
   /**
    * State before editing started
    */
@@ -239,22 +228,18 @@ export class DashboardScene extends SceneObjectBase<DashboardSceneState> impleme
    * Dashboard changes tracker
    */
   private _changeTracker: DashboardSceneChangeTracker;
-
   /**
    * Remember scroll position when going into panel edit
    */
   private _scrollRef?: ScrollRefElement;
   private _prevScrollPos?: number;
-
   protected _renderBeforeActivation = true;
-
   public serializer: DashboardSceneSerializerLike<
     Dashboard | DashboardV2Spec,
     DashboardMeta | DashboardWithAccessInfo<DashboardV2Spec>['metadata'],
     Dashboard | DashboardV2Spec,
     DashboardJson | DashboardV2Spec
   >;
-
   public constructor(state: Partial<DashboardSceneState>, serializerVersion: 'v1' | 'v2' = 'v1') {
     super({
       title: t('dashboard-scene.dashboard-scene.title.dashboard', 'Dashboard'),
@@ -269,48 +254,35 @@ export class DashboardScene extends SceneObjectBase<DashboardSceneState> impleme
       layoutOrchestrator: new DashboardLayoutOrchestrator(),
       preferences: state.preferences ?? {},
     });
-
     this.serializer =
       serializerVersion === 'v2' ? getDashboardSceneSerializer('v2') : getDashboardSceneSerializer('v1');
-
     this._changeTracker = new DashboardSceneChangeTracker(this);
-
     this.addActivationHandler(() => this._activationHandler());
   }
-
   private _activationHandler() {
     let prevSceneContext = window.__grafanaSceneContext;
     const isNew = locationService.getLocation().pathname === '/dashboard/new';
-
     window.__grafanaSceneContext = this;
-
     this._initializePanelSearch();
-
     if (this.state.isEditing) {
       this._initialUrlState = locationService.getLocation();
       this._changeTracker.startTrackingChanges();
     }
-
     if (isNew) {
       this.onEnterEditMode();
       this.setState({ isDirty: true });
     }
-
     if (!this.state.meta.isEmbedded && this.state.uid) {
       dashboardWatcher.watch(this.state.uid);
     }
-
     let clearKeyBindings = () => {};
     if (!config.publicDashboardAccessToken) {
       clearKeyBindings = setupKeyboardShortcuts(this);
     }
     const oldDashboardWrapper = new DashboardModelCompatibilityWrapper(this);
-
     // @ts-expect-error
     getDashboardSrv().setCurrent(oldDashboardWrapper);
-
     const destroyMutationClient = createMutationClient(this);
-
     return () => {
       destroyMutationClient();
       window.__grafanaSceneContext = prevSceneContext;
@@ -320,20 +292,17 @@ export class DashboardScene extends SceneObjectBase<DashboardSceneState> impleme
       dashboardWatcher.leave();
     };
   }
-
   private _initializePanelSearch() {
     const systemPanelFilter = sceneGraph.lookupVariable(PANEL_SEARCH_VAR, this)?.getValue();
     if (typeof systemPanelFilter === 'string') {
       this.setState({ panelSearch: systemPanelFilter });
     }
-
     const panelsPerRow = sceneGraph.lookupVariable(PANELS_PER_ROW_VAR, this)?.getValue();
     if (typeof panelsPerRow === 'string') {
       const perRow = Number.parseInt(panelsPerRow, 10);
       this.setState({ panelsPerRow: Number.isInteger(perRow) ? perRow : undefined });
     }
   }
-
   public setDefaultVariables(defaultVariables: VariableKind[]) {
     const variableSet = sceneGraph.getVariables(this);
     const userVars = variableSet.state.variables.filter((v) => !v.state.origin);
@@ -342,48 +311,37 @@ export class DashboardScene extends SceneObjectBase<DashboardSceneState> impleme
         try {
           return createSceneVariableFromVariableModelV2(v);
         } catch (err) {
-          console.error(err);
+          structLog('error', err);
           return null;
         }
       })
       .filter((v): v is SceneVariable => Boolean(v));
-
     variableSet.setState({ variables: [...defaultVarObjects, ...userVars] });
   }
-
   public setDefaultLinks(defaultLinks: DashboardLink[]) {
     const userLinks = this.state.links.filter((l) => !l.origin);
     this.setState({ links: [...defaultLinks, ...userLinks] });
   }
-
   public clearDefaultControls() {
     const variableSet = sceneGraph.getVariables(this);
     const nonDefaultVars = variableSet.state.variables.filter((v) => !v.state.origin);
     variableSet.setState({ variables: nonDefaultVars });
-
     const nonDefaultLinks = this.state.links.filter((l) => !l.origin);
     this.setState({ links: nonDefaultLinks });
   }
-
   public onEnterEditMode = () => {
     // Save this state
     this._initialState = sceneUtils.cloneSceneObjectState(this.state, { isDirty: false });
     this._initialUrlState = locationService.getLocation();
-
     // Switch to edit mode
     this.setState({ isEditing: true, editable: true });
-
     // Propagate change edit mode change to children
     this.state.body.editModeChanged?.(true);
-
     this._changeTracker.startTrackingChanges();
   };
-
   public saveCompleted(saveModel: Dashboard | DashboardV2Spec, result: SaveDashboardResponseDTO, folderUid?: string) {
     this.serializer.onSaveComplete(saveModel, result);
-
     this._changeTracker.stopTrackingChanges();
-
     this.setState({
       version: result.version,
       isDirty: false,
@@ -398,29 +356,22 @@ export class DashboardScene extends SceneObjectBase<DashboardSceneState> impleme
       },
       overlay: undefined,
     });
-
     this.state.editPanel?.dashboardSaved();
-
     this._initialState = sceneUtils.cloneSceneObjectState(this.state);
     this._initialUrlState = locationService.getLocation();
-
     this._changeTracker.startTrackingChanges();
   }
-
   public exitEditMode({ skipConfirm, restoreInitialState }: { skipConfirm: boolean; restoreInitialState?: boolean }) {
     if (!this.canDiscard()) {
-      console.error('Trying to discard back to a state that does not exist, initialState undefined');
+      structLog('error', 'Trying to discard back to a state that does not exist, initialState undefined');
       return;
     }
-
     if (!this.state.isDirty || skipConfirm || !hasActualSaveChanges(this) || this.managedResourceCannotBeEdited()) {
       this.exitEditModeConfirmed(restoreInitialState || this.state.isDirty);
       return;
     }
-
     if (config.featureToggles.dashboardNewLayouts) {
       const canSave = Boolean(this.state.meta.canSave);
-
       appEvents.publish(
         new ShowConfirmModalEvent({
           title: t('dashboard-scene.dashboard-scene.modal.title.unsaved-changes', 'Unsaved changes'),
@@ -465,11 +416,9 @@ export class DashboardScene extends SceneObjectBase<DashboardSceneState> impleme
       );
     }
   }
-
   private exitEditModeConfirmed(restoreInitialState = true) {
     // No need to listen to changes anymore
     this._changeTracker.stopTrackingChanges();
-
     // We are updating url and removing editview and editPanel.
     // The initial url may be including edit view, edit panel or inspect query params if the user pasted the url,
     // hence we need to cleanup those query params to get back to the dashboard view. Otherwise url sync can trigger overlays.
@@ -480,9 +429,7 @@ export class DashboardScene extends SceneObjectBase<DashboardSceneState> impleme
       inspectTab: null,
       shareView: null,
     });
-
     locationService.replace(locationUtil.stripBaseFromUrl(url));
-
     if (restoreInitialState) {
       //  Restore initial state and disable editing
       this.setState({ ...this._initialState, isEditing: false });
@@ -491,22 +438,18 @@ export class DashboardScene extends SceneObjectBase<DashboardSceneState> impleme
       // Do not restore
       this.setState({ isEditing: false });
     }
-
     // if we are in edit panel, we need to onDiscard()
     // so the useEffect cleanup comes later and
     // doesn't try to commit the changes
     if (this.state.editPanel) {
       this.state.editPanel.onDiscard();
     }
-
     // Disable grid dragging
     this.state.body.editModeChanged?.(false);
   }
-
   public canDiscard() {
     return this._initialState !== undefined;
   }
-
   /**
    * Discard changes and revert to the last saved state, while keeping edit mode enabled.
    * This is useful for flows where you want to continue an action (for example share/export)
@@ -514,18 +457,14 @@ export class DashboardScene extends SceneObjectBase<DashboardSceneState> impleme
    */
   public discardChangesAndKeepEditing() {
     if (!this.canDiscard()) {
-      console.error('Trying to discard back to a state that does not exist, initialState undefined');
+      structLog('error', 'Trying to discard back to a state that does not exist, initialState undefined');
       return;
     }
-
     // Stop tracking while we reset state.
     this._changeTracker.stopTrackingChanges();
-
     const restoredState = sceneUtils.cloneSceneObjectState(this._initialState!, { isDirty: false });
-
     // Ensure the restored layout stays editable.
     restoredState.body.editModeChanged?.(true);
-
     this.setState({
       ...restoredState,
       isEditing: true,
@@ -535,29 +474,22 @@ export class DashboardScene extends SceneObjectBase<DashboardSceneState> impleme
       editview: undefined,
       overlay: undefined,
     });
-
     this._changeTracker.startTrackingChanges();
   }
-
   public pauseTrackingChanges() {
     this._changeTracker.stopTrackingChanges();
   }
-
   public resumeTrackingChanges() {
     this._changeTracker.startTrackingChanges();
   }
-
   public onRestore = async (version: DecoratedRevisionModel): Promise<boolean> => {
     const api = await getDashboardAPI();
     // the id here is the resource version in k8s, use this instead to get the specific version
     const versionRsp = await api.restoreDashboardVersion(version.uid, version.id);
-
     if (!Number.isInteger(versionRsp.version)) {
       return false;
     }
-
     let dashScene: DashboardScene;
-
     // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
     if (isDashboardV2Spec(version.data as Dashboard | DashboardV2Spec)) {
       const api = await getDashboardAPI('v2');
@@ -569,24 +501,18 @@ export class DashboardScene extends SceneObjectBase<DashboardSceneState> impleme
         dashboard: new DashboardModel(version.data as Dashboard),
         meta: this.state.meta,
       };
-
       dashScene = transformSaveModelToScene(dashboardDTO);
     }
-
     const newState = sceneUtils.cloneSceneObjectState(dashScene.state);
     newState.version = versionRsp.version;
-
     this.setState(newState);
     this.exitEditMode({ skipConfirm: true, restoreInitialState: false });
-
     return true;
   };
-
   public openSaveDrawer({ saveAsCopy, onSaveSuccess }: { saveAsCopy?: boolean; onSaveSuccess?: () => void }) {
     if (!this.state.isEditing) {
       return;
     }
-
     this.setState({
       overlay: new SaveDashboardDrawer({
         dashboardRef: this.getRef(),
@@ -596,11 +522,9 @@ export class DashboardScene extends SceneObjectBase<DashboardSceneState> impleme
       }),
     });
   }
-
   public getPageNav(location: H.Location, navIndex: NavIndex) {
     const { meta, viewPanel, editPanel, title, uid } = this.state;
     const isNew = !Boolean(uid);
-
     let pageNav: NavModelItem = {
       text: title,
       url: getDashboardUrl({
@@ -612,9 +536,7 @@ export class DashboardScene extends SceneObjectBase<DashboardSceneState> impleme
         isSnapshot: meta.isSnapshot,
       }),
     };
-
     const { folderUid } = meta;
-
     if (folderUid) {
       const folderNavModel = getNavModel(navIndex, `folder-dashboards-${folderUid}`).main;
       // If the folder hasn't loaded (maybe user doesn't have permission on it?) then
@@ -626,7 +548,6 @@ export class DashboardScene extends SceneObjectBase<DashboardSceneState> impleme
         };
       }
     }
-
     if (viewPanel) {
       pageNav = {
         text: t('dashboard-scene.dashboard-scene.text.view-panel', 'View panel'),
@@ -637,35 +558,27 @@ export class DashboardScene extends SceneObjectBase<DashboardSceneState> impleme
         }),
       };
     }
-
     if (editPanel) {
       pageNav = {
         text: t('dashboard-scene.dashboard-scene.text.edit-panel', 'Edit panel'),
         parentItem: pageNav,
       };
     }
-
     return pageNav;
   }
-
   public getInitialState(): DashboardSceneState | undefined {
     return this._initialState;
   }
-
   public addPanel(vizPanel: VizPanel): void {
     if (!this.state.isEditing) {
       this.onEnterEditMode();
     }
-
     // Add panel to layout
     this.state.body.addPanel(vizPanel);
   }
-
   public createLibraryPanel(panelToReplace: VizPanel, libPanel: LibraryPanel) {
     const behavior = new LibraryPanelBehavior({ uid: libPanel.uid, name: libPanel.name });
-
     const parent = panelToReplace.parent;
-
     if (parent instanceof DashboardGridItem) {
       const body = panelToReplace.clone({
         $behaviors: [behavior],
@@ -673,7 +586,6 @@ export class DashboardScene extends SceneObjectBase<DashboardSceneState> impleme
       parent.setState({ body });
       return;
     }
-
     if (parent instanceof AutoGridItem) {
       // Auto grid only supports creating library panels from the source panel (AutoGridItem.state.body).
       const body = parent.state.body.clone({
@@ -683,99 +595,76 @@ export class DashboardScene extends SceneObjectBase<DashboardSceneState> impleme
       parent.handleEditChange();
       return;
     }
-
     throw new Error("Trying to replace a panel that doesn't have a parent layout item");
   }
-
   public duplicatePanel(vizPanel: VizPanel) {
     getLayoutManagerFor(vizPanel).duplicatePanel?.(vizPanel);
   }
-
   public copyPanel(vizPanel: VizPanel) {
     if (config.featureToggles.dashboardNewLayouts) {
       const gridItem = vizPanel.parent;
-
       if (gridItem instanceof AutoGridItem) {
         const elements = getElement(gridItem, this);
         const gridItemKind = serializeAutoGridItem(gridItem);
-
         clearClipboard();
         store.set(LS_PANEL_COPY_KEY, JSON.stringify({ elements, gridItem: gridItemKind }));
       } else if (gridItem instanceof DashboardGridItem) {
         const elements = getElement(gridItem, this);
         const gridItemKind = gridItemToGridLayoutItemKind(gridItem);
-
         clearClipboard();
         store.set(LS_PANEL_COPY_KEY, JSON.stringify({ elements, gridItem: gridItemKind }));
       } else {
-        console.error('Trying to copy a panel that is not DashboardGridItem child');
+        structLog('error', 'Trying to copy a panel that is not DashboardGridItem child');
         throw new Error('Trying to copy a panel that is not DashboardGridItem child');
       }
       return;
     }
-
     if (!vizPanel.parent) {
       return;
     }
-
     let gridItem = vizPanel.parent;
-
     if (!(gridItem instanceof DashboardGridItem)) {
-      console.error('Trying to copy a panel that is not DashboardGridItem child');
+      structLog('error', 'Trying to copy a panel that is not DashboardGridItem child');
       throw new Error('Trying to copy a panel that is not DashboardGridItem child');
     }
-
     const jsonData = gridItemToPanel(gridItem);
-
     clearClipboard();
     store.set(LS_PANEL_COPY_KEY, JSON.stringify(jsonData));
   }
-
   public pastePanel() {
     const jsonData = store.get(LS_PANEL_COPY_KEY);
     const jsonObj = JSON.parse(jsonData);
     const panelModel = new PanelModel(jsonObj);
     const gridItem = buildGridItemForPanel(panelModel);
     const panel = gridItem.state.body;
-
     this.addPanel(panel);
-
     store.delete(LS_PANEL_COPY_KEY);
   }
-
   /** @internal */
   private static extractPanelStyles(panel: VizPanel, styleConfig: PanelStyleConfig): PanelStyles {
     const styles: PanelStyles = {};
-
     if (!panel.state.fieldConfig?.defaults) {
       return styles;
     }
-
     styles.fieldConfig = { defaults: {} };
-
     const defaults = styles.fieldConfig.defaults;
     const panelDefaults = panel.state.fieldConfig.defaults;
-
     // default props (color)
     for (const key of styleConfig.fieldConfig.defaultsProps) {
       copyFieldConfigPropIfDefined(panelDefaults, defaults, key);
     }
-
     // custom props (lineWidth, fillOpacity, etc.)
     if (panel.state.fieldConfig.defaults.custom) {
       const customDefaults: Record<string, unknown> = {};
       const panelCustom: Record<string, unknown> = panel.state.fieldConfig.defaults.custom;
-
       for (const key of styleConfig.fieldConfig.customProps) {
         const value = panelCustom[key];
         if (value !== undefined) {
           customDefaults[key] = value;
         }
       }
-
       defaults.custom = customDefaults;
     }
-
     // panel-level options (colorMode, graphMode, textMode, etc.)
     if (styleConfig.options?.props && panel.state.options) {
       const extracted = extractOptionProps(panel.state.options, styleConfig.options.props);
@@ -783,43 +672,34 @@ export class DashboardScene extends SceneObjectBase<DashboardSceneState> impleme
         styles.options = extracted;
       }
     }
-
     return styles;
   }
-
   /** @internal */
   public copyPanelStyles(vizPanel: VizPanel) {
     if (!config.featureToggles.panelStyleActions) {
       return;
     }
-
     const panelType = vizPanel.state.pluginId;
     const styleConfig = getPanelStyleConfig(panelType);
-
     if (!styleConfig) {
       return;
     }
-
     const stylesToCopy: CopiedPanelStyles = {
       panelType,
       styles: DashboardScene.extractPanelStyles(vizPanel, styleConfig),
     };
-
     store.set(LS_STYLES_COPY_KEY, JSON.stringify(stylesToCopy));
     appEvents.emit('alert-success', ['Panel styles copied.']);
   }
-
   /** @internal */
   public static hasPanelStylesToPaste(panelType: string): boolean {
     if (!config.featureToggles.panelStyleActions) {
       return false;
     }
-
     const stylesJson = store.get(LS_STYLES_COPY_KEY);
     if (!stylesJson) {
       return false;
     }
-
     try {
       const stylesCopy: CopiedPanelStyles = JSON.parse(stylesJson);
       return stylesCopy.panelType === panelType;
@@ -827,56 +707,46 @@ export class DashboardScene extends SceneObjectBase<DashboardSceneState> impleme
       return false;
     }
   }
-
   /** @internal */
   public pastePanelStyles(vizPanel: VizPanel) {
     if (!config.featureToggles.panelStyleActions) {
       return;
     }
-
     const stylesJson = store.get(LS_STYLES_COPY_KEY);
     if (!stylesJson) {
       return;
     }
-
     try {
       const stylesCopy: CopiedPanelStyles = JSON.parse(stylesJson);
-
       const panelType = vizPanel.state.pluginId;
-
       if (stylesCopy.panelType !== panelType) {
         return;
       }
-
       if (stylesCopy.styles.fieldConfig?.defaults) {
         const newDefaults = {
           ...vizPanel.state.fieldConfig?.defaults,
           ...stylesCopy.styles.fieldConfig.defaults,
         };
-
         if (stylesCopy.styles.fieldConfig.defaults.custom) {
           newDefaults.custom = {
             ...vizPanel.state.fieldConfig?.defaults?.custom,
             ...stylesCopy.styles.fieldConfig.defaults.custom,
           };
         }
-
         vizPanel.onFieldConfigChange({
           ...vizPanel.state.fieldConfig,
           defaults: newDefaults,
         });
       }
-
       if (stylesCopy.styles.options) {
         vizPanel.onOptionsChange({
           ...vizPanel.state.options,
           ...stylesCopy.styles.options,
         });
       }
-
       appEvents.emit('alert-success', ['Panel styles applied.']);
     } catch (e) {
-      console.error('Error pasting panel styles:', e);
+      structLog('error', 'Error pasting panel styles:', e);
       appEvents.emit('alert-error', ['Error pasting panel styles.']);
       DashboardInteractions.panelStylesMenuClicked(
         'paste',
@@ -886,15 +756,12 @@ export class DashboardScene extends SceneObjectBase<DashboardSceneState> impleme
       );
     }
   }
-
   public removePanel(panel: VizPanel) {
     getLayoutManagerFor(panel).removePanel?.(panel);
   }
-
   public updatePanelTitle(panel: VizPanel, title: string) {
     panel.setState({ title, hoverHeader: getUpdatedHoverHeader(title, panel.state.$timeRange) });
   }
-
   public async changePanelPlugin(
     panel: VizPanel,
     newPluginId: string,
@@ -902,33 +769,25 @@ export class DashboardScene extends SceneObjectBase<DashboardSceneState> impleme
     newFieldConfig?: FieldConfigSource
   ) {
     const { fieldConfig: prevFieldConfig } = panel.state;
-
     let cleanFieldConfig: FieldConfigSource = {
       defaults: { ...prevFieldConfig.defaults, custom: {} },
       overrides: filterFieldConfigOverrides(prevFieldConfig.overrides, isStandardFieldProp),
     };
-
     if (newFieldConfig) {
       cleanFieldConfig = { ...newFieldConfig, overrides: cleanFieldConfig.overrides };
     }
-
     await panel.changePluginType(newPluginId, newOptions, cleanFieldConfig);
-
     if (newOptions) {
       panel.onOptionsChange(newOptions, true);
     }
-
     if (newFieldConfig) {
       panel.onFieldConfigChange({ ...newFieldConfig, overrides: cleanFieldConfig.overrides }, true);
     }
-
     const pluginMeta = await getPanelPluginMeta(newPluginId);
     const skipDataQuery = pluginMeta?.skipDataQuery ?? false;
-
     if (skipDataQuery && panel.state.$data) {
       panel.setState({ $data: undefined });
     }
-
     if (!skipDataQuery && !panel.state.$data) {
       panel.setState({
         $data: new SceneDataTransformer({
@@ -941,59 +800,46 @@ export class DashboardScene extends SceneObjectBase<DashboardSceneState> impleme
       });
     }
   }
-
   public unlinkLibraryPanel(panel: VizPanel) {
     if (!panel.parent) {
       return;
     }
-
     const parent = panel.parent;
-
     if (parent instanceof DashboardGridItem) {
       parent.state.body.setState({ $behaviors: undefined });
       return;
     }
-
     if (parent instanceof AutoGridItem) {
       parent.state.body.setState({ $behaviors: undefined });
       parent.handleEditChange();
       return;
     }
-
-    console.error('Trying to unlink a lib panel in a layout that is not DashboardGridItem or AutoGridItem');
+    structLog('error', 'Trying to unlink a lib panel in a layout that is not DashboardGridItem or AutoGridItem');
   }
-
   public showModal(modal: SceneObject) {
     this.setState({ overlay: modal });
   }
-
   public closeModal() {
     this.setState({ overlay: undefined });
   }
-
   public onOpenSettings = () => {
     locationService.partial({ editview: 'settings' });
   };
-
   public onShowAddLibraryPanelDrawer(panelToReplaceRef?: SceneObjectRef<VizPanel>) {
     this.setState({
       overlay: new AddLibraryPanelDrawer({ panelToReplaceRef }),
     });
   }
-
   public onCreateNewRow() {
     return addNewRowTo(this.state.body);
   }
-
   public onCreateNewPanel(): VizPanel {
     const profiler = getDashboardSceneProfiler();
     const vizPanel = getDefaultVizPanel();
     profiler.attachProfilerToPanel(vizPanel);
-
     this.addPanel(vizPanel);
     return vizPanel;
   }
-
   public switchLayout(layout: DashboardLayoutManager, skipUndo?: boolean) {
     const currentLayout = this.state.body;
     const perform = () => this.setState({ body: layout });
@@ -1009,25 +855,19 @@ export class DashboardScene extends SceneObjectBase<DashboardSceneState> impleme
       });
     }
   }
-
   public getLayout(): DashboardLayoutManager {
     return this.state.body;
   }
-
   /**
    * Called by the SceneQueryRunner to provide contextual parameters (tracking) props for the request
    */
   public enrichDataRequest(sceneObject: SceneObject): Partial<DataQueryRequest> {
     const dashboard = getDashboardSceneFor(sceneObject);
-
     let panel = getClosestVizPanel(sceneObject);
-
     if (dashboard.state.isEditing && dashboard.state.editPanel) {
       panel = dashboard.state.editPanel.state.panelRef.resolve();
     }
-
     let panelId = 0;
-
     if (panel && panel.state.key) {
       if (isRepeatCloneOrChildOf(panel)) {
         // We check if any of the panel ancestors are clones because we can't use the original panel ID in this case
@@ -1038,7 +878,6 @@ export class DashboardScene extends SceneObjectBase<DashboardSceneState> impleme
         panelId = getPanelIdForVizPanel(panel);
       }
     }
-
     return {
       app: CoreApp.Dashboard,
       dashboardUID: this.state.uid,
@@ -1048,22 +887,18 @@ export class DashboardScene extends SceneObjectBase<DashboardSceneState> impleme
       dashboardTitle: this.state.title,
     };
   }
-
   canEditDashboard() {
     const {
       meta: { isSnapshot, isEmbedded, canEdit, canMakeEditable },
     } = this.state;
     return !isSnapshot && !isEmbedded && Boolean(canEdit || canMakeEditable || config.viewersCanEdit);
   }
-
   public getInitialSaveModel() {
     return this.serializer.initialSaveModel;
   }
-
   public getSnapshotUrl() {
     return this.serializer.getSnapshotUrl() ?? '';
   }
-
   /** Hacky temp function until we refactor transformSaveModelToScene a bit */
   setInitialSaveModel(model?: Dashboard, meta?: DashboardMeta, apiVersion?: string): void;
   setInitialSaveModel(
@@ -1083,30 +918,23 @@ export class DashboardScene extends SceneObjectBase<DashboardSceneState> impleme
     this.serializer.metadata = meta;
     this.serializer.apiVersion = apiVersion;
   }
-
   public getTrackingInformation() {
     return this.serializer.getTrackingInformation(this);
   }
-
   public getDynamicDashboardsTrackingInformation() {
     return this.serializer.getDynamicDashboardsTrackingInformation(this);
   }
-
   public async onDashboardDelete() {
     // Need to mark it non dirty to navigate away without unsaved changes warning
     this.setState({ isDirty: false });
     locationService.replace('/');
   }
-
   public getDashboardPanels() {
     return dashboardSceneGraph.getVizPanels(this);
   }
-
   public getTransformationCounts(saveModel?: Dashboard | DashboardV2Spec): Record<string, number> | undefined {
     const model = saveModel ?? this.getSaveModel();
-
     const transformationCounts = new Map<string, number>();
-
     // Handle V1 dashboards
     if ('panels' in model && model.panels) {
       for (const panel of model.panels) {
@@ -1121,7 +949,6 @@ export class DashboardScene extends SceneObjectBase<DashboardSceneState> impleme
         }
       }
     }
-
     // Handle V2 dashboards
     if ('elements' in model && model.elements) {
       for (const element of Object.values(model.elements)) {
@@ -1129,12 +956,10 @@ export class DashboardScene extends SceneObjectBase<DashboardSceneState> impleme
         if (element.kind !== 'Panel') {
           continue;
         }
-
         const dataSpec = element.spec.data?.spec;
         if (!dataSpec || typeof dataSpec !== 'object') {
           continue;
         }
-
         // Count transformations
         const transformations = dataSpec.transformations;
         if (Array.isArray(transformations)) {
@@ -1145,20 +970,15 @@ export class DashboardScene extends SceneObjectBase<DashboardSceneState> impleme
         }
       }
     }
-
     if (transformationCounts.size === 0) {
       return undefined;
     }
-
     // Convert map to object
     return Object.fromEntries(transformationCounts);
   }
-
   public getExpressionCounts(saveModel?: Dashboard | DashboardV2Spec): Record<string, number> | undefined {
     const model = saveModel ?? this.getSaveModel();
-
     const expressionCounts = new Map<string, number>();
-
     // Handle V1 dashboards
     if ('panels' in model && model.panels) {
       for (const panel of model.panels) {
@@ -1170,7 +990,6 @@ export class DashboardScene extends SceneObjectBase<DashboardSceneState> impleme
               target?.datasource && typeof target.datasource === 'object' && 'uid' in target.datasource
                 ? target.datasource.uid
                 : undefined;
-
             const targetType = target?.type;
             if (datasourceUid === '__expr__' && typeof targetType === 'string' && targetType) {
               expressionCounts.set(targetType, (expressionCounts.get(targetType) || 0) + 1);
@@ -1179,7 +998,6 @@ export class DashboardScene extends SceneObjectBase<DashboardSceneState> impleme
         }
       }
     }
-
     // Handle V2 dashboards
     if ('elements' in model && model.elements) {
       for (const element of Object.values(model.elements)) {
@@ -1187,12 +1005,10 @@ export class DashboardScene extends SceneObjectBase<DashboardSceneState> impleme
         if (element.kind !== 'Panel') {
           continue;
         }
-
         const dataSpec = element.spec.data?.spec;
         if (!dataSpec || typeof dataSpec !== 'object') {
           continue;
         }
-
         // Count expressions from queries
         const queries = dataSpec.queries;
         if (Array.isArray(queries)) {
@@ -1201,14 +1017,11 @@ export class DashboardScene extends SceneObjectBase<DashboardSceneState> impleme
             if (!querySpec || typeof querySpec !== 'object') {
               continue;
             }
-
             const datasource = querySpec.datasource;
             const datasourceName =
               datasource && typeof datasource === 'object' && 'name' in datasource ? datasource.name : undefined;
-
             const spec = querySpec.spec;
             const queryType = spec && typeof spec === 'object' && 'type' in spec ? spec.type : undefined;
-
             if (datasourceName === '__expr__' && typeof queryType === 'string' && queryType) {
               expressionCounts.set(queryType, (expressionCounts.get(queryType) || 0) + 1);
             }
@@ -1216,33 +1029,26 @@ export class DashboardScene extends SceneObjectBase<DashboardSceneState> impleme
         }
       }
     }
-
     if (expressionCounts.size === 0) {
       return undefined;
     }
-
     // Convert map to object
     return Object.fromEntries(expressionCounts);
   }
-
   public onSetScrollRef = (scrollElement: ScrollRefElement): void => {
     this._scrollRef = scrollElement;
   };
-
   public rememberScrollPos() {
     this._prevScrollPos = this._scrollRef?.scrollTop;
   }
-
   public restoreScrollPos() {
     if (this._prevScrollPos !== undefined) {
       this._scrollRef?.scrollTo(0, this._prevScrollPos!);
     }
   }
-
   getSaveModel(): Dashboard | DashboardV2Spec {
     return this.serializer.getSaveModel(this);
   }
-
   // Helper method to build K8s resource structure
   private buildResourceForCreate(spec: Dashboard | DashboardV2Spec, isNew: boolean): ResourceForCreate<unknown> {
     const { meta } = this.state;
@@ -1261,19 +1067,16 @@ export class DashboardScene extends SceneObjectBase<DashboardSceneState> impleme
       spec,
     };
   }
-
   // Get the dashboard in native K8s form (using the appropriate apiVersion)
   getSaveResource(options: SaveDashboardAsOptions): ResourceForCreate<unknown> {
     const spec = this.getSaveAsModel(options);
     return this.buildResourceForCreate(spec, options.isNew ?? false);
   }
-
   // Wrap a raw dashboard spec in K8s resource format
   // Used by JSON model editor for Git sync dashboards
   getSaveResourceFromSpec(rawSpec: Dashboard | DashboardV2Spec): ResourceForCreate<unknown> {
     return this.buildResourceForCreate(rawSpec, false);
   }
-
   // Get raw JSON from JSON model editor if currently active
   // Returns undefined if not in JSON editor mode or if JSON is invalid
   getRawJsonFromEditor(): Dashboard | DashboardV2Spec | undefined {
@@ -1286,50 +1089,40 @@ export class DashboardScene extends SceneObjectBase<DashboardSceneState> impleme
     }
     return undefined;
   }
-
   getSaveAsModel(options: SaveDashboardAsOptions): Dashboard | DashboardV2Spec {
     return this.serializer.getSaveAsModel(this, options);
   }
-
   getDashboardChanges(saveTimeRange?: boolean, saveVariables?: boolean, saveRefresh?: boolean): DashboardChangeInfo {
     const rawJson = this.getRawJsonFromEditor();
     return this.serializer.getDashboardChangesFromScene(this, { saveTimeRange, saveVariables, saveRefresh, rawJson });
   }
-
   getManagerKind(): ManagerKind | undefined {
     return this.state.meta.k8s?.annotations?.[AnnoKeyManagerKind];
   }
-
   getManagerIdentity(): string | undefined {
     // get repo name if any
     return this.state.meta.k8s?.annotations?.[AnnoKeyManagerIdentity];
   }
-
   isManaged() {
     return Boolean(this.getManagerKind());
   }
-
   isManagedRepository() {
     if (!config.featureToggles.provisioning) {
       return false;
     }
     return Boolean(this.getManagerKind() === ManagerKind.Repo);
   }
-
   managedResourceCannotBeEdited() {
     return (
       this.isManaged() && !this.isManagedRepository() && !this.state.meta.k8s?.annotations?.[AnnoKeyManagerAllowsEdits]
     );
   }
-
   getPath() {
     return this.state.meta.k8s?.annotations?.[AnnoKeySourcePath];
   }
-
   private hasVariableErrors(): boolean {
     return Boolean(this.state.$variables?.state.variables.find((v) => Boolean(v.state.error)));
   }
-
   /**
    * Default layout used for new Tab and Row containers
    * Undefined if default layout is not set in preferences
@@ -1340,11 +1133,9 @@ export class DashboardScene extends SceneObjectBase<DashboardSceneState> impleme
     }
     return undefined;
   }
-
   getDefaultLayoutType() {
     return this.state.preferences?.defaultLayoutTemplate?.descriptor?.id;
   }
-
   updateDefaultLayoutTemplate(template: DashboardLayoutManager) {
     this.setState({
       preferences: {
@@ -1354,20 +1145,15 @@ export class DashboardScene extends SceneObjectBase<DashboardSceneState> impleme
     });
   }
 }
-
 export class DashboardVariableDependency implements SceneVariableDependencyConfigLike {
   private _emptySet = new Set<string>();
-
   public constructor(private _dashboard: DashboardScene) {}
-
   getNames(): Set<string> {
     return this._emptySet;
   }
-
   public hasDependencyOn(): boolean {
     return false;
   }
-
   public variableUpdateCompleted(variable: SceneVariable, hasChanged: boolean) {
     if (hasChanged) {
       // Temp solution for some core panels (like dashlist) to know that variables have changed
@@ -1376,7 +1162,6 @@ export class DashboardVariableDependency implements SceneVariableDependencyConfi
       // variable changes. TODO: We should redirect plugin devs to use VariablesChanged event
       this._dashboard.publishEvent(new RefreshEvent());
     }
-
     if (variable.state.name === PANEL_SEARCH_VAR) {
       const searchValue = variable.getValue();
       if (typeof searchValue === 'string') {

--- a/public/app/features/dashboard-scene/scene/DashboardSceneUrlSync.ts
+++ b/public/app/features/dashboard-scene/scene/DashboardSceneUrlSync.ts
@@ -1,26 +1,21 @@
+import { structLog } from '@grafana/data';
 import { type SceneObjectUrlSyncHandler, type SceneObjectUrlValues, type VizPanel } from '@grafana/scenes';
 import { contextSrv } from 'app/core/services/context_srv';
-
 import { buildPanelEditScene } from '../panel-edit/PanelEditor';
 import { createDashboardEditViewFor } from '../settings/utils';
 import { ShareDrawer } from '../sharing/ShareDrawer/ShareDrawer';
 import { findEditPanel, getLibraryPanelBehavior } from '../utils/utils';
-
 import { type DashboardScene, type DashboardSceneState } from './DashboardScene';
 import { type LibraryPanelBehavior } from './LibraryPanelBehavior';
 import { UNCONFIGURED_PANEL_PLUGIN_ID } from './UnconfiguredPanel';
 import { DefaultGridLayoutManager } from './layout-default/DefaultGridLayoutManager';
-
 export class DashboardSceneUrlSync implements SceneObjectUrlSyncHandler {
   constructor(private _scene: DashboardScene) {}
-
   getKeys(): string[] {
     return ['inspect', 'viewPanel', 'editPanel', 'editview', 'autofitpanels', 'shareView'];
   }
-
   getUrlState(): SceneObjectUrlValues {
     const state = this._scene.state;
-
     return {
       autofitpanels: this.getAutoFitPanels(),
       viewPanel: state.viewPanel,
@@ -30,22 +25,17 @@ export class DashboardSceneUrlSync implements SceneObjectUrlSyncHandler {
       orgId: contextSrv.user.orgId.toString(),
     };
   }
-
   private getAutoFitPanels(): string | undefined {
     if (this._scene.state.body instanceof DefaultGridLayoutManager) {
       return this._scene.state.body.state.grid.state.UNSAFE_fitPanels ? 'true' : undefined;
     }
-
     return undefined;
   }
-
   updateFromUrl(values: SceneObjectUrlValues): void {
     const { viewPanel, isEditing, editPanel, shareView } = this._scene.state;
     const update: Partial<DashboardSceneState> = {};
-
     if (typeof values.editview === 'string' && this._scene.canEditDashboard()) {
       update.editview = createDashboardEditViewFor(values.editview);
-
       // If we are not in editing (for example after full page reload)
       if (!isEditing) {
         if (this._scene.state.editable) {
@@ -59,44 +49,36 @@ export class DashboardSceneUrlSync implements SceneObjectUrlSyncHandler {
     } else if (values.hasOwnProperty('editview')) {
       update.editview = undefined;
     }
-
     // Handle view panel state
     if (typeof values.viewPanel === 'string') {
       update.viewPanel = values.viewPanel;
     } else if (viewPanel && values.viewPanel === null) {
       update.viewPanel = undefined;
     }
-
     // Handle edit panel state
     if (typeof values.editPanel === 'string') {
       const panel = findEditPanel(this._scene, values.editPanel);
-
       if (!panel) {
-        console.warn(`Panel ${values.editPanel} not found`);
+        structLog('warn', `Panel ${values.editPanel} not found`);
         return;
       }
-
       // We cannot simultaneously be in edit and view panel state.
       if (this._scene.state.viewPanel) {
         update.viewPanel = undefined;
       }
-
       // If we are not in editing (for example after full page reload)
       if (!isEditing) {
         this._scene.onEnterEditMode();
       }
-
       const libPanelBehavior = getLibraryPanelBehavior(panel);
       if (libPanelBehavior && !libPanelBehavior?.state.isLoaded) {
         this._waitForLibPanelToLoadBeforeEnteringPanelEdit(panel, libPanelBehavior);
         return;
       }
-
       update.editPanel = buildPanelEditScene(panel, panel.state.pluginId === UNCONFIGURED_PANEL_PLUGIN_ID);
     } else if (editPanel && values.editPanel === null) {
       update.editPanel = undefined;
     }
-
     if (typeof values.shareView === 'string') {
       update.shareView = values.shareView;
       update.overlay = new ShareDrawer({
@@ -106,21 +88,17 @@ export class DashboardSceneUrlSync implements SceneObjectUrlSyncHandler {
       update.overlay = undefined;
       update.shareView = undefined;
     }
-
     const layout = this._scene.state.body;
     if (layout instanceof DefaultGridLayoutManager) {
       const UNSAFE_fitPanels = typeof values.autofitpanels === 'string';
-
       if (!!layout.state.grid.state.UNSAFE_fitPanels !== UNSAFE_fitPanels) {
         layout.state.grid.setState({ UNSAFE_fitPanels });
       }
     }
-
     if (Object.keys(update).length > 0) {
       this._scene.setState(update);
     }
   }
-
   /**
    * Temporary solution, with some refactoring of PanelEditor we can remove this
    */

--- a/public/app/features/dashboard-scene/scene/GoToSnapshotOriginButton.tsx
+++ b/public/app/features/dashboard-scene/scene/GoToSnapshotOriginButton.tsx
@@ -1,13 +1,11 @@
+import { structLog } from '@grafana/data';
 import { css } from '@emotion/css';
-
 import { textUtil } from '@grafana/data';
 import { t } from '@grafana/i18n';
 import { config, locationService } from '@grafana/runtime';
 import { ConfirmModal, ToolbarButton } from '@grafana/ui';
-
 import { appEvents } from '../../../core/app_events';
 import { ShowModalReactEvent } from '../../../types/events';
-
 export function GoToSnapshotOriginButton(props: { originalURL: string }) {
   return (
     <ToolbarButton
@@ -19,7 +17,6 @@ export function GoToSnapshotOriginButton(props: { originalURL: string }) {
     />
   );
 }
-
 export const onOpenSnapshotOriginalDashboard = (originalUrl: string) => {
   const relativeURL = originalUrl ?? '';
   const sanitizedRelativeURL = textUtil.sanitizeUrl(relativeURL);
@@ -59,6 +56,6 @@ export const onOpenSnapshotOriginalDashboard = (originalUrl: string) => {
       locationService.push(sanitizedRelativeURL);
     }
   } catch (err) {
-    console.error('Failed to open original dashboard', err);
+    structLog('error', 'Failed to open original dashboard', err);
   }
 };

--- a/public/app/features/dashboard-scene/scene/export/exporters.ts
+++ b/public/app/features/dashboard-scene/scene/export/exporters.ts
@@ -1,5 +1,5 @@
+import { structLog } from '@grafana/data';
 import { defaults, each, sortBy } from 'lodash';
-
 import { type DataSourceRef, type VariableOption, VariableRefresh } from '@grafana/data';
 import { getDataSourceSrv } from '@grafana/runtime';
 import { getPanelPluginMeta } from '@grafana/runtime/internal';
@@ -22,20 +22,16 @@ import { type PanelModel, type GridPos } from 'app/features/dashboard/state/Pane
 import { getLibraryPanel } from 'app/features/library-panels/state/api';
 import { variableRegexExec } from 'app/features/variables/utils';
 import { dispatch } from 'app/store/store';
-
 import { isPanelModelLibraryPanel } from '../../../library-panels/guard';
 import { LibraryElementKind } from '../../../library-panels/types';
 import { type DashboardJson } from '../../../manage-dashboards/types';
 import { isConstant } from '../../../variables/guard';
-
 // This label is used to store the export label for a datasource when exporting a V2 dashboard for external sharing.
 // E.g. if a dashboard has two datasources with the same type, the export label will be used to distinguish them.
 export const ExportLabel = 'grafana.app/export-label';
-
 export interface InputUsage {
   libraryPanels?: LibraryPanelRef[];
 }
-
 export interface Input {
   name: string;
   type: string;
@@ -44,7 +40,6 @@ export interface Input {
   description: string;
   usage?: InputUsage;
 }
-
 interface Requires {
   [key: string]: {
     type: string;
@@ -53,26 +48,22 @@ interface Requires {
     version: string;
   };
 }
-
 export interface ExternalDashboard {
   __inputs?: Input[];
   __elements?: Record<string, LibraryElementExport>;
   __requires?: Array<Requires[string]>;
   panels: Array<PanelModel | PanelWithExportableLibraryPanel>;
 }
-
 interface PanelWithExportableLibraryPanel {
   gridPos: GridPos;
   id: number;
   libraryPanel: LibraryPanelRef;
 }
-
 function isExportableLibraryPanel(
   p: PanelModel | PanelWithExportableLibraryPanel
 ): p is PanelWithExportableLibraryPanel {
   return Boolean(p.libraryPanel?.name && p.libraryPanel?.uid);
 }
-
 interface DataSources {
   [key: string]: {
     name: string;
@@ -84,72 +75,61 @@ interface DataSources {
     usage?: InputUsage;
   };
 }
-
 export interface LibraryElementExport {
   name: string;
   uid: string;
   model: any;
   kind: LibraryElementKind;
 }
-
 export async function makeExportableV1(dashboard: DashboardModel) {
   // clean up repeated rows and panels,
   // this is done on the live real dashboard instance, not on a clone
   // so we need to undo this
   // this is pretty hacky and needs to be changed
   dashboard.cleanUpRepeats();
-
   const saveModel = dashboard.getSaveModelCloneOld();
-
   // undo repeat cleanup
   dashboard.processRepeats();
-
   const inputs: Input[] = [];
   const requires: Requires = {};
   const datasources: DataSources = {};
-  const variableLookup: { [key: string]: any } = {};
+  const variableLookup: {
+    [key: string]: any;
+  } = {};
   const libraryPanels: Map<string, LibraryElementExport> = new Map<string, LibraryElementExport>();
-
   for (const variable of saveModel.getVariables()) {
     variableLookup[variable.name] = variable;
   }
-
-  const datasourceVariableRefNameMap: { [key: string]: string } = {};
-
+  const datasourceVariableRefNameMap: {
+    [key: string]: string;
+  } = {};
   const templateizeDatasourceUsage = (obj: any, fallback?: DataSourceRef) => {
     if (obj.datasource === undefined) {
       obj.datasource = fallback;
       return;
     }
-
     let datasource = obj.datasource;
     let datasourceVariable: any = null;
-
     const datasourceUid: string | undefined = datasource?.uid;
     const match = datasourceUid && variableRegexExec(datasourceUid);
     let varName: string | undefined;
-
     if (match) {
       varName = match[1] || match[2] || match[4];
       datasourceVariable = variableLookup[varName];
-
       // if datasource variable is already templated, skip it
       if (datasourceVariableRefNameMap[varName]) {
         return;
       }
-
       if (datasourceVariable && datasourceVariable.current) {
         datasource = datasourceVariable.current.value;
       }
     }
-
     return getDataSourceSrv()
       .get(datasource)
       .then((ds) => {
         if (ds.meta?.builtIn) {
           return;
         }
-
         // add data source type to require list
         requires['datasource' + ds.meta?.id] = {
           type: 'datasource',
@@ -157,12 +137,10 @@ export async function makeExportableV1(dashboard: DashboardModel) {
           name: ds.meta.name,
           version: ds.meta.info.version || '1.0.0',
         };
-
         const libraryPanel = obj.libraryPanel;
         const libraryPanelSuffix = !!libraryPanel ? '-for-library-panel' : '';
         let refName = 'DS_' + ds.name.replace(' ', '_').toUpperCase() + libraryPanelSuffix.toUpperCase();
         const templatedUid = '${' + refName + '}';
-
         datasources[refName] = {
           name: refName,
           label: ds.name,
@@ -172,37 +150,30 @@ export async function makeExportableV1(dashboard: DashboardModel) {
           pluginName: ds.meta?.name,
           usage: datasources[refName]?.usage,
         };
-
         if (!!libraryPanel) {
           const libPanels = datasources[refName]?.usage?.libraryPanels || [];
           libPanels.push({ name: libraryPanel.name, uid: libraryPanel.uid });
-
           datasources[refName].usage = {
             libraryPanels: libPanels,
           };
         }
-
         // if panel or query is relying on a datasource variable
         // skip templating datasource uid but save the reference so we can set datasource variable's current prop
         if (datasourceVariable && varName) {
           datasourceVariableRefNameMap[varName] = '${' + refName + '}';
           return;
         }
-
         obj.datasource = { type: ds.meta.id, uid: templatedUid };
       });
   };
-
   const processPanel = async (panel: PanelModel) => {
     if (panel.type !== 'row') {
       await templateizeDatasourceUsage(panel);
-
       if (panel.targets) {
         for (const target of panel.targets) {
           await templateizeDatasourceUsage(target, panel.datasource!);
         }
       }
-
       const panelDef = await getPanelPluginMeta(panel.type);
       if (panelDef) {
         requires['panel' + panelDef.id] = {
@@ -214,7 +185,6 @@ export async function makeExportableV1(dashboard: DashboardModel) {
       }
     }
   };
-
   const processLibraryPanels = async (panel: PanelModel) => {
     if (isPanelModelLibraryPanel(panel)) {
       const { name, uid } = panel.libraryPanel;
@@ -223,21 +193,17 @@ export async function makeExportableV1(dashboard: DashboardModel) {
         const libPanel = await getLibraryPanel(uid, true);
         model = libPanel.model;
       }
-
       await templateizeDatasourceUsage(model);
-
       const { gridPos, id, ...rest } = model as any;
       if (!libraryPanels.has(uid)) {
         libraryPanels.set(uid, { name, uid, kind: LibraryElementKind.Panel, model: rest });
       }
     }
   };
-
   try {
     // check up panel data sources
     for (const panel of saveModel.panels) {
       await processPanel(panel);
-
       // handle collapsed rows
       if (panel.collapsed !== undefined && panel.collapsed === true && panel.panels) {
         for (const rowPanel of panel.panels) {
@@ -245,7 +211,6 @@ export async function makeExportableV1(dashboard: DashboardModel) {
         }
       }
     }
-
     // templatize template vars
     for (const variable of saveModel.getVariables()) {
       if (variable.type === 'query') {
@@ -269,12 +234,10 @@ export async function makeExportableV1(dashboard: DashboardModel) {
         await templateizeDatasourceUsage(variable);
       }
     }
-
     // templatize annotations vars
     for (const annotationDef of saveModel.annotations.list) {
       await templateizeDatasourceUsage(annotationDef);
     }
-
     // add grafana version
     requires['grafana'] = {
       type: 'grafana',
@@ -282,7 +245,6 @@ export async function makeExportableV1(dashboard: DashboardModel) {
       name: 'Grafana',
       version: config.buildInfo.version,
     };
-
     // we need to process all panels again after all the promises are resolved
     // so all data sources, variables and targets have been templateized when we process library panels
     for (const panel of saveModel.panels) {
@@ -293,11 +255,9 @@ export async function makeExportableV1(dashboard: DashboardModel) {
         }
       }
     }
-
     each(datasources, (value: any) => {
       inputs.push(value);
     });
-
     // templatize constants
     for (const variable of saveModel.getVariables()) {
       if (isConstant(variable)) {
@@ -319,7 +279,6 @@ export async function makeExportableV1(dashboard: DashboardModel) {
         variable.options = [variable.current];
       }
     }
-
     const __elements = [...libraryPanels.entries()].reduce<Record<string, LibraryElementExport>>(
       (prev, [curKey, curLibPanel]) => {
         prev[curKey] = curLibPanel;
@@ -327,7 +286,6 @@ export async function makeExportableV1(dashboard: DashboardModel) {
       },
       {}
     );
-
     // make inputs and requires a top thing
     const newObj: DashboardJson = defaults(
       {
@@ -337,7 +295,6 @@ export async function makeExportableV1(dashboard: DashboardModel) {
       },
       saveModel
     );
-
     // Remove extraneous props from library panels
     for (let i = 0; i < newObj.panels.length; i++) {
       const libPanel = newObj.panels[i];
@@ -349,22 +306,19 @@ export async function makeExportableV1(dashboard: DashboardModel) {
         };
       }
     }
-
     return newObj;
   } catch (err) {
-    console.error('Export failed:', err);
+    structLog('error', 'Export failed:', err);
     return {
       error: err,
     };
   }
 }
-
 /**
  * Converts a LibraryPanelKind to a PanelKind with embedded panel configuration
  */
 async function convertLibraryPanelToInlinePanel(libraryPanelElement: LibraryPanelKind): Promise<PanelKind> {
   const { libraryPanel, id, title } = libraryPanelElement.spec;
-
   try {
     // Load the full library panel definition
     const fullLibraryPanel = await getLibraryPanel(libraryPanel.uid, true);
@@ -374,8 +328,7 @@ async function convertLibraryPanelToInlinePanel(libraryPanelElement: LibraryPane
     inlinePanel.spec.id = id;
     return inlinePanel;
   } catch (error) {
-    console.error(`Failed to load library panel ${libraryPanel.uid}:`, error);
-
+    structLog('error', `Failed to load library panel ${libraryPanel.uid}:`, error);
     const errorMessage = error instanceof Error ? error.message : 'Unknown error';
     dispatch(
       notifyApp(
@@ -384,7 +337,6 @@ async function convertLibraryPanelToInlinePanel(libraryPanelElement: LibraryPane
         )
       )
     );
-
     // Return a placeholder panel if library panel can't be loaded
     return {
       kind: 'Panel',
@@ -417,79 +369,62 @@ async function convertLibraryPanelToInlinePanel(libraryPanelElement: LibraryPane
     };
   }
 }
-
 export async function makeExportableV2(dashboard: DashboardV2Spec, isSharingExternally = false) {
-  const dataQueryLabels: { [key: string]: Map<string, number> } = {};
-
+  const dataQueryLabels: {
+    [key: string]: Map<string, number>;
+  } = {};
   // get all datasource variables
   const datasourceVariables = dashboard.variables.filter((v) => v.kind === 'DatasourceVariable');
-
   const processDataQueryKind = (dataQueryKind: DataQueryKind) => {
     if (!dataQueryKind.datasource?.name) {
       return;
     }
-
     const datasourceUid = dataQueryKind.datasource.name;
-
     if (isReferencingDsTemplateVariable(datasourceUid)) {
       return;
     }
-
     dataQueryKind.labels = {
       ...(dataQueryKind.labels ?? {}),
       [ExportLabel]: getLabel(dataQueryKind.group, datasourceUid),
     };
-
     dataQueryKind.datasource = undefined;
   };
-
   const processAdHocAndGroupByVariables = (variable: AdhocVariableKind | GroupByVariableKind) => {
     const datasourceUid = variable.datasource?.name;
-
     if (!datasourceUid) {
       return;
     }
-
     if (isReferencingDsTemplateVariable(datasourceUid)) {
       return;
     }
-
     variable.labels = {
       ...(variable.labels ?? {}),
       [ExportLabel]: getLabel(variable.group, datasourceUid),
     };
     variable.datasource = undefined;
   };
-
   const isReferencingDsTemplateVariable = (datasourceUid: string) => {
     if (datasourceUid.startsWith('$')) {
       const varName =
         datasourceUid.startsWith('${') && datasourceUid.endsWith('}')
           ? datasourceUid.slice(2, -1)
           : datasourceUid.slice(1);
-
       return !!datasourceVariables.find((v) => v.spec.name === varName);
     }
-
     return false;
   };
-
   const getLabel = (datasourceGroup: string, datasourceUid: string) => {
     let group = dataQueryLabels[datasourceGroup];
-
     if (!group) {
       group = new Map<string, number>();
       dataQueryLabels[datasourceGroup] = group;
     }
-
     if (!group.has(datasourceUid)) {
       group.set(datasourceUid, group.size + 1);
     }
-
     const index = group.get(datasourceUid);
     return `${datasourceGroup}-${index}`;
   };
-
   const processPanel = (panel: PanelKind) => {
     if (panel.spec.data.spec.queries) {
       for (const query of panel.spec.data.spec.queries) {
@@ -497,10 +432,8 @@ export async function makeExportableV2(dashboard: DashboardV2Spec, isSharingExte
       }
     }
   };
-
   try {
     const elements = dashboard.elements;
-
     // process elements
     for (const [key, element] of Object.entries(elements)) {
       if (element.kind === 'Panel') {
@@ -517,7 +450,6 @@ export async function makeExportableV2(dashboard: DashboardV2Spec, isSharingExte
         // For internal exports, keep library panels as-is
       }
     }
-
     // process template variables
     for (const variable of dashboard.variables) {
       if (variable.kind === 'QueryVariable') {
@@ -536,15 +468,13 @@ export async function makeExportableV2(dashboard: DashboardV2Spec, isSharingExte
         processAdHocAndGroupByVariables(variable);
       }
     }
-
     // process annotations vars
     for (const annotation of dashboard.annotations) {
       processDataQueryKind(annotation.spec.query);
     }
-
     return dashboard;
   } catch (err) {
-    console.error('Export failed:', err);
+    structLog('error', 'Export failed:', err);
     return {
       error: err,
     };

--- a/public/app/features/dashboard-scene/scene/layout-auto-grid/AutoGridItem.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-auto-grid/AutoGridItem.tsx
@@ -1,6 +1,6 @@
+import { structLog } from '@grafana/data';
 import { isEqual } from 'lodash';
 import React from 'react';
-
 import {
   CustomVariable,
   MultiValueVariable,
@@ -12,18 +12,15 @@ import {
   type VizPanel,
 } from '@grafana/scenes';
 import { type OptionsPaneCategoryDescriptor } from 'app/features/dashboard/components/PanelEditor/OptionsPaneCategoryDescriptor';
-
 import { ConditionalRenderingGroup } from '../../conditional-rendering/group/ConditionalRenderingGroup';
 import { DashboardStateChangedEvent, RepeatsUpdatedEvent } from '../../edit-pane/shared';
 import { getCloneKey, getLocalVariableValueSet } from '../../utils/clone';
 import { getMultiVariableValues } from '../../utils/utils';
 import { scrollCanvasElementIntoView } from '../layouts-shared/scrollCanvasElementIntoView';
 import { type DashboardLayoutItem } from '../types/DashboardLayoutItem';
-
 import { getOptions } from './AutoGridItemEditor';
 import { AutoGridItemRenderer } from './AutoGridItemRenderer';
 import { AutoGridLayout } from './AutoGridLayout';
-
 export interface AutoGridItemState extends SceneObjectState {
   body: VizPanel;
   hideWhenNoData?: boolean;
@@ -33,53 +30,41 @@ export interface AutoGridItemState extends SceneObjectState {
   conditionalRendering?: ConditionalRenderingGroup;
   repeatedConditionalRendering?: ConditionalRenderingGroup[];
 }
-
 export class AutoGridItem extends SceneObjectBase<AutoGridItemState> implements DashboardLayoutItem {
   public static Component = AutoGridItemRenderer;
-
   protected _variableDependency = new VariableDependencyConfig(this, {
     variableNames: this.state.variableName ? [this.state.variableName] : [],
     onVariableUpdateCompleted: () => this.performRepeat(),
   });
-
   public readonly isDashboardLayoutItem = true;
   public containerRef = React.createRef<HTMLDivElement>();
   private _prevRepeatValues?: VariableValueSingle[];
-
   public constructor(state: AutoGridItemState) {
     super({ ...state, conditionalRendering: state?.conditionalRendering ?? ConditionalRenderingGroup.createEmpty() });
     this.addActivationHandler(() => this._activationHandler());
   }
-
   private _activationHandler() {
     if (this.state.variableName) {
       this.performRepeat();
     }
-
     this._subs.add(this.subscribeToEvent(DashboardStateChangedEvent, () => this.handleEditChange()));
-
     const deactivate = this.state.conditionalRendering?.activate();
-
     return () => {
       if (deactivate) {
         deactivate();
       }
     };
   }
-
   public getOptions(): OptionsPaneCategoryDescriptor[] {
     return getOptions(this);
   }
-
   public setElementBody(body: VizPanel): void {
     this.setState({ body });
   }
-
   public performRepeat() {
     if (!this.state.variableName || sceneGraph.hasVariableDependencyInLoadingState(this)) {
       return;
     }
-
     const variable =
       sceneGraph.lookupVariable(this.state.variableName, this) ??
       new CustomVariable({
@@ -89,31 +74,24 @@ export class AutoGridItem extends SceneObjectBase<AutoGridItemState> implements 
         text: '',
         query: 'A',
       });
-
     if (!(variable instanceof MultiValueVariable)) {
-      console.error('DashboardGridItem: Variable is not a MultiValueVariable');
+      structLog('error', 'DashboardGridItem: Variable is not a MultiValueVariable');
       return;
     }
-
     const { values, texts } = getMultiVariableValues(variable);
-
     if (isEqual(this._prevRepeatValues, values)) {
       return;
     }
-
     const panelToRepeat = this.state.body;
     const repeatedPanels: VizPanel[] = [];
-
     // when variable has no options (due to error or similar) it will not render any panels at all
     // adding a placeholder in this case so that there is at least empty panel that can display error
     const emptyVariablePlaceholderOption = {
       values: [''],
       texts: variable.hasAllValue() ? ['All'] : ['None'],
     };
-
     const variableValues = values.length ? values : emptyVariablePlaceholderOption.values;
     const variableTexts = texts.length ? texts : emptyVariablePlaceholderOption.texts;
-
     // Loop through variable values and create repeats
     for (let index = 0; index < variableValues.length; index++) {
       const isSource = index === 0;
@@ -123,65 +101,53 @@ export class AutoGridItem extends SceneObjectBase<AutoGridItemState> implements 
             key: getCloneKey(panelToRepeat.state.key!, index),
             repeatSourceKey: panelToRepeat.state.key,
           });
-
       clone.setState({ $variables: getLocalVariableValueSet(variable, variableValues[index], variableTexts[index]) });
-
       if (index > 0) {
         repeatedPanels.push(clone);
       }
     }
-
     let repeatedConditionalRendering: ConditionalRenderingGroup[] | undefined;
-
     if (this.state.conditionalRendering) {
       repeatedConditionalRendering = repeatedPanels.reduce<ConditionalRenderingGroup[]>((acc, panel) => {
         const conditionalRendering = this.state.conditionalRendering!.clone();
         conditionalRendering.setTarget(panel);
         acc.push(conditionalRendering);
-
         return acc;
       }, []);
-
       this.state.conditionalRendering.setTarget(panelToRepeat);
     }
-
     this.setState({ repeatedPanels, repeatedConditionalRendering });
     this._prevRepeatValues = values;
     this.publishEvent(new RepeatsUpdatedEvent(this), true);
   }
-
   public getPanelCount() {
     return (this.state.repeatedPanels?.length ?? 0) + 1;
   }
-
   public setRepeatByVariable(variableName: string | undefined) {
     const stateUpdate: Partial<AutoGridItemState> = { variableName };
-
     if (!variableName) {
       stateUpdate.repeatedPanels = undefined;
     }
-
     if (this.state.body.state.$variables) {
       this.state.body.setState({ $variables: undefined });
     }
-
     this._variableDependency.setVariableNames(variableName ? [variableName] : []);
-
     this.setState(stateUpdate);
     this.performRepeat();
   }
-
   public getParentGrid(): AutoGridLayout {
     if (!(this.parent instanceof AutoGridLayout)) {
       throw new Error('Parent is not a AutoGridLayout');
     }
-
     return this.parent;
   }
-
-  public getBoundingBox(): { width: number; height: number; top: number; left: number } {
+  public getBoundingBox(): {
+    width: number;
+    height: number;
+    top: number;
+    left: number;
+  } {
     const rect = this.containerRef.current!.getBoundingClientRect();
-
     return {
       width: rect.width,
       height: rect.height,
@@ -189,13 +155,10 @@ export class AutoGridItem extends SceneObjectBase<AutoGridItemState> implements 
       left: this.containerRef.current!.offsetLeft,
     };
   }
-
   public handleEditChange() {
     this._prevRepeatValues = undefined;
-
     this.performRepeat();
   }
-
   public scrollIntoView() {
     scrollCanvasElementIntoView(this, this.containerRef);
   }

--- a/public/app/features/dashboard-scene/scene/layout-auto-grid/AutoGridLayoutManager.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-auto-grid/AutoGridLayoutManager.tsx
@@ -1,3 +1,4 @@
+import { structLog } from '@grafana/data';
 import { AppEvents } from '@grafana/data';
 import { t } from '@grafana/i18n';
 import { config, getAppEvents } from '@grafana/runtime';
@@ -14,7 +15,6 @@ import { type Spec as DashboardV2Spec } from '@grafana/schema/apis/dashboard.gra
 import { GRID_CELL_VMARGIN } from 'app/core/constants';
 import { type OptionsPaneItemDescriptor } from 'app/features/dashboard/components/PanelEditor/OptionsPaneItemDescriptor';
 import DashboardEmpty from 'app/features/dashboard/dashgrid/DashboardEmpty/DashboardEmpty';
-
 import { dashboardEditActions, NewObjectAddedToCanvasEvent } from '../../edit-pane/shared';
 import { serializeAutoGridLayout } from '../../serialization/layoutSerializers/AutoGridLayoutSerializer';
 import { dashboardSceneGraph, type PanelIdGenerator } from '../../utils/dashboardSceneGraph';
@@ -32,11 +32,9 @@ import { type DashboardDropTarget } from '../types/DashboardDropTarget';
 import { type DashboardLayoutGrid } from '../types/DashboardLayoutGrid';
 import { type DashboardLayoutManager } from '../types/DashboardLayoutManager';
 import { type LayoutRegistryItem } from '../types/LayoutRegistryItem';
-
 import { AutoGridItem } from './AutoGridItem';
 import { AutoGridLayout } from './AutoGridLayout';
 import { getEditOptions } from './AutoGridLayoutManagerEditor';
-
 interface AutoGridLayoutManagerState extends SceneObjectState {
   layout: AutoGridLayout;
   maxColumnCount: number;
@@ -48,23 +46,18 @@ interface AutoGridLayoutManagerState extends SceneObjectState {
   /** Position index where a placeholder should be shown for external drops */
   dropPosition?: number | null;
 }
-
 export type AutoGridColumnWidth = 'narrow' | 'standard' | 'wide' | 'custom' | number;
 export type AutoGridRowHeight = 'short' | 'standard' | 'tall' | 'custom' | number;
-
 export const AUTO_GRID_DEFAULT_MAX_COLUMN_COUNT = 3;
 export const AUTO_GRID_DEFAULT_COLUMN_WIDTH = 'standard';
 export const AUTO_GRID_DEFAULT_ROW_HEIGHT = 'standard';
-
 export class AutoGridLayoutManager
   extends SceneObjectBase<AutoGridLayoutManagerState>
   implements DashboardLayoutGrid, DashboardDropTarget
 {
   public static Component = AutoGridLayoutManagerRenderer;
-
   public readonly isDashboardLayoutManager = true;
   public readonly isDashboardDropTarget = true as const;
-
   public static readonly descriptor: LayoutRegistryItem = {
     get name() {
       return t('dashboard.auto-grid.name', 'Auto');
@@ -77,19 +70,15 @@ export class AutoGridLayoutManager
     isGridLayout: true,
     icon: 'apps',
   };
-
   public serialize(isSnapshot?: boolean): DashboardV2Spec['layout'] {
     return serializeAutoGridLayout(this, isSnapshot);
   }
-
   public readonly descriptor = AutoGridLayoutManager.descriptor;
-
   public constructor(state: Partial<AutoGridLayoutManagerState>) {
     const maxColumnCount = state.maxColumnCount ?? AUTO_GRID_DEFAULT_MAX_COLUMN_COUNT;
     const columnWidth = state.columnWidth ?? AUTO_GRID_DEFAULT_COLUMN_WIDTH;
     const rowHeight = state.rowHeight ?? AUTO_GRID_DEFAULT_ROW_HEIGHT;
     const fillScreen = state.fillScreen ?? false;
-
     super({
       ...state,
       maxColumnCount,
@@ -105,25 +94,18 @@ export class AutoGridLayoutManager
         }),
     });
   }
-
   public getOutlineChildren(): SceneObject[] {
     const children: SceneObject[] = [];
-
     for (const child of this.state.layout.state.children) {
       children.push(child.state.body, ...(child.state.repeatedPanels || []));
     }
-
     return children;
   }
-
   public addPanel(vizPanel: VizPanel) {
     const panelId = dashboardSceneGraph.getNextPanelId(this);
-
     vizPanel.setState({ key: getVizPanelKeyForPanelId(panelId) });
     vizPanel.clearParent();
-
     const newGridItem = new AutoGridItem({ body: vizPanel });
-
     dashboardEditActions.addElement({
       addedObject: vizPanel,
       source: this,
@@ -137,10 +119,8 @@ export class AutoGridLayoutManager
       },
     });
   }
-
   public pastePanel() {
     let panel;
-
     try {
       panel = getAutoGridItemFromClipboard(getDashboardSceneFor(this));
     } catch (error) {
@@ -150,7 +130,6 @@ export class AutoGridLayoutManager
       });
       return;
     }
-
     if (config.featureToggles.dashboardNewLayouts) {
       dashboardEditActions.edit({
         description: t('dashboard.edit-actions.paste-panel', 'Paste panel'),
@@ -169,18 +148,14 @@ export class AutoGridLayoutManager
       this.state.layout.setState({ children: [...this.state.layout.state.children, panel] });
       this.publishEvent(new NewObjectAddedToCanvasEvent(panel), true);
     }
-
     clearClipboard();
   }
-
   public removePanel(panel: VizPanel) {
     const gridItem = panel.parent;
     if (!(gridItem instanceof AutoGridItem)) {
       return;
     }
-
     const gridItemIndex = this.state.layout.state.children.indexOf(gridItem);
-
     dashboardEditActions.removeElement({
       removedObject: panel,
       source: this,
@@ -200,15 +175,12 @@ export class AutoGridLayoutManager
       },
     });
   }
-
   // panelIdGenerator is a shared counter to ensure unique panel IDs across siblings.
   public duplicate(panelIdGenerator?: PanelIdGenerator): DashboardLayoutManager {
     const children = this.state.layout.state.children;
     const clonedChildren: AutoGridItem[] = [];
-
     if (children.length) {
       const nextId = panelIdGenerator ?? dashboardSceneGraph.getPanelIdGenerator(children[0].state.body);
-
       children.forEach((child) => {
         const clone = child.clone({
           key: undefined,
@@ -216,11 +188,9 @@ export class AutoGridLayoutManager
             key: getVizPanelKeyForPanelId(nextId()),
           }),
         });
-
         clonedChildren.push(clone);
       });
     }
-
     return this.clone({
       key: undefined,
       layout: this.state.layout.clone({
@@ -229,14 +199,12 @@ export class AutoGridLayoutManager
       }),
     });
   }
-
   public mergeGrid(other: DashboardLayoutGrid) {
     const sourceLayout =
       other instanceof AutoGridLayoutManager
         ? other.state.layout
         : AutoGridLayoutManager.createFromLayout(other).state.layout;
     const movedChildren = [...sourceLayout.state.children];
-
     // Remove from source and append to destination
     sourceLayout.setState({ children: [] });
     movedChildren.forEach((child) => {
@@ -244,120 +212,94 @@ export class AutoGridLayoutManager
     });
     this.state.layout.setState({ children: [...this.state.layout.state.children, ...movedChildren] });
   }
-
   public duplicatePanel(panel: VizPanel) {
     const gridItem = panel.parent;
     if (!(gridItem instanceof AutoGridItem)) {
-      console.error('Trying to duplicate a panel that is not inside a DashboardGridItem');
+      structLog('error', 'Trying to duplicate a panel that is not inside a DashboardGridItem');
       return;
     }
-
     const newPanelId = dashboardSceneGraph.getNextPanelId(this);
     const grid = this.state.layout;
-
     const newPanel = panel.clone({
       key: getVizPanelKeyForPanelId(newPanelId),
     });
-
     const newGridItem = gridItem.clone({
       key: getGridItemKeyForPanelId(newPanelId),
       body: newPanel,
     });
-
     const sourceIndex = grid.state.children.indexOf(gridItem);
     const newChildren = [...grid.state.children];
-
     // insert after
     newChildren.splice(sourceIndex + 1, 0, newGridItem);
-
     grid.setState({ children: newChildren });
-
     this.publishEvent(new NewObjectAddedToCanvasEvent(newPanel), true);
   }
-
   public getVizPanels(): VizPanel[] {
     const panels: VizPanel[] = [];
-
     for (const child of this.state.layout.state.children) {
       if (child instanceof AutoGridItem) {
         panels.push(child.state.body);
       }
     }
-
     return panels;
   }
-
   public editModeChanged(isEditing: boolean) {
     this.state.layout.setState({ isDraggable: isEditing });
     forceRenderChildren(this.state.layout, true);
   }
-
   public cloneLayout(ancestorKey: string, isSource: boolean): DashboardLayoutManager {
     return this.clone({});
   }
-
   public getOptions(): OptionsPaneItemDescriptor[] {
     return getEditOptions(this);
   }
-
   public onMaxColumnCountChanged(maxColumnCount: number) {
     this.setState({ maxColumnCount: maxColumnCount });
     this.state.layout.setState({
       templateColumns: getTemplateColumnsTemplate(maxColumnCount, this.state.columnWidth),
     });
   }
-
   public onColumnWidthChanged(columnWidth: AutoGridColumnWidth) {
     if (columnWidth === 'custom') {
       columnWidth = getNamedColumWidthInPixels(this.state.columnWidth);
     }
-
     this.setState({ columnWidth: columnWidth });
     this.state.layout.setState({
       templateColumns: getTemplateColumnsTemplate(this.state.maxColumnCount, this.state.columnWidth),
     });
   }
-
   public onFillScreenChanged(fillScreen: boolean) {
     this.setState({ fillScreen });
     this.state.layout.setState({
       autoRows: getAutoRowsTemplate(this.state.rowHeight, fillScreen),
     });
   }
-
   public onRowHeightChanged(rowHeight: AutoGridRowHeight) {
     if (rowHeight === 'custom') {
       rowHeight = getNamedHeightInPixels(this.state.rowHeight);
     }
-
     this.setState({ rowHeight });
     this.state.layout.setState({
       autoRows: getAutoRowsTemplate(rowHeight, this.state.fillScreen),
     });
   }
-
   public static createEmpty(): AutoGridLayoutManager {
     return new AutoGridLayoutManager({});
   }
-
   public static createFromLayout(layout: DashboardLayoutManager): AutoGridLayoutManager {
     const panels = layout.getVizPanels();
     const children: AutoGridItem[] = [];
-
     for (let panel of panels) {
       const variableName = panel.parent instanceof DashboardGridItem ? panel.parent.state.variableName : undefined;
       children.push(new AutoGridItem({ body: panel.clone(), variableName }));
     }
-
     const layoutManager = AutoGridLayoutManager.createEmpty();
     layoutManager.state.layout.setState({
       children,
       isDraggable: getDashboardSceneFor(layout).state.isEditing,
     });
-
     return layoutManager;
   }
-
   public addGridItem(gridItem: SceneGridItemLike): void {
     if (!(gridItem instanceof AutoGridItem)) {
       // If it's a DashboardGridItem, convert it to AutoGridItem
@@ -367,32 +309,25 @@ export class AutoGridLayoutManager
         }
         const panel = gridItem.state.body;
         panel.clearParent();
-
         const newGridItem = new AutoGridItem({
           body: panel,
           variableName: gridItem.state.variableName,
         });
-
         this.state.layout.setState({ children: [...this.state.layout.state.children, newGridItem] });
         return;
       }
       throw new Error('Grid item must be an AutoGridItem or DashboardGridItem');
     }
-
     // Clear parent before moving
     gridItem.clearParent();
-
     this.state.layout.setState({ children: [...this.state.layout.state.children, gridItem] });
   }
-
   public setIsDropTarget(isDropTarget: boolean): void {
     this.setState({ isDropTarget });
   }
-
   public setDropPosition(position: number | null): void {
     this.setState({ dropPosition: position });
   }
-
   public draggedGridItemOutside(gridItem: SceneGridItemLike): void {
     if (gridItem instanceof AutoGridItem) {
       this.state.layout.setState({
@@ -401,11 +336,9 @@ export class AutoGridLayoutManager
     }
     this.setState({ isDropTarget: false });
   }
-
   public draggedGridItemInside(gridItem: SceneGridItemLike, position?: number): void {
     trackDropItemCrossLayout(gridItem);
     let newGridItem: AutoGridItem;
-
     if (gridItem instanceof AutoGridItem) {
       gridItem.clearParent();
       newGridItem = gridItem;
@@ -415,7 +348,6 @@ export class AutoGridLayoutManager
       }
       const panel = gridItem.state.body;
       panel.clearParent();
-
       newGridItem = new AutoGridItem({
         body: panel,
         variableName: gridItem.state.variableName,
@@ -423,9 +355,7 @@ export class AutoGridLayoutManager
     } else {
       throw new Error('Grid item must be an AutoGridItem or DashboardGridItem');
     }
-
     const children = [...this.state.layout.state.children];
-
     if (position !== undefined && position >= 0 && position <= children.length) {
       // Insert at specific position
       children.splice(position, 0, newGridItem);
@@ -433,34 +363,27 @@ export class AutoGridLayoutManager
       // Append to end
       children.push(newGridItem);
     }
-
     this.state.layout.setState({ children });
     this.setState({ isDropTarget: false, dropPosition: null });
   }
 }
-
 function AutoGridLayoutManagerRenderer({ model }: SceneComponentProps<AutoGridLayoutManager>) {
   const dashboard = useDashboard(model);
   const { children } = useSceneObjectState(model.state.layout, { shouldActivateOrKeepAlive: true });
-
   if (model.parent === dashboard && children.length === 0) {
     return (
       <DashboardEmpty dashboard={dashboard} canCreate={!!dashboard.state.meta.canEdit} key="dashboard-empty-state" />
     );
   }
-
   return <model.state.layout.Component model={model.state.layout} />;
 }
-
 export function getTemplateColumnsTemplate(maxColumnCount: number, columnWidth: AutoGridColumnWidth) {
   return `repeat(auto-fit, minmax(min(max(100% / ${maxColumnCount} - ${GRID_CELL_VMARGIN}px, ${getNamedColumWidthInPixels(columnWidth)}px), 100%), 1fr))`;
 }
-
 function getNamedColumWidthInPixels(columnWidth: AutoGridColumnWidth) {
   if (typeof columnWidth === 'number') {
     return columnWidth;
   }
-
   switch (columnWidth) {
     case 'narrow':
       return 192;
@@ -472,12 +395,10 @@ function getNamedColumWidthInPixels(columnWidth: AutoGridColumnWidth) {
       return 448;
   }
 }
-
 function getNamedHeightInPixels(rowHeight: AutoGridRowHeight) {
   if (typeof rowHeight === 'number') {
     return rowHeight;
   }
-
   switch (rowHeight) {
     case 'short':
       return 168;
@@ -489,7 +410,6 @@ function getNamedHeightInPixels(rowHeight: AutoGridRowHeight) {
       return 320;
   }
 }
-
 export function getAutoRowsTemplate(rowHeight: AutoGridRowHeight, fillScreen: boolean) {
   const rowHeightPixels = getNamedHeightInPixels(rowHeight);
   const maxRowHeightValue = fillScreen ? 'auto' : `${rowHeightPixels}px`;

--- a/public/app/features/dashboard-scene/scene/layout-default/DashboardGridItem.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-default/DashboardGridItem.tsx
@@ -1,7 +1,7 @@
+import { structLog } from '@grafana/data';
 import { isEqual } from 'lodash';
 import React from 'react';
 import { type Unsubscribable } from 'rxjs';
-
 import {
   type VizPanel,
   SceneObjectBase,
@@ -16,18 +16,15 @@ import {
 } from '@grafana/scenes';
 import { GRID_COLUMN_COUNT } from 'app/core/constants';
 import { type OptionsPaneCategoryDescriptor } from 'app/features/dashboard/components/PanelEditor/OptionsPaneCategoryDescriptor';
-
 import { DashboardStateChangedEvent, RepeatsUpdatedEvent } from '../../edit-pane/shared';
 import { getCloneKey, getLocalVariableValueSet } from '../../utils/clone';
 import { getMultiVariableValues } from '../../utils/utils';
 import { scrollCanvasElementIntoView, scrollIntoView } from '../layouts-shared/scrollCanvasElementIntoView';
 import { type DashboardLayoutItem } from '../types/DashboardLayoutItem';
-
 import { getDashboardGridItemOptions } from './DashboardGridItemEditor';
 import { DashboardGridItemRenderer } from './DashboardGridItemRenderer';
 import { DashboardGridItemVariableDependencyHandler } from './DashboardGridItemVariableDependencyHandler';
 import { RowRepeaterBehavior } from './RowRepeaterBehavior';
-
 export interface DashboardGridItemState extends SceneGridItemStateLike {
   body: VizPanel;
   repeatedPanels?: VizPanel[];
@@ -36,109 +33,83 @@ export interface DashboardGridItemState extends SceneGridItemStateLike {
   repeatDirection?: RepeatDirection;
   maxPerRow?: number;
 }
-
 export type RepeatDirection = 'v' | 'h';
-
 export class DashboardGridItem
   extends SceneObjectBase<DashboardGridItemState>
   implements SceneGridItemLike, DashboardLayoutItem
 {
   public static Component = DashboardGridItemRenderer;
-
   protected _variableDependency = new DashboardGridItemVariableDependencyHandler(this);
-
   public readonly isDashboardLayoutItem = true;
   public containerRef = React.createRef<HTMLDivElement>();
-
   private _prevRepeatValues?: VariableValueSingle[];
   private _gridSizeSub: Unsubscribable | undefined;
-
   public constructor(state: DashboardGridItemState) {
     super(state);
-
     this.addActivationHandler(() => this._activationHandler());
   }
-
   private _activationHandler() {
     this.handleVariableName();
-
     this._subs.add(this.subscribeToEvent(DashboardStateChangedEvent, () => this.handleEditChange()));
-
     return () => {
       this._handleGridSizeUnsubscribe();
     };
   }
-
   private _handleGridSizeSubscribe() {
     if (!this._gridSizeSub) {
       this._gridSizeSub = this.subscribeToState((newState, prevState) => this._handleGridResize(newState, prevState));
     }
   }
-
   private _handleGridSizeUnsubscribe() {
     if (this._gridSizeSub) {
       this._gridSizeSub.unsubscribe();
       this._gridSizeSub = undefined;
     }
   }
-
   private _handleGridResize(newState: DashboardGridItemState, prevState: DashboardGridItemState) {
     if (newState.height === prevState.height) {
       return;
     }
-
     const stateChange: Partial<DashboardGridItemState> = {};
-
     if (this.getRepeatDirection() === 'v') {
       stateChange.itemHeight = Math.ceil(newState.height! / this.getChildCount());
     } else {
       const rowCount = Math.ceil(this.getChildCount() / this.getMaxPerRow());
       stateChange.itemHeight = Math.ceil(newState.height! / rowCount);
     }
-
     if (stateChange.itemHeight !== this.state.itemHeight) {
       this.setState(stateChange);
     }
   }
-
   public getChildCount() {
     return (this.state.repeatedPanels?.length ?? 0) + 1;
   }
-
   public getClassName(): string {
     return this.state.variableName ? 'panel-repeater-grid-item' : '';
   }
-
   public getOptions(): OptionsPaneCategoryDescriptor[] {
     return getDashboardGridItemOptions(this);
   }
-
   public setElementBody(body: VizPanel): void {
     this.setState({ body });
   }
-
   public handleEditChange() {
     this._prevRepeatValues = undefined;
-
     if (this.parent instanceof SceneGridRow) {
       const repeater = this.parent.state.$behaviors?.find((b) => b instanceof RowRepeaterBehavior);
       if (repeater) {
         repeater.resetPrevRepeatValues();
       }
     }
-
     if (this.state.variableName && this.state.repeatDirection === 'h' && this.state.width !== GRID_COLUMN_COUNT) {
       this.setState({ width: GRID_COLUMN_COUNT });
     }
-
     this.performRepeat();
   }
-
   public performRepeat() {
     if (!this.state.variableName || sceneGraph.hasVariableDependencyInLoadingState(this)) {
       return;
     }
-
     const variable =
       sceneGraph.lookupVariable(this.state.variableName, this) ??
       new CustomVariable({
@@ -148,31 +119,24 @@ export class DashboardGridItem
         text: '',
         query: 'A',
       });
-
     if (!(variable instanceof MultiValueVariable)) {
-      console.error('DashboardGridItem: Variable is not a MultiValueVariable');
+      structLog('error', 'DashboardGridItem: Variable is not a MultiValueVariable');
       return;
     }
-
     const { values, texts } = getMultiVariableValues(variable);
-
     if (isEqual(this._prevRepeatValues, values)) {
       return;
     }
-
     const panelToRepeat = this.state.body;
     const repeatedPanels: VizPanel[] = [];
-
     // when variable has no options (due to error or similar) it will not render any panels at all
     // adding a placeholder in this case so that there is at least empty panel that can display error
     const emptyVariablePlaceholderOption = {
       values: [''],
       texts: variable.hasAllValue() ? ['All'] : ['None'],
     };
-
     const variableValues = values.length ? values : emptyVariablePlaceholderOption.values;
     const variableTexts = texts.length ? texts : emptyVariablePlaceholderOption.texts;
-
     // Loop through variable values and create repeats
     for (let index = 0; index < variableValues.length; index++) {
       const isSource = index === 0;
@@ -182,30 +146,24 @@ export class DashboardGridItem
             key: getCloneKey(panelToRepeat.state.key!, index),
             repeatSourceKey: panelToRepeat.state.key,
           });
-
       clone.setState({ $variables: getLocalVariableValueSet(variable, variableValues[index], variableTexts[index]) });
-
       if (index > 0) {
         repeatedPanels.push(clone);
       }
     }
-
     const direction = this.getRepeatDirection();
     const stateChange: Partial<DashboardGridItemState> = { repeatedPanels: repeatedPanels };
     const itemHeight = this.state.itemHeight ?? 10;
     const prevHeight = this.state.height;
     const maxPerRow = this.getMaxPerRow();
     const panelCount = repeatedPanels.length + 1; // +1 for the source panel
-
     if (direction === 'h') {
       const rowCount = Math.ceil(panelCount / maxPerRow);
       stateChange.height = rowCount * itemHeight;
     } else {
       stateChange.height = panelCount * itemHeight;
     }
-
     this.setState(stateChange);
-
     if (prevHeight !== this.state.height) {
       const layout = sceneGraph.getLayout(this);
       if (layout instanceof SceneGridLayout) {
@@ -217,59 +175,45 @@ export class DashboardGridItem
         layout.forceRender();
       }
     }
-
     this._prevRepeatValues = values;
     this.publishEvent(new RepeatsUpdatedEvent(this), true);
   }
-
   public handleVariableName() {
     if (this.state.variableName) {
       this._handleGridSizeSubscribe();
     } else {
       this._handleGridSizeUnsubscribe();
     }
-
     this.performRepeat();
   }
-
   public setRepeatByVariable(variableName: string | undefined) {
     const stateUpdate: Partial<DashboardGridItemState> = { variableName };
-
     if (!variableName) {
       stateUpdate.repeatedPanels = undefined;
     }
-
     if (variableName && !this.state.repeatDirection) {
       stateUpdate.repeatDirection = 'h';
     }
-
     if (this.state.body.state.$variables) {
       this.state.body.setState({ $variables: undefined });
     }
-
     this.setState(stateUpdate);
   }
-
   public getMaxPerRow(): number {
     return this.state.maxPerRow ?? 4;
   }
-
   public setMaxPerRow(maxPerRow: number | undefined) {
     this.setState({ maxPerRow });
   }
-
   public getRepeatDirection(): RepeatDirection {
     return this.state.repeatDirection === 'v' ? 'v' : 'h';
   }
-
   public setRepeatDirection(repeatDirection: RepeatDirection) {
     this.setState({ repeatDirection });
   }
-
   public isRepeated(): boolean {
     return this.state.variableName !== undefined;
   }
-
   public scrollIntoView() {
     const gridItemEl = document.querySelector(`[data-griditem-key="${this.state.key}"`);
     if (gridItemEl instanceof HTMLElement) {

--- a/public/app/features/dashboard-scene/scene/layout-default/DefaultGridLayoutManager.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-default/DefaultGridLayoutManager.tsx
@@ -1,5 +1,5 @@
+import { structLog } from '@grafana/data';
 import { css, cx } from '@emotion/css';
-
 import { AppEvents, type GrafanaTheme2 } from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';
 import { t } from '@grafana/i18n';
@@ -22,7 +22,6 @@ import { type Spec as DashboardV2Spec } from '@grafana/schema/apis/dashboard.gra
 import { useStyles2 } from '@grafana/ui';
 import { GRID_COLUMN_COUNT } from 'app/core/constants';
 import DashboardEmpty from 'app/features/dashboard/dashgrid/DashboardEmpty/DashboardEmpty';
-
 import {
   dashboardEditActions,
   NewObjectAddedToCanvasEvent,
@@ -52,24 +51,19 @@ import { dashboardCanvasAddButtonHoverStyles } from '../layouts-shared/styles';
 import { type DashboardLayoutGrid } from '../types/DashboardLayoutGrid';
 import { type DashboardLayoutManager } from '../types/DashboardLayoutManager';
 import { type LayoutRegistryItem } from '../types/LayoutRegistryItem';
-
 import { DashboardGridItem } from './DashboardGridItem';
 import { RowRepeaterBehavior } from './RowRepeaterBehavior';
 import { findSpaceForNewPanel } from './findSpaceForNewPanel';
 import { RowActions } from './row-actions/RowActions';
-
 interface DefaultGridLayoutManagerState extends SceneObjectState {
   grid: SceneGridLayout;
 }
-
 export class DefaultGridLayoutManager
   extends SceneObjectBase<DefaultGridLayoutManagerState>
   implements DashboardLayoutGrid
 {
   public static Component = DefaultGridLayoutManagerRenderer;
-
   public readonly isDashboardLayoutManager = true;
-
   public static readonly descriptor: LayoutRegistryItem = {
     get name() {
       return t('dashboard.default-layout.name', 'Custom');
@@ -82,19 +76,14 @@ export class DefaultGridLayoutManager
     isGridLayout: true,
     icon: 'window-grid',
   };
-
   public serialize(isSnapshot?: boolean): DashboardV2Spec['layout'] {
     return serializeDefaultGridLayout(this, isSnapshot);
   }
-
   public readonly descriptor = DefaultGridLayoutManager.descriptor;
-
   public constructor(state: DefaultGridLayoutManagerState) {
     super(state);
-
     this.addActivationHandler(() => this._activationHandler());
   }
-
   public mergeGrid(other: DashboardLayoutGrid) {
     let offset = 0;
     for (const child of this.state.grid.state.children) {
@@ -103,18 +92,15 @@ export class DefaultGridLayoutManager
         offset = newOffset;
       }
     }
-
     const sourceGrid =
       other instanceof DefaultGridLayoutManager
         ? other.state.grid
         : DefaultGridLayoutManager.createFromLayout(other).state.grid;
     const movedChildren = [...sourceGrid.state.children];
-
     for (const child of movedChildren) {
       const currentY = child.state.y ?? 0;
       child.setState({ y: currentY + offset });
     }
-
     // Remove from source and append to destination
     sourceGrid.setState({ children: [] });
     for (const child of movedChildren) {
@@ -122,7 +108,6 @@ export class DefaultGridLayoutManager
     }
     this.state.grid.setState({ children: [...this.state.grid.state.children, ...movedChildren] });
   }
-
   private _activationHandler() {
     if (config.featureToggles.dashboardNewLayouts) {
       this._subs.add(
@@ -134,7 +119,6 @@ export class DefaultGridLayoutManager
         })
       );
     }
-
     this._subs.add(
       this.state.grid.subscribeToState(({ children: newChildren }, { children: prevChildren }) => {
         if (newChildren.length === prevChildren.length) {
@@ -143,13 +127,10 @@ export class DefaultGridLayoutManager
       })
     );
   }
-
   public addPanel(vizPanel: VizPanel) {
     const panelId = dashboardSceneGraph.getNextPanelId(this);
-
     vizPanel.setState({ key: getVizPanelKeyForPanelId(panelId) });
     vizPanel.clearParent();
-
     // With new edit mode we add panels to the bottom of the grid
     if (config.featureToggles.dashboardNewLayouts) {
       const emptySpace = findSpaceForNewPanel(this.state.grid);
@@ -158,7 +139,6 @@ export class DefaultGridLayoutManager
         body: vizPanel,
         key: getGridItemKeyForPanelId(panelId),
       });
-
       dashboardEditActions.addElement({
         addedObject: vizPanel,
         source: this,
@@ -180,15 +160,12 @@ export class DefaultGridLayoutManager
         body: vizPanel,
         key: getGridItemKeyForPanelId(panelId),
       });
-
       this.state.grid.setState({ children: [newGridItem, ...this.state.grid.state.children] });
     }
   }
-
   public pastePanel() {
     const emptySpace = findSpaceForNewPanel(this.state.grid);
     let newGridItem;
-
     try {
       newGridItem = getDashboardGridItemFromClipboard(getDashboardSceneFor(this), emptySpace);
     } catch (error) {
@@ -198,7 +175,6 @@ export class DefaultGridLayoutManager
       });
       return;
     }
-
     if (config.featureToggles.dashboardNewLayouts) {
       dashboardEditActions.edit({
         description: t('dashboard.edit-actions.paste-panel', 'Paste panel'),
@@ -216,39 +192,30 @@ export class DefaultGridLayoutManager
     } else {
       this.state.grid.setState({ children: [...this.state.grid.state.children, newGridItem] });
     }
-
     clearClipboard();
   }
-
   public removePanel(panel: VizPanel) {
     const gridItem = panel.parent!;
-
     if (!(gridItem instanceof DashboardGridItem)) {
       throw new Error('Trying to remove panel that is not inside a DashboardGridItem');
     }
-
     const layout = this.state.grid;
-
     let row: SceneGridRow | undefined;
-
     try {
       row = sceneGraph.getAncestor(gridItem, SceneGridRow);
     } catch {
       row = undefined;
     }
-
     if (row) {
       row.setState({ children: row.state.children.filter((child) => child !== gridItem) });
       layout.forceRender();
       return;
     }
-
     if (!config.featureToggles.dashboardNewLayouts) {
       // No undo/redo support in legacy edit mode
       layout.setState({ children: layout.state.children.filter((child) => child !== gridItem) });
       return;
     }
-
     dashboardEditActions.removeElement({
       removedObject: gridItem.state.body,
       source: this,
@@ -256,21 +223,17 @@ export class DefaultGridLayoutManager
       undo: () => layout.setState({ children: [...layout.state.children, gridItem] }),
     });
   }
-
   public duplicatePanel(vizPanel: VizPanel) {
     const gridItem = vizPanel.parent;
     if (!(gridItem instanceof DashboardGridItem)) {
-      console.error('Trying to duplicate a panel that is not inside a DashboardGridItem');
+      structLog('error', 'Trying to duplicate a panel that is not inside a DashboardGridItem');
       return;
     }
-
     let panelState;
     let panelData;
     let newGridItem;
-
     const newPanelId = dashboardSceneGraph.getNextPanelId(this);
     const grid = this.state.grid;
-
     if (gridItem instanceof DashboardGridItem) {
       panelState = sceneUtils.cloneSceneObjectState(gridItem.state.body.state);
       panelData = sceneGraph.getData(gridItem.state.body).clone();
@@ -278,16 +241,13 @@ export class DefaultGridLayoutManager
       panelState = sceneUtils.cloneSceneObjectState(vizPanel.state);
       panelData = sceneGraph.getData(vizPanel).clone();
     }
-
     // when we duplicate a panel we don't want to clone the alert state
     delete panelData.state.data?.alertState;
-
     const newPanel = new VizPanel({
       ...panelState,
       $data: panelData,
       key: getVizPanelKeyForPanelId(newPanelId),
     });
-
     newGridItem = new DashboardGridItem({
       x: gridItem.state.x,
       y: gridItem.state.y,
@@ -300,22 +260,18 @@ export class DefaultGridLayoutManager
       key: getGridItemKeyForPanelId(newPanelId),
       body: newPanel,
     });
-
     // No undo/redo support in legacy edit mode
     if (!config.featureToggles.dashboardNewLayouts) {
       if (gridItem.parent instanceof SceneGridRow) {
         const row = gridItem.parent;
-
         row.setState({ children: [...row.state.children, newGridItem] });
         grid.forceRender();
         return;
       }
-
       grid.setState({ children: [...grid.state.children, newGridItem] });
       this.publishEvent(new NewObjectAddedToCanvasEvent(newPanel), true);
       return;
     }
-
     const parent = gridItem.parent instanceof SceneGridRow ? gridItem.parent : grid;
     dashboardEditActions.edit({
       description: t('dashboard.edit-actions.duplicate-panel', 'Duplicate panel'),
@@ -334,17 +290,14 @@ export class DefaultGridLayoutManager
       },
     });
   }
-
   // panelIdGenerator is a shared counter to ensure unique panel IDs across siblings.
   public duplicate(panelIdGenerator?: PanelIdGenerator): DashboardLayoutManager {
     const children = this.state.grid.state.children;
     const hasGridItem = children.find((child) => child instanceof DashboardGridItem);
     const clonedChildren: SceneGridItemLike[] = [];
-
     if (children.length) {
       const nextId =
         panelIdGenerator ?? dashboardSceneGraph.getPanelIdGenerator(hasGridItem ? hasGridItem.state.body : this);
-
       children.forEach((child) => {
         if (child instanceof DashboardGridItem) {
           const clone = child.clone({
@@ -353,14 +306,12 @@ export class DefaultGridLayoutManager
               key: getVizPanelKeyForPanelId(nextId()),
             }),
           });
-
           clonedChildren.push(clone);
         } else {
           clonedChildren.push(child.clone({ key: undefined }));
         }
       });
     }
-
     const clone = this.clone({
       key: undefined,
       grid: this.state.grid.clone({
@@ -368,18 +319,14 @@ export class DefaultGridLayoutManager
         children: clonedChildren,
       }),
     });
-
     return clone;
   }
-
   public getVizPanels(): VizPanel[] {
     const panels: VizPanel[] = [];
-
     this.state.grid.forEachChild((child) => {
       if (!(child instanceof DashboardGridItem) && !(child instanceof SceneGridRow)) {
         throw new Error('Child is not a DashboardGridItem or SceneGridRow, invalid scene');
       }
-
       if (child instanceof DashboardGridItem && child.state.body instanceof VizPanel) {
         panels.push(child.state.body);
       } else if (child instanceof SceneGridRow) {
@@ -390,70 +337,55 @@ export class DefaultGridLayoutManager
         });
       }
     });
-
     return panels;
   }
-
   public addNewRow(): SceneGridRow {
     const id = dashboardSceneGraph.getNextPanelId(this);
-
     const row = new SceneGridRow({
       key: getVizPanelKeyForPanelId(id),
       title: t('dashboard-scene.default-grid-layout-manager.row.title.row-title', 'Row title'),
       actions: new RowActions({}),
       y: 0,
     });
-
     const sceneGridLayout = this.state.grid;
-
     // find all panels until the first row and put them into the newly created row. If there are no other rows,
     // add all panels to the row. If there are no panels just create an empty row
     const indexTillNextRow = sceneGridLayout.state.children.findIndex((child) => child instanceof SceneGridRow);
     const rowChildren = sceneGridLayout.state.children
       .splice(0, indexTillNextRow === -1 ? sceneGridLayout.state.children.length : indexTillNextRow)
       .map((child) => child.clone());
-
     if (rowChildren) {
       row.setState({ children: rowChildren });
     }
-
     sceneGridLayout.setState({ children: [row, ...sceneGridLayout.state.children] });
-
     this.publishEvent(new NewObjectAddedToCanvasEvent(row), true);
     return row;
   }
-
   public editModeChanged(isEditing: boolean) {
     const updateResizeAndDragging = () => {
       this.state.grid.setState({ isDraggable: isEditing, isResizable: isEditing });
       forceRenderChildren(this.state.grid, true);
     };
-
     if (config.featureToggles.dashboardNewLayouts) {
       // We do this in a timeout to wait a bit with enabling dragging as dragging enables grid animations
       // if we show the edit pane without animations it opens much faster and feels more responsive
       setTimeout(updateResizeAndDragging, 10);
       return;
     }
-
     updateResizeAndDragging();
   }
-
   public activateRepeaters() {
     if (!this.isActive) {
       this.activate();
     }
-
     if (!this.state.grid.isActive) {
       this.state.grid.activate();
     }
-
     this.state.grid.forEachChild((child) => {
       if (child instanceof DashboardGridItem && !child.isActive) {
         child.activate();
         return;
       }
-
       if (child instanceof SceneGridRow && child.state.$behaviors) {
         for (const behavior of child.state.$behaviors) {
           if (behavior instanceof RowRepeaterBehavior && !child.isActive) {
@@ -461,7 +393,6 @@ export class DefaultGridLayoutManager
             break;
           }
         }
-
         child.state.children.forEach((child) => {
           if (child instanceof DashboardGridItem && !child.isActive) {
             child.activate();
@@ -471,65 +402,50 @@ export class DefaultGridLayoutManager
       }
     });
   }
-
   public getOutlineChildren(): SceneObject[] {
     const children: SceneObject[] = [];
-
     for (const child of this.state.grid.state.children) {
       // Flatten repeated grid items
       if (child instanceof DashboardGridItem) {
         children.push(child.state.body, ...(child.state.repeatedPanels || []));
       }
     }
-
     return children;
   }
-
   public cloneLayout(ancestorKey: string, isSource: boolean): DashboardLayoutManager {
     return this.clone({});
   }
-
   public removeRow(row: SceneGridRow, removePanels = false) {
     const sceneGridLayout = this.state.grid;
-
     const children = sceneGridLayout.state.children.filter((child) => child.state.key !== row.state.key);
-
     if (!removePanels) {
       const rowChildren = row.state.children.map((child) => child.clone());
       const indexOfRow = sceneGridLayout.state.children.findIndex((child) => child.state.key === row.state.key);
-
       children.splice(indexOfRow, 0, ...rowChildren);
     }
-
     this.publishEvent(new ObjectRemovedFromCanvasEvent(row), true);
-
     sceneGridLayout.setState({ children });
   }
-
   public collapseAllRows() {
     this.state.grid.state.children.forEach((child) => {
       if (!(child instanceof SceneGridRow)) {
         return;
       }
-
       if (!child.state.isCollapsed) {
         this.state.grid.toggleRow(child);
       }
     });
   }
-
   public expandAllRows() {
     this.state.grid.state.children.forEach((child) => {
       if (!(child instanceof SceneGridRow)) {
         return;
       }
-
       if (child.state.isCollapsed) {
         this.state.grid.toggleRow(child);
       }
     });
   }
-
   public addGridItem(gridItem: SceneGridItemLike): void {
     if (!(gridItem instanceof DashboardGridItem)) {
       // If it's an AutoGridItem, convert it to DashboardGridItem
@@ -539,7 +455,6 @@ export class DefaultGridLayoutManager
         }
         const panel = gridItem.state.body;
         panel.clearParent();
-
         const emptySpace = findSpaceForNewPanel(this.state.grid);
         const newGridItem = new DashboardGridItem({
           x: emptySpace?.x ?? 0,
@@ -550,17 +465,14 @@ export class DefaultGridLayoutManager
           body: panel,
           variableName: gridItem.state.variableName,
         });
-
         this.state.grid.setState({ children: [...this.state.grid.state.children, newGridItem] });
         return;
       }
       throw new Error('Grid item must be a DashboardGridItem or AutoGridItem');
     }
-
     // Move the whole grid item to another CustomGrid
     // Clear parent before moving
     gridItem.clearParent();
-
     // Find empty space for the grid item, preserving its size
     const emptySpace = findSpaceForNewPanel(this.state.grid);
     if (emptySpace) {
@@ -571,15 +483,12 @@ export class DefaultGridLayoutManager
         // Keep original width and height
       });
     }
-
     this.state.grid.setState({ children: [...this.state.grid.state.children, gridItem] });
   }
-
   public static createFromLayout(currentLayout: DashboardLayoutManager): DefaultGridLayoutManager {
     const panels = currentLayout.getVizPanels();
     return DefaultGridLayoutManager.fromVizPanels(panels);
   }
-
   public static createEmpty(): DefaultGridLayoutManager {
     return new DefaultGridLayoutManager({
       grid: new SceneGridLayout({
@@ -589,19 +498,15 @@ export class DefaultGridLayoutManager
       }),
     });
   }
-
   public static fromVizPanels(panels: VizPanel[] = []): DefaultGridLayoutManager {
     const children: DashboardGridItem[] = [];
     const panelHeight = 10;
     const panelWidth = GRID_COLUMN_COUNT / 3;
     let currentY = 0;
     let currentX = 0;
-
     for (let panel of panels) {
       const variableName = panel.parent instanceof AutoGridItem ? panel.parent.state.variableName : undefined;
-
       panel.clearParent();
-
       children.push(
         new DashboardGridItem({
           key: getGridItemKeyForPanelId(getPanelIdForVizPanel(panel)),
@@ -614,15 +519,12 @@ export class DefaultGridLayoutManager
           variableName,
         })
       );
-
       currentX += panelWidth;
-
       if (currentX + panelWidth > GRID_COLUMN_COUNT) {
         currentX = 0;
         currentY += panelHeight;
       }
     }
-
     return new DefaultGridLayoutManager({
       grid: new SceneGridLayout({
         children: children,
@@ -631,7 +533,6 @@ export class DefaultGridLayoutManager
       }),
     });
   }
-
   public static fromGridItems(
     gridItems: SceneGridItemLike[],
     isDraggable?: boolean,
@@ -640,10 +541,8 @@ export class DefaultGridLayoutManager
     const children = gridItems.reduce<SceneGridItemLike[]>((acc, gridItem) => {
       gridItem.clearParent();
       acc.push(gridItem);
-
       return acc;
     }, []);
-
     return new DefaultGridLayoutManager({
       grid: new SceneGridLayout({
         children,
@@ -653,7 +552,6 @@ export class DefaultGridLayoutManager
     });
   }
 }
-
 function DefaultGridLayoutManagerRenderer({ model }: SceneComponentProps<DefaultGridLayoutManager>) {
   const { children } = useSceneObjectState(model.state.grid, { shouldActivateOrKeepAlive: true });
   const dashboard = useDashboard(model);
@@ -662,18 +560,15 @@ function DefaultGridLayoutManagerRenderer({ model }: SceneComponentProps<Default
   const styles = useStyles2(getStyles);
   const showCanvasActions = isEditing && config.featureToggles.dashboardNewLayouts && !hasClonedParents;
   const soloPanelContext = useSoloPanelContext();
-
   if (soloPanelContext) {
     return children.map((child) => <child.Component model={child} key={child.state.key!} />);
   }
-
   // If we are top level layout and we have no children, show empty state
   if (model.parent === dashboard && children.length === 0) {
     return (
       <DashboardEmpty dashboard={dashboard} canCreate={!!dashboard.state.meta.canEdit} key="dashboard-empty-state" />
     );
   }
-
   return (
     <div
       className={cx(styles.container, isEditing && styles.containerEditing)}
@@ -688,21 +583,16 @@ function DefaultGridLayoutManagerRenderer({ model }: SceneComponentProps<Default
     </div>
   );
 }
-
 const OriginalSceneGridRowRenderer = SceneGridRow.Component;
 // @ts-expect-error
 SceneGridRow.Component = SceneGridRowRenderer;
-
 function SceneGridRowRenderer({ model }: SceneComponentProps<SceneGridRow>) {
   const soloPanelContext = useSoloPanelContext();
-
   if (soloPanelContext) {
     return model.state.children.map((child) => <child.Component model={child} key={child.state.key!} />);
   }
-
   return <OriginalSceneGridRowRenderer model={model} />;
 }
-
 function getStyles(theme: GrafanaTheme2) {
   return {
     container: css({
@@ -715,7 +605,6 @@ function getStyles(theme: GrafanaTheme2) {
       '&:hover .dashboard-canvas-controls': {
         opacity: 1,
       },
-
       // In editing the add actions should live at the bottom of the grid so we have to
       // disable flex grow on the SceneGridLayouts first div
       '> div:first-child': {

--- a/public/app/features/dashboard-scene/scene/layout-default/RowRepeaterBehavior.ts
+++ b/public/app/features/dashboard-scene/scene/layout-default/RowRepeaterBehavior.ts
@@ -1,5 +1,5 @@
+import { structLog } from '@grafana/data';
 import { isEqual } from 'lodash';
-
 import {
   MultiValueVariable,
   sceneGraph,
@@ -11,123 +11,92 @@ import {
   VariableDependencyConfig,
   type VariableValueSingle,
 } from '@grafana/scenes';
-
 import { getCloneKey, getLocalVariableValueSet } from '../../utils/clone';
 import { getMultiVariableValues } from '../../utils/utils';
-
 interface RowRepeaterBehaviorState extends SceneObjectState {
   variableName: string;
 }
-
 export class RowRepeaterBehavior extends SceneObjectBase<RowRepeaterBehaviorState> {
   protected _variableDependency = new VariableDependencyConfig(this, {
     variableNames: [this.state.variableName],
     onVariableUpdateCompleted: () => this.performRepeat(),
   });
-
   private _prevRepeatValues?: VariableValueSingle[];
   private _clonedRows?: SceneGridRow[];
-
   public constructor(state: RowRepeaterBehaviorState) {
     super(state);
-
     this.addActivationHandler(() => this._activationHandler());
   }
-
   private _activationHandler() {
     this.performRepeat();
-
     const layout = this._getLayout();
     const originalRow = this._getRow();
-
     const sub = layout.subscribeToState(() => {
       const repeatedRows = layout.state.children.filter(
         (child) => child instanceof SceneGridRow && child.state.repeatSourceKey === originalRow.state.key
       );
-
       // go through cloned rows, search for panels that are not clones
       for (const row of repeatedRows) {
         if (!(row instanceof SceneGridRow)) {
           continue;
         }
-
         // if no differences in row children compared to original, then no new panel added to clone
         if (row.state.children.length === originalRow.state.children.length) {
           continue;
         }
-
         this.performRepeat(true);
       }
     });
-
     return () => {
       sub.unsubscribe();
     };
   }
-
   private _getRow(): SceneGridRow {
     if (!(this.parent instanceof SceneGridRow)) {
       throw new Error('RepeatedRowBehavior: Parent is not a SceneGridRow');
     }
-
     return this.parent;
   }
-
   private _getLayout(): SceneGridLayout {
     const layout = sceneGraph.getLayout(this);
-
     if (!(layout instanceof SceneGridLayout)) {
       throw new Error('RepeatedRowBehavior: Layout is not a SceneGridLayout');
     }
-
     return layout;
   }
-
   public performRepeat(force = false) {
     if (this._variableDependency.hasDependencyInLoadingState()) {
       return;
     }
-
     const variable = sceneGraph.lookupVariable(this.state.variableName, this.parent?.parent!);
-
     if (!variable) {
-      console.error('RepeatedRowBehavior: Variable not found');
+      structLog('error', 'RepeatedRowBehavior: Variable not found');
       return;
     }
-
     if (!(variable instanceof MultiValueVariable)) {
-      console.error('RepeatedRowBehavior: Variable is not a MultiValueVariable');
+      structLog('error', 'RepeatedRowBehavior: Variable is not a MultiValueVariable');
       return;
     }
-
     const rowToRepeat = this._getRow();
     const layout = this._getLayout();
     const { values, texts } = getMultiVariableValues(variable);
-
     // Do nothing if values are the same
     if (isEqual(this._prevRepeatValues, values) && !force) {
       return;
     }
-
     this._prevRepeatValues = values;
-
     this._clonedRows = [];
-
     const rowContent = rowToRepeat.state.children;
     const rowContentHeight = getRowContentHeight(rowContent);
-
     let maxYOfRows = 0;
-
     // when variable has no options (due to error or similar) it will not render any panels at all
     // adding a placeholder in this case so that there is at least empty panel that can display error
     const emptyVariablePlaceholderOption = {
       values: [''],
       texts: variable.hasAllValue() ? ['All'] : ['None'],
     };
-
     const variableValues = values.length ? values : emptyVariablePlaceholderOption.values;
     const variableTexts = texts.length ? texts : emptyVariablePlaceholderOption.texts;
-
     for (let rowIndex = 0; rowIndex < variableValues.length; rowIndex++) {
       const isSourceRow = rowIndex === 0;
       const rowClone = isSourceRow
@@ -139,64 +108,48 @@ export class RowRepeaterBehavior extends SceneObjectBase<RowRepeaterBehaviorStat
             $behaviors: [],
             actions: undefined,
           });
-
       rowClone.setState({
         $variables: getLocalVariableValueSet(variable, variableValues[rowIndex], variableTexts[rowIndex]),
         children: [],
       });
-
       const children: SceneGridItemLike[] = [];
-
       for (const sourceItem of rowContent) {
         const sourceItemY = sourceItem.state.y ?? 0;
         const cloneItem = rowIndex > 0 ? sourceItem.clone() : sourceItem;
         const cloneItemY = sourceItemY + (rowContentHeight + 1) * rowIndex;
-
         // Update grid item keys on clone rows (not needed on source row)
         // Needed to not have duplicate grid items keys in the same grid
         if (rowIndex > 0) {
           cloneItem.setState({ y: cloneItemY, key: rowClone.state.key + sourceItem.state.key! });
         }
-
         children.push(cloneItem);
-
         if (maxYOfRows < cloneItemY + cloneItem.state.height!) {
           maxYOfRows = cloneItemY + cloneItem.state.height!;
         }
       }
-
       rowClone.setState({ children });
-
       this._clonedRows.push(rowClone);
     }
-
     updateLayout(layout, this._clonedRows, maxYOfRows, rowToRepeat.state.key!);
   }
-
   public removeBehavior() {
     const row = this._getRow();
     const layout = this._getLayout();
     const children = getLayoutChildrenFilterOutRepeatClones(layout, row.state.key!);
-
     layout.setState({ children: children });
-
     // Remove behavior and the scoped local variable
     row.setState({ $behaviors: row.state.$behaviors!.filter((b) => b !== this), $variables: undefined });
   }
-
   public resetPrevRepeatValues() {
     this._prevRepeatValues = undefined;
   }
 }
-
 function getRowContentHeight(panels: SceneGridItemLike[]): number {
   let maxY = 0;
   let minY = Number.MAX_VALUE;
-
   if (panels.length === 0) {
     return 0;
   }
-
   for (const panel of panels) {
     if (panel.state.y! + panel.state.height! > maxY) {
       maxY = panel.state.y! + panel.state.height!;
@@ -205,29 +158,22 @@ function getRowContentHeight(panels: SceneGridItemLike[]): number {
       minY = panel.state.y!;
     }
   }
-
   return maxY - minY;
 }
-
 function updateLayout(layout: SceneGridLayout, rows: SceneGridRow[], maxYOfRows: number, rowKey: string) {
   const allChildren = getLayoutChildrenFilterOutRepeatClones(layout, rowKey);
   const index = allChildren.findIndex((child) => child instanceof SceneGridRow && child.state.key === rowKey);
-
   if (index === -1) {
     throw new Error('RowRepeaterBehavior: Parent row not found in layout children');
   }
-
   const newChildren = [...allChildren.slice(0, index), ...rows, ...allChildren.slice(index + 1)];
-
   // Is there grid items after rows?
   if (allChildren.length > index + 1) {
     const childrenAfter = allChildren.slice(index + 1);
     const firstChildAfterY = childrenAfter[0].state.y!;
     const diff = maxYOfRows - firstChildAfterY;
-
     for (const child of childrenAfter) {
       child.setState({ y: child.state.y! + diff });
-
       if (child instanceof SceneGridRow) {
         for (const rowChild of child.state.children) {
           rowChild.setState({ y: rowChild.state.y! + diff });
@@ -235,10 +181,8 @@ function updateLayout(layout: SceneGridLayout, rows: SceneGridRow[], maxYOfRows:
       }
     }
   }
-
   layout.setState({ children: newChildren });
 }
-
 function getLayoutChildrenFilterOutRepeatClones(layout: SceneGridLayout, rowKey: string) {
   return layout.state.children.filter(
     (child) => !(child instanceof SceneGridRow) || child.state.repeatSourceKey !== rowKey

--- a/public/app/features/dashboard-scene/scene/layout-rows/RowItem.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-rows/RowItem.tsx
@@ -1,5 +1,5 @@
+import { structLog } from '@grafana/data';
 import React from 'react';
-
 import { store } from '@grafana/data';
 import { t } from '@grafana/i18n';
 import { logWarning } from '@grafana/runtime';
@@ -19,7 +19,6 @@ import { appEvents } from 'app/core/app_events';
 import { LS_ROW_COPY_KEY } from 'app/core/constants';
 import kbn from 'app/core/utils/kbn';
 import { ShowConfirmModalEvent } from 'app/types/events';
-
 import { ConditionalRenderingGroup } from '../../conditional-rendering/group/ConditionalRenderingGroup';
 import { dashboardEditActions } from '../../edit-pane/shared';
 import { serializeRow } from '../../serialization/layoutSerializers/RowsLayoutSerializer';
@@ -40,12 +39,10 @@ import { isDashboardLayoutGrid } from '../types/DashboardLayoutGrid';
 import { type DashboardLayoutManager } from '../types/DashboardLayoutManager';
 import { type EditableDashboardElement, type EditableDashboardElementInfo } from '../types/EditableDashboardElement';
 import { type LayoutParent } from '../types/LayoutParent';
-
 import { useEditOptions } from './RowItemEditor';
 import { RowItemRenderer } from './RowItemRenderer';
 import { RowItems } from './RowItems';
 import { RowsLayoutManager } from './RowsLayoutManager';
-
 export interface RowItemState extends SceneObjectState {
   layout: DashboardLayoutManager;
   title?: string;
@@ -59,21 +56,17 @@ export interface RowItemState extends SceneObjectState {
   /** Marks object as a repeated object and a key pointer to source object */
   repeatSourceKey?: string;
 }
-
 export class RowItem
   extends SceneObjectBase<RowItemState>
   implements LayoutParent, BulkActionElement, EditableDashboardElement, DashboardDropTarget
 {
   public static Component = RowItemRenderer;
-
   protected _variableDependency = new VariableDependencyConfig(this, {
     statePaths: ['title'],
   });
-
   public readonly isEditableDashboardElement = true;
   public readonly isDashboardDropTarget = true;
   public containerRef: React.MutableRefObject<HTMLDivElement | null> = React.createRef<HTMLDivElement>();
-
   public constructor(state?: Partial<RowItemState>) {
     super({
       ...state,
@@ -81,20 +74,16 @@ export class RowItem
       layout: state?.layout ?? AutoGridLayoutManager.createEmpty(),
       conditionalRendering: state?.conditionalRendering ?? ConditionalRenderingGroup.createEmpty(),
     });
-
     this.addActivationHandler(() => this._activationHandler());
   }
-
   private _activationHandler() {
     const deactivate = this.state.conditionalRendering?.activate();
-
     return () => {
       if (deactivate) {
         deactivate();
       }
     };
   }
-
   public getEditableElementInfo(): EditableDashboardElementInfo {
     const isHidden = !this.state.conditionalRendering?.state.result;
     return {
@@ -104,7 +93,6 @@ export class RowItem
       isHidden,
     };
   }
-
   public getOutlineChildren(isEditing?: boolean): SceneObject[] {
     const layoutChildren = this.state.layout.getOutlineChildren();
     if (
@@ -116,18 +104,14 @@ export class RowItem
     }
     return layoutChildren;
   }
-
   public getLayout(): DashboardLayoutManager {
     return this.state.layout;
   }
-
   public getSlug(): string {
     return kbn.slugifyForUrl(interpolateSectionTitle(this, this.state.title ?? 'Row'));
   }
-
   public switchLayout(layout: DashboardLayoutManager) {
     const currentLayout = this.state.layout;
-
     dashboardEditActions.edit({
       description: t('dashboard.edit-actions.switch-layout-row', 'Switch layout'),
       source: this,
@@ -141,19 +125,15 @@ export class RowItem
       },
     });
   }
-
   public useEditPaneOptions = useEditOptions.bind(this);
-
   public onDelete() {
     this.getParentLayout().removeRow(this);
   }
-
   public onConfirmDelete() {
     if (this.getLayout().getVizPanels().length === 0) {
       this.onDelete();
       return;
     }
-
     appEvents.publish(
       new ShowConfirmModalEvent({
         title: t('dashboard.rows-layout.delete-row-title', 'Delete row?'),
@@ -168,38 +148,30 @@ export class RowItem
       })
     );
   }
-
   public createMultiSelectedElement(items: SceneObject[]): RowItems {
     return new RowItems(items.filter((item) => item instanceof RowItem));
   }
-
   public onDuplicate() {
     this.getParentLayout().duplicateRow(this);
   }
-
   // panelIdGenerator is a shared sequential counter created by the parent layout
   // we forward id to ensure sibling tabs never produce duplicate panel IDs
   public duplicate(panelIdGenerator?: PanelIdGenerator): RowItem {
     return this.clone({ key: undefined, layout: this.getLayout().duplicate(panelIdGenerator) });
   }
-
   public serialize(): RowsLayoutRowKind {
     return serializeRow(this);
   }
-
   public onCopy() {
     const elements = getElements(this.getLayout(), getDashboardSceneFor(this));
-
     clearClipboard();
     store.set(LS_ROW_COPY_KEY, JSON.stringify({ elements, row: this.serialize() }));
   }
-
   public setIsDropTarget(isDropTarget: boolean) {
     if (!!this.state.isDropTarget !== isDropTarget) {
       this.setState({ isDropTarget });
     }
   }
-
   public draggedGridItemOutside?(gridItem: SceneGridItemLike): void {
     // Remove from source layout
     if (gridItem instanceof DashboardGridItem || gridItem instanceof AutoGridItem) {
@@ -212,10 +184,8 @@ export class RowItem
         if (wasDraggable) {
           layout.setState({ isDraggable: false });
         }
-
         const newChildren = layout.state.children.filter((child) => child !== gridItem);
         layout.setState({ children: newChildren });
-
         // Restore isDraggable after a microtask to ensure react-grid-layout processes the change
         if (wasDraggable) {
           queueMicrotask(() => {
@@ -227,43 +197,36 @@ export class RowItem
         layout.setState({ children: newChildren });
       } else {
         const warningMessage = 'Grid item has unexpected parent type';
-        console.warn(warningMessage);
+        structLog('warn', warningMessage);
         logWarning(warningMessage);
       }
     }
     this.setIsDropTarget(false);
   }
-
   public draggedGridItemInside(gridItem: SceneGridItemLike): void {
     trackDropItemCrossLayout(gridItem);
     const layout = this.getLayout();
-
     if (isDashboardLayoutGrid(layout)) {
       layout.addGridItem(gridItem);
     } else {
       const warningMessage = 'Layout manager does not support addGridItem';
-      console.warn(warningMessage);
+      structLog('warn', warningMessage);
       logWarning(warningMessage);
     }
     this.setIsDropTarget(false);
   }
-
   public onChangeTitle(title: string) {
     this.setState({ title });
   }
-
   public onChangeName(name: string) {
     this.onChangeTitle(name);
   }
-
   public onHeaderHiddenToggle(hideHeader = !this.state.hideHeader) {
     this.setState({ hideHeader });
   }
-
   public onChangeFillScreen(fillScreen: boolean) {
     this.setState({ fillScreen });
   }
-
   public onChangeRepeat(repeat: string | undefined) {
     if (repeat) {
       this.setState({ repeatByVariable: repeat });
@@ -275,27 +238,21 @@ export class RowItem
       });
     }
   }
-
   public onCollapseToggle() {
     this.setState({ collapse: !this.state.collapse });
   }
-
   public getParentLayout(): RowsLayoutManager {
     return sceneGraph.getAncestor(this, RowsLayoutManager);
   }
-
   public scrollIntoView() {
     scrollCanvasElementIntoView(this, this.containerRef);
   }
-
   public getCollapsedState(): boolean {
     return this.state.collapse ?? false;
   }
-
   public setCollapsedState(collapse: boolean) {
     this.setState({ collapse });
   }
-
   public hasUniqueTitle(): boolean {
     const parentLayout = this.getParentLayout();
     const duplicateTitles = parentLayout.duplicateTitles();

--- a/public/app/features/dashboard-scene/scene/layout-tabs/TabItem.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-tabs/TabItem.tsx
@@ -1,5 +1,5 @@
+import { structLog } from '@grafana/data';
 import React from 'react';
-
 import { store } from '@grafana/data';
 import { t } from '@grafana/i18n';
 import { logWarning } from '@grafana/runtime';
@@ -19,7 +19,6 @@ import { appEvents } from 'app/core/app_events';
 import { LS_TAB_COPY_KEY } from 'app/core/constants';
 import kbn from 'app/core/utils/kbn';
 import { ShowConfirmModalEvent } from 'app/types/events';
-
 import { ConditionalRenderingGroup } from '../../conditional-rendering/group/ConditionalRenderingGroup';
 import { dashboardEditActions } from '../../edit-pane/shared';
 import { serializeTab } from '../../serialization/layoutSerializers/TabsLayoutSerializer';
@@ -42,12 +41,10 @@ import { isDashboardLayoutGrid } from '../types/DashboardLayoutGrid';
 import { type DashboardLayoutManager } from '../types/DashboardLayoutManager';
 import { type EditableDashboardElement, type EditableDashboardElementInfo } from '../types/EditableDashboardElement';
 import { type LayoutParent } from '../types/LayoutParent';
-
 import { useEditOptions } from './TabItemEditor';
 import { TabItemRenderer } from './TabItemRenderer';
 import { TabItems } from './TabItems';
 import { TabsLayoutManager } from './TabsLayoutManager';
-
 export interface TabItemState extends SceneObjectState {
   layout: DashboardLayoutManager;
   title?: string;
@@ -58,22 +55,17 @@ export interface TabItemState extends SceneObjectState {
   /** Marks object as a repeated object and a key pointer to source object */
   repeatSourceKey?: string;
 }
-
 export class TabItem
   extends SceneObjectBase<TabItemState>
   implements LayoutParent, BulkActionElement, EditableDashboardElement, DashboardDropTarget
 {
   public static Component = TabItemRenderer;
-
   protected _variableDependency = new VariableDependencyConfig(this, {
     statePaths: ['title'],
   });
-
   public readonly isEditableDashboardElement = true;
   public readonly isDashboardDropTarget = true;
-
   public containerRef = React.createRef<HTMLDivElement>();
-
   constructor(state?: Partial<TabItemState>) {
     super({
       ...state,
@@ -81,20 +73,16 @@ export class TabItem
       layout: state?.layout ?? AutoGridLayoutManager.createEmpty(),
       conditionalRendering: state?.conditionalRendering ?? ConditionalRenderingGroup.createEmpty(),
     });
-
     this.addActivationHandler(() => this._activationHandler());
   }
-
   private _activationHandler() {
     const deactivate = this.state.conditionalRendering?.activate();
-
     return () => {
       if (deactivate) {
         deactivate();
       }
     };
   }
-
   public getEditableElementInfo(): EditableDashboardElementInfo {
     const isHidden = !this.state.conditionalRendering?.state.result;
     return {
@@ -104,7 +92,6 @@ export class TabItem
       isHidden,
     };
   }
-
   public getOutlineChildren(isEditing?: boolean): SceneObject[] {
     const layoutChildren = this.state.layout.getOutlineChildren();
     if (
@@ -116,18 +103,14 @@ export class TabItem
     }
     return layoutChildren;
   }
-
   public getLayout(): DashboardLayoutManager {
     return this.state.layout;
   }
-
   public getSlug(): string {
     return kbn.slugifyForUrl(interpolateSectionTitle(this, this.state.title ?? 'Tab'));
   }
-
   public switchLayout(layout: DashboardLayoutManager) {
     const currentLayout = this.state.layout;
-
     dashboardEditActions.edit({
       description: t('dashboard.edit-actions.switch-layout-tab', 'Switch layout'),
       source: this,
@@ -141,20 +124,16 @@ export class TabItem
       },
     });
   }
-
   public useEditPaneOptions = useEditOptions.bind(this);
-
   public onDelete() {
     const layout = this.getParentLayout();
     layout.removeTab(this);
   }
-
   public onConfirmDelete() {
     if (this.getLayout().getVizPanels().length === 0) {
       this.onDelete();
       return;
     }
-
     appEvents.publish(
       new ShowConfirmModalEvent({
         title: t('dashboard.tabs-layout.delete-tab-title', 'Delete tab?'),
@@ -169,41 +148,33 @@ export class TabItem
       })
     );
   }
-
   public serialize(): TabsLayoutTabKind {
     return serializeTab(this);
   }
-
   public onCopy() {
     const elements = getElements(this.getLayout(), getDashboardSceneFor(this));
     clearClipboard();
     store.set(LS_TAB_COPY_KEY, JSON.stringify({ elements, tab: this.serialize() }));
   }
-
   public createMultiSelectedElement(items: SceneObject[]): TabItems {
     return new TabItems(items.filter((item) => item instanceof TabItem));
   }
-
   public onDuplicate(): void {
     this.getParentLayout().duplicateTab(this);
   }
-
   // panelIdGenerator is a shared sequential counter created by the parent layout
   // we forward id to ensure sibling tabs never produce duplicate panel IDs
   public duplicate(panelIdGenerator?: PanelIdGenerator): TabItem {
     return this.clone({ key: undefined, layout: this.getLayout().duplicate(panelIdGenerator) });
   }
-
   public onChangeTitle(title: string) {
     this.setState({ title });
     const currentTabSlug = this.getSlug();
     this.getParentLayout().setState({ currentTabSlug });
   }
-
   public onChangeName(name: string): void {
     this.onChangeTitle(name);
   }
-
   public onChangeRepeat(repeat: string | undefined) {
     if (repeat) {
       this.setState({ repeatByVariable: repeat });
@@ -215,13 +186,11 @@ export class TabItem
       });
     }
   }
-
   public setIsDropTarget(isDropTarget: boolean) {
     if (!!this.state.isDropTarget !== isDropTarget) {
       this.setState({ isDropTarget });
     }
   }
-
   public draggedGridItemOutside?(gridItem: SceneGridItemLike): void {
     // Remove from source layout
     if (gridItem instanceof DashboardGridItem || gridItem instanceof AutoGridItem) {
@@ -234,17 +203,15 @@ export class TabItem
         layout.setState({ children: newChildren });
       } else {
         const warningMessage = 'Grid item has unexpected parent type';
-        console.warn(warningMessage);
+        structLog('warn', warningMessage);
         logWarning(warningMessage);
       }
     }
     this.setIsDropTarget(false);
   }
-
   public draggedGridItemInside(gridItem: SceneGridItemLike): void {
     trackDropItemCrossLayout(gridItem);
     const layout = this.getLayout();
-
     if (isDashboardLayoutGrid(layout)) {
       layout.addGridItem(gridItem);
     } else if (layout instanceof RowsLayoutManager) {
@@ -256,40 +223,35 @@ export class TabItem
           rowLayout.addGridItem(gridItem);
         } else {
           const warningMessage = 'First row layout does not support addGridItem';
-          console.warn(warningMessage);
+          structLog('warn', warningMessage);
           logWarning(warningMessage);
         }
       }
     } else {
       const warningMessage = 'Layout manager does not support addGridItem';
-      console.warn(warningMessage);
+      structLog('warn', warningMessage);
       logWarning(warningMessage);
     }
     this.setIsDropTarget(false);
-
     const parentLayout = this.getParentLayout();
     if (parentLayout.state.currentTabSlug !== this.getSlug()) {
       parentLayout.setState({ currentTabSlug: this.getSlug() });
     }
   }
-
   /**
    * Accept a dropped row into this tab.
    * If the tab doesn't have a RowsLayoutManager, convert the layout first.
    */
   public acceptDroppedRow(row: RowItem): void {
     const currentLayout = this.getLayout();
-
     // Clear the parent reference from the row before adding to new layout
     row.clearParent();
-
     if (currentLayout instanceof RowsLayoutManager) {
       // Already has a RowsLayoutManager, just add the row
       currentLayout.addNewRow(row);
     } else {
       // Need to convert the layout to RowsLayoutManager
       let rowsLayout: RowsLayoutManager;
-
       // If the current layout is empty, just create a new RowsLayoutManager with only the dropped row
       if (currentLayout.getVizPanels().length === 0) {
         rowsLayout = new RowsLayoutManager({ rows: [row] });
@@ -300,34 +262,27 @@ export class TabItem
         rowsLayout = RowsLayoutManager.createFromLayout(currentLayout);
         rowsLayout.setState({ rows: [...rowsLayout.state.rows, row] });
       }
-
       // Clear the parent reference from the old layout
       currentLayout.clearParent();
-
       // Switch to the new rows layout
       this.setState({ layout: rowsLayout });
     }
-
     // Ensure this tab is active after the drop
     const parentLayout = this.getParentLayout();
     if (parentLayout.state.currentTabSlug !== this.getSlug()) {
       parentLayout.setState({ currentTabSlug: this.getSlug() });
     }
   }
-
   public getParentLayout(): TabsLayoutManager {
     return sceneGraph.getAncestor(this, TabsLayoutManager);
   }
-
   public scrollIntoView(): void {
     const tabsLayout = this.getParentLayout();
     if (tabsLayout.getCurrentTab() !== this) {
       tabsLayout.switchToTab(this);
     }
-
     scrollCanvasElementIntoView(this, this.containerRef);
   }
-
   public hasUniqueTitle(): boolean {
     const parentLayout = this.getParentLayout();
     const duplicateTitles = parentLayout.duplicateTitles();

--- a/public/app/features/dashboard-scene/serialization/DashboardSceneSerializer.ts
+++ b/public/app/features/dashboard-scene/serialization/DashboardSceneSerializer.ts
@@ -1,3 +1,4 @@
+import { structLog } from '@grafana/data';
 import { logWarning } from '@grafana/runtime';
 import { type Dashboard } from '@grafana/schema';
 import { type Spec as DashboardV2Spec } from '@grafana/schema/apis/dashboard.grafana.app/v2';
@@ -14,23 +15,29 @@ import {
 } from 'app/features/dashboard/utils/tracking';
 import { type DashboardJson } from 'app/features/manage-dashboards/types';
 import { type DashboardMeta, type SaveDashboardResponseDTO } from 'app/types/dashboard';
-
 import { getRawDashboardChanges, getRawDashboardV2Changes } from '../saving/getDashboardChanges';
 import { type DashboardChangeInfo } from '../saving/shared';
 import { type DashboardScene } from '../scene/DashboardScene';
 import { makeExportableV1, makeExportableV2 } from '../scene/export/exporters';
 import { getVariablesCompatibility } from '../utils/getVariablesCompatibility';
 import { getVizPanelKeyForPanelId } from '../utils/utils';
-
 import { transformSceneToSaveModel } from './transformSceneToSaveModel';
 import { transformSceneToSaveModelSchemaV2 } from './transformSceneToSaveModelSchemaV2';
-
 /**
  * T is the type of the save model
  * M is the type of the metadata
  * I is the type of the initial save model. By default it's the same as T.
  */
-export interface DashboardSceneSerializerLike<T, M, I = T, E = T | { error: unknown }> {
+export interface DashboardSceneSerializerLike<
+  T,
+  M,
+  I = T,
+  E =
+    | T
+    | {
+        error: unknown;
+      },
+> {
   /**
    * The save model which the dashboard scene was originally created from
    */
@@ -58,10 +65,14 @@ export interface DashboardSceneSerializerLike<T, M, I = T, E = T | { error: unkn
   getElementIdForPanel: (panelId: number) => string | undefined;
   getElementPanelMapping: () => Map<string, number>;
   getDSReferencesMapping: () => DSReferencesMapping;
-  makeExportableExternally: (s: DashboardScene) => Promise<E | { error: unknown }>;
+  makeExportableExternally: (s: DashboardScene) => Promise<
+    | E
+    | {
+        error: unknown;
+      }
+  >;
   getK8SMetadata: () => Partial<ObjectMeta> | undefined;
 }
-
 export interface DashboardTrackingInfo {
   uid?: string;
   title?: string;
@@ -71,7 +82,6 @@ export interface DashboardTrackingInfo {
   settings_nowdelay?: number;
   settings_livenow?: boolean;
 }
-
 export interface DynamicDashboardsTrackingInformation {
   panelCount: number;
   rowCount: number;
@@ -86,12 +96,10 @@ export interface DynamicDashboardsTrackingInformation {
   dashStructure: string;
   panelsByDatasourceType: Record<string, number>;
 }
-
 interface DynamicDashboardTrackingInformationStructureNode {
   kind: string;
   children?: DynamicDashboardTrackingInformationStructureNode[];
 }
-
 interface DynamicDashboardsTrackingInformationLayoutParsing
   extends Omit<
     DynamicDashboardsTrackingInformation,
@@ -99,7 +107,6 @@ interface DynamicDashboardsTrackingInformationLayoutParsing
   > {
   dashStructure: DynamicDashboardTrackingInformationStructureNode[];
 }
-
 export interface DSReferencesMapping {
   // panel id as keys, map as value. Map<refId, group> as value, if undefined, it means the datasource type was not defined
   panels: Map<string, Map<string, string | undefined>>;
@@ -108,7 +115,6 @@ export interface DSReferencesMapping {
   // annotation name as keys, group as value, if undefined, it means the datasource type was not defined
   annotations: Map<string, string | undefined>;
 }
-
 export class V1DashboardSerializer
   implements DashboardSceneSerializerLike<Dashboard, DashboardMeta, Dashboard, DashboardJson>
 {
@@ -120,10 +126,8 @@ export class V1DashboardSerializer
     variables: new Map(),
     annotations: new Map(),
   };
-
   initializeElementMapping(saveModel: Dashboard | undefined) {
     this.elementPanelMap.clear();
-
     if (!saveModel || !saveModel.panels) {
       return;
     }
@@ -134,24 +138,19 @@ export class V1DashboardSerializer
       }
     });
   }
-
   getElementPanelMapping() {
     return this.elementPanelMap;
   }
-
   initializeDSReferencesMapping(saveModel: Dashboard | undefined) {
     // To be implemented in a different PR
     return {};
   }
-
   getDSReferencesMapping() {
     return this.defaultDsReferencesMap;
   }
-
   getPanelIdForElement(elementId: string) {
     return this.elementPanelMap.get(elementId);
   }
-
   getElementIdForPanel(panelId: number) {
     // First try to find an existing mapping
     for (const [elementId, id] of this.elementPanelMap.entries()) {
@@ -159,21 +158,17 @@ export class V1DashboardSerializer
         return elementId;
       }
     }
-
     // For runtime-created panels, generate a new element identifier
     const newElementId = getVizPanelKeyForPanelId(panelId);
     // Store the new mapping for future lookups
     this.elementPanelMap.set(newElementId, panelId);
     return newElementId;
   }
-
   getSaveModel(s: DashboardScene) {
     return transformSceneToSaveModel(s);
   }
-
   getSaveAsModel(s: DashboardScene, options: SaveDashboardAsOptions) {
     const saveModel = this.getSaveModel(s);
-
     return {
       ...saveModel,
       id: null,
@@ -183,7 +178,6 @@ export class V1DashboardSerializer
       tags: options.copyTags === false ? [] : saveModel.tags,
     };
   }
-
   getDashboardChangesFromScene(
     scene: DashboardScene,
     options: {
@@ -202,9 +196,7 @@ export class V1DashboardSerializer
       options.saveVariables,
       options.saveRefresh
     );
-
     const hasFolderChanges = scene.getInitialState()?.meta.folderUid !== scene.state.meta.folderUid;
-
     return {
       ...changeInfo,
       hasFolderChanges,
@@ -212,7 +204,6 @@ export class V1DashboardSerializer
       hasMigratedToV2: false,
     };
   }
-
   onSaveComplete(saveModel: Dashboard, result: SaveDashboardResponseDTO): void {
     this.initialSaveModel = {
       ...saveModel,
@@ -227,16 +218,13 @@ export class V1DashboardSerializer
       },
     };
   }
-
   getK8SMetadata() {
     return this.metadata?.k8s;
   }
-
   getTrackingInformation(): DashboardTrackingInfo | undefined {
     const panelTypes = this.initialSaveModel?.panels?.map((p) => p.type) || [];
     const panels = getPanelPluginCounts(panelTypes);
     const variables = getV1SchemaVariables(this.initialSaveModel?.templating?.list || []);
-
     if (this.initialSaveModel) {
       return {
         uid: this.initialSaveModel.uid,
@@ -251,16 +239,13 @@ export class V1DashboardSerializer
     }
     return undefined;
   }
-
   getDynamicDashboardsTrackingInformation(): undefined {
     // We don't have dynamic dashboards in V1 schema
     return undefined;
   }
-
   getSnapshotUrl() {
     return this.initialSaveModel?.snapshot?.originalUrl;
   }
-
   async makeExportableExternally(s: DashboardScene) {
     const saveModel = this.getSaveModel(s);
     const oldModel = new DashboardModel(saveModel, undefined, {
@@ -271,7 +256,6 @@ export class V1DashboardSerializer
     return await makeExportableV1(oldModel);
   }
 }
-
 export class V2DashboardSerializer
   implements
     DashboardSceneSerializerLike<
@@ -289,18 +273,14 @@ export class V2DashboardSerializer
     variables: new Map(),
     annotations: new Map(),
   };
-
   getElementPanelMapping() {
     return this.elementPanelMap;
   }
-
   initializeElementMapping(saveModel: DashboardV2Spec | undefined) {
     this.elementPanelMap.clear();
-
     if (!saveModel || !saveModel.elements) {
       return;
     }
-
     const elementKeys = Object.keys(saveModel.elements);
     elementKeys.forEach((key) => {
       const elementPanel = saveModel.elements[key];
@@ -309,7 +289,6 @@ export class V2DashboardSerializer
       }
     });
   }
-
   initializeDSReferencesMapping(saveModel: DashboardV2Spec | undefined) {
     // The saveModel could be undefined or not a DashboardV2Spec
     // when dashboardsNewLayout is enabled, saveModel could be v1
@@ -319,7 +298,6 @@ export class V2DashboardSerializer
     }
     // initialize the object
     this.defaultDsReferencesMap = { panels: new Map(), variables: new Map(), annotations: new Map() };
-
     // initialize autossigned panel queries ds references map
     const elementKeys = Object.keys(saveModel?.elements || {});
     elementKeys.forEach((key) => {
@@ -327,21 +305,18 @@ export class V2DashboardSerializer
       if (elementPanel?.kind === 'Panel') {
         // check if the elementPanel.spec.datasource is defined
         const panelQueries = elementPanel.spec.data.spec.queries;
-
         for (const query of panelQueries) {
           if (!query.spec.query.datasource?.name) {
             // Datasources without UID. Here we're saving elements with only type!
             const elementId = this.getElementIdForPanel(elementPanel.spec.id);
             const panelDsqueries = this.defaultDsReferencesMap.panels.get(elementId) || new Map();
             const datasourceType = query.spec.query.group || undefined;
-
             panelDsqueries.set(query.spec.refId, datasourceType);
             this.defaultDsReferencesMap.panels.set(elementId, panelDsqueries);
           }
         }
       }
     });
-
     // initialize autossigned variable ds references map
     if (saveModel?.variables) {
       for (const variable of saveModel.variables) {
@@ -353,12 +328,11 @@ export class V2DashboardSerializer
           }
         } else {
           const warningMsg = 'Dashboard serializer: Undefined variable found in dashboard save model, ignoring it';
-          console.warn(warningMsg);
+          structLog('warn', warningMsg);
           logWarning(warningMsg);
         }
       }
     }
-
     // initialize annotations ds references map
     if (saveModel?.annotations) {
       for (const annotation of saveModel.annotations) {
@@ -369,15 +343,12 @@ export class V2DashboardSerializer
       }
     }
   }
-
   getDSReferencesMapping() {
     return this.defaultDsReferencesMap;
   }
-
   getPanelIdForElement(elementId: string) {
     return this.elementPanelMap.get(elementId);
   }
-
   getElementIdForPanel(panelId: number) {
     // First try to find an existing mapping
     for (const [elementId, id] of this.elementPanelMap.entries()) {
@@ -385,18 +356,15 @@ export class V2DashboardSerializer
         return elementId;
       }
     }
-
     // For runtime-created panels, generate a new element identifier
     const newElementId = getVizPanelKeyForPanelId(panelId);
     // Store the new mapping for future lookups
     this.elementPanelMap.set(newElementId, panelId);
     return newElementId;
   }
-
   getSaveModel(s: DashboardScene) {
     return transformSceneToSaveModelSchemaV2(s);
   }
-
   getSaveAsModel(s: DashboardScene, options: SaveDashboardAsOptions) {
     const saveModel = this.getSaveModel(s);
     return {
@@ -406,7 +374,6 @@ export class V2DashboardSerializer
       tags: options.copyTags === false ? [] : saveModel.tags,
     };
   }
-
   getDashboardChangesFromScene(
     scene: DashboardScene,
     options: {
@@ -425,10 +392,8 @@ export class V2DashboardSerializer
       options.saveVariables,
       options.saveRefresh
     );
-
     const hasFolderChanges = scene.getInitialState()?.meta.folderUid !== scene.state.meta.folderUid;
     const isNew = !Boolean(scene.getInitialState()?.uid);
-
     return {
       ...changeInfo,
       hasFolderChanges,
@@ -437,7 +402,6 @@ export class V2DashboardSerializer
       hasMigratedToV2: !!changeInfo.hasMigratedToV2,
     };
   }
-
   onSaveComplete(saveModel: DashboardV2Spec, result: SaveDashboardResponseDTO): void {
     this.initialSaveModel = {
       ...saveModel,
@@ -449,32 +413,26 @@ export class V2DashboardSerializer
       };
     }
   }
-
   getK8SMetadata() {
     return this.metadata;
   }
-
   getTrackingInformation(s: DashboardScene): DashboardTrackingInfo | undefined {
     if (!this.initialSaveModel) {
       return undefined;
     }
-
     const panelPluginIds =
       'elements' in this.initialSaveModel
         ? Object.values(this.initialSaveModel.elements).reduce<string[]>((acc, e) => {
             if (e.kind !== 'Panel') {
               return acc;
             }
-
             acc.push(e.spec.vizConfig.group);
-
             return acc;
           }, [])
         : [];
     const panels = getPanelPluginCounts(panelPluginIds);
     const variables =
       'variables' in this.initialSaveModel! ? getV2SchemaVariables(this.initialSaveModel.variables) : [];
-
     const rowCount =
       'layout' in this.initialSaveModel
         ? this.initialSaveModel.layout.kind === 'RowsLayout'
@@ -493,12 +451,10 @@ export class V2DashboardSerializer
       ...variables,
     };
   }
-
   getDynamicDashboardsTrackingInformation(): DynamicDashboardsTrackingInformation | undefined {
     if (!this.initialSaveModel || !isDashboardV2Spec(this.initialSaveModel)) {
       return undefined;
     }
-
     const dashStructure: DynamicDashboardTrackingInformationStructureNode[] = [];
     const result = this._parseDynamicDashboardsLayouts(
       {
@@ -517,7 +473,6 @@ export class V2DashboardSerializer
       0,
       dashStructure
     );
-
     return {
       ...result,
       dashStructure: JSON.stringify(result.dashStructure),
@@ -527,15 +482,12 @@ export class V2DashboardSerializer
           if (kind !== 'Panel') {
             return panelsAcc;
           }
-
           return panelSpec.data.spec.queries.reduce((queriesAcc, { spec: querySpec }) => {
             if (!querySpec.query.datasource) {
               return queriesAcc;
             }
-
             queriesAcc[querySpec.query.group] = queriesAcc[querySpec.query.group] ?? 0;
             queriesAcc[querySpec.query.group]++;
-
             return queriesAcc;
           }, panelsAcc);
         },
@@ -543,15 +495,12 @@ export class V2DashboardSerializer
       ),
     };
   }
-
   getSnapshotUrl() {
     return this.metadata?.annotations?.[AnnoKeyDashboardSnapshotOriginalUrl];
   }
-
   async makeExportableExternally(s: DashboardScene) {
     return await makeExportableV2(this.getSaveModel(s));
   }
-
   private _parseDynamicDashboardsLayouts(
     result: DynamicDashboardsTrackingInformationLayoutParsing,
     layout: DashboardV2Spec['layout'],
@@ -559,14 +508,12 @@ export class V2DashboardSerializer
     structureTarget: DynamicDashboardTrackingInformationStructureNode[]
   ): DynamicDashboardsTrackingInformationLayoutParsing {
     result.maxNestingLevel = Math.max(result.maxNestingLevel, nestingLevel);
-
     switch (layout.kind) {
       case 'GridLayout':
         result.customGridLayoutCount++;
         result.panelCount += layout.spec.items.length;
         structureTarget.push(...layout.spec.items.map(() => ({ kind: 'panel' })));
         return result;
-
       case 'AutoGridLayout':
         result.autoLayoutCount++;
         result.panelCount += layout.spec.items.length;
@@ -576,7 +523,6 @@ export class V2DashboardSerializer
           result.conditionalRenderRulesCount
         );
         return result;
-
       case 'RowsLayout':
         result.rowsLayoutCount++;
         result.rowCount += layout.spec.rows.length;
@@ -589,7 +535,6 @@ export class V2DashboardSerializer
             ? acc
             : this._parseDynamicDashboardsLayouts(acc, row.spec.layout, rowsNextingLevel, children);
         }, result);
-
       case 'TabsLayout':
         result.tabsLayoutCount++;
         result.tabCount += layout.spec.tabs.length;
@@ -602,13 +547,11 @@ export class V2DashboardSerializer
             ? acc
             : this._parseDynamicDashboardsLayouts(acc, tab.spec.layout, tabsNextingLevel, children);
         }, result);
-
       default:
         return result;
     }
   }
 }
-
 export function getDashboardSceneSerializer(): DashboardSceneSerializerLike<
   Dashboard,
   DashboardMeta,
@@ -637,6 +580,5 @@ export function getDashboardSceneSerializer(
   if (version === 'v2') {
     return new V2DashboardSerializer();
   }
-
   return new V1DashboardSerializer();
 }

--- a/public/app/features/dashboard-scene/serialization/angularMigration.ts
+++ b/public/app/features/dashboard-scene/serialization/angularMigration.ts
@@ -1,8 +1,7 @@
+import { structLog } from '@grafana/data';
 import { defaults, cloneDeep } from 'lodash';
-
 import { type PanelModel as PanelModelFromData, type PanelPlugin } from '@grafana/data';
 import { autoMigrateAngular, type PanelModel } from 'app/features/dashboard/state/PanelModel';
-
 /**
  * Data structure for Angular migration information stored in v2 schema options.
  */
@@ -12,7 +11,6 @@ export interface AngularMigrationData {
   /** Angular-specific options not part of the Panel schema */
   originalOptions: Record<string, unknown>;
 }
-
 /**
  * Type guard to check if an unknown value is AngularMigrationData.
  */
@@ -23,33 +21,29 @@ export function isAngularMigrationData(value: unknown): value is AngularMigratio
   if (!('autoMigrateFrom' in value) || !('originalOptions' in value)) {
     return false;
   }
-
   const { autoMigrateFrom, originalOptions } = value;
   return typeof autoMigrateFrom === 'string' && typeof originalOptions === 'object';
 }
-
 export function getAngularPanelMigrationHandler(oldModel: PanelModel) {
   return function handleAngularPanelMigrations(panel: PanelModelFromData, plugin: PanelPlugin) {
     if ('angularPanelCtrl' in plugin && plugin.angularPanelCtrl) {
       panel.options = { angularOptions: oldModel.getOptionsToRemember() };
       return;
     }
-
     if (!oldModel.options || Object.keys(oldModel.options).length === 0) {
       defaults(panel, oldModel.getOptionsToRemember());
-
       // Some plugins rely on being able to access targets to set up the fieldConfig when migrating from angular.
       const targetClone = cloneDeep(oldModel.targets);
       Object.defineProperty(panel, 'targets', {
         get: function () {
-          console.warn(
+          structLog(
+            'warn',
             'Accessing the targets property when migrating a panel plugin is deprecated. Changes to this property will be ignored.'
           );
           return targetClone;
         },
       });
     }
-
     if (oldModel.autoMigrateFrom) {
       const wasAngular = autoMigrateAngular[oldModel.autoMigrateFrom] != null;
       const oldOptions = oldModel.getOptionsToRemember();
@@ -61,7 +55,6 @@ export function getAngularPanelMigrationHandler(oldModel: PanelModel) {
     }
   };
 }
-
 /**
  * Returns a migration handler for v2 schema panels that need Angular migrations.
  *
@@ -88,13 +81,11 @@ export function getV2AngularMigrationHandler(migrationData: AngularMigrationData
   return function handleV2AngularMigration(panel: PanelModelFromData, plugin: PanelPlugin) {
     const { autoMigrateFrom, originalOptions } = migrationData;
     const wasAngular = autoMigrateAngular[autoMigrateFrom] != null;
-
     // Handle plugins that still use angularPanelCtrl
     if ('angularPanelCtrl' in plugin && plugin.angularPanelCtrl) {
       panel.options = { angularOptions: originalOptions };
       return;
     }
-
     // Spread originalOptions onto the panel object.
     // This is critical for plugins that use setMigrationHandler (like text panel) which expect
     // Angular properties (content, mode, etc.) to be directly on the panel object.
@@ -102,19 +93,18 @@ export function getV2AngularMigrationHandler(migrationData: AngularMigrationData
     if (originalOptions && Object.keys(originalOptions).length > 0) {
       defaults(panel, originalOptions);
     }
-
     // Some plugins rely on being able to access targets to set up the fieldConfig when migrating from angular.
     // Proxy the targets property with a deprecation warning.
     const targetClone = cloneDeep(panel.targets);
     Object.defineProperty(panel, 'targets', {
       get: function () {
-        console.warn(
+        structLog(
+          'warn',
           'Accessing the targets property when migrating a panel plugin is deprecated. Changes to this property will be ignored.'
         );
         return targetClone;
       },
     });
-
     // For panels with onPanelTypeChanged (e.g., singlestat -> stat), call the handler
     if (plugin.onPanelTypeChanged) {
       // For Angular panels, wrap in { angular: ... } to match expected format

--- a/public/app/features/dashboard-scene/serialization/layoutSerializers/utils.ts
+++ b/public/app/features/dashboard-scene/serialization/layoutSerializers/utils.ts
@@ -1,3 +1,4 @@
+import { structLog } from '@grafana/data';
 import { getNextRefId } from '@grafana/data';
 import { config } from '@grafana/runtime';
 import { getPanelPluginMetasMapSync, type PanelPluginMetas } from '@grafana/runtime/internal';
@@ -26,7 +27,6 @@ import {
 } from '@grafana/schema/apis/dashboard.grafana.app/v2';
 import { SHARED_DASHBOARD_QUERY } from 'app/plugins/datasource/dashboard/constants';
 import { MIXED_DATASOURCE_NAME } from 'app/plugins/datasource/mixed/MixedDataSource';
-
 import { ConditionalRenderingGroup } from '../../conditional-rendering/group/ConditionalRenderingGroup';
 import { DashboardDatasourceBehaviour } from '../../scene/DashboardDatasourceBehaviour';
 import { type DashboardScene } from '../../scene/DashboardScene';
@@ -47,32 +47,25 @@ import { createElements, vizPanelToSchemaV2 } from '../transformSceneToSaveModel
 import { transformMappingsToV1 } from '../transformToV1TypesUtils';
 import { transformDataTopic } from '../transformToV2TypesUtils';
 import { normalizeTransformation } from '../transformationCompat';
-
 export function buildVizPanel(panel: PanelKind, id?: number): VizPanel {
   const titleItems: SceneObject[] = [];
-
   titleItems.push(
     new VizPanelLinks({
       rawLinks: panel.spec.links,
       menu: new VizPanelLinksMenu({ $behaviors: [panelLinksBehavior] }),
     })
   );
-
   titleItems.push(new PanelNotices());
-
   const queryOptions = panel.spec.data.spec.queryOptions;
   const timeOverrideShown = (queryOptions.timeFrom || queryOptions.timeShift) && !queryOptions.hideTimeOverride;
-
   // Extract __angularMigration data if present
   // This data is used to run Angular panel migrations in v2 (e.g., singlestat -> stat)
   const rawOptions = panel.spec.vizConfig.spec.options ?? {};
   const rawAngularMigration = rawOptions.__angularMigration;
   const angularMigration = isAngularMigrationData(rawAngularMigration) ? rawAngularMigration : undefined;
-
   // Create clean options without __angularMigration (it's only for migration, not for the panel)
   const options = { ...rawOptions };
   delete options.__angularMigration;
-
   const vizPanelState: VizPanelState = {
     key: getVizPanelKeyForPanelId(id ?? panel.spec.id),
     title: panel.spec.title?.substring(0, 5000),
@@ -97,19 +90,16 @@ export function buildVizPanel(panel: PanelKind, id?: number): VizPanel {
     $behaviors: [],
     extendPanelContext: setDashboardPanelContext,
   };
-
   // Set up Angular migration handler if migration data is present
   // This enables proper migration of options from Angular panels (e.g., singlestat format/valueName)
   if (angularMigration) {
     vizPanelState._UNSAFE_customMigrationHandler = getV2AngularMigrationHandler(angularMigration);
   }
-
   if (!config.publicDashboardAccessToken) {
     vizPanelState.menu = new VizPanelMenu({
       $behaviors: [panelMenuBehavior],
     });
   }
-
   if (queryOptions.timeFrom || queryOptions.timeShift || queryOptions.timeCompare) {
     vizPanelState.$timeRange = new PanelTimeRange({
       timeFrom: queryOptions.timeFrom,
@@ -118,24 +108,18 @@ export function buildVizPanel(panel: PanelKind, id?: number): VizPanel {
       compareWith: queryOptions.timeCompare,
     });
   }
-
   vizPanelState._UNSAFE_clearPreviousFieldValues = Boolean(config.featureToggles.clearPreviousFieldValues);
-
   return new VizPanel(vizPanelState);
 }
-
 export function buildLibraryPanel(panel: LibraryPanelKind, id?: number): VizPanel {
   const titleItems: SceneObject[] = [];
-
   titleItems.push(
     new VizPanelLinks({
       rawLinks: [],
       menu: new VizPanelLinksMenu({ $behaviors: [panelLinksBehavior] }),
     })
   );
-
   titleItems.push(new PanelNotices());
-
   const vizPanelState: VizPanelState = {
     key: getVizPanelKeyForPanelId(id ?? panel.spec.id),
     titleItems,
@@ -162,24 +146,19 @@ export function buildLibraryPanel(panel: LibraryPanelKind, id?: number): VizPane
       overrides: [],
     },
   };
-
   if (!config.publicDashboardAccessToken) {
     vizPanelState.menu = new VizPanelMenu({
       $behaviors: [panelMenuBehavior],
     });
   }
-
   vizPanelState._UNSAFE_clearPreviousFieldValues = Boolean(config.featureToggles.clearPreviousFieldValues);
-
   return new VizPanel(vizPanelState);
 }
-
 export function createPanelDataProvider(
   panelKind: PanelKind,
   panelMetas: PanelPluginMetas = getPanelPluginMetasMapSync()
 ): SceneDataProvider | undefined {
   const panel = panelKind.spec;
-
   const targets =
     // Default to an array with an empty data query with a `refId` already assigned
     Array.isArray(panel.data?.spec.queries) && panel.data?.spec.queries.length > 0
@@ -189,18 +168,14 @@ export function createPanelDataProvider(
   if (!targets?.length) {
     return undefined;
   }
-
   // Skip setting query runner for panel plugins with skipDataQuery
   if (panelMetas[panel.vizConfig?.group]?.skipDataQuery) {
     return undefined;
   }
-
   // Ensure all queries have unique refIds before converting to scene queries
   const queriesWithUniqueRefIds = ensureUniqueRefIds(targets);
-
   let dataProvider: SceneDataProvider | undefined = undefined;
   const datasource = getPanelDataSource(panelKind);
-
   dataProvider = new SceneQueryRunner({
     datasource,
     queries: queriesWithUniqueRefIds.map(panelQueryKindToSceneQuery),
@@ -214,7 +189,6 @@ export function createPanelDataProvider(
     },
     $behaviors: [new DashboardDatasourceBehaviour({})],
   });
-
   // Wrap inner data provider in a data transformer
   return new SceneDataTransformer({
     $data: dataProvider,
@@ -228,7 +202,6 @@ export function createPanelDataProvider(
     }),
   });
 }
-
 /**
  * Get panel-level datasource for a v2beta1 panel.
  *
@@ -248,42 +221,34 @@ export function getPanelDataSource(panel: PanelKind): DataSourceRef | undefined 
   if (!queries?.length) {
     return undefined;
   }
-
   // Check if multiple queries use Dashboard datasource - this needs mixed mode
   const dashboardDsQueryCount = queries.filter((q) => q.spec.query.datasource?.name === SHARED_DASHBOARD_QUERY).length;
   if (dashboardDsQueryCount > 1) {
     return { type: 'mixed', uid: MIXED_DATASOURCE_NAME };
   }
-
   // Get all datasources from queries
   const datasources = queries.map((query) =>
     query.spec.query.datasource?.name
       ? { uid: query.spec.query.datasource.name, type: query.spec.query.group }
       : getRuntimePanelDataSource(query.spec.query)
   );
-
   const firstDatasource = datasources[0];
-
   // Check if queries use different datasources
   const isMixedDatasource = datasources.some(
     (ds) => ds?.uid !== firstDatasource?.uid || ds?.type !== firstDatasource?.type
   );
-
   if (isMixedDatasource) {
     return { type: 'mixed', uid: MIXED_DATASOURCE_NAME };
   }
-
   // Handle case where all queries use Dashboard datasource - needs to set datasource for proper data fetching
   // See DashboardDatasourceBehaviour.tsx for more details
   if (firstDatasource?.uid === SHARED_DASHBOARD_QUERY) {
     return { type: 'datasource', uid: SHARED_DASHBOARD_QUERY };
   }
-
   // Only return mixed datasource - for non-mixed panels, each query already has its own datasource
   // This matches the Go backend behavior which doesn't add panel.datasource for non-mixed panels
   return undefined;
 }
-
 /**
  * Get runtime datasource for a query variable.
  * For V2→V1 conversion consistency:
@@ -295,21 +260,17 @@ export function getPanelDataSource(panel: PanelKind): DataSourceRef | undefined 
 export function getRuntimeVariableDataSource(variable: QueryVariableKind): DataSourceRef | undefined {
   const explicitUid = variable.spec.query.datasource?.name;
   const queryType = variable.spec.query.group;
-
   // If explicit UID provided, resolve fully
   if (explicitUid) {
     return getDataSourceForQuery({ uid: explicitUid, type: queryType }, queryType);
   }
-
   // If only type provided (no explicit UID), return type-only to match backend V2→V1 conversion
   if (queryType) {
     return { type: queryType };
   }
-
   // Neither UID nor type - no datasource
   return undefined;
 }
-
 /**
  * Get runtime datasource for a panel query or annotation.
  * For V2→V1 conversion consistency:
@@ -321,21 +282,17 @@ export function getRuntimeVariableDataSource(variable: QueryVariableKind): DataS
 export function getRuntimePanelDataSource(query: DataQueryKind): DataSourceRef | undefined {
   const explicitUid = query.datasource?.name;
   const queryType = query.group;
-
   // If explicit UID provided, resolve fully
   if (explicitUid) {
     return getDataSourceForQuery({ uid: explicitUid, type: queryType }, queryType);
   }
-
   // If only type provided (no explicit UID), return type-only to match backend V2→V1 conversion
   if (queryType) {
     return { type: queryType };
   }
-
   // Neither UID nor type - no datasource
   return undefined;
 }
-
 /**
  * Resolves a datasource reference for a query.
  * @param querySpecDS - The datasource specified in the query
@@ -347,11 +304,9 @@ export function getDataSourceForQuery(querySpecDS: DataSourceRef | undefined | n
   if (querySpecDS?.uid) {
     return querySpecDS;
   }
-
   // Otherwise try to infer datasource based on query kind (kind = ds type)
   const defaultDatasource = config.defaultDatasource;
   const dsList = config.datasources;
-
   // First check if the default datasource matches the query type
   if (dsList && dsList[defaultDatasource] && dsList[defaultDatasource].meta.id === queryKind) {
     // In the datasource list from bootData "id" is the type and the uid could be uid or the name
@@ -361,18 +316,16 @@ export function getDataSourceForQuery(querySpecDS: DataSourceRef | undefined | n
       type: dsList[defaultDatasource].meta.id,
     };
   }
-
   // Look up by query type/kind from all available datasources
   const bestGuess = dsList && Object.values(dsList).find((ds) => ds.meta.id === queryKind);
-
   if (bestGuess) {
     return { uid: bestGuess.uid, type: bestGuess.meta.id };
   } else if (dsList && dsList[defaultDatasource]) {
     // Fallback to default datasource even if type doesn't match
     // In the datasource list from bootData "id" is the type and the uid could be uid or the name
     // in cases like grafana, dashboard or mixed datasource
-
-    console.warn(
+    structLog(
+      'warn',
       `Could not find datasource for query kind ${queryKind}, defaulting to ${dsList[defaultDatasource].meta.id}`
     );
     return {
@@ -380,11 +333,9 @@ export function getDataSourceForQuery(querySpecDS: DataSourceRef | undefined | n
       type: dsList[defaultDatasource].meta.id,
     };
   }
-
   if (dsList && !dsList[defaultDatasource]) {
     throw new Error(`Default datasource ${defaultDatasource} not found in datasource list`);
   }
-
   // In the datasource list from bootData "id" is the type and the uid could be uid or the name
   // in cases like grafana, dashboard or mixed datasource
   return {
@@ -392,11 +343,9 @@ export function getDataSourceForQuery(querySpecDS: DataSourceRef | undefined | n
     type: dsList[defaultDatasource].meta.id,
   };
 }
-
 export function ensureUniqueRefIds(queries: PanelQueryKind[]): PanelQueryKind[] {
   // Adapter to make PanelQueryKind[] work with getNextRefId (which expects { refId }[])
   const refIdAdapter = queries.map((q) => ({ refId: q.spec.refId }));
-
   for (let i = 0; i < queries.length; i++) {
     if (!queries[i].spec.refId) {
       const newRefId = getNextRefId(refIdAdapter);
@@ -404,17 +353,14 @@ export function ensureUniqueRefIds(queries: PanelQueryKind[]): PanelQueryKind[] 
       refIdAdapter[i] = { refId: newRefId };
     }
   }
-
   return queries;
 }
-
 export function panelQueryKindToSceneQuery(query: PanelQueryKind): SceneDataQuery {
   // Add datasource to match Go backend V2→V1 conversion:
   // - If explicit UID (datasource.name) exists → add { uid, type }
   // - If only type (group) exists → add { type } only
   // - If neither → no datasource
   const datasource = getRuntimePanelDataSource(query.spec.query);
-
   return {
     refId: query.spec.refId,
     hide: query.spec.hidden,
@@ -422,21 +368,17 @@ export function panelQueryKindToSceneQuery(query: PanelQueryKind): SceneDataQuer
     ...query.spec.query.spec,
   };
 }
-
 export function getLayout(sceneState: DashboardLayoutManager): DashboardV2Spec['layout'] {
   return sceneState.serialize();
 }
-
 export function getConditionalRendering(
   item: TabsLayoutTabKind | RowsLayoutRowKind | AutoGridLayoutItemKind
 ): ConditionalRenderingGroup {
   if (!item.spec.conditionalRendering) {
     return ConditionalRenderingGroup.createEmpty();
   }
-
   return ConditionalRenderingGroup.deserialize(item.spec.conditionalRendering);
 }
-
 export function getElements(layout: DashboardLayoutManager, scene: DashboardScene): DashboardV2Spec['elements'] {
   const panels = layout.getVizPanels();
   const dsReferencesMapping = scene.serializer.getDSReferencesMapping();
@@ -445,7 +387,6 @@ export function getElements(layout: DashboardLayoutManager, scene: DashboardScen
   });
   return createElements(panelsArray, scene);
 }
-
 export function getElement(
   gridItem: AutoGridItem | DashboardGridItem,
   scene: DashboardScene

--- a/public/app/features/dashboard-scene/serialization/transformSaveModelSchemaV2ToScene.ts
+++ b/public/app/features/dashboard-scene/serialization/transformSaveModelSchemaV2ToScene.ts
@@ -1,5 +1,5 @@
+import { structLog } from '@grafana/data';
 import { uniqueId } from 'lodash';
-
 import { config, getDataSourceSrv } from '@grafana/runtime';
 import {
   AdHocFiltersVariable,
@@ -64,7 +64,6 @@ import {
   getDashboardComponentInteractionCallback,
 } from 'app/features/dashboard/services/DashboardProfiler';
 import { type DashboardMeta } from 'app/types/dashboard';
-
 import { addPanelsOnLoadBehavior } from '../addToDashboard/addPanelsOnLoadBehavior';
 import { dashboardAnalyticsInitializer } from '../behaviors/DashboardAnalyticsInitializerBehavior';
 import { DefaultControlsBehavior } from '../behaviors/DefaultControlsBehavior';
@@ -78,7 +77,6 @@ import { DashboardReloadBehavior } from '../scene/DashboardReloadBehavior';
 import { DashboardScene } from '../scene/DashboardScene';
 import { type DashboardLayoutManager } from '../scene/types/DashboardLayoutManager';
 import { getIntervalsFromQueryString } from '../utils/utils';
-
 import { transformV2ToV1AnnotationQuery } from './annotations';
 import { SnapshotVariable } from './custom-variables/SnapshotVariable';
 import { migrateGroupByVariablesV2 } from './groupByMigration';
@@ -92,9 +90,7 @@ import {
   transformVariableRefreshToEnumV1,
 } from './transformToV1TypesUtils';
 import { LEGACY_STRING_VALUE_KEY } from './transformToV2TypesUtils';
-
 const DEFAULT_DATASOURCE = 'default';
-
 export type TypedVariableModelV2 =
   | QueryVariableKind
   | TextVariableKind
@@ -105,22 +101,18 @@ export type TypedVariableModelV2 =
   | GroupByVariableKind
   | AdhocVariableKind
   | SwitchVariableKind;
-
 export function transformSaveModelSchemaV2ToScene(
   dto: DashboardWithAccessInfo<DashboardV2Spec>,
   options?: LoadDashboardOptions
 ): DashboardScene {
   const { spec: dashboard, metadata, apiVersion } = dto;
-
   const annotations = dashboard.annotations ?? [];
   const found = annotations.some((item) => item.spec.builtIn);
   if (!found) {
     annotations.unshift(getGrafanaBuiltInAnnotation());
   }
-
   const annotationLayers = annotations.map((annotation) => {
     const annotationQuerySpec = transformV2ToV1AnnotationQuery(annotation);
-
     const layerState = {
       key: uniqueId('annotations-'),
       query: annotationQuerySpec,
@@ -129,10 +121,8 @@ export function transformSaveModelSchemaV2ToScene(
       isHidden: Boolean(annotation.spec.hide),
       placement: annotation.spec.placement,
     };
-
     return new DashboardAnnotationsDataLayer(layerState);
   });
-
   // Create alert states data layer if unified alerting is enabled
   let alertStatesLayer: AlertStatesDataLayer | undefined;
   if (config.unifiedAlertingEnabled) {
@@ -141,10 +131,8 @@ export function transformSaveModelSchemaV2ToScene(
       name: 'Alert States',
     });
   }
-
   const isDashboardEditable = Boolean(dashboard.editable);
   const canSave = dto.access.canSave !== false;
-
   const meta: DashboardMeta = {
     canShare: dto.access.canShare !== false,
     canSave,
@@ -163,7 +151,6 @@ export function transformSaveModelSchemaV2ToScene(
     isSnapshot: Boolean(metadata.annotations?.[AnnoKeyDashboardIsSnapshot]),
     isEmbedded: Boolean(metadata.annotations?.[AnnoKeyEmbedded]),
     publicDashboardEnabled: dto.access.isPublic,
-
     // UI-only metadata, ref: DashboardModel.initMeta
     showSettings: Boolean(dto.access.canEdit),
     canMakeEditable: canSave && !isDashboardEditable,
@@ -171,28 +158,23 @@ export function transformSaveModelSchemaV2ToScene(
     version: metadata.generation,
     k8s: metadata,
   };
-
   // Ref: DashboardModel.initMeta
   if (!isDashboardEditable) {
     meta.canEdit = false;
     meta.canDelete = false;
     meta.canSave = false;
   }
-
   const layoutManager: DashboardLayoutManager = layoutDeserializerRegistry
     .get(dashboard.layout.kind)
     .deserialize(dashboard.layout, dashboard.elements, dashboard.preload);
-
   let templateLayoutManager: DashboardLayoutManager | undefined = undefined;
   if (config.featureToggles.dashboardDefaultLayoutSelector && dashboard.preferences?.layout) {
     templateLayoutManager = layoutDeserializerRegistry
       .get(dashboard.preferences.layout.kind)
       .deserialize(dashboard.preferences.layout, {}, false);
   }
-
   // Create profiler once and reuse to avoid duplicate metadata setting
   const dashboardProfiler = getDashboardSceneProfilerWithMetadata(metadata.name, dashboard.title);
-
   const enableProfiling =
     config.dashboardPerformanceMetrics.findIndex((uid) => uid === '*' || uid === metadata.name) !== -1;
   const queryController = new behaviors.SceneQueryController(
@@ -201,7 +183,6 @@ export function transformSaveModelSchemaV2ToScene(
     },
     dashboardProfiler
   );
-
   const interactionTracker = new behaviors.SceneInteractionTracker(
     {
       enableInteractionTracking: enableProfiling,
@@ -209,7 +190,6 @@ export function transformSaveModelSchemaV2ToScene(
     },
     dashboardProfiler
   );
-
   const dashboardScene = new DashboardScene(
     {
       preferences: templateLayoutManager
@@ -276,31 +256,24 @@ export function transformSaveModelSchemaV2ToScene(
     },
     'v2'
   );
-
   dashboardScene.setInitialSaveModel(dto.spec, dto.metadata, apiVersion);
-
   // Enable panel profiling for this dashboard using the composed SceneRenderProfiler
   enablePanelProfilingForDashboard(dashboardScene, metadata.name);
-
   return dashboardScene;
 }
-
 function getVariables(
   dashboard: DashboardV2Spec,
   isSnapshot: boolean,
   defaultVariables?: VariableKind[]
 ): SceneVariableSet | undefined {
   let variables: SceneVariableSet | undefined;
-
   if (isSnapshot) {
     variables = createVariablesForSnapshot(dashboard);
   } else {
     variables = createVariablesForDashboard(dashboard, defaultVariables);
   }
-
   return variables;
 }
-
 function createVariablesForDashboard(dashboard: DashboardV2Spec, defaultVariables: VariableKind[] = []) {
   const isDefined = (v: SceneVariable | null): v is SceneVariable => Boolean(v);
   const variables = migrateGroupByVariablesV2(dashboard.variables ?? []);
@@ -309,35 +282,31 @@ function createVariablesForDashboard(dashboard: DashboardV2Spec, defaultVariable
       try {
         return createSceneVariableFromVariableModel(v);
       } catch (err) {
-        console.error(err);
+        structLog('error', err);
         return null;
       }
     })
     // TODO: Remove filter
     // Added temporarily to allow skipping non-compatible variables
     .filter(isDefined);
-
   const defaultVariableObjects = defaultVariables
     .map((v) => {
       try {
         return createSceneVariableFromVariableModel(v);
       } catch (err) {
-        console.error(err);
+        structLog('error', err);
         return null;
       }
     })
     .filter(isDefined);
-
   // Explicitly disable scopes for public dashboards
   if (config.featureToggles.scopeFilters && !config.publicDashboardAccessToken) {
     variableObjects.push(new ScopesVariable({ enable: true }));
   }
-
   return new SceneVariableSet({
     variables: [...defaultVariableObjects, ...variableObjects],
   });
 }
-
 export function createSceneVariableFromVariableModel(variable: TypedVariableModelV2): SceneVariable {
   const commonProperties = {
     name: variable.spec.name,
@@ -353,12 +322,10 @@ export function createSceneVariableFromVariableModel(variable: TypedVariableMode
       },
       variable.group
     );
-
     // Separate filters by origin - filters with origin go to originFilters, others go to filters
     const originFilters: AdHocFilterWithLabels[] = [];
     const filters: AdHocFilterWithLabels[] = [];
     variable.spec.filters?.forEach((filter) => (filter.origin ? originFilters.push(filter) : filters.push(filter)));
-
     const adhocVariableState: AdHocFiltersVariable['state'] = {
       ...commonProperties,
       type: 'adhoc',
@@ -389,7 +356,6 @@ export function createSceneVariableFromVariableModel(variable: TypedVariableMode
     }
     return new AdHocFiltersVariable(adhocVariableState);
   }
-
   if (variable.kind === defaultCustomVariableKind().kind) {
     return new CustomVariable({
       ...commonProperties,
@@ -494,7 +460,6 @@ export function createSceneVariableFromVariableModel(variable: TypedVariableMode
         val = variable.spec.current.value[0];
       }
     }
-
     return new TextBoxVariable({
       ...commonProperties,
       value: val,
@@ -509,7 +474,6 @@ export function createSceneVariableFromVariableModel(variable: TypedVariableMode
       },
       variable.group
     );
-
     return new GroupByVariable({
       ...commonProperties,
       datasource: ds,
@@ -540,42 +504,34 @@ export function createSceneVariableFromVariableModel(variable: TypedVariableMode
     throw new Error(`Scenes: Unsupported variable type ${variable.kind}`);
   }
 }
-
 function getDataQueryForVariable(variable: QueryVariableKind) {
   return LEGACY_STRING_VALUE_KEY in variable.spec.query.spec
     ? (variable.spec.query.spec[LEGACY_STRING_VALUE_KEY] ?? '')
     : variable.spec.query.spec;
 }
-
 export function getCurrentValueForOldIntervalModel(variable: IntervalVariableKind, intervals: string[]): string {
   // Handle missing current object or value
   const currentValue = variable.spec.current?.value;
   const selectedInterval = Array.isArray(currentValue) ? currentValue[0] : currentValue;
-
   // If no intervals are available, return empty string (will use default from IntervalVariable)
   if (intervals.length === 0) {
     return '';
   }
-
   // If no selected interval, return the first valid interval
   if (!selectedInterval) {
     return intervals[0];
   }
-
   // If the interval is the old auto format, return the new auto interval from scenes.
   if (selectedInterval.startsWith('$__auto_interval_')) {
     return '$__auto';
   }
-
   // Check if the selected interval is valid.
   if (intervals.includes(selectedInterval)) {
     return selectedInterval;
   }
-
   // If the selected interval is not valid, return the first valid interval.
   return intervals[0];
 }
-
 export function createVariablesForSnapshot(dashboard: DashboardV2Spec): SceneVariableSet {
   const variableObjects = (dashboard.variables ?? [])
     .map((v) => {
@@ -589,7 +545,6 @@ export function createVariablesForSnapshot(dashboard: DashboardV2Spec): SceneVar
             },
             v.group
           );
-
           return new AdHocFiltersVariable({
             name: v.spec.name,
             label: v.spec.label,
@@ -616,23 +571,24 @@ export function createVariablesForSnapshot(dashboard: DashboardV2Spec): SceneVar
         // for other variable types we are using the SnapshotVariable
         return createSnapshotVariable(v);
       } catch (err) {
-        console.error(err);
+        structLog('error', err);
         return null;
       }
     })
     // TODO: Remove filter
     // Added temporarily to allow skipping non-compatible variables
     .filter((v): v is SceneVariable => Boolean(v));
-
   return new SceneVariableSet({
     variables: variableObjects,
   });
 }
-
 /** Snapshots variables are read-only and should not be updated */
 export function createSnapshotVariable(variable: TypedVariableModelV2): SceneVariable {
   let snapshotVariable: SnapshotVariable;
-  let current: { value: string | string[]; text: string | string[] };
+  let current: {
+    value: string | string[];
+    text: string | string[];
+  };
   if (variable.kind === 'IntervalVariable') {
     const intervals = getIntervalsFromQueryString(variable.spec.query);
     const currentInterval = getCurrentValueForOldIntervalModel(variable, intervals);
@@ -646,7 +602,6 @@ export function createSnapshotVariable(variable: TypedVariableModelV2): SceneVar
     });
     return snapshotVariable;
   }
-
   if (variable.kind === 'ConstantVariable' || variable.kind === 'AdhocVariable') {
     current = {
       value: '',
@@ -663,7 +618,6 @@ export function createSnapshotVariable(variable: TypedVariableModelV2): SceneVar
       text: variable.spec.current?.text ?? '',
     };
   }
-
   snapshotVariable = new SnapshotVariable({
     name: variable.spec.name,
     label: variable.spec.label,
@@ -674,15 +628,12 @@ export function createSnapshotVariable(variable: TypedVariableModelV2): SceneVar
   });
   return snapshotVariable;
 }
-
 export function getPanelElement(dashboard: DashboardV2Spec, elementName: string): PanelKind | undefined {
   return dashboard.elements[elementName].kind === 'Panel' ? dashboard.elements[elementName] : undefined;
 }
-
 export function getLibraryPanelElement(dashboard: DashboardV2Spec, elementName: string): LibraryPanelKind | undefined {
   return dashboard.elements[elementName].kind === 'LibraryPanel' ? dashboard.elements[elementName] : undefined;
 }
-
 function getGrafanaBuiltInAnnotation(): AnnotationQueryKind {
   const grafanaBuiltAnnotation: AnnotationQueryKind = {
     kind: 'AnnotationQuery',
@@ -703,6 +654,5 @@ function getGrafanaBuiltInAnnotation(): AnnotationQueryKind {
       builtIn: true,
     },
   };
-
   return grafanaBuiltAnnotation;
 }

--- a/public/app/features/dashboard-scene/serialization/transformSceneToSaveModelSchemaV2.ts
+++ b/public/app/features/dashboard-scene/serialization/transformSceneToSaveModelSchemaV2.ts
@@ -1,5 +1,5 @@
+import { structLog } from '@grafana/data';
 import { omit } from 'lodash';
-
 import { type AnnotationQuery, isEmptyObject, type TimeRange } from '@grafana/data';
 import { config } from '@grafana/runtime';
 import { ExpressionDatasourceRef } from '@grafana/runtime/internal';
@@ -20,7 +20,6 @@ import { sortedDeepCloneWithoutNulls } from 'app/core/utils/object';
 import { getPanelDataFrames } from 'app/features/dashboard/components/HelpWizard/utils';
 import { GrafanaQueryType } from 'app/plugins/datasource/grafana/types';
 import { MIXED_DATASOURCE_NAME } from 'app/plugins/datasource/mixed/MixedDataSource';
-
 import {
   type Spec as DashboardV2Spec,
   defaultSpec as defaultDashboardV2Spec,
@@ -62,7 +61,6 @@ import { isLinkEditable } from '../settings/links/utils';
 import { dashboardSceneGraph } from '../utils/dashboardSceneGraph';
 import { djb2Hash } from '../utils/djb2Hash';
 import { getLibraryPanelBehavior, getPanelIdForVizPanel, getQueryRunnerFor, isLibraryPanel } from '../utils/utils';
-
 import { type DSReferencesMapping } from './DashboardSceneSerializer';
 import { transformV1ToV2AnnotationQuery } from './annotations';
 import { sceneVariablesSetToSchemaV2Variables } from './sceneVariablesSetToVariables';
@@ -73,7 +71,6 @@ type DeepPartial<T> = T extends object
       [P in keyof T]?: DeepPartial<T[P]>;
     }
   : T;
-
 /**
  * Transform a DashboardScene to a v2beta1 DashboardSpec.
  * @param scene - The DashboardScene to transform
@@ -82,16 +79,11 @@ type DeepPartial<T> = T extends object
 export function transformSceneToSaveModelSchemaV2(scene: DashboardScene, isSnapshot = false): DashboardV2Spec {
   const sceneDash = scene.state;
   const timeRange = sceneDash.$timeRange!.state;
-
   const controlsState = sceneDash.controls?.state;
   const refreshPicker = controlsState?.refreshPicker;
-
   const dsReferencesMapping = scene.serializer.getDSReferencesMapping();
-
   const timeSettingsDefaults = defaultTimeSettingsSpec();
-
   let preferences: Preferences | undefined = undefined;
-
   if (config.featureToggles.dashboardDefaultLayoutSelector && sceneDash.preferences?.defaultLayoutTemplate) {
     const template = sceneDash.preferences.defaultLayoutTemplate;
     const serialized = template.serialize();
@@ -101,7 +93,6 @@ export function transformSceneToSaveModelSchemaV2(scene: DashboardScene, isSnaps
       };
     }
   }
-
   const dashboardSchemaV2: DeepPartial<DashboardV2Spec> = {
     //dashboard settings
     title: sceneDash.title,
@@ -130,7 +121,6 @@ export function transformSceneToSaveModelSchemaV2(scene: DashboardScene, isSnaps
       })),
     tags: sceneDash.tags ?? defaultDashboardV2Spec().tags,
     // EOF dashboard settings
-
     // time settings
     timeSettings: {
       timezone: timeRange.timeZone || timeSettingsDefaults.timezone,
@@ -145,24 +135,19 @@ export function transformSceneToSaveModelSchemaV2(scene: DashboardScene, isSnaps
       quickRanges: controlsState?.timePicker.state.quickRanges,
     },
     // EOF time settings
-
     // variables
     variables: getVariables(sceneDash, dsReferencesMapping),
     // EOF variables
-
     // elements
     elements: getElements(scene, dsReferencesMapping, isSnapshot),
     // EOF elements
-
     // annotations
     annotations: getAnnotations(sceneDash, dsReferencesMapping),
     // EOF annotations
-
     // layout
     layout: sceneDash.body.serialize(isSnapshot),
     // EOF layout
   };
-
   try {
     // validateDashboardSchemaV2 will throw an error if the dashboard is not valid
     if (validateDashboardSchemaV2(dashboardSchemaV2)) {
@@ -172,18 +157,15 @@ export function transformSceneToSaveModelSchemaV2(scene: DashboardScene, isSnaps
     // should never reach this point, validation should throw an error
     throw new Error('Error we could transform the dashboard to schema v2: ' + dashboardSchemaV2);
   } catch (reason) {
-    console.error('Error transforming dashboard to schema v2: ' + reason, dashboardSchemaV2);
+    structLog('error', 'Error transforming dashboard to schema v2: ' + reason, dashboardSchemaV2);
     throw new Error('Error transforming dashboard to schema v2: ' + reason);
   }
 }
-
 function getCursorSync(state: DashboardSceneState) {
   const cursorSync = state.$behaviors?.find((b): b is behaviors.CursorSync => b instanceof behaviors.CursorSync)?.state
     .sync;
-
   return transformCursorSynctoEnum(cursorSync);
 }
-
 function getLiveNow(state: DashboardSceneState) {
   const liveNow =
     state.$behaviors?.find((b): b is behaviors.LiveNowTimer => b instanceof behaviors.LiveNowTimer)?.isEnabled ||
@@ -194,19 +176,15 @@ function getLiveNow(state: DashboardSceneState) {
   }
   return Boolean(liveNow);
 }
-
 function getElements(scene: DashboardScene, dsReferencesMapping?: DSReferencesMapping, isSnapshot = false) {
   const panels = scene.state.body.getVizPanels() ?? [];
-
   // For snapshot serialization we must also include repeated panel clones (panel repeaters store clones in state,
   // not as layout children), otherwise the snapshot layout will reference elements that are missing.
   if (isSnapshot) {
     panels.push(...getRepeatedPanelsForSnapshot(scene));
   }
-
   return panels.reduce<Record<string, Element>>((elements, vizPanel) => {
     const element = vizPanelToSchemaV2(vizPanel, dsReferencesMapping, isSnapshot);
-
     // Snapshot layout expands repeaters into explicit panels and references repeat clones by their `key`.
     // Non-clone panels should keep their stable element identifier.
     const elementKey =
@@ -218,46 +196,37 @@ function getElements(scene: DashboardScene, dsReferencesMapping?: DSReferencesMa
             return vizPanel.state.key;
           })()
         : dashboardSceneGraph.getElementIdentifierForVizPanel(vizPanel);
-
     elements[elementKey] = element;
     return elements;
   }, {});
 }
-
 function getRepeatedPanelsForSnapshot(scene: DashboardScene): VizPanel[] {
   const panels: VizPanel[] = [];
-
   const repeaters = sceneGraph.findAllObjects(scene.getRoot(), (obj) => {
     const state = obj.state;
     if (state === null || typeof state !== 'object') {
       return false;
     }
-
     const repeatedPanels = Object.getOwnPropertyDescriptor(state, 'repeatedPanels')?.value;
     return Array.isArray(repeatedPanels) && repeatedPanels.length > 0;
   });
-
   for (const repeater of repeaters) {
     const state = repeater.state;
     if (state === null || typeof state !== 'object') {
       continue;
     }
-
     const repeatedPanels = Object.getOwnPropertyDescriptor(state, 'repeatedPanels')?.value;
     if (!Array.isArray(repeatedPanels)) {
       continue;
     }
-
     for (const panel of repeatedPanels) {
       if (panel instanceof VizPanel) {
         panels.push(panel);
       }
     }
   }
-
   return panels;
 }
-
 export function vizPanelToSchemaV2(
   vizPanel: VizPanel,
   dsReferencesMapping?: DSReferencesMapping,
@@ -278,14 +247,11 @@ export function vizPanelToSchemaV2(
     };
     return elementSpec;
   }
-
   const defaults = handleFieldConfigDefaultsConversion(vizPanel);
-
   const vizFieldConfig: FieldConfigSource = {
     defaults,
     overrides: vizPanel.state.fieldConfig?.overrides ?? [],
   };
-
   const elementSpec: PanelKind = {
     kind: 'Panel',
     spec: {
@@ -320,19 +286,15 @@ export function vizPanelToSchemaV2(
   };
   return elementSpec;
 }
-
 function handleFieldConfigDefaultsConversion(vizPanel: VizPanel) {
   if (!vizPanel.state.fieldConfig || !vizPanel.state.fieldConfig.defaults) {
     return defaultFieldConfig();
   }
-
   // Handle type conversion for color mode
   const rawColor = vizPanel.state.fieldConfig.defaults.color;
   let color: FieldColor | undefined;
-
   if (rawColor) {
     const convertedMode = colorIdEnumToColorIdV2(rawColor.mode);
-
     if (convertedMode) {
       color = {
         ...rawColor,
@@ -340,12 +302,10 @@ function handleFieldConfigDefaultsConversion(vizPanel: VizPanel) {
       };
     }
   }
-
   // Remove null from the defaults because schema V2 doesn't support null for these fields
   const decimals = vizPanel.state.fieldConfig.defaults.decimals ?? undefined;
   const min = vizPanel.state.fieldConfig.defaults.min ?? undefined;
   const max = vizPanel.state.fieldConfig.defaults.max ?? undefined;
-
   const defaults = Object.fromEntries(
     Object.entries({
       ...vizPanel.state.fieldConfig.defaults,
@@ -364,10 +324,8 @@ function handleFieldConfigDefaultsConversion(vizPanel: VizPanel) {
       return value !== undefined;
     })
   );
-
   return defaults;
 }
-
 function getPanelLinks(panel: VizPanel): DataLink[] {
   const vizLinks = dashboardSceneGraph.getPanelLinks(panel);
   if (vizLinks) {
@@ -375,7 +333,6 @@ function getPanelLinks(panel: VizPanel): DataLink[] {
   }
   return [];
 }
-
 export function getVizPanelQueries(
   vizPanel: VizPanel,
   dsReferencesMapping?: DSReferencesMapping,
@@ -383,18 +340,15 @@ export function getVizPanelQueries(
 ): PanelQueryKind[] {
   const queries: PanelQueryKind[] = [];
   const queryRunner = getQueryRunnerFor(vizPanel);
-
   if (isSnapshot) {
     const dataProvider = vizPanel.state.$data;
     if (!dataProvider) {
       return queries;
     }
-
     let snapshotData = getPanelDataFrames(dataProvider.state.data);
     if (dataProvider instanceof SceneDataTransformer) {
       snapshotData = getPanelDataFrames(dataProvider.state.$data!.state.data);
     }
-
     const snapshotQuery: DataQueryKind = {
       kind: 'DataQuery',
       version: defaultDataQueryKind().version,
@@ -407,7 +361,6 @@ export function getVizPanelQueries(
         snapshot: snapshotData,
       },
     };
-
     queries.push({
       kind: 'PanelQuery',
       spec: {
@@ -416,13 +369,10 @@ export function getVizPanelQueries(
         hidden: false,
       },
     });
-
     return queries;
   }
-
   // Regular query handling (non-snapshot)
   const vizPanelQueries = queryRunner?.state.queries;
-
   if (vizPanelQueries) {
     vizPanelQueries.forEach((query) => {
       // Check if this is a default empty query (refId "A", empty spec)
@@ -430,13 +380,11 @@ export function getVizPanelQueries(
       const querySpec = omit(query, 'datasource', 'refId', 'hide');
       const isDefaultEmptyQuery =
         query.refId === 'A' && !query.datasource && vizPanelQueries.length === 1 && Object.keys(querySpec).length === 0;
-
       // For default empty queries, don't use getElementDatasource as it will assign a datasource
       // Instead, leave datasource undefined so it gets deleted below
       const queryDatasource = isDefaultEmptyQuery
         ? undefined
         : getElementDatasource(vizPanel, query, 'panel', queryRunner, dsReferencesMapping);
-
       const dataQuery: DataQueryKind = {
         kind: 'DataQuery',
         version: defaultDataQueryKind().version,
@@ -448,11 +396,9 @@ export function getVizPanelQueries(
         },
         spec: querySpec,
       };
-
       if (!dataQuery.datasource?.name) {
         delete dataQuery.datasource;
       }
-
       const querySpecObj: PanelQuerySpec = {
         query: dataQuery,
         refId: query.refId,
@@ -466,20 +412,17 @@ export function getVizPanelQueries(
   }
   return queries;
 }
-
 export function getDataQueryKind(query: SceneDataQuery | string | undefined, queryRunner?: SceneQueryRunner): string {
   // Handle undefined query - return default data source type
   if (query === undefined || query === null) {
     const defaultDS = getDefaultDataSourceRef();
     return defaultDS?.type || '';
   }
-
   // Query is a string - get default data source type
   if (typeof query === 'string') {
     const defaultDS = getDefaultDataSourceRef();
     return defaultDS?.type || '';
   }
-
   // If query has a datasource UID (even without type), check if it matches the queryRunner's datasource
   // Only use queryRunner's type if the UIDs match or if query has no datasource at all
   if (queryRunner?.state.datasource?.type) {
@@ -490,25 +433,20 @@ export function getDataQueryKind(query: SceneDataQuery | string | undefined, que
     }
     return queryRunner.state.datasource.type;
   }
-
   // Fall back to default datasource
   const defaultDS = getDefaultDataSourceRef();
   return defaultDS?.type || '';
 }
-
 function getVizPanelTransformations(vizPanel: VizPanel): TransformationKind[] {
   let transformations: TransformationKind[] = [];
   const dataProvider = vizPanel.state.$data;
   if (dataProvider instanceof SceneDataTransformer) {
     const transformationList = dataProvider.state.transformations;
-
     if (transformationList.length === 0) {
       return [];
     }
-
     for (const transformationItem of transformationList) {
       const transformation = transformationItem;
-
       if ('id' in transformation) {
         const transformationSpec: TransformationSpec = {
           disabled: transformation.disabled,
@@ -516,7 +454,6 @@ function getVizPanelTransformations(vizPanel: VizPanel): TransformationKind[] {
           ...(transformation.topic && { topic: transformation.topic }),
           options: transformation.options,
         };
-
         transformations.push({
           kind: 'Transformation',
           group: transformation.id,
@@ -529,18 +466,14 @@ function getVizPanelTransformations(vizPanel: VizPanel): TransformationKind[] {
   }
   return transformations;
 }
-
 function getVizPanelQueryOptions(vizPanel: VizPanel): QueryOptionsSpec {
   let queryOptions: QueryOptionsSpec = {};
   const queryRunner = getQueryRunnerFor(vizPanel);
-
   if (queryRunner) {
     queryOptions.maxDataPoints = queryRunner.state.maxDataPoints;
-
     if (queryRunner.state.cacheTimeout) {
       queryOptions.cacheTimeout = queryRunner.state.cacheTimeout;
     }
-
     if (queryRunner.state.queryCachingTTL) {
       queryOptions.queryCachingTTL = queryRunner.state.queryCachingTTL;
     }
@@ -548,9 +481,7 @@ function getVizPanelQueryOptions(vizPanel: VizPanel): QueryOptionsSpec {
       queryOptions.interval = queryRunner.state.minInterval;
     }
   }
-
   const panelTime = vizPanel.state.$timeRange;
-
   if (panelTime instanceof PanelTimeRange) {
     queryOptions.timeFrom = panelTime.state.timeFrom;
     queryOptions.timeShift = panelTime.state.timeShift;
@@ -559,7 +490,6 @@ function getVizPanelQueryOptions(vizPanel: VizPanel): QueryOptionsSpec {
   }
   return queryOptions;
 }
-
 export function createElements(panels: Element[], scene: DashboardScene): Record<string, Element> {
   return panels.reduce<Record<string, Element>>((elements, panel) => {
     let elementKey = scene.serializer.getElementIdForPanel(panel.spec.id);
@@ -567,10 +497,8 @@ export function createElements(panels: Element[], scene: DashboardScene): Record
     return elements;
   }, {});
 }
-
 function getVariables(oldDash: DashboardSceneState, dsReferencesMapping?: DSReferencesMapping) {
   const variablesSet = oldDash.$variables;
-
   // variables is an array of all variables kind (union)
   let variables: Array<
     | QueryVariableKind
@@ -583,14 +511,11 @@ function getVariables(oldDash: DashboardSceneState, dsReferencesMapping?: DSRefe
     | AdhocVariableKind
     | SwitchVariableKind
   > = [];
-
   if (variablesSet instanceof SceneVariableSet) {
     variables = sceneVariablesSetToSchemaV2Variables(variablesSet, false, dsReferencesMapping);
   }
-
   return variables;
 }
-
 function getAnnotations(state: DashboardSceneState, dsReferencesMapping?: DSReferencesMapping): AnnotationQueryKind[] {
   const data = state.$data;
   if (!(data instanceof DashboardDataLayerSet)) {
@@ -601,49 +526,40 @@ function getAnnotations(state: DashboardSceneState, dsReferencesMapping?: DSRefe
     if (!(layer instanceof dataLayers.AnnotationsDataLayer)) {
       continue;
     }
-
     const datasource = getElementDatasource(layer, layer.state.query, 'annotation', undefined, dsReferencesMapping);
-
     let layerDs = layer.state.query.datasource;
-
     if (!layerDs || !layerDs.type) {
       // This can happen only if we are transforming a scene that was created
       // from a v1 spec. In v1 annotation layer can contain no datasource ref, which is guaranteed
       // for layers created for v2 schema. See transform transformSaveModelSchemaV2ToScene.ts.
       // In this case we will resolve default data source
       layerDs = getDefaultDataSourceRef();
-      console.error(
+      structLog(
+        'error',
         'Misconfigured AnnotationsDataLayer: Data source is required for annotations. Resolving default data source',
         layer,
         layerDs
       );
     }
-
     const result = transformV1ToV2AnnotationQuery(layer.state.query, layerDs.type!, layerDs.uid!, {
       enable: layer.state.isEnabled,
       hide: layer.state.isHidden,
     });
-
     const annotationQuery = layer.state.query;
-
     // If filter is an empty array, don't save it
     if (annotationQuery.filter?.ids?.length) {
       result.spec.filter = annotationQuery.filter;
     }
-
     // Finally, if the datasource references mapping did not containt data source ref,
     // this means that the original model that was fetched did not contain it. In such scenario we don't want to save
     // the explicit data source reference, so lets remove it from the save model.
     if (!datasource) {
       delete result.spec.query.datasource;
     }
-
     annotations.push(result);
   }
-
   return annotations;
 }
-
 export function getAnnotationQueryKind(annotationQuery: AnnotationQuery): string {
   if (annotationQuery.datasource?.type) {
     return annotationQuery.datasource.type;
@@ -656,23 +572,18 @@ export function getAnnotationQueryKind(annotationQuery: AnnotationQuery): string
     return 'grafana';
   }
 }
-
 export function getDefaultDataSourceRef(): DataSourceRef {
   // we need to return the default datasource configured in the BootConfig
   const defaultDatasource = config.defaultDatasource;
-
   // get default datasource type
   const dsList = config.datasources;
   const ds = dsList[defaultDatasource];
-
   // If we can't find the default datasource, fall back to grafana
   if (!ds) {
     return { type: 'grafana', uid: '-- Grafana --' };
   }
-
   return { type: ds.type, uid: ds.uid };
 }
-
 export function trimDashboardForSnapshot(title: string, time: TimeRange, dash: DashboardV2Spec, panel?: VizPanel) {
   let spec: DashboardV2Spec = {
     ...dash,
@@ -684,24 +595,20 @@ export function trimDashboardForSnapshot(title: string, time: TimeRange, dash: D
     },
     links: [],
   };
-
   // When VizPanel is present, we are snapshoting a single panel. The rest of the panels is removed from the dashboard,
   // and the panel is resized to 24x20 grid and placed at the top of the dashboard.
   if (panel) {
     const panelId = getPanelIdForVizPanel(panel);
-
     // Find the panel in elements
     const panelElementKey = Object.keys(dash.elements || {}).find((key) => {
       const element = dash.elements![key];
       return element.spec.id === panelId;
     });
-
     if (panelElementKey) {
       // Keep only this panel in elements
       spec.elements = {
         [panelElementKey]: dash.elements![panelElementKey],
       };
-
       spec.layout = {
         kind: 'GridLayout',
         spec: {
@@ -724,7 +631,6 @@ export function trimDashboardForSnapshot(title: string, time: TimeRange, dash: D
       };
     }
   }
-
   // Remove links from all panels
   spec.elements = Object.fromEntries(
     Object.entries(spec.elements).map(([key, element]) => {
@@ -734,7 +640,6 @@ export function trimDashboardForSnapshot(title: string, time: TimeRange, dash: D
       return [key, element];
     })
   );
-
   if (spec.annotations) {
     const annotations = spec.annotations.filter((annotation) => annotation.spec.enable) || [];
     const trimedAnnotations = annotations.map((annotation): AnnotationQueryKind => {
@@ -752,7 +657,6 @@ export function trimDashboardForSnapshot(title: string, time: TimeRange, dash: D
     });
     spec.annotations = trimedAnnotations;
   }
-
   if (spec.variables) {
     spec.variables.forEach((variable) => {
       if ('query' in variable.spec) {
@@ -762,22 +666,18 @@ export function trimDashboardForSnapshot(title: string, time: TimeRange, dash: D
         variable.spec.options =
           variable.spec.current && !isEmptyObject(variable.spec.current) ? [variable.spec.current] : [];
       }
-
       if ('refresh' in variable.spec) {
         variable.spec.refresh = 'never';
       }
     });
   }
-
   return spec;
 }
-
 // Function to know if the dashboard transformed is a valid DashboardV2Spec
 export function validateDashboardSchemaV2(dash: unknown): dash is DashboardV2Spec {
   if (typeof dash !== 'object' || dash === null || Array.isArray(dash)) {
     throw new Error('Dashboard is not an object or is null');
   }
-
   // Required properties
   if (!('title' in dash) || typeof dash.title !== 'string') {
     throw new Error('Title is not a string');
@@ -797,7 +697,6 @@ export function validateDashboardSchemaV2(dash: unknown): dash is DashboardV2Spe
   if (!('layout' in dash) || typeof dash.layout !== 'object' || dash.layout === null) {
     throw new Error('Layout is not an object or is null');
   }
-
   // Optional properties - only validate if present
   if ('description' in dash && dash.description !== undefined && typeof dash.description !== 'string') {
     throw new Error('Description is not a string');
@@ -807,7 +706,6 @@ export function validateDashboardSchemaV2(dash: unknown): dash is DashboardV2Spe
       const typeValues: DashboardCursorSync[] = ['Off', 'Crosshair', 'Tooltip'];
       return typeValues;
     })();
-
     if (typeof dash.cursorSync !== 'string' || !validCursorSyncValues.includes(dash.cursorSync)) {
       throw new Error('CursorSync is not a valid value');
     }
@@ -830,10 +728,8 @@ export function validateDashboardSchemaV2(dash: unknown): dash is DashboardV2Spe
   if ('id' in dash && dash.id !== undefined && typeof dash.id !== 'number') {
     throw new Error('ID is not a number');
   }
-
   // Time settings validation
   const timeSettings = dash.timeSettings;
-
   // Required time settings
   if (!('from' in timeSettings) || typeof timeSettings.from !== 'string') {
     throw new Error('From is not a string');
@@ -847,7 +743,6 @@ export function validateDashboardSchemaV2(dash: unknown): dash is DashboardV2Spe
   if (!('hideTimepicker' in timeSettings) || typeof timeSettings.hideTimepicker !== 'boolean') {
     throw new Error('HideTimepicker is not a boolean');
   }
-
   // Optional time settings with defaults
   if (
     'autoRefreshIntervals' in timeSettings &&
@@ -884,21 +779,17 @@ export function validateDashboardSchemaV2(dash: unknown): dash is DashboardV2Spe
   ) {
     throw new Error('FiscalYearStartMonth is not a number');
   }
-
   // Layout validation
   if (!('kind' in dash.layout)) {
     throw new Error('Layout kind is required');
   }
-
   if (dash.layout.kind === 'GridLayout') {
     validateGridLayout(dash.layout);
   } else if (dash.layout.kind === 'RowsLayout') {
     validateRowsLayout(dash.layout);
   }
-
   return true;
 }
-
 function validateGridLayout(layout: unknown) {
   if (typeof layout !== 'object' || layout === null) {
     throw new Error('Layout is not an object or is null');
@@ -913,7 +804,6 @@ function validateGridLayout(layout: unknown) {
     throw new Error('Layout spec items is not an array');
   }
 }
-
 function validateRowsLayout(layout: unknown) {
   if (typeof layout !== 'object' || layout === null) {
     throw new Error('Layout is not an object or is null');
@@ -928,7 +818,6 @@ function validateRowsLayout(layout: unknown) {
     throw new Error('Layout spec items is not an array');
   }
 }
-
 export function getAutoAssignedDSRef(
   element: VizPanel | SceneVariables | dataLayers.AnnotationsDataLayer,
   type: 'panels' | 'variables' | 'annotations',
@@ -941,19 +830,15 @@ export function getAutoAssignedDSRef(
     const elementKey = dashboardSceneGraph.getElementIdentifierForVizPanel(element);
     return elementMapReferences.panels.get(elementKey) || new Map();
   }
-
   if (type === 'variables') {
     return elementMapReferences.variables;
   }
-
   if (type === 'annotations') {
     return elementMapReferences.annotations;
   }
-
   // if type is not panels, annotations, or variables, throw error
   throw new Error(`Invalid type ${type} for getAutoAssignedDSRef`);
 }
-
 /**
  * Returns the datasource value that should be persisted for a panel query, variable or annotation
  * - Undefined if the datasource was not defined in the initial save model
@@ -963,12 +848,10 @@ export function getAutoAssignedDSRef(
 export function getPersistedDSFor<T extends SceneDataQuery | QueryVariable | AnnotationQuery>(
   element: T,
   autoAssignedDsRef: Map<string, string | undefined>,
-
   type: 'query' | 'variable' | 'annotation',
   context?: SceneQueryRunner
 ): DataSourceRef | undefined {
   let datasource: DataSourceRef | undefined;
-
   // First, try to resolve from the element's current datasource if it has one
   if (type === 'query') {
     if ('datasource' in element && element.datasource) {
@@ -978,43 +861,35 @@ export function getPersistedDSFor<T extends SceneDataQuery | QueryVariable | Ann
         datasource = element.datasource;
       }
     }
-
     const panelDS = context?.state?.datasource;
     if (panelDS?.uid) {
       const notMixed = panelDS?.uid !== MIXED_DATASOURCE_NAME;
       const notExpr =
         !datasource ||
         (datasource.uid !== ExpressionDatasourceRef.uid && datasource.type !== ExpressionDatasourceRef.type);
-
       if (notMixed && (!datasource || (panelDS?.uid !== datasource.uid && notExpr))) {
         datasource = panelDS;
       }
     }
   }
-
   if (type === 'variable' && 'state' in element && 'datasource' in element.state) {
     datasource = element.state.datasource || undefined;
   }
-
   if (type === 'annotation' && 'datasource' in element) {
     datasource = element.datasource || undefined;
   }
-
   // If a datasource was resolved from the element, use it
   if (datasource) {
     return datasource;
   }
-
   const elementId = getElementIdentifier(element, type);
   if (autoAssignedDsRef?.has(elementId)) {
     const dsType = autoAssignedDsRef.get(elementId);
     // If the ds type was defined, return datasource with only the type; otherwise undefined
     return dsType ? { type: dsType } : undefined;
   }
-
   return undefined;
 }
-
 /**
  * Helper function to extract which identifier to use from a query or variable element
  * @returns refId for queries, name for variables
@@ -1028,44 +903,35 @@ function getElementIdentifier<T extends SceneDataQuery | QueryVariable | Annotat
   if (type === 'query') {
     return 'refId' in element ? element.refId : '';
   }
-
   if (type === 'variable') {
     // when is type variable look for the name of the variable
     return 'state' in element && 'name' in element.state ? element.state.name : '';
   }
-
   // when is type annotation look for annotation name
   if (type === 'annotation') {
     return 'name' in element ? element.name : '';
   }
-
   throw new Error(`Invalid type ${type} for getElementIdentifier`);
 }
-
 function isVizPanel(element: VizPanel | SceneVariables | dataLayers.AnnotationsDataLayer): element is VizPanel {
   // FIXME: is there another way to do this?
   return 'pluginId' in element.state;
 }
-
 function isSceneVariables(
   element: VizPanel | SceneVariables | dataLayers.AnnotationsDataLayer
 ): element is SceneVariables {
   // Check for properties unique to SceneVariables but not in VizPanel
   return !('pluginId' in element.state) && ('variables' in element.state || 'getValue' in element);
 }
-
 function isSceneDataQuery(query: SceneDataQuery | QueryVariable | AnnotationQuery): query is SceneDataQuery {
   return 'refId' in query && !('state' in query);
 }
-
 function isAnnotationQuery(query: SceneDataQuery | QueryVariable | AnnotationQuery): query is AnnotationQuery {
   return 'datasource' in query && 'name' in query;
 }
-
 function isQueryVariable(query: SceneDataQuery | QueryVariable | AnnotationQuery): query is QueryVariable {
   return 'state' in query && 'name' in query.state;
 }
-
 /**
  * Get the persisted datasource for a panel query, annotation or variable
  * When a panel query, annotation or variable is created it could not have a datasource set
@@ -1092,17 +958,14 @@ export function getElementDatasource(
     const autoAssignedRefs = getAutoAssignedDSRef(element, 'panels', dsReferencesMapping);
     result = getPersistedDSFor(queryElement, autoAssignedRefs, 'query', queryRunner);
   }
-
   if (type === 'variable') {
     if (!isSceneVariables(element) || !isQueryVariable(queryElement)) {
       return undefined;
     }
     // Get datasource for variable
     const autoAssignedRefs = getAutoAssignedDSRef(element, 'variables', dsReferencesMapping);
-
     result = getPersistedDSFor(queryElement, autoAssignedRefs, 'variable');
   }
-
   if (type === 'annotation') {
     if (!isAnnotationQuery(queryElement)) {
       return undefined;
@@ -1111,7 +974,6 @@ export function getElementDatasource(
     const autoAssignedRefs = getAutoAssignedDSRef(element, 'annotations', dsReferencesMapping);
     result = getPersistedDSFor(queryElement, autoAssignedRefs, 'annotation');
   }
-
   // Avoid returning an empty object
   return Object.keys(result || {}).length > 0 ? result : undefined;
 }

--- a/public/app/features/dashboard-scene/serialization/transformToV1TypesUtils.ts
+++ b/public/app/features/dashboard-scene/serialization/transformToV1TypesUtils.ts
@@ -1,3 +1,4 @@
+import { structLog } from '@grafana/data';
 import { type FieldConfigSource as FieldConfigSourceV1, SpecialValueMatch as SpecialValueMatchV1 } from '@grafana/data';
 import {
   VariableHide as VariableHideV1,
@@ -16,7 +17,6 @@ import {
   type SpecialValueMatch,
   type ThresholdsMode,
 } from '@grafana/schema/apis/dashboard.grafana.app/v2';
-
 export function transformVariableRefreshToEnumV1(refresh?: VariableRefresh): VariableRefreshV1 {
   switch (refresh) {
     case 'never':
@@ -29,7 +29,6 @@ export function transformVariableRefreshToEnumV1(refresh?: VariableRefresh): Var
       return VariableRefreshV1.never;
   }
 }
-
 export function transformVariableHideToEnumV1(hide?: VariableHide): VariableHideV1 {
   switch (hide) {
     case 'dontHide':
@@ -44,7 +43,6 @@ export function transformVariableHideToEnumV1(hide?: VariableHide): VariableHide
       return VariableHideV1.dontHide;
   }
 }
-
 export function transformSortVariableToEnumV1(sort?: VariableSort): VariableSortV1 {
   switch (sort) {
     case 'disabled':
@@ -69,7 +67,6 @@ export function transformSortVariableToEnumV1(sort?: VariableSort): VariableSort
       return VariableSortV1.disabled;
   }
 }
-
 export function transformCursorSyncV2ToV1(cursorSync: DashboardCursorSync): DashboardCursorSyncV1 {
   switch (cursorSync) {
     case 'Crosshair':
@@ -82,7 +79,6 @@ export function transformCursorSyncV2ToV1(cursorSync: DashboardCursorSync): Dash
       return DashboardCursorSyncV1.Off;
   }
 }
-
 function transformSpecialValueMatchToV1(match: SpecialValueMatch): SpecialValueMatchV1 | undefined {
   switch (match) {
     case 'true':
@@ -98,11 +94,10 @@ function transformSpecialValueMatchToV1(match: SpecialValueMatch): SpecialValueM
     case 'empty':
       return SpecialValueMatchV1.Empty;
     default:
-      console.warn(`Skipping special value mapping with unknown match type: "${match}"`);
+      structLog('warn', `Skipping special value mapping with unknown match type: "${match}"`);
       return undefined;
   }
 }
-
 export function transformMappingsToV1(fieldConfig: FieldConfigSource): FieldConfigSourceV1 {
   const getThresholdsMode = (mode: ThresholdsMode): ThresholdsModeV1 => {
     switch (mode) {
@@ -114,11 +109,9 @@ export function transformMappingsToV1(fieldConfig: FieldConfigSource): FieldConf
         return ThresholdsModeV1.Absolute;
     }
   };
-
   const transformedDefaults: any = {
     ...fieldConfig.defaults,
   };
-
   if (fieldConfig.defaults.mappings) {
     transformedDefaults.mappings = fieldConfig.defaults.mappings.flatMap((mapping) => {
       switch (mapping.type) {
@@ -139,11 +132,9 @@ export function transformMappingsToV1(fieldConfig: FieldConfigSource): FieldConf
           };
         case 'special': {
           const v1Match = transformSpecialValueMatchToV1(mapping.options.match);
-
           if (v1Match === undefined) {
             return [];
           }
-
           return {
             ...mapping,
             options: {
@@ -158,14 +149,12 @@ export function transformMappingsToV1(fieldConfig: FieldConfigSource): FieldConf
       }
     });
   }
-
   if (fieldConfig.defaults.thresholds) {
     transformedDefaults.thresholds = {
       ...fieldConfig.defaults.thresholds,
       mode: getThresholdsMode(fieldConfig.defaults.thresholds.mode),
     };
   }
-
   return {
     ...fieldConfig,
     defaults: transformedDefaults,

--- a/public/app/features/dashboard-scene/settings/AnnotationsEditView.tsx
+++ b/public/app/features/dashboard-scene/settings/AnnotationsEditView.tsx
@@ -1,3 +1,4 @@
+import { structLog } from '@grafana/data';
 import {
   type AnnotationQuery,
   getDataSourceRef,
@@ -8,7 +9,6 @@ import {
 import { getDataSourceSrv } from '@grafana/runtime';
 import { type SceneComponentProps, SceneObjectBase, type VizPanel, dataLayers } from '@grafana/scenes';
 import { Page } from 'app/core/components/Page/Page';
-
 import { DashboardAnnotationsDataLayer } from '../scene/DashboardAnnotationsDataLayer';
 import { NEW_ANNOTATION_NAME } from '../scene/DashboardDataLayerSet';
 import { type DashboardScene } from '../scene/DashboardScene';
@@ -16,61 +16,48 @@ import { NavToolbarActions } from '../scene/NavToolbarActions';
 import { dataLayersToAnnotations } from '../serialization/dataLayersToAnnotations';
 import { dashboardSceneGraph } from '../utils/dashboardSceneGraph';
 import { getDashboardSceneFor } from '../utils/utils';
-
 import { EditListViewSceneUrlSync } from './EditListViewSceneUrlSync';
 import { AnnotationSettingsEdit } from './annotations/AnnotationSettingsEdit';
 import { AnnotationSettingsList } from './annotations/AnnotationSettingsList';
 import { type DashboardEditView, type DashboardEditViewState, useDashboardEditPageNav } from './utils';
-
 export enum MoveDirection {
   UP = -1,
   DOWN = 1,
 }
-
 export interface AnnotationsEditViewState extends DashboardEditViewState {
   editIndex?: number | undefined;
 }
-
 export class AnnotationsEditView extends SceneObjectBase<AnnotationsEditViewState> implements DashboardEditView {
   static Component = AnnotationsSettingsView;
-
   public getUrlKey(): string {
     return 'annotations';
   }
-
   protected _urlSync = new EditListViewSceneUrlSync(this);
-
   private get _dashboard(): DashboardScene {
     return getDashboardSceneFor(this);
   }
-
   public getDataLayer(editIndex: number): dataLayers.AnnotationsDataLayer {
     const data = dashboardSceneGraph.getDataLayers(this._dashboard);
     const layer = data.state.annotationLayers[editIndex];
-
     if (!(layer instanceof dataLayers.AnnotationsDataLayer)) {
       throw new Error('AnnotationsDataLayer not found at index ' + editIndex);
     }
-
     return layer;
   }
-
   public getDashboard(): DashboardScene {
     return this._dashboard;
   }
-
   public getDataSourceRefForAnnotation = () => {
     // get current default datasource ref from instance settings
     // null is passed to get the default datasource
     const defaultInstanceDS = getDataSourceSrv().getInstanceSettings(null);
     // check for an annotation flag in the plugin json to see if it supports annotations
     if (!defaultInstanceDS || !defaultInstanceDS.meta.annotations) {
-      console.error('Default datasource does not support annotations');
+      structLog('error', 'Default datasource does not support annotations');
       return undefined;
     }
     return getDataSourceRef(defaultInstanceDS);
   };
-
   public onNew = async () => {
     const newAnnotationQuery: AnnotationQuery = {
       name: NEW_ANNOTATION_NAME,
@@ -78,50 +65,37 @@ export class AnnotationsEditView extends SceneObjectBase<AnnotationsEditViewStat
       datasource: this.getDataSourceRefForAnnotation(),
       iconColor: 'red',
     };
-
     const newAnnotation = new DashboardAnnotationsDataLayer({
       query: newAnnotationQuery,
       name: newAnnotationQuery.name,
       isEnabled: Boolean(newAnnotationQuery.enable),
       isHidden: Boolean(newAnnotationQuery.hide),
     });
-
     const data = dashboardSceneGraph.getDataLayers(this._dashboard);
-
     data.addAnnotationLayer(newAnnotation);
     this.setState({ editIndex: data.state.annotationLayers.length - 1 });
   };
-
   public onEdit = (idx: number) => {
     this.setState({ editIndex: idx });
   };
-
   public onBackToList = () => {
     this.setState({ editIndex: undefined });
   };
-
   public onMove = (idx: number, direction: MoveDirection) => {
     const data = dashboardSceneGraph.getDataLayers(this._dashboard);
     const layers = [...data.state.annotationLayers];
-
     const [layer] = layers.splice(idx, 1);
     layers.splice(idx + direction, 0, layer);
-
     data.setState({ annotationLayers: layers });
   };
-
   public onDelete = (idx: number) => {
     const data = dashboardSceneGraph.getDataLayers(this._dashboard);
     const layers = [...data.state.annotationLayers];
-
     layers.splice(idx, 1);
-
     data.setState({ annotationLayers: layers });
   };
-
   public onUpdate = (annotation: AnnotationQuery, editIndex: number) => {
     const layer = this.getDataLayer(editIndex);
-
     layer.setState({
       name: annotation.name,
       isEnabled: Boolean(annotation.enable),
@@ -129,22 +103,18 @@ export class AnnotationsEditView extends SceneObjectBase<AnnotationsEditViewStat
       placement: annotation.placement,
       query: annotation,
     });
-
     //need to rerun the layer to update the query and
     //see the annotation on the panel
     layer.runLayer();
   };
 }
-
 function AnnotationsSettingsView({ model }: SceneComponentProps<AnnotationsEditView>) {
   const dashboard = model.getDashboard();
   const { annotationLayers } = dashboardSceneGraph.getDataLayers(dashboard).useState();
   const { navModel, pageNav } = useDashboardEditPageNav(dashboard, model.getUrlKey());
   const { editIndex } = model.useState();
   const panels = dashboardSceneGraph.getVizPanels(dashboard);
-
   const annotations: AnnotationQuery[] = dataLayersToAnnotations(annotationLayers);
-
   if (editIndex != null && editIndex < annotationLayers.length) {
     return (
       <AnnotationsSettingsEditView
@@ -160,7 +130,6 @@ function AnnotationsSettingsView({ model }: SceneComponentProps<AnnotationsEditV
       />
     );
   }
-
   return (
     <Page navModel={navModel} pageNav={pageNav} layout={PageLayoutType.Standard}>
       <NavToolbarActions dashboard={dashboard} />
@@ -174,7 +143,6 @@ function AnnotationsSettingsView({ model }: SceneComponentProps<AnnotationsEditV
     </Page>
   );
 }
-
 interface AnnotationsSettingsEditViewProps {
   annotationLayer: dataLayers.AnnotationsDataLayer;
   pageNav: NavModelItem;
@@ -186,7 +154,6 @@ interface AnnotationsSettingsEditViewProps {
   onBackToList: () => void;
   onDelete: (idx: number) => void;
 }
-
 function AnnotationsSettingsEditView({
   annotationLayer,
   pageNav,
@@ -199,12 +166,10 @@ function AnnotationsSettingsEditView({
   onDelete,
 }: AnnotationsSettingsEditViewProps) {
   const { name, query } = annotationLayer.useState();
-
   const editAnnotationPageNav = {
     text: name,
     parentItem: pageNav,
   };
-
   return (
     <Page navModel={navModel} pageNav={editAnnotationPageNav} layout={PageLayoutType.Standard}>
       <NavToolbarActions dashboard={dashboard} />

--- a/public/app/features/dashboard-scene/settings/GeneralSettingsEditView.tsx
+++ b/public/app/features/dashboard-scene/settings/GeneralSettingsEditView.tsx
@@ -1,5 +1,5 @@
+import { structLog } from '@grafana/data';
 import { type ChangeEvent } from 'react';
-
 import { PageLayoutType } from '@grafana/data';
 import { Trans, t } from '@grafana/i18n';
 import { config } from '@grafana/runtime';
@@ -24,7 +24,6 @@ import { GenAIDashDescriptionButton } from 'app/features/dashboard/components/Ge
 import { GenAIDashTitleButton } from 'app/features/dashboard/components/GenAI/GenAIDashTitleButton';
 import { MoveProvisionedDashboardDrawer } from 'app/features/provisioning/components/Dashboards/MoveProvisionedDashboardDrawer';
 import { ProvisioningAwareFolderPicker } from 'app/features/provisioning/components/Shared/ProvisioningAwareFolderPicker';
-
 import { updateNavModel } from '../pages/utils';
 import { type DashboardScene } from '../scene/DashboardScene';
 import { NavToolbarActions } from '../scene/NavToolbarActions';
@@ -32,10 +31,8 @@ import { AutoGridLayoutManager } from '../scene/layout-auto-grid/AutoGridLayoutM
 import { DefaultGridLayoutManager } from '../scene/layout-default/DefaultGridLayoutManager';
 import { dashboardSceneGraph } from '../utils/dashboardSceneGraph';
 import { getDashboardSceneFor } from '../utils/utils';
-
 import { DeleteDashboardButton } from './DeleteDashboardButton';
 import { type DashboardEditView, type DashboardEditViewState, useDashboardEditPageNav } from './utils';
-
 export interface GeneralSettingsEditViewState extends DashboardEditViewState {
   showMoveModal?: boolean;
   moveModalProps?: {
@@ -43,7 +40,6 @@ export interface GeneralSettingsEditViewState extends DashboardEditViewState {
     targetFolderTitle?: string;
   };
 }
-
 export class GeneralSettingsEditView
   extends SceneObjectBase<GeneralSettingsEditViewState>
   implements DashboardEditView
@@ -51,27 +47,21 @@ export class GeneralSettingsEditView
   private get _dashboard(): DashboardScene {
     return getDashboardSceneFor(this);
   }
-
   public getUrlKey(): string {
     return 'settings';
   }
-
   public getDashboard(): DashboardScene {
     return this._dashboard;
   }
-
   public getTimeRange() {
     return sceneGraph.getTimeRange(this._dashboard);
   }
-
   public getRefreshPicker() {
     return this.getDashboardControls().state.refreshPicker;
   }
-
   public getCursorSync() {
     return dashboardSceneGraph.getCursorSync(this._dashboard);
   }
-
   public getLiveNowTimer(): behaviors.LiveNowTimer {
     const liveNowTimer = sceneGraph.findObject(this._dashboard, (s) => s instanceof behaviors.LiveNowTimer);
     if (liveNowTimer instanceof behaviors.LiveNowTimer) {
@@ -80,41 +70,32 @@ export class GeneralSettingsEditView
       throw new Error('LiveNowTimer could not be found');
     }
   }
-
   public getDashboardControls() {
     return this._dashboard.state.controls!;
   }
-
   public onTitleChange = (value: string) => {
     this._dashboard.setState({ title: value });
   };
-
   public onDescriptionChange = (value: string) => {
     this._dashboard.setState({ description: value });
   };
-
   public onTagsChange = (value: string[]) => {
     this._dashboard.setState({ tags: value });
   };
-
   public onFolderChange = async (newUID: string | undefined, newTitle: string | undefined) => {
     const newMeta = {
       ...this._dashboard.state.meta,
       folderUid: newUID || this._dashboard.state.meta.folderUid,
       folderTitle: newTitle || this._dashboard.state.meta.folderTitle,
     };
-
     if (newMeta.folderUid) {
       await updateNavModel(newMeta.folderUid);
     }
-
     this._dashboard.setState({ meta: newMeta });
   };
-
   public onEditableChange = (value: boolean) => {
     this._dashboard.setState({ editable: value });
   };
-
   public onDefaultGridChange = (value: string) => {
     if (value === AutoGridLayoutManager.descriptor.id) {
       this._dashboard.updateDefaultLayoutTemplate(AutoGridLayoutManager.createEmpty());
@@ -122,57 +103,46 @@ export class GeneralSettingsEditView
       this._dashboard.updateDefaultLayoutTemplate(DefaultGridLayoutManager.createEmpty());
     }
   };
-
   public onTimeZoneChange = (value: TimeZone) => {
     this.getTimeRange().setState({
       timeZone: value,
     });
   };
-
   public onWeekStartChange = (value?: WeekStart) => {
     this.getTimeRange().setState({ weekStart: value });
   };
-
   public onRefreshIntervalChange = (value: string[]) => {
     const control = this.getRefreshPicker();
     control?.setState({
       intervals: value,
     });
   };
-
   public onNowDelayChange = (value: string) => {
     const timeRange = this.getTimeRange();
-
     timeRange?.setState({
       UNSAFE_nowDelay: value,
     });
   };
-
   public onHideTimePickerChange = (value: boolean) => {
     this.getDashboardControls()?.setState({
       hideTimeControls: value,
     });
   };
-
   public onLiveNowChange = (enable: boolean) => {
     try {
       const liveNow = this.getLiveNowTimer();
       enable ? liveNow.enable() : liveNow.disable();
     } catch (err) {
-      console.error(err);
+      structLog('error', err);
     }
   };
-
   public onTooltipChange = (value: number) => {
     this.getCursorSync()?.setState({ sync: value });
   };
-
   public onPreloadChange = (preload: boolean) => {
     this._dashboard.setState({ preload });
   };
-
   public onDeleteDashboard = () => {};
-
   public onProvisionedFolderChange = async (newUID?: string, newTitle?: string) => {
     if (newUID !== this._dashboard.state.meta.folderUid) {
       this.setState({
@@ -184,14 +154,12 @@ export class GeneralSettingsEditView
       });
     }
   };
-
   public onMoveModalDismiss = () => {
     this.setState({
       showMoveModal: false,
       moveModalProps: undefined,
     });
   };
-
   public onMoveSuccess = (folderUID: string, folderTitle: string) => {
     const newMeta = {
       ...this._dashboard.state.meta,
@@ -201,10 +169,8 @@ export class GeneralSettingsEditView
     this._dashboard.setState({ meta: newMeta });
     this.onMoveModalDismiss();
   };
-
   static Component = GeneralSettingsEditViewComponent;
 }
-
 function GeneralSettingsEditViewComponent({ model }: SceneComponentProps<GeneralSettingsEditView>) {
   const dashboard = model.getDashboard();
   const { navModel, pageNav } = useDashboardEditPageNav(dashboard, model.getUrlKey());
@@ -225,7 +191,6 @@ function GeneralSettingsEditViewComponent({ model }: SceneComponentProps<General
       value: false,
     },
   ];
-
   const DEFAULT_GRID_OPTIONS = [
     {
       label: t('dashboard-scene.general-settings-edit-view.default_grid_options.label.auto', 'Auto grid'),
@@ -236,9 +201,7 @@ function GeneralSettingsEditViewComponent({ model }: SceneComponentProps<General
       value: DefaultGridLayoutManager.descriptor.id,
     },
   ];
-
   const defaultGrid = dashboard.getDefaultLayoutType();
-
   const GRAPH_TOOLTIP_OPTIONS = [
     {
       value: 0,
@@ -259,7 +222,6 @@ function GeneralSettingsEditViewComponent({ model }: SceneComponentProps<General
       ),
     },
   ];
-
   return (
     <Page navModel={navModel} pageNav={pageNav} layout={PageLayoutType.Standard}>
       <NavToolbarActions dashboard={dashboard} />

--- a/public/app/features/dashboard-scene/settings/VariablesEditView.tsx
+++ b/public/app/features/dashboard-scene/settings/VariablesEditView.tsx
@@ -1,6 +1,6 @@
+import { structLog } from '@grafana/data';
 import { useMemo } from 'react';
 import { v4 as uuidv4 } from 'uuid';
-
 import { type NavModel, type NavModelItem, PageLayoutType } from '@grafana/data';
 import {
   type SceneComponentProps,
@@ -10,13 +10,11 @@ import {
   sceneGraph,
 } from '@grafana/scenes';
 import { Page } from 'app/core/components/Page/Page';
-
 import { type DashboardScene } from '../scene/DashboardScene';
 import { NavToolbarActions } from '../scene/NavToolbarActions';
 import { transformSceneToSaveModel } from '../serialization/transformSceneToSaveModel';
 import { getDashboardSceneFor } from '../utils/utils';
 import { createUsagesNetwork, transformUsagesToNetwork } from '../variables/utils';
-
 import { EditListViewSceneUrlSync } from './EditListViewSceneUrlSync';
 import { type DashboardEditView, type DashboardEditViewState, useDashboardEditPageNav } from './utils';
 import { ProvisionedVariablesSection } from './variables/ProvisionedVariablesSection';
@@ -31,105 +29,82 @@ import {
   getVariableScene,
   isVariableEditable,
 } from './variables/utils';
-
 export interface VariablesEditViewState extends DashboardEditViewState {
   editIndex?: number | undefined;
 }
-
 export class VariablesEditView extends SceneObjectBase<VariablesEditViewState> implements DashboardEditView {
   public static Component = VariableEditorSettingsListView;
-
   public getUrlKey(): string {
     return 'variables';
   }
-
   protected _urlSync = new EditListViewSceneUrlSync(this);
-
   public getDashboard(): DashboardScene {
     return getDashboardSceneFor(this);
   }
-
   public getVariableSet(): SceneVariables {
     return sceneGraph.getVariables(this.getDashboard());
   }
-
   private getVariableIndex = (identifier: string) => {
     const variables = this.getVariables();
     return variables.findIndex((variable) => variable.state.name === identifier);
   };
-
   private replaceEditVariable = (newVariable: SceneVariable) => {
     // Find the index of the variable to be deleted
     const variableIndex = this.state.editIndex ?? -1;
     const { variables } = this.getVariableSet().state;
     const variable = variables[variableIndex];
-
     if (!variable) {
       // Handle the case where the variable is not found
-      console.error('Variable not found');
+      structLog('error', 'Variable not found');
       return;
     }
-
     const updatedVariables = [...variables.slice(0, variableIndex), newVariable, ...variables.slice(variableIndex + 1)];
-
     // Update the state or the variables array
     this.getVariableSet().setState({ variables: updatedVariables });
   };
-
   public onDelete = (identifier: string) => {
     // Find the index of the variable to be deleted
     const variableIndex = this.getVariableIndex(identifier);
     const { variables } = this.getVariableSet().state;
     if (variableIndex === -1) {
       // Handle the case where the variable is not found
-      console.error('Variable not found');
+      structLog('error', 'Variable not found');
       return;
     }
-
     // Create a new array excluding the variable to be deleted
     const updatedVariables = [...variables.slice(0, variableIndex), ...variables.slice(variableIndex + 1)];
-
     // Update the state or the variables array
     this.getVariableSet().setState({ variables: updatedVariables });
     // Remove editIndex otherwise switches to next variable in list
     this.setState({ editIndex: undefined });
   };
-
   public getVariables() {
     return this.getVariableSet().state.variables;
   }
-
   public onDuplicated = (identifier: string) => {
     const variableIndex = this.getVariableIndex(identifier);
     const variables = this.getVariableSet().state.variables;
-
     if (variableIndex === -1) {
-      console.error('Variable not found');
+      structLog('error', 'Variable not found');
       return;
     }
-
     const variableToUpdate = variables[variableIndex];
     let copyNumber = 0;
     let newName = `copy_of_${variableToUpdate.state.name}`;
-
     // Check if the name is unique, if not, increment the copy number
     while (variables.some((v) => v.state.name === newName)) {
       copyNumber++;
       newName = `copy_of_${variableToUpdate.state.name}_${copyNumber}`;
     }
-
     //clone the original variable, update name and key
     const newVariable = variableToUpdate.clone({ ...variableToUpdate.state, name: newName, key: uuidv4() });
-
     const updatedVariables = [
       ...variables.slice(0, variableIndex + 1),
       newVariable,
       ...variables.slice(variableIndex + 1),
     ];
-
     this.getVariableSet().setState({ variables: updatedVariables });
   };
-
   public onOrderChanged = (fromIndex: number, toIndex: number) => {
     const variables = this.getVariableSet().state.variables;
     if (!this.getVariableSet()) {
@@ -137,7 +112,7 @@ export class VariablesEditView extends SceneObjectBase<VariablesEditViewState> i
     }
     // check the index are within the variables array
     if (fromIndex < 0 || fromIndex >= variables.length || toIndex < 0 || toIndex >= variables.length) {
-      console.error('Invalid index');
+      structLog('error', 'Invalid index');
       return;
     }
     const updatedVariables = [...variables];
@@ -147,87 +122,70 @@ export class VariablesEditView extends SceneObjectBase<VariablesEditViewState> i
     const variablesScene = this.getVariableSet();
     variablesScene.setState({ variables: updatedVariables });
   };
-
   public onEdit = (identifier: string) => {
     const variableIndex = this.getVariableIndex(identifier);
     if (variableIndex === -1) {
-      console.error('Variable not found');
+      structLog('error', 'Variable not found');
       return;
     }
     this.setState({ editIndex: variableIndex });
   };
-
   public onAdd = () => {
     const variables = this.getVariables();
     const variableIndex = variables.length;
     //add the new variable to the end of the array
     const defaultNewVariable = getVariableDefault(variables);
-
     this.getVariableSet().setState({ variables: [...this.getVariables(), defaultNewVariable] });
     this.setState({ editIndex: variableIndex });
   };
-
   public onTypeChange = (type: EditableVariableType) => {
     // Find the index of the variable to be deleted
     const variableIndex = this.state.editIndex ?? -1;
     const { variables } = this.getVariableSet().state;
     const variable = variables[variableIndex];
-
     if (!variable) {
       // Handle the case where the variable is not found
-      console.error('Variable not found');
+      structLog('error', 'Variable not found');
       return;
     }
-
     const { name, label } = variable.state;
     const newVariable = getVariableScene(type, { name, label });
     this.replaceEditVariable(newVariable);
   };
-
   public onGoBack = () => {
     this.setState({ editIndex: undefined });
   };
-
   public onValidateVariableName = (name: string, key: string | undefined): [true, string] | [false, null] => {
     let errorText = null;
     if (!RESERVED_GLOBAL_VARIABLE_NAME_REGEX.test(name)) {
       errorText = "Template names cannot begin with '__', that's reserved for Grafana's global variables";
     }
-
     if (!WORD_CHARACTERS_REGEX.test(name)) {
       errorText = 'Only word characters are allowed in variable names';
     }
-
     const variable = this.getVariableSet().getByName(name)?.state;
-
     if (variable && variable.key !== key) {
       errorText = 'Variable with the same name already exists';
     }
-
     if (errorText) {
       return [true, errorText];
     }
-
     return [false, null];
   };
-
   public getSaveModel = () => {
     return transformSceneToSaveModel(this.getDashboard());
   };
-
   public getUsages = () => {
     const model = this.getSaveModel();
     const usages = createUsagesNetwork(this.getVariables(), model);
     return usages;
   };
-
   public getUsagesNetwork = () => {
     const usages = this.getUsages();
     const usagesNetwork = transformUsagesToNetwork(usages);
     return usagesNetwork;
   };
 }
-
 function VariableEditorSettingsListView({ model }: SceneComponentProps<VariablesEditView>) {
   const dashboard = model.getDashboard();
   const { navModel, pageNav } = useDashboardEditPageNav(dashboard, model.getUrlKey());
@@ -239,7 +197,6 @@ function VariableEditorSettingsListView({ model }: SceneComponentProps<Variables
   const usagesNetwork = useMemo(() => model.getUsagesNetwork(), [model]);
   const usages = useMemo(() => model.getUsages(), [model]);
   const saveModel = model.getSaveModel();
-
   if (editIndex !== undefined && variables[editIndex]) {
     const variable = variables[editIndex];
     if (variable) {
@@ -256,7 +213,6 @@ function VariableEditorSettingsListView({ model }: SceneComponentProps<Variables
       );
     }
   }
-
   return (
     <Page navModel={navModel} pageNav={pageNav} layout={PageLayoutType.Standard}>
       <NavToolbarActions dashboard={dashboard} />
@@ -275,7 +231,6 @@ function VariableEditorSettingsListView({ model }: SceneComponentProps<Variables
     </Page>
   );
 }
-
 interface VariableEditorSettingsEditViewProps {
   variable: SceneVariable;
   pageNav: NavModelItem;
@@ -285,7 +240,6 @@ interface VariableEditorSettingsEditViewProps {
   onGoBack: () => void;
   onDelete: (variableName: string) => void;
 }
-
 function VariableEditorSettingsView({
   variable,
   pageNav,
@@ -296,7 +250,6 @@ function VariableEditorSettingsView({
   onDelete,
 }: VariableEditorSettingsEditViewProps) {
   const { name } = variable.useState();
-
   const editVariablePageNav = {
     text: name,
     parentItem: pageNav,

--- a/public/app/features/dashboard-scene/settings/VersionsEditView.tsx
+++ b/public/app/features/dashboard-scene/settings/VersionsEditView.tsx
@@ -1,7 +1,7 @@
+import { structLog } from '@grafana/data';
 import { skipToken } from '@reduxjs/toolkit/query/react';
 import * as React from 'react';
 import { useMemo } from 'react';
-
 import { PageLayoutType, dateTimeFormat, dateTimeFormatTimeAgo } from '@grafana/data';
 import { Trans } from '@grafana/i18n';
 import { type SceneComponentProps, SceneObjectBase, sceneGraph } from '@grafana/scenes';
@@ -21,33 +21,31 @@ import {
   type RevisionModel,
   VERSIONS_FETCH_LIMIT,
 } from 'app/features/dashboard/types/revisionModels';
-
 import { type DashboardScene } from '../scene/DashboardScene';
 import { NavToolbarActions } from '../scene/NavToolbarActions';
 import { getDashboardSceneFor } from '../utils/utils';
-
 import { type DashboardEditView, type DashboardEditViewState, useDashboardEditPageNav } from './utils';
 import { VersionsHistoryButtons } from './version-history/VersionHistoryButtons';
 import { VersionHistoryComparison } from './version-history/VersionHistoryComparison';
 import { VersionHistoryHeader } from './version-history/VersionHistoryHeader';
 import { VersionHistoryTable } from './version-history/VersionHistoryTable';
-
 export interface VersionsEditViewState extends DashboardEditViewState {
   versions?: DecoratedRevisionModel[];
   isLoading?: boolean;
   isAppending?: boolean;
   viewMode?: 'list' | 'compare';
-  diffData?: { lhs: object; rhs: object };
+  diffData?: {
+    lhs: object;
+    rhs: object;
+  };
   newInfo?: DecoratedRevisionModel;
   baseInfo?: DecoratedRevisionModel;
   isNewLatest?: boolean;
 }
-
 export class VersionsEditView extends SceneObjectBase<VersionsEditViewState> implements DashboardEditView {
   public static Component = VersionsEditorSettingsListView;
   private _limit: number = VERSIONS_FETCH_LIMIT;
   private _continueToken = '';
-
   constructor(state: VersionsEditViewState) {
     super({
       ...state,
@@ -58,55 +56,44 @@ export class VersionsEditView extends SceneObjectBase<VersionsEditViewState> imp
       isNewLatest: false,
       diffData: { lhs: {}, rhs: {} },
     });
-
     this.addActivationHandler(() => {
       this.fetchVersions();
     });
   }
-
   private get _dashboard(): DashboardScene {
     return getDashboardSceneFor(this);
   }
-
-  public get diffData(): { lhs: object; rhs: object } {
+  public get diffData(): {
+    lhs: object;
+    rhs: object;
+  } {
     return this.state.diffData ?? { lhs: {}, rhs: {} };
   }
-
   public get versions(): DecoratedRevisionModel[] {
     return this.state.versions ?? [];
   }
-
   public get limit(): number {
     return this._limit;
   }
-
   public get continueToken(): string {
     return this._continueToken;
   }
-
   public getUrlKey(): string {
     return 'versions';
   }
-
   public getDashboard(): DashboardScene {
     return this._dashboard;
   }
-
   public getTimeRange() {
     return sceneGraph.getTimeRange(this._dashboard);
   }
-
   public fetchVersions = (append = false): void => {
     const uid = this._dashboard.state.uid;
-
     if (!uid) {
       return;
     }
-
     this.setState({ isAppending: append });
-
     const options = append ? { limit: this._limit, continueToken: this._continueToken } : { limit: this._limit };
-
     getDashboardAPI()
       .then(async (api) => {
         const result = await api.listDashboardHistory(uid, options);
@@ -118,10 +105,9 @@ export class VersionsEditView extends SceneObjectBase<VersionsEditViewState> imp
         // Update the continueToken for the next request, if available
         this._continueToken = result.metadata.continue ?? '';
       })
-      .catch((err) => console.log(err))
+      .catch((err) => structLog('log', err))
       .finally(() => this.setState({ isAppending: false }));
   };
-
   private transformToRevisionModels(items: Array<Resource<unknown>>): RevisionModel[] {
     return items.map(
       (item): RevisionModel => ({
@@ -140,12 +126,10 @@ export class VersionsEditView extends SceneObjectBase<VersionsEditViewState> imp
       })
     );
   }
-
   public getDiff = () => {
     const selectedVersions = this.versions.filter((version) => version.checked);
     const [newInfo, baseInfo] = selectedVersions;
     const isNewLatest = newInfo.version === this._dashboard.state.version;
-
     // Use the already-loaded data from listDashboardHistory - no need for another API call
     this.setState({
       baseInfo,
@@ -156,7 +140,6 @@ export class VersionsEditView extends SceneObjectBase<VersionsEditViewState> imp
       diffData: { lhs: baseInfo.data, rhs: newInfo.data },
     });
   };
-
   public reset = () => {
     this._continueToken = '';
     this.setState({
@@ -168,7 +151,6 @@ export class VersionsEditView extends SceneObjectBase<VersionsEditViewState> imp
       viewMode: 'list',
     });
   };
-
   public onCheck = (ev: React.FormEvent<HTMLInputElement>, versionId: number) => {
     this.setState({
       versions: this.versions.map((version) =>
@@ -176,10 +158,8 @@ export class VersionsEditView extends SceneObjectBase<VersionsEditViewState> imp
       ),
     });
   };
-
   private decorateVersions(versions: RevisionModel[]): DecoratedRevisionModel[] {
     const timeZone = this.getTimeRange().getTimeZone();
-
     return versions.map((version) => {
       return {
         ...version,
@@ -190,19 +170,16 @@ export class VersionsEditView extends SceneObjectBase<VersionsEditViewState> imp
     });
   }
 }
-
 function VersionsEditorSettingsListView({ model }: SceneComponentProps<VersionsEditView>) {
   const dashboard = model.getDashboard();
   const { isLoading, isAppending, viewMode, baseInfo, newInfo, isNewLatest } = model.useState();
   const { navModel, pageNav } = useDashboardEditPageNav(dashboard, model.getUrlKey());
-
   const userKeys = useMemo(
     () => [...new Set(model.versions.map((v) => v.createdBy).filter(Boolean))],
     [model.versions]
   );
   const { data: displayData } = useGetDisplayMappingQuery(userKeys.length > 0 ? { key: userKeys } : skipToken);
   const isLoadingUserDisplayNames = userKeys.length > 0 && !displayData;
-
   const versionsWithDisplayNames = useMemo(() => {
     if (!displayData) {
       return model.versions;
@@ -219,7 +196,6 @@ function VersionsEditorSettingsListView({ model }: SceneComponentProps<VersionsE
       return displayName ? { ...version, createdBy: displayName } : version;
     });
   }, [model.versions, displayData]);
-
   const canCompare = model.versions.filter((version) => version.checked).length === 2;
   const showButtons = model.versions.length > 1;
   const hasMore = model.versions.length >= model.limit;
@@ -228,7 +204,6 @@ function VersionsEditorSettingsListView({ model }: SceneComponentProps<VersionsE
     model.versions.find((rev) => rev.version === 1) ||
     model.versions.length % model.limit !== 0 ||
     model.continueToken === '';
-
   const viewModeCompare = (
     <>
       <VersionHistoryHeader
@@ -250,7 +225,6 @@ function VersionsEditorSettingsListView({ model }: SceneComponentProps<VersionsE
       )}
     </>
   );
-
   const viewModeList = (
     <>
       {isLoading ? (
@@ -276,9 +250,7 @@ function VersionsEditorSettingsListView({ model }: SceneComponentProps<VersionsE
       )}
     </>
   );
-
   const isProvisioned = dashboard.isManagedRepository();
-
   return (
     <Page navModel={navModel} pageNav={pageNav} layout={PageLayoutType.Standard}>
       <NavToolbarActions dashboard={dashboard} />
@@ -296,7 +268,6 @@ function VersionsEditorSettingsListView({ model }: SceneComponentProps<VersionsE
     </Page>
   );
 }
-
 const VersionsHistorySpinner = ({ msg }: { msg: string }) => (
   <Stack>
     <Spinner />

--- a/public/app/features/dashboard-scene/settings/annotations/AnnotationQueryOptions.tsx
+++ b/public/app/features/dashboard-scene/settings/annotations/AnnotationQueryOptions.tsx
@@ -1,6 +1,6 @@
+import { structLog } from '@grafana/data';
 import { useCallback, useState } from 'react';
 import { useAsync } from 'react-use';
-
 import { AppEvents, CoreApp, type DataSourceInstanceSettings, getDataSourceRef } from '@grafana/data';
 import { t, Trans } from '@grafana/i18n';
 import { getAppEvents, getDataSourceSrv } from '@grafana/runtime';
@@ -10,15 +10,11 @@ import StandardAnnotationQueryEditor from 'app/features/annotations/components/S
 import { updateAnnotationFromSavedQuery } from 'app/features/annotations/utils/savedQueryUtils';
 import { DataSourcePicker } from 'app/features/datasources/components/picker/DataSourcePicker';
 import { useQueryLibraryContext } from 'app/features/explore/QueryLibrary/QueryLibraryContext';
-
 import { dashboardEditActions } from '../../edit-pane/shared';
-
 import { type AnnotationLayer } from './AnnotationEditableElement';
-
 export function AnnotationQueryEditorButton({ layer }: { layer: AnnotationLayer }) {
   const { queryLibraryEnabled } = useQueryLibraryContext();
   const [isModalOpen, setIsModalOpen] = useState(false);
-
   return (
     <>
       <Box display={'flex'} direction={'column'} paddingBottom={1}>
@@ -59,15 +55,12 @@ export function AnnotationQueryEditorButton({ layer }: { layer: AnnotationLayer 
     </>
   );
 }
-
 function QueryLibraryButton({ layer, onQuerySelected }: { layer: AnnotationLayer; onQuerySelected?: () => void }) {
   const { openDrawer, closeDrawer } = useQueryLibraryContext();
-
   const { query } = layer.useState();
   const { value: datasource } = useAsync(() => {
     return getDataSourceSrv().get(query?.datasource);
   }, [query?.datasource]);
-
   const onSelectFromQueryLibrary = useCallback(() => {
     openDrawer({
       options: {
@@ -79,7 +72,7 @@ function QueryLibraryButton({ layer, onQuerySelected }: { layer: AnnotationLayer
           layer.setState({ query: updatedQuery });
           layer.runLayer();
         } catch (error) {
-          console.error('Failed to replace annotation query!', error);
+          structLog('error', 'Failed to replace annotation query!', error);
           getAppEvents().publish({
             type: AppEvents.alertError.name,
             payload: ['Failed to create annotation query!', error instanceof Error ? error.message : error],
@@ -91,26 +84,21 @@ function QueryLibraryButton({ layer, onQuerySelected }: { layer: AnnotationLayer
       },
     });
   }, [closeDrawer, layer, onQuerySelected, openDrawer, query]);
-
   if (!datasource) {
     return null;
   }
-
   return (
     <Button variant="secondary" tooltip="" onClick={onSelectFromQueryLibrary} size="sm" fullWidth>
       <Trans i18nKey="dashboard-scene.annotation-query-library-dropdown.use-saved-query">Use saved query</Trans>
     </Button>
   );
 }
-
 function AnnotationDataSourcePicker({ layer }: { layer: AnnotationLayer }) {
   const { query } = layer.useState();
-
   const onDataSourceChange = useCallback(
     (ds: DataSourceInstanceSettings) => {
       const dsRef = getDataSourceRef(ds);
       const oldQuery = query;
-
       // If the data source type changed, reset the query to defaults
       const newQuery =
         query.datasource?.type !== dsRef.type
@@ -126,7 +114,6 @@ function AnnotationDataSourcePicker({ layer }: { layer: AnnotationLayer }) {
               type: query.type,
             }
           : { ...query, datasource: dsRef };
-
       dashboardEditActions.edit({
         description: t('dashboard.edit-pane.annotation.change-data-source', 'Change annotation data source'),
         source: layer,
@@ -142,23 +129,18 @@ function AnnotationDataSourcePicker({ layer }: { layer: AnnotationLayer }) {
     },
     [layer, query]
   );
-
   return (
     <Field label={t('dashboard.edit-pane.annotation.data-source', 'Data source')} noMargin>
       <DataSourcePicker annotations variables current={query?.datasource} onChange={onDataSourceChange} />
     </Field>
   );
 }
-
 function AnnotationQueryEditor({ layer }: { layer: AnnotationLayer }) {
   const { query } = layer.useState();
-
   const { value: ds } = useAsync(() => {
     return getDataSourceSrv().get(query?.datasource);
   }, [query?.datasource]);
-
   const dsi = getDataSourceSrv().getInstanceSettings(query?.datasource);
-
   const onChange = useCallback(
     (newQuery: typeof query) => {
       layer.setState({ query: newQuery });
@@ -166,11 +148,9 @@ function AnnotationQueryEditor({ layer }: { layer: AnnotationLayer }) {
     },
     [layer]
   );
-
   if (!ds?.annotations || !dsi || !query) {
     return null;
   }
-
   return (
     <StandardAnnotationQueryEditor
       disableSavedQueries

--- a/public/app/features/dashboard-scene/settings/variables/editors/AdHocFiltersVariableEditor.tsx
+++ b/public/app/features/dashboard-scene/settings/variables/editors/AdHocFiltersVariableEditor.tsx
@@ -1,7 +1,7 @@
+import { structLog } from '@grafana/data';
 import { noop } from 'lodash';
 import { type FormEvent, useCallback, useMemo, useState } from 'react';
 import { useAsync } from 'react-use';
-
 import {
   type DataSourceInstanceSettings,
   type MetricFindValue,
@@ -12,43 +12,31 @@ import { t } from '@grafana/i18n';
 import { config, getDataSourceSrv } from '@grafana/runtime';
 import { AdHocFiltersVariable, type AdHocFilterWithLabels, type SceneVariable } from '@grafana/scenes';
 import { OptionsPaneItemDescriptor } from 'app/features/dashboard/components/PanelEditor/OptionsPaneItemDescriptor';
-
 import { AdHocOriginFiltersController } from '../components/AdHocOriginFiltersController';
 import { AdHocVariableForm } from '../components/AdHocVariableForm';
-
 interface AdHocFiltersVariableEditorProps {
   variable: AdHocFiltersVariable;
   onRunQuery: (variable: AdHocFiltersVariable) => void;
   inline?: boolean;
 }
-
 const ORIGIN_DASHBOARD = 'dashboard';
-
 function isOriginDashboard(f: AdHocFilterWithLabels) {
   return f.origin === ORIGIN_DASHBOARD;
 }
-
 function isGroupByOriginFilter(f: AdHocFilterWithLabels) {
   return isOriginDashboard(f) && f.operator === 'groupBy';
 }
-
 export function AdHocFiltersVariableEditor(props: AdHocFiltersVariableEditorProps) {
   const { variable } = props;
   const { datasource: datasourceRef, defaultKeys, allowCustomValue, enableGroupBy } = variable.useState();
-
   const [wip, setWip] = useState<AdHocFilterWithLabels | undefined>(undefined);
-
   const [originalFilters, setOriginalFilters] = useState<AdHocFilterWithLabels[]>(() => variable.getOriginalFilters());
-
   const adhocOriginFilters = useMemo(
     () => originalFilters.filter((f) => isOriginDashboard(f) && !isGroupByOriginFilter(f)),
     [originalFilters]
   );
-
   const groupByOriginFilters = useMemo(() => originalFilters.filter(isGroupByOriginFilter), [originalFilters]);
-
   const groupByEnabled = config.featureToggles.dashboardUnifiedDrilldownControls && enableGroupBy;
-
   const updateOriginalFilters = useCallback(
     (filters: AdHocFilterWithLabels[]) => {
       setOriginalFilters(filters);
@@ -57,12 +45,10 @@ export function AdHocFiltersVariableEditor(props: AdHocFiltersVariableEditorProp
     },
     [variable]
   );
-
   const originFiltersController = useMemo(() => {
     if (!config.featureToggles.adHocFilterDefaultValues && !config.featureToggles.dashboardUnifiedDrilldownControls) {
       return undefined;
     }
-
     return new AdHocOriginFiltersController(
       adhocOriginFilters,
       (filters) => {
@@ -77,12 +63,10 @@ export function AdHocFiltersVariableEditor(props: AdHocFiltersVariableEditorProp
       () => variable._getOperators()
     );
   }, [variable, adhocOriginFilters, originalFilters, wip, allowCustomValue, updateOriginalFilters]);
-
   const defaultGroupByValues: Array<SelectableValue<string>> = useMemo(
     () => groupByOriginFilters.map((f) => ({ value: f.key, label: f.keyLabel || f.key })),
     [groupByOriginFilters]
   );
-
   const onDefaultGroupByChange = (items: Array<SelectableValue<string>>) => {
     const groupByFilters: AdHocFilterWithLabels[] = items
       .filter((item) => item.value != null)
@@ -96,11 +80,9 @@ export function AdHocFiltersVariableEditor(props: AdHocFiltersVariableEditorProp
     const keep = originalFilters.filter((f) => !isGroupByOriginFilter(f));
     updateOriginalFilters([...keep, ...groupByFilters]);
   };
-
   const { value: datasourceSettings } = useAsync(async () => {
     return await getDataSourceSrv().get(datasourceRef);
   }, [datasourceRef]);
-
   const message = datasourceSettings?.getTagKeys
     ? t(
         'dashboard-scene.ad-hoc-filters-variable-editor.message-supported',
@@ -110,11 +92,9 @@ export function AdHocFiltersVariableEditor(props: AdHocFiltersVariableEditorProp
         'dashboard-scene.ad-hoc-filters-variable-editor.message-not-supported',
         'This data source does not support filters.'
       );
-
   const onDataSourceChange = async (ds: DataSourceInstanceSettings) => {
     const dsRef = getDataSourceRef(ds);
     const dsInstance = await getDataSourceSrv().get(dsRef);
-
     variable.setState({
       datasource: dsRef,
       supportsMultiValueOperators: ds.meta.multiValueFilterOperators,
@@ -123,28 +103,23 @@ export function AdHocFiltersVariableEditor(props: AdHocFiltersVariableEditorProp
       }),
     });
   };
-
   const onDefaultKeysChange = (defaultKeys?: MetricFindValue[]) => {
     variable.setState({
       defaultKeys,
     });
   };
-
   const onAllowCustomValueChange = (event: FormEvent<HTMLInputElement>) => {
     variable.setState({ allowCustomValue: event.currentTarget.checked });
   };
-
   const onEnableGroupByChange = (event: FormEvent<HTMLInputElement>) => {
     variable.setState({ enableGroupBy: event.currentTarget.checked });
   };
-
   const { value: groupByKeyOptions = [] } = useAsync(async () => {
     if (!groupByEnabled) {
       return [];
     }
     return variable._getGroupByKeys(null);
   }, [variable, groupByEnabled]);
-
   return (
     <AdHocVariableForm
       datasource={datasourceRef ?? undefined}
@@ -166,13 +141,11 @@ export function AdHocFiltersVariableEditor(props: AdHocFiltersVariableEditorProp
     />
   );
 }
-
 export function getAdHocFilterOptions(variable: SceneVariable): OptionsPaneItemDescriptor[] {
   if (!(variable instanceof AdHocFiltersVariable)) {
-    console.warn('getAdHocFilterOptions: variable is not an AdHocFiltersVariable');
+    structLog('warn', 'getAdHocFilterOptions: variable is not an AdHocFiltersVariable');
     return [];
   }
-
   return [
     new OptionsPaneItemDescriptor({
       id: `variable-${variable.state.name}-value`,

--- a/public/app/features/dashboard-scene/settings/variables/editors/ConstantVariableEditor.tsx
+++ b/public/app/features/dashboard-scene/settings/variables/editors/ConstantVariableEditor.tsx
@@ -1,33 +1,26 @@
+import { structLog } from '@grafana/data';
 import { type FormEvent } from 'react';
 import { lastValueFrom } from 'rxjs';
-
 import { t } from '@grafana/i18n';
 import { ConstantVariable, type SceneVariable } from '@grafana/scenes';
 import { Input } from '@grafana/ui';
 import { OptionsPaneItemDescriptor } from 'app/features/dashboard/components/PanelEditor/OptionsPaneItemDescriptor';
-
 import { ConstantVariableForm } from '../components/ConstantVariableForm';
-
 interface ConstantVariableEditorProps {
   variable: ConstantVariable;
 }
-
 export function ConstantVariableEditor({ variable }: ConstantVariableEditorProps) {
   const { value } = variable.useState();
-
   const onConstantValueChange = (event: FormEvent<HTMLInputElement>) => {
     variable.setState({ value: event.currentTarget.value });
   };
-
   return <ConstantVariableForm constantValue={value.toString()} onChange={onConstantValueChange} />;
 }
-
 export function getConstantVariableOptions(variable: SceneVariable): OptionsPaneItemDescriptor[] {
   if (!(variable instanceof ConstantVariable)) {
-    console.warn('getConstantVariableOptions: variable is not a ConstantVariable');
+    structLog('warn', 'getConstantVariableOptions: variable is not a ConstantVariable');
     return [];
   }
-
   return [
     new OptionsPaneItemDescriptor({
       title: t('dashboard-scene.constant-variable-form.label-value', 'Value'),
@@ -36,15 +29,12 @@ export function getConstantVariableOptions(variable: SceneVariable): OptionsPane
     }),
   ];
 }
-
 function ConstantValueInput({ variable, id }: { variable: ConstantVariable; id?: string }) {
   const { value } = variable.useState();
-
   const onBlur = async (event: FormEvent<HTMLInputElement>) => {
     variable.setState({ value: event.currentTarget.value });
     await lastValueFrom(variable.validateAndUpdate!());
   };
-
   return (
     <Input
       id={id}

--- a/public/app/features/dashboard-scene/settings/variables/editors/GroupByVariableEditor.tsx
+++ b/public/app/features/dashboard-scene/settings/variables/editors/GroupByVariableEditor.tsx
@@ -1,7 +1,7 @@
+import { structLog } from '@grafana/data';
 import { noop } from 'lodash';
 import { type FormEvent } from 'react';
 import { useAsync } from 'react-use';
-
 import {
   type DataSourceInstanceSettings,
   type MetricFindValue,
@@ -11,23 +11,18 @@ import {
 import { getDataSourceSrv } from '@grafana/runtime';
 import { GroupByVariable, type SceneVariable } from '@grafana/scenes';
 import { OptionsPaneItemDescriptor } from 'app/features/dashboard/components/PanelEditor/OptionsPaneItemDescriptor';
-
 import { GroupByVariableForm } from '../components/GroupByVariableForm';
-
 interface GroupByVariableEditorProps {
   variable: GroupByVariable;
   onRunQuery: () => void;
   inline?: boolean;
 }
-
 export function GroupByVariableEditor(props: GroupByVariableEditorProps) {
   const { variable, onRunQuery, inline } = props;
   const { datasource: datasourceRef, defaultOptions, allowCustomValue = true, defaultValue } = variable.useState();
-
   const { value: datasource } = useAsync(async () => {
     return await getDataSourceSrv().get(datasourceRef);
   }, [variable.state]);
-
   const { value: groupByKeys = [] } = useAsync(async () => {
     if (!datasource?.getGroupByKeys) {
       return [];
@@ -36,23 +31,18 @@ export function GroupByVariableEditor(props: GroupByVariableEditorProps) {
     const keys = Array.isArray(result) ? result : (result.data ?? []);
     return keys.map((k) => ({ label: k.text || String(k.value), value: String(k.value) }));
   }, [datasource]);
-
   const message = datasource?.getGroupByKeys
     ? 'Group by dimensions are applied automatically to all queries that target this data source'
     : 'This data source does not support group by variable yet.';
-
   const onDataSourceChange = async (ds: DataSourceInstanceSettings) => {
     const dsRef = getDataSourceRef(ds);
-
     variable.setState({ datasource: dsRef });
     onRunQuery();
   };
-
   const onDefaultOptionsChange = async (defaultOptions?: MetricFindValue[]) => {
     variable.setState({ defaultOptions });
     onRunQuery();
   };
-
   const onDefaultValueChange = (options: Array<SelectableValue<string>>) => {
     if (options.length === 0) {
       variable.setState({
@@ -71,7 +61,6 @@ export function GroupByVariableEditor(props: GroupByVariableEditorProps) {
     }
     onRunQuery();
   };
-
   const defaultValueSelection: Array<SelectableValue<string>> = defaultValue
     ? Array.isArray(defaultValue.value)
       ? defaultValue.value.map((v, i) => {
@@ -81,11 +70,9 @@ export function GroupByVariableEditor(props: GroupByVariableEditorProps) {
         })
       : [{ value: String(defaultValue.value), label: String(defaultValue.text ?? defaultValue.value) }]
     : [];
-
   const onAllowCustomValueChange = (event: FormEvent<HTMLInputElement>) => {
     variable.setState({ allowCustomValue: event.currentTarget.checked });
   };
-
   return (
     <GroupByVariableForm
       defaultOptions={defaultOptions}
@@ -103,13 +90,11 @@ export function GroupByVariableEditor(props: GroupByVariableEditorProps) {
     />
   );
 }
-
 export function getGroupByVariableOptions(variable: SceneVariable): OptionsPaneItemDescriptor[] {
   if (!(variable instanceof GroupByVariable)) {
-    console.warn('getAdHocFilterOptions: variable is not an AdHocFiltersVariable');
+    structLog('warn', 'getAdHocFilterOptions: variable is not an AdHocFiltersVariable');
     return [];
   }
-
   return [
     new OptionsPaneItemDescriptor({
       id: `variable-${variable.state.name}-value`,

--- a/public/app/features/dashboard-scene/settings/variables/editors/IntervalVariableEditor.tsx
+++ b/public/app/features/dashboard-scene/settings/variables/editors/IntervalVariableEditor.tsx
@@ -1,6 +1,6 @@
+import { structLog } from '@grafana/data';
 import { noop } from 'lodash';
 import { type ChangeEvent, type FormEvent } from 'react';
-
 import { type SelectableValue } from '@grafana/data';
 import { IntervalVariable, type SceneVariable } from '@grafana/scenes';
 import { OptionsPaneItemDescriptor } from 'app/features/dashboard/components/PanelEditor/OptionsPaneItemDescriptor';
@@ -8,46 +8,35 @@ import {
   getIntervalsFromQueryString,
   getIntervalsQueryFromNewIntervalModel,
 } from 'app/features/dashboard-scene/utils/utils';
-
 import { IntervalVariableForm } from '../components/IntervalVariableForm';
-
 interface IntervalVariableEditorProps {
   variable: IntervalVariable;
   onRunQuery: () => void;
   inline?: boolean;
 }
-
 export function IntervalVariableEditor({ variable, onRunQuery, inline }: IntervalVariableEditorProps) {
   const { intervals, autoStepCount, autoEnabled, autoMinInterval, value } = variable.useState();
-
   //transform intervals array into string
   const intervalsCombined = getIntervalsQueryFromNewIntervalModel(intervals);
-
   const onIntervalsChange = (event: FormEvent<HTMLInputElement>) => {
     const newIntervals = getIntervalsFromQueryString(event.currentTarget.value);
     // if the current value is not in the new intervals, set the value to the first interval
     const newValue = newIntervals.includes(value) ? value : newIntervals[0];
-
     variable.setState({
       intervals: newIntervals,
       value: newValue,
     });
-
     onRunQuery();
   };
-
   const onAutoCountChanged = (option: SelectableValue<number>) => {
     variable.setState({ autoStepCount: option.value });
   };
-
   const onAutoEnabledChange = (event: ChangeEvent<HTMLInputElement>) => {
     variable.setState({ autoEnabled: event.target.checked });
   };
-
   const onAutoMinIntervalChanged = (event: FormEvent<HTMLInputElement>) => {
     variable.setState({ autoMinInterval: event.currentTarget.value });
   };
-
   return (
     <IntervalVariableForm
       intervals={intervalsCombined}
@@ -62,13 +51,11 @@ export function IntervalVariableEditor({ variable, onRunQuery, inline }: Interva
     />
   );
 }
-
 export function getIntervalVariableOptions(variable: SceneVariable): OptionsPaneItemDescriptor[] {
   if (!(variable instanceof IntervalVariable)) {
-    console.warn('getIntervalVariableOptions: variable is not an IntervalVariable');
+    structLog('warn', 'getIntervalVariableOptions: variable is not an IntervalVariable');
     return [];
   }
-
   return [
     new OptionsPaneItemDescriptor({
       id: `variable-${variable.state.name}-value`,

--- a/public/app/features/dashboard-scene/settings/variables/editors/QueryVariableEditor.tsx
+++ b/public/app/features/dashboard-scene/settings/variables/editors/QueryVariableEditor.tsx
@@ -1,6 +1,6 @@
+import { structLog } from '@grafana/data';
 import { type FormEvent, useState } from 'react';
 import { useAsync } from 'react-use';
-
 import {
   type DataSourceInstanceSettings,
   getDataSourceRef,
@@ -25,17 +25,14 @@ import {
   type StaticOptionsOrderType,
   type StaticOptionsType,
 } from 'app/features/variables/query/QueryVariableStaticOptions';
-
 import { QueryVariableEditorForm } from '../components/QueryVariableForm';
 import { VariableValuesPreview } from '../components/VariableValuesPreview';
 import { hasVariableOptions } from '../utils';
-
 interface QueryVariableEditorProps {
   variable: QueryVariable;
   onRunQuery: () => void;
 }
 type VariableQueryType = QueryVariable['state']['query'];
-
 export function QueryVariableEditor({ variable, onRunQuery }: QueryVariableEditorProps) {
   const {
     datasource,
@@ -53,7 +50,6 @@ export function QueryVariableEditor({ variable, onRunQuery }: QueryVariableEdito
     staticOptionsOrder,
   } = variable.useState();
   const { value: timeRange } = sceneGraph.getTimeRange(variable).useState();
-
   const onRegExChange = (event: React.FormEvent<HTMLTextAreaElement>) => {
     variable.setState({ regex: event.currentTarget.value });
   };
@@ -80,29 +76,24 @@ export function QueryVariableEditor({ variable, onRunQuery }: QueryVariableEdito
   };
   const onDataSourceChange = (dsInstanceSettings: DataSourceInstanceSettings, preserveQuery = false) => {
     const datasource = getDataSourceRef(dsInstanceSettings);
-
     if (!preserveQuery && (variable.state.datasource?.type || '') !== datasource.type) {
       variable.setState({ datasource, query: '', definition: '' });
       return;
     }
-
     variable.setState({ datasource });
   };
   const onQueryChange = (query: VariableQueryType) => {
     variable.setState({ query, definition: getQueryDef(query) });
     onRunQuery();
   };
-
   const onStaticOptionsChange = (staticOptions: StaticOptionsType) => {
     onRunQuery();
     variable.setState({ staticOptions });
   };
-
   const onStaticOptionsOrderChange = (staticOptionsOrder: StaticOptionsOrderType) => {
     onRunQuery();
     variable.setState({ staticOptionsOrder });
   };
-
   return (
     <QueryVariableEditorForm
       datasource={datasource ?? undefined}
@@ -135,13 +126,11 @@ export function QueryVariableEditor({ variable, onRunQuery }: QueryVariableEdito
     />
   );
 }
-
 export function getQueryVariableOptions(variable: SceneVariable): OptionsPaneItemDescriptor[] {
   if (!(variable instanceof QueryVariable)) {
-    console.warn('getQueryVariableOptions: variable is not a QueryVariable');
+    structLog('warn', 'getQueryVariableOptions: variable is not a QueryVariable');
     return [];
   }
-
   return [
     new OptionsPaneItemDescriptor({
       id: `variable-${variable.state.name}-value`,
@@ -149,14 +138,11 @@ export function getQueryVariableOptions(variable: SceneVariable): OptionsPaneIte
     }),
   ];
 }
-
 export function ModalEditor({ variable }: { variable: QueryVariable }) {
   const [isOpen, setIsOpen] = useState(false);
-
   const onRunQuery = () => {
     variable.refreshOptions();
   };
-
   return (
     <>
       <Box display={'flex'} direction={'column'} paddingBottom={1}>
@@ -201,7 +187,6 @@ export function ModalEditor({ variable }: { variable: QueryVariable }) {
     </>
   );
 }
-
 export function Editor({ variable }: { variable: QueryVariable }) {
   const {
     datasource: datasourceRef,
@@ -219,29 +204,22 @@ export function Editor({ variable }: { variable: QueryVariable }) {
     const datasource = await getDataSourceSrv().get(datasourceRef ?? '');
     const VariableQueryEditor = await getVariableQueryEditor(datasource);
     const defaultQuery = datasource?.variables?.getDefaultQuery?.();
-
     if (!query && defaultQuery) {
       const newQuery =
         typeof defaultQuery === 'string' ? defaultQuery : { ...defaultQuery, refId: defaultQuery.refId ?? 'A' };
       onQueryChange(newQuery);
     }
-
     return { datasource, VariableQueryEditor };
   }, [datasourceRef]);
-
   const { datasource: selectedDatasource, VariableQueryEditor } = dsConfig ?? {};
-
   const onDataSourceChange = (dsInstanceSettings: DataSourceInstanceSettings) => {
     const datasource = getDataSourceRef(dsInstanceSettings);
-
     if ((variable.state.datasource?.type || '') !== datasource.type) {
       variable.setState({ datasource, query: '', definition: '' });
       return;
     }
-
     variable.setState({ datasource });
   };
-
   const onQueryChange = (query: VariableQueryType) => {
     variable.setState({ query, definition: getQueryDef(query) });
   };
@@ -263,9 +241,7 @@ export function Editor({ variable }: { variable: QueryVariable }) {
   const onStaticOptionsOrderChange = (staticOptionsOrder: StaticOptionsOrderType) => {
     variable.setState({ staticOptionsOrder });
   };
-
   const isHasVariableOptions = hasVariableOptions(variable);
-
   return (
     <div data-testid={selectors.pages.Dashboard.Settings.Variables.Edit.QueryVariable.editor}>
       {/* eslint-disable-next-line @grafana/require-no-margin */}
@@ -318,7 +294,6 @@ export function Editor({ variable }: { variable: QueryVariable }) {
     </div>
   );
 }
-
 function getQueryDef(query: VariableQueryType) {
   if (typeof query === 'string') {
     return query;

--- a/public/app/features/dashboard-scene/settings/variables/editors/SwitchVariableEditor.tsx
+++ b/public/app/features/dashboard-scene/settings/variables/editors/SwitchVariableEditor.tsx
@@ -1,36 +1,29 @@
+import { structLog } from '@grafana/data';
 import { type SceneVariable, SwitchVariable } from '@grafana/scenes';
 import { OptionsPaneItemDescriptor } from 'app/features/dashboard/components/PanelEditor/OptionsPaneItemDescriptor';
-
 import { SwitchVariableForm } from '../components/SwitchVariableForm';
-
 interface SwitchVariableEditorProps {
   variable: SwitchVariable;
   inline?: boolean;
 }
-
 export function SwitchVariableEditor({ variable, inline = false }: SwitchVariableEditorProps) {
   const { value, enabledValue, disabledValue } = variable.useState();
-
   const onEnabledValueChange = (newEnabledValue: string) => {
     const isCurrentlyEnabled = value === enabledValue;
-
     if (isCurrentlyEnabled) {
       variable.setState({ enabledValue: newEnabledValue, value: newEnabledValue });
     } else {
       variable.setState({ enabledValue: newEnabledValue });
     }
   };
-
   const onDisabledValueChange = (newDisabledValue: string) => {
     const isCurrentlyDisabled = value === disabledValue;
-
     if (isCurrentlyDisabled) {
       variable.setState({ disabledValue: newDisabledValue, value: newDisabledValue });
     } else {
       variable.setState({ disabledValue: newDisabledValue });
     }
   };
-
   return (
     <SwitchVariableForm
       enabledValue={enabledValue}
@@ -41,13 +34,11 @@ export function SwitchVariableEditor({ variable, inline = false }: SwitchVariabl
     />
   );
 }
-
 export function getSwitchVariableOptions(variable: SceneVariable): OptionsPaneItemDescriptor[] {
   if (!(variable instanceof SwitchVariable)) {
-    console.warn('getSwitchVariableOptions: variable is not a SwitchVariable');
+    structLog('warn', 'getSwitchVariableOptions: variable is not a SwitchVariable');
     return [];
   }
-
   return [
     new OptionsPaneItemDescriptor({
       id: `variable-${variable.state.name}-value`,

--- a/public/app/features/dashboard-scene/settings/variables/editors/TextBoxVariableEditor.tsx
+++ b/public/app/features/dashboard-scene/settings/variables/editors/TextBoxVariableEditor.tsx
@@ -1,34 +1,27 @@
+import { structLog } from '@grafana/data';
 import { noop } from 'lodash';
 import { type FormEvent } from 'react';
-
 import { t } from '@grafana/i18n';
 import { type SceneVariable, TextBoxVariable } from '@grafana/scenes';
 import { OptionsPaneItemDescriptor } from 'app/features/dashboard/components/PanelEditor/OptionsPaneItemDescriptor';
-
 import { TextBoxVariableForm } from '../components/TextBoxVariableForm';
-
 interface TextBoxVariableEditorProps {
   variable: TextBoxVariable;
   onChange: (variable: TextBoxVariable) => void;
   inline?: boolean;
 }
-
 export function TextBoxVariableEditor({ variable, inline }: TextBoxVariableEditorProps) {
   const { value } = variable.useState();
-
   const onTextValueChange = (e: FormEvent<HTMLInputElement>) => {
     variable.setState({ value: e.currentTarget.value });
   };
-
   return <TextBoxVariableForm defaultValue={value} onBlur={onTextValueChange} inline={inline} />;
 }
-
 export function getTextBoxVariableOptions(variable: SceneVariable): OptionsPaneItemDescriptor[] {
   if (!(variable instanceof TextBoxVariable)) {
-    console.warn('getTextBoxVariableOptions: variable is not a TextBoxVariable');
+    structLog('warn', 'getTextBoxVariableOptions: variable is not a TextBoxVariable');
     return [];
   }
-
   return [
     new OptionsPaneItemDescriptor({
       title: t('dashboard-scene.textbox-variable-form.label-value', 'Value'),

--- a/public/app/features/dashboard-scene/sharing/ExportButton/ExportAsImage.tsx
+++ b/public/app/features/dashboard-scene/sharing/ExportButton/ExportAsImage.tsx
@@ -1,8 +1,8 @@
+import { structLog } from '@grafana/data';
 import { css } from '@emotion/css';
 import { saveAs } from 'file-saver';
 import { useEffect } from 'react';
 import { useAsyncFn } from 'react-use';
-
 import { type GrafanaTheme2 } from '@grafana/data';
 import { Trans, t } from '@grafana/i18n';
 import { config } from '@grafana/runtime';
@@ -10,45 +10,36 @@ import { type SceneComponentProps, SceneObjectBase } from '@grafana/scenes';
 import { Alert, Button, TextLink, useStyles2 } from '@grafana/ui';
 import { DashboardInteractions } from 'app/features/dashboard-scene/utils/interactions';
 import { getDashboardSceneFor } from 'app/features/dashboard-scene/utils/utils';
-
 import { ImagePreview } from '../components/ImagePreview';
 import { type SceneShareTabState, type ShareView } from '../types';
-
 import { generateDashboardImage } from './utils';
-
 export class ExportAsImage extends SceneObjectBase<SceneShareTabState> implements ShareView {
   static Component = ExportAsImageRenderer;
-
   public getTabLabel() {
     return t('share-modal.image.title', 'Export as image');
   }
 }
-
 function ExportAsImageRenderer({ model }: SceneComponentProps<ExportAsImage>) {
   const { onDismiss } = model.useState();
   const dashboard = getDashboardSceneFor(model);
   const styles = useStyles2(getStyles);
-
   const [{ loading: isLoading, value: imageBlob, error }, onExport] = useAsyncFn(async () => {
     try {
       const result = await generateDashboardImage({
         dashboard,
         scale: config.rendererDefaultImageScale || 1,
       });
-
       if (result.error) {
         throw new Error(result.error);
       }
-
       DashboardInteractions.generateDashboardImageClicked({
         scale: config.rendererDefaultImageScale || 1,
         shareResource: 'dashboard',
         success: true,
       });
-
       return result.blob;
     } catch (error) {
-      console.error('Error exporting image:', error);
+      structLog('error', 'Error exporting image:', error);
       DashboardInteractions.generateDashboardImageClicked({
         scale: config.rendererDefaultImageScale || 1,
         shareResource: 'dashboard',
@@ -58,7 +49,6 @@ function ExportAsImageRenderer({ model }: SceneComponentProps<ExportAsImage>) {
       throw error; // Re-throw to let useAsyncFn handle the error state
     }
   }, [dashboard]);
-
   // Clean up object URLs when component unmounts
   useEffect(() => {
     return () => {
@@ -67,26 +57,21 @@ function ExportAsImageRenderer({ model }: SceneComponentProps<ExportAsImage>) {
       }
     };
   }, [imageBlob]);
-
   const onDownload = () => {
     if (!imageBlob) {
       return;
     }
-
     const time = new Date().getTime();
     const name = dashboard.state.title;
     saveAs(imageBlob, `${name}-${time}.png`);
-
     DashboardInteractions.downloadDashboardImageClicked({
       fileName: `${name}-${time}.png`,
       shareResource: 'dashboard',
     });
   };
-
   if (!config.rendererAvailable) {
     return <RendererAlert />;
   }
-
   return (
     <main>
       <p className={styles.info}>
@@ -140,12 +125,10 @@ function ExportAsImageRenderer({ model }: SceneComponentProps<ExportAsImage>) {
     </main>
   );
 }
-
 function RendererAlert() {
   if (config.rendererAvailable) {
     return null;
   }
-
   return (
     <Alert severity="info" title={t('share-modal.link.render-alert', 'Image renderer plugin not installed')}>
       <div>{t('share-modal.link.render-alert', 'Image renderer plugin not installed')}</div>
@@ -161,7 +144,6 @@ function RendererAlert() {
     </Alert>
   );
 }
-
 const getStyles = (theme: GrafanaTheme2) => ({
   info: css({
     marginBottom: theme.spacing(2),

--- a/public/app/features/dashboard-scene/utils/DashboardModelCompatibilityWrapper.ts
+++ b/public/app/features/dashboard-scene/utils/DashboardModelCompatibilityWrapper.ts
@@ -1,5 +1,5 @@
+import { structLog } from '@grafana/data';
 import { Subscription } from 'rxjs';
-
 import {
   type AnnotationQuery,
   DashboardCursorSync,
@@ -9,27 +9,21 @@ import {
 } from '@grafana/data';
 import { TimeRangeUpdatedEvent } from '@grafana/runtime';
 import { behaviors, sceneGraph, type SceneObject, VizPanel } from '@grafana/scenes';
-
 import { DashboardDataLayerSet } from '../scene/DashboardDataLayerSet';
 import { type DashboardScene } from '../scene/DashboardScene';
 import { dataLayersToAnnotations } from '../serialization/dataLayersToAnnotations';
-
 import { PanelModelCompatibilityWrapper } from './PanelModelCompatibilityWrapper';
 import { findVizPanelByKey, getVizPanelKeyForPanelId } from './utils';
-
 /**
  * Will move this to make it the main way we remain somewhat compatible with getDashboardSrv().getCurrent
  */
 export class DashboardModelCompatibilityWrapper {
   public events = new EventBusSrv();
   private _subs = new Subscription();
-
   public constructor(private _scene: DashboardScene) {
     const timeRange = sceneGraph.getTimeRange(_scene);
-
     // Copied from DashboardModel, as this function is passed around
     this.formatDate = this.formatDate.bind(this);
-
     this._subs.add(
       timeRange.subscribeToState((state, prev) => {
         if (state.value !== prev.value) {
@@ -38,54 +32,42 @@ export class DashboardModelCompatibilityWrapper {
       })
     );
   }
-
   public get uid() {
     return this._scene.state.uid ?? null;
   }
-
   public get title() {
     return this._scene.state.title;
   }
-
   public get description() {
     return this._scene.state.description;
   }
-
   public get editable() {
     return this._scene.state.editable;
   }
-
   public get graphTooltip() {
     return this._getSyncMode();
   }
-
   public get timepicker() {
     return {
       refresh_intervals: this._scene.state.controls!.state.refreshPicker.state.intervals,
       hidden: this._scene.state.controls!.state.hideTimeControls ?? false,
     };
   }
-
   public get timezone() {
     return this.getTimezone();
   }
-
   public get weekStart() {
     return sceneGraph.getTimeRange(this._scene).state.weekStart;
   }
-
   public get tags() {
     return this._scene.state.tags;
   }
-
   public get links() {
     return this._scene.state.links;
   }
-
   public get meta() {
     return this._scene.state.meta;
   }
-
   public get time() {
     const time = sceneGraph.getTimeRange(this._scene);
     return {
@@ -93,40 +75,36 @@ export class DashboardModelCompatibilityWrapper {
       to: time.state.to,
     };
   }
-
   public get panels() {
     const panels = findAllObjects(this._scene, (o) => {
       return Boolean(o instanceof VizPanel);
     });
     return panels.map((p) => new PanelModelCompatibilityWrapper(p as VizPanel));
   }
-
   /**
    * Used from from timeseries migration handler to migrate time regions to dashboard annotations
    */
-  public get annotations(): { list: AnnotationQuery[] } {
-    const annotations: { list: AnnotationQuery[] } = { list: [] };
-
+  public get annotations(): {
+    list: AnnotationQuery[];
+  } {
+    const annotations: {
+      list: AnnotationQuery[];
+    } = { list: [] };
     if (this._scene.state.$data instanceof DashboardDataLayerSet) {
       annotations.list = dataLayersToAnnotations(this._scene.state.$data.state.annotationLayers);
     }
-
     return annotations;
   }
-
   public getTimezone() {
     const time = sceneGraph.getTimeRange(this._scene);
     return time.getTimeZone();
   }
-
   public sharedTooltipModeEnabled() {
     return this._getSyncMode() > 0;
   }
-
   public sharedCrosshairModeOnly() {
     return this._getSyncMode() === 1;
   }
-
   private _getSyncMode() {
     if (this._scene.state.$behaviors) {
       for (const behavior of this._scene.state.$behaviors) {
@@ -135,59 +113,47 @@ export class DashboardModelCompatibilityWrapper {
         }
       }
     }
-
     return DashboardCursorSync.Off;
   }
-
   public otherPanelInFullscreen(panel: unknown) {
     return false;
   }
-
   public formatDate(date: DateTimeInput, format?: string) {
     return dateTimeFormat(date, {
       format,
       timeZone: this.getTimezone(),
     });
   }
-
   public getPanelById(id: number): PanelModelCompatibilityWrapper | null {
     const vizPanel = findVizPanelByKey(this._scene, getVizPanelKeyForPanelId(id));
     if (vizPanel) {
       return new PanelModelCompatibilityWrapper(vizPanel);
     }
-
     return null;
   }
-
   /**
    * Mainly implemented to support Getting started panel's dismiss button.
    */
   public removePanel(panel: PanelModelCompatibilityWrapper) {
     const vizPanel = findVizPanelByKey(this._scene, getVizPanelKeyForPanelId(panel.id));
     if (!vizPanel) {
-      console.error('Trying to remove a panel that was not found in scene', panel);
+      structLog('error', 'Trying to remove a panel that was not found in scene', panel);
       return;
     }
-
     this._scene.removePanel(vizPanel);
   }
-
   public canEditAnnotations(dashboardUID?: string) {
     return Boolean(this._scene.state.meta.annotationsPermissions?.dashboard.canEdit);
   }
-
   public panelInitialized() {}
-
   public destroy() {
     this.events.removeAllListeners();
     this._subs.unsubscribe();
   }
-
   public hasUnsavedChanges() {
     return this._scene.state.isDirty;
   }
 }
-
 function findAllObjects(root: SceneObject, check: (o: SceneObject) => boolean) {
   let result: SceneObject[] = [];
   root.forEachChild((child) => {
@@ -197,6 +163,5 @@ function findAllObjects(root: SceneObject, check: (o: SceneObject) => boolean) {
       result = result.concat(findAllObjects(child, check));
     }
   });
-
   return result;
 }

--- a/public/app/features/dashboard-scene/utils/PanelModelCompatibilityWrapper.ts
+++ b/public/app/features/dashboard-scene/utils/PanelModelCompatibilityWrapper.ts
@@ -1,65 +1,50 @@
+import { structLog } from '@grafana/data';
 import { type PanelModel } from '@grafana/data';
 import { SceneDataTransformer, type VizPanel } from '@grafana/scenes';
 import { type DataSourceRef, type DataTransformerConfig } from '@grafana/schema';
-
 import { getPanelIdForVizPanel, getQueryRunnerFor } from './utils';
-
 export class PanelModelCompatibilityWrapper implements PanelModel {
   constructor(private _vizPanel: VizPanel) {}
-
   public get id() {
     const id = getPanelIdForVizPanel(this._vizPanel);
-
     if (isNaN(id)) {
-      console.error('VizPanel key could not be translated to a legacy numeric panel id', this._vizPanel);
+      structLog('error', 'VizPanel key could not be translated to a legacy numeric panel id', this._vizPanel);
       return 0;
     }
-
     return id;
   }
-
   public get description() {
     return this._vizPanel.state.description;
   }
-
   public get type() {
     return this._vizPanel.state.pluginId;
   }
-
   public get title() {
     return this._vizPanel.state.title;
   }
-
   public get transformations() {
     if (this._vizPanel.state.$data instanceof SceneDataTransformer) {
       return this._vizPanel.state.$data.state.transformations as DataTransformerConfig[];
     }
-
     return [];
   }
-
   public get targets() {
     const queryRunner = getQueryRunnerFor(this._vizPanel);
     if (!queryRunner) {
       return [];
     }
-
     return queryRunner.state.queries;
   }
-
   public get datasource(): DataSourceRef | null | undefined {
     const queryRunner = getQueryRunnerFor(this._vizPanel);
     return queryRunner?.state.datasource;
   }
-
   public get options() {
     return this._vizPanel.state.options;
   }
-
   public get fieldConfig() {
     return this._vizPanel.state.fieldConfig;
   }
-
   public get pluginVersion() {
     return this._vizPanel.state.pluginVersion;
   }

--- a/public/app/features/dashboard-scene/utils/dashboardControls.ts
+++ b/public/app/features/dashboard-scene/utils/dashboardControls.ts
@@ -1,109 +1,127 @@
+import { structLog } from '@grafana/data';
 import { nanoid } from 'nanoid';
 import { filter, Observable, scan, share, type Subscriber } from 'rxjs';
-
 import { type DataSourceApi } from '@grafana/data';
 import { getDataSourceSrv, reportInteraction } from '@grafana/runtime';
 import { type SceneVariable } from '@grafana/scenes';
 import { type DashboardLink, type DataSourceRef } from '@grafana/schema';
 import { type VariableKind } from '@grafana/schema/apis/dashboard.grafana.app/v2';
-
 type LoadDefaultControlsPhase = 'default_variables' | 'default_links';
-type InvokeAndTrackOptions = { traceId: string; phase: LoadDefaultControlsPhase; datasourceType?: string };
-
+type InvokeAndTrackOptions = {
+  traceId: string;
+  phase: LoadDefaultControlsPhase;
+  datasourceType?: string;
+};
 async function invokeAndTrack<T>(action: () => Promise<T>, options: InvokeAndTrackOptions): Promise<T> {
   const start = performance.now();
   const result = await action();
-
   reportInteraction('dashboards_load_default_controls', {
     ...options,
     duration_ms: Math.round(performance.now() - start),
   });
-
   return result;
 }
-
 export type DefaultControlEvent =
-  | { type: 'variables'; data: VariableKind[] }
-  | { type: 'links'; data: DashboardLink[] };
-
+  | {
+      type: 'variables';
+      data: VariableKind[];
+    }
+  | {
+      type: 'links';
+      data: DashboardLink[];
+    };
 function loadDefaultControlsRaw$(refs: DataSourceRef[]): Observable<DefaultControlEvent> {
   return new Observable((subscriber) => {
     if (refs.length === 0) {
       subscriber.complete();
       return;
     }
-
     const traceId = nanoid(8);
     const promises = refs.map((ref) => loadControlsFromRef(ref, traceId, subscriber));
-
     Promise.all(promises).then(() => subscriber.complete());
   });
 }
-
 // share() multicasts the raw observable so that loadDefaultVariables$ and
 // loadDefaultLinks$ reuse a single subscription — without it, each stream
 // would independently load all datasources, doubling the network requests.
 export function loadDefaultControlsShared$(refs: DataSourceRef[]) {
   return loadDefaultControlsRaw$(refs).pipe(share());
 }
-
 export function loadDefaultVariables$(source$: Observable<DefaultControlEvent>): Observable<VariableKind[]> {
   return source$.pipe(
-    filter((e): e is Extract<DefaultControlEvent, { type: 'variables' }> => e.type === 'variables'),
-    scan<Extract<DefaultControlEvent, { type: 'variables' }>, VariableKind[]>(
-      (acc, event) => [...acc, ...event.data].sort(sortVariables),
-      []
-    )
+    filter(
+      (
+        e
+      ): e is Extract<
+        DefaultControlEvent,
+        {
+          type: 'variables';
+        }
+      > => e.type === 'variables'
+    ),
+    scan<
+      Extract<
+        DefaultControlEvent,
+        {
+          type: 'variables';
+        }
+      >,
+      VariableKind[]
+    >((acc, event) => [...acc, ...event.data].sort(sortVariables), [])
   );
 }
-
 export function loadDefaultLinks$(source$: Observable<DefaultControlEvent>): Observable<DashboardLink[]> {
   return source$.pipe(
-    filter((e): e is Extract<DefaultControlEvent, { type: 'links' }> => e.type === 'links'),
-    scan<Extract<DefaultControlEvent, { type: 'links' }>, DashboardLink[]>(
-      (acc, event) => [...acc, ...event.data].sort(sortLinks),
-      []
-    )
+    filter(
+      (
+        e
+      ): e is Extract<
+        DefaultControlEvent,
+        {
+          type: 'links';
+        }
+      > => e.type === 'links'
+    ),
+    scan<
+      Extract<
+        DefaultControlEvent,
+        {
+          type: 'links';
+        }
+      >,
+      DashboardLink[]
+    >((acc, event) => [...acc, ...event.data].sort(sortLinks), [])
   );
 }
-
 const collator = new Intl.Collator();
-
 function sortVariables(a: VariableKind, b: VariableKind): number {
   const groupCmp = collator.compare(a.spec.origin?.group ?? '', b.spec.origin?.group ?? '');
   return groupCmp !== 0 ? groupCmp : collator.compare(a.spec.name, b.spec.name);
 }
-
 function sortLinks(a: DashboardLink, b: DashboardLink): number {
   const groupCmp = collator.compare(a.origin?.group ?? '', b.origin?.group ?? '');
   return groupCmp !== 0 ? groupCmp : collator.compare(a.title ?? '', b.title ?? '');
 }
-
 async function loadControlsFromRef(ref: DataSourceRef, traceId: string, subscriber: Subscriber<DefaultControlEvent>) {
   let ds: DataSourceApi;
-
   try {
     ds = await getDataSourceSrv().get(ref);
   } catch (e) {
-    console.warn('Failed to load datasource', ref, e);
+    structLog('warn', 'Failed to load datasource', ref, e);
     return;
   }
-
   await Promise.all([emitDefaultVariables(ds, traceId, subscriber), emitDefaultLinks(ds, traceId, subscriber)]);
 }
-
 async function emitDefaultVariables(ds: DataSourceApi, traceId: string, subscriber: Subscriber<DefaultControlEvent>) {
   if (typeof ds.getDefaultVariables !== 'function') {
     return;
   }
-
   try {
     const variables = await invokeAndTrack(ds.getDefaultVariables.bind(ds), {
       traceId,
       phase: 'default_variables',
       datasourceType: ds.type,
     });
-
     if (variables?.length) {
       const sanitizedType = ds.type.replace(/\W/g, '_');
       const data: VariableKind[] = variables.map((v) => {
@@ -119,22 +137,19 @@ async function emitDefaultVariables(ds: DataSourceApi, traceId: string, subscrib
       subscriber.next({ type: 'variables', data });
     }
   } catch (e) {
-    console.warn('Failed to load default variables from datasource', ds.type, e);
+    structLog('warn', 'Failed to load default variables from datasource', ds.type, e);
   }
 }
-
 async function emitDefaultLinks(ds: DataSourceApi, traceId: string, subscriber: Subscriber<DefaultControlEvent>) {
   if (typeof ds.getDefaultLinks !== 'function') {
     return;
   }
-
   try {
     const links = await invokeAndTrack(ds.getDefaultLinks.bind(ds), {
       traceId,
       phase: 'default_links',
       datasourceType: ds.type,
     });
-
     if (links?.length) {
       subscriber.next({
         type: 'links',
@@ -145,26 +160,21 @@ async function emitDefaultLinks(ds: DataSourceApi, traceId: string, subscriber: 
       });
     }
   } catch (e) {
-    console.warn('Failed to load default links from datasource', ds.type, e);
+    structLog('warn', 'Failed to load default links from datasource', ds.type, e);
   }
 }
-
 const sortByProp = <T>(items: T[], propGetter: (item: T) => Object | undefined) => {
   return items.sort((a, b) => {
     const aProp = propGetter(a) ?? false;
     const bProp = propGetter(b) ?? false;
-
     if (aProp && !bProp) {
       return -1;
     }
-
     if (!aProp && bProp) {
       return 1;
     }
-
     return 0;
   });
 };
-
 export const sortDefaultVarsFirst = (items: SceneVariable[]) => sortByProp(items, (item) => item.state.origin);
 export const sortDefaultLinksFirst = (items: DashboardLink[]) => sortByProp(items, (item) => item.origin);

--- a/public/app/features/dashboard-scene/utils/variables.ts
+++ b/public/app/features/dashboard-scene/utils/variables.ts
@@ -1,3 +1,4 @@
+import { structLog } from '@grafana/data';
 import { type AdHocVariableFilter, type TypedVariableModel } from '@grafana/data';
 import { config, getDataSourceSrv } from '@grafana/runtime';
 import {
@@ -16,15 +17,11 @@ import {
 } from '@grafana/scenes';
 import { type VariableKind } from '@grafana/schema/apis/dashboard.grafana.app/v2';
 import { type DashboardModel } from 'app/features/dashboard/state/DashboardModel';
-
 import { SnapshotVariable } from '../serialization/custom-variables/SnapshotVariable';
 import { migrateGroupByVariablesV1 } from '../serialization/groupByMigration';
 import { createSceneVariableFromVariableModel as createSceneVariableFromVariableModelV2 } from '../serialization/transformSaveModelSchemaV2ToScene';
-
 import { getCurrentValueForOldIntervalModel, getIntervalsFromQueryString } from './utils';
-
 const DEFAULT_DATASOURCE = 'default';
-
 export function createVariablesForDashboard(oldModel: DashboardModel, defaultVariables: VariableKind[] = []) {
   const variables = migrateGroupByVariablesV1(oldModel.templating.list);
   const variableObjects = variables
@@ -32,35 +29,31 @@ export function createVariablesForDashboard(oldModel: DashboardModel, defaultVar
       try {
         return createSceneVariableFromVariableModel(v);
       } catch (err) {
-        console.error(err);
+        structLog('error', err);
         return null;
       }
     })
     // TODO: Remove filter
     // Added temporarily to allow skipping non-compatible variables
     .filter((v): v is SceneVariable => Boolean(v));
-
   const defaultVariableObjects = defaultVariables
     .map((v) => {
       try {
         return createSceneVariableFromVariableModelV2(v);
       } catch (err) {
-        console.error(err);
+        structLog('error', err);
         return null;
       }
     })
     .filter((v): v is SceneVariable => Boolean(v));
-
   // Explicitly disable scopes for public dashboards
   if (config.featureToggles.scopeFilters && !config.publicDashboardAccessToken) {
     variableObjects.push(new ScopesVariable({ enable: true }));
   }
-
   return new SceneVariableSet({
     variables: [...defaultVariableObjects, ...variableObjects],
   });
 }
-
 export function createVariablesForSnapshot(oldModel: DashboardModel) {
   const variableObjects = oldModel.templating.list
     .map((v) => {
@@ -91,23 +84,24 @@ export function createVariablesForSnapshot(oldModel: DashboardModel) {
         // for other variable types we are using the SnapshotVariable
         return createSnapshotVariable(v);
       } catch (err) {
-        console.error(err);
+        structLog('error', err);
         return null;
       }
     })
     // TODO: Remove filter
     // Added temporarily to allow skipping non-compatible variables
     .filter((v): v is SceneVariable => Boolean(v));
-
   return new SceneVariableSet({
     variables: variableObjects,
   });
 }
-
 /** Snapshots variables are read-only and should not be updated */
 export function createSnapshotVariable(variable: TypedVariableModel): SceneVariable {
   let snapshotVariable: SnapshotVariable;
-  let current: { value: string | string[]; text: string | string[] };
+  let current: {
+    value: string | string[];
+    text: string | string[];
+  };
   if (variable.type === 'interval') {
     // If query is missing, extract intervals from options instead of using defaults
     let intervals: string[];
@@ -131,7 +125,6 @@ export function createSnapshotVariable(variable: TypedVariableModel): SceneVaria
     });
     return snapshotVariable;
   }
-
   if (variable.type === 'system' || variable.type === 'constant' || variable.type === 'adhoc') {
     current = {
       value: '',
@@ -143,7 +136,6 @@ export function createSnapshotVariable(variable: TypedVariableModel): SceneVaria
       text: variable.current?.text ?? '',
     };
   }
-
   snapshotVariable = new SnapshotVariable({
     name: variable.name,
     label: variable.label,
@@ -154,7 +146,6 @@ export function createSnapshotVariable(variable: TypedVariableModel): SceneVaria
   });
   return snapshotVariable;
 }
-
 export function createSceneVariableFromVariableModel(variable: TypedVariableModel): SceneVariable {
   const commonProperties = {
     name: variable.name,
@@ -166,7 +157,6 @@ export function createSceneVariableFromVariableModel(variable: TypedVariableMode
     const originFilters: AdHocVariableFilter[] = [];
     const filters: AdHocVariableFilter[] = [];
     variable.filters?.forEach((filter) => (filter.origin ? originFilters.push(filter) : filters.push(filter)));
-
     return new AdHocFiltersVariable({
       ...commonProperties,
       description: variable.description,
@@ -298,7 +288,6 @@ export function createSceneVariableFromVariableModel(variable: TypedVariableMode
         val = variable.current.value[0];
       }
     }
-
     return new TextBoxVariable({
       ...commonProperties,
       value: val,
@@ -332,7 +321,6 @@ export function createSceneVariableFromVariableModel(variable: TypedVariableMode
       }
       return value;
     };
-
     return new SwitchVariable({
       ...commonProperties,
       value: pickFirstValue(variable.current?.value),

--- a/public/app/features/dashboard/api/DashboardAPIVersionResolver.test.ts
+++ b/public/app/features/dashboard/api/DashboardAPIVersionResolver.test.ts
@@ -1,3 +1,4 @@
+import * as grafanaData from '@grafana/data';
 import { getBackendSrv } from '@grafana/runtime';
 
 import { dashboardAPIVersionResolver } from './DashboardAPIVersionResolver';
@@ -30,12 +31,13 @@ function mockDiscoveryFailure() {
   } as any);
 }
 
+let structLogSpy: jest.SpiedFunction<typeof grafanaData.structLog>;
+
 describe('DashboardAPIVersionResolver', () => {
   beforeEach(() => {
     dashboardAPIVersionResolver.reset();
     jest.clearAllMocks();
-    jest.spyOn(console, 'log').mockImplementation();
-    jest.spyOn(console, 'warn').mockImplementation();
+    structLogSpy = jest.spyOn(grafanaData, 'structLog').mockImplementation();
   });
 
   describe('resolve', () => {
@@ -152,27 +154,35 @@ describe('DashboardAPIVersionResolver', () => {
     });
 
     describe('debug logging', () => {
-      beforeEach(() => localStorage.setItem('grafana.debug.dashboardAPI', 'true'));
+      beforeEach(() => {
+        localStorage.setItem('grafana.debug.dashboardAPI', 'true');
+        structLogSpy.mockClear();
+      });
       afterEach(() => localStorage.removeItem('grafana.debug.dashboardAPI'));
 
       it('should log resolved versions', async () => {
         mockDiscoveryResponse(['v2', 'v1']);
         await dashboardAPIVersionResolver.resolve();
-        expect(console.log).toHaveBeenCalledWith(expect.stringContaining('Version negotiation'));
+        expect(structLogSpy).toHaveBeenCalledWith('log', expect.stringContaining('Version negotiation'));
       });
 
       it('should log on discovery failure', async () => {
         mockDiscoveryFailure();
         await dashboardAPIVersionResolver.resolve();
-        expect(console.log).toHaveBeenCalledWith(expect.stringContaining('discovery failed'), expect.any(Error));
+        expect(structLogSpy).toHaveBeenCalledWith(
+          'log',
+          expect.stringContaining('discovery failed'),
+          expect.any(Error)
+        );
       });
     });
 
     it('should not log when debug is disabled', async () => {
+      structLogSpy.mockClear();
       localStorage.removeItem('grafana.debug.dashboardAPI');
       mockDiscoveryResponse(['v2', 'v1']);
       await dashboardAPIVersionResolver.resolve();
-      expect(console.log).not.toHaveBeenCalled();
+      expect(structLogSpy).not.toHaveBeenCalled();
     });
   });
 

--- a/public/app/features/dashboard/api/ResponseTransformers.ts
+++ b/public/app/features/dashboard/api/ResponseTransformers.ts
@@ -1,3 +1,4 @@
+import { structLog } from '@grafana/data';
 import { type MetricFindValue, type TypedVariableModel, type AnnotationQuery } from '@grafana/data';
 import { config } from '@grafana/runtime';
 import {
@@ -82,10 +83,8 @@ import {
   transformVariableRefreshToEnum,
 } from 'app/features/dashboard-scene/serialization/transformToV2TypesUtils';
 import { type DashboardDataDTO, type DashboardDTO } from 'app/types/dashboard';
-
 import { type DashboardWithAccessInfo } from './types';
 import { isDashboardResource, isDashboardV0Spec, isDashboardV2Resource, isDashboardV2Spec } from './utils';
-
 export function ensureV2Response(
   dto: DashboardDTO | DashboardWithAccessInfo<DashboardDataDTO> | DashboardWithAccessInfo<DashboardV2Spec>
 ): DashboardWithAccessInfo<DashboardV2Spec> {
@@ -93,18 +92,15 @@ export function ensureV2Response(
     return dto;
   }
   let dashboard: DashboardDataDTO;
-
   if (isDashboardResource(dto)) {
     dashboard = dto.spec;
   } else {
     dashboard = dto.dashboard;
   }
-
   let accessMeta: DashboardWithAccessInfo<DashboardV2Spec>['access'];
   let annotationsMeta: DashboardWithAccessInfo<DashboardV2Spec>['metadata']['annotations'];
   let labelsMeta: DashboardWithAccessInfo<DashboardV2Spec>['metadata']['labels'];
   let creationTimestamp;
-
   if (isDashboardResource(dto)) {
     accessMeta = dto.access;
     annotationsMeta = { ...dto.metadata.annotations };
@@ -141,17 +137,14 @@ export function ensureV2Response(
       // FIXME -- lets not put non-annotation data in annotations!
       annotationsMeta[AnnoKeyDashboardIsSnapshot] = 'true';
     }
-
     creationTimestamp = dto.meta.created;
     labelsMeta = {
       [DeprecatedInternalId]: dashboard.id?.toString() ?? undefined,
     };
   }
-
   if (annotationsMeta?.[AnnoKeyDashboardIsSnapshot]) {
     annotationsMeta[AnnoKeyDashboardSnapshotOriginalUrl] = dashboard.snapshot?.originalUrl;
   }
-
   const metadata = {
     creationTimestamp: creationTimestamp || '', // TODO verify this empty string is valid
     name: dashboard.uid,
@@ -159,7 +152,6 @@ export function ensureV2Response(
     annotations: annotationsMeta,
     labels: labelsMeta,
   };
-
   if (!isDashboardResource(dto)) {
     if (isDashboardV2Spec(dto.dashboard)) {
       // sometimes we can have a v2 spec returned through legacy api like public dashboard
@@ -173,7 +165,6 @@ export function ensureV2Response(
       };
     }
   }
-
   const timeSettingsDefaults = defaultTimeSettingsSpec();
   const dashboardDefaults = defaultDashboardV2Spec();
   const [elements, layout] = getElementsFromPanels(dashboard.panels || []);
@@ -181,7 +172,6 @@ export function ensureV2Response(
   // that would allow accessing unique properties for each variable type that the API returns
   const variables = getVariables(dashboard.templating?.list || []);
   const annotations = getAnnotations(dashboard.annotations?.list || []);
-
   const spec: DashboardV2Spec = {
     title: dashboard.title,
     description: dashboard.description,
@@ -225,7 +215,6 @@ export function ensureV2Response(
     elements,
     layout,
   };
-
   return {
     apiVersion: 'v2',
     kind: 'DashboardWithAccessInfo',
@@ -234,7 +223,6 @@ export function ensureV2Response(
     access: accessMeta,
   };
 }
-
 export function ensureV1Response(
   dashboard: DashboardDTO | DashboardWithAccessInfo<DashboardV2Spec> | DashboardWithAccessInfo<DashboardDataDTO>
 ): DashboardDTO {
@@ -242,7 +230,6 @@ export function ensureV1Response(
   if (!isDashboardResource(dashboard)) {
     return dashboard;
   }
-
   const spec = dashboard.spec;
   // if dashboard is on v1 schema
   if (isDashboardV0Spec(spec)) {
@@ -282,12 +269,10 @@ export function ensureV1Response(
     };
   }
 }
-
 export const ResponseTransformers = {
   ensureV2Response,
   ensureV1Response,
 };
-
 function getElementsFromPanels(
   panels: Array<Panel | RowPanel>
 ): [DashboardV2Spec['elements'], DashboardV2Spec['layout']] {
@@ -298,27 +283,20 @@ function getElementsFromPanels(
       items: [],
     },
   };
-
   if (!panels) {
     return [elements, layout];
   }
-
   if (panels.some(isRowPanel)) {
     return convertToRowsLayout(panels);
   }
-
   // iterate over panels
   for (const p of panels) {
     const [element, elementName] = buildElement(p);
-
     elements[elementName] = element;
-
     layout.spec.items.push(buildGridItemKind(p, elementName));
   }
-
   return [elements, layout];
 }
-
 function convertToRowsLayout(
   panels: Array<Panel | RowPanel>
 ): [DashboardV2Spec['elements'], DashboardV2Spec['layout']] {
@@ -331,7 +309,6 @@ function convertToRowsLayout(
       rows: [],
     },
   };
-
   for (const p of panels) {
     if (isRowPanel(p)) {
       legacyRowY = p.gridPos!.y;
@@ -339,7 +316,6 @@ function convertToRowsLayout(
         // Flush current row to layout before we create a new one
         layout.spec.rows.push(currentRow);
       }
-
       // If the row is collapsed it will have panels
       const rowElements = [];
       for (const panel of p.panels || []) {
@@ -347,13 +323,10 @@ function convertToRowsLayout(
         elements[name] = element;
         rowElements.push(buildGridItemKind(panel, name, yOffsetInRows(panel, legacyRowY)));
       }
-
       currentRow = buildRowKind(p, rowElements);
     } else {
       const [element, elementName] = buildElement(p);
-
       elements[elementName] = element;
-
       if (currentRow) {
         // Collect panels to current layout row
         if (currentRow.spec.layout.kind === 'GridLayout') {
@@ -369,11 +342,9 @@ function convertToRowsLayout(
             items: [buildGridItemKind(p, elementName)],
           },
         };
-
         // Since this row does not exist in V1, we simulate it being outside of the grid above the first panel
         // The Y position does not matter for the rows layout, but it's used to calculate the position of the panels in the grid layout in the row.
         legacyRowY = -1;
-
         currentRow = {
           kind: 'RowsLayoutRow',
           spec: {
@@ -386,25 +357,21 @@ function convertToRowsLayout(
       }
     }
   }
-
   if (currentRow) {
     // Flush last row to layout
     layout.spec.rows.push(currentRow);
   }
   return [elements, layout];
 }
-
 function isRowPanel(panel: Panel | RowPanel): panel is RowPanel {
   return panel.type === 'row';
 }
-
 function getWeekStart(weekStart?: string, defaultWeekStart?: WeekStart): WeekStart | undefined {
   if (!weekStart || !isWeekStart(weekStart)) {
     return defaultWeekStart;
   }
   return weekStart;
 }
-
 function buildRowKind(p: RowPanel, elements: GridLayoutItemKind[]): RowsLayoutRowKind {
   return {
     kind: 'RowsLayoutRow',
@@ -421,7 +388,6 @@ function buildRowKind(p: RowPanel, elements: GridLayoutItemKind[]): RowsLayoutRo
     },
   };
 }
-
 function buildGridItemKind(p: Panel, elementName: string, yOverride?: number): GridLayoutItemKind {
   return {
     kind: 'GridLayoutItem',
@@ -447,14 +413,11 @@ function buildGridItemKind(p: Panel, elementName: string, yOverride?: number): G
     },
   };
 }
-
 function yOffsetInRows(p: Panel, rowY: number): number {
   return p.gridPos!.y - rowY - GRID_ROW_HEIGHT;
 }
-
 function buildElement(p: Panel): [PanelKind | LibraryPanelKind, string] {
   const element_identifier = `panel-${p.id}`;
-
   if (p.libraryPanel) {
     // LibraryPanelKind
     const panelKind: LibraryPanelKind = {
@@ -468,7 +431,6 @@ function buildElement(p: Panel): [PanelKind | LibraryPanelKind, string] {
         title: p.title ?? '',
       },
     };
-
     return [panelKind, element_identifier];
   } else {
     // PanelKind
@@ -476,29 +438,24 @@ function buildElement(p: Panel): [PanelKind | LibraryPanelKind, string] {
     return [panelKind, element_identifier];
   }
 }
-
 function getDefaultDatasourceType() {
   // if there is no default datasource, return 'grafana' as default
   return getDefaultDataSourceRef()?.type ?? 'grafana';
 }
-
 export function getDefaultDatasource(): DataSourceRef {
   const defaultDataSourceRef = getDefaultDataSourceRef() ?? { type: 'grafana', uid: '-- Grafana --' };
-
   if (defaultDataSourceRef.uid && !defaultDataSourceRef.apiVersion) {
     // get api version from config
     const defaultDatasource = config.defaultDatasource;
     const dsInstance = config.datasources[defaultDatasource];
     defaultDataSourceRef.apiVersion = dsInstance.apiVersion ?? undefined;
   }
-
   return {
     apiVersion: defaultDataSourceRef.apiVersion,
     type: defaultDataSourceRef.type,
     uid: defaultDataSourceRef.uid,
   };
 }
-
 export function getPanelQueries(targets: DataQuery[], panelDatasource: DataSourceRef): PanelQueryKind[] | undefined {
   return targets.map((t) => {
     const { refId, hide, datasource, ...query } = t;
@@ -530,7 +487,6 @@ export function getPanelQueries(targets: DataQuery[], panelDatasource: DataSourc
     return q;
   });
 }
-
 /**
  * Known Panel properties from the Panel schema (dashboard_kind.cue).
  * These should NOT be passed to Angular migration handlers.
@@ -564,7 +520,6 @@ const knownPanelProperties = new Set([
   'fieldConfig',
   'autoMigrateFrom',
 ]);
-
 /**
  * Extracts only the Angular-specific options from a panel,
  * filtering out all known Panel schema properties.
@@ -580,15 +535,11 @@ function extractAngularOptions(panel: Panel): Record<string, unknown> {
   }
   return result;
 }
-
 export function buildPanelKind(p: Panel): PanelKind {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/consistent-type-assertions
   const queries = getPanelQueries((p.targets as any) || [], p.datasource ?? { type: '', uid: '' });
-
   const transformations = getPanelTransformations(p.transformations || []);
-
   const fieldConfig = p.fieldConfig || defaultFieldConfigSource();
-
   // match backend conversion behavior
   if (fieldConfig.defaults.mappings && fieldConfig.defaults.mappings.length === 0) {
     delete fieldConfig.defaults.mappings;
@@ -597,7 +548,6 @@ export function buildPanelKind(p: Panel): PanelKind {
   if (fieldConfig.defaults.custom && Object.keys(fieldConfig.defaults.custom).length === 0) {
     delete fieldConfig.defaults.custom;
   }
-
   // match backend conversion behavior
   // Only set first threshold step value to null if it's explicitly null or undefined
   // Preserve 0 values (0 is falsy but should be kept as 0, not converted to null)
@@ -609,13 +559,11 @@ export function buildPanelKind(p: Panel): PanelKind {
   ) {
     fieldConfig.defaults.thresholds.steps[0]!.value = null;
   }
-
   // Build options with Angular migration data if needed (matches backend behavior)
   // autoMigrateFrom is set during v0->v1 migration when Angular panels are converted
   let { autoMigrateFrom } = p;
   let options = p.options ?? {};
   const originalOptions = extractAngularOptions(p);
-
   // When autoMigrateFrom is present OR when there are Angular-specific properties at root level,
   // compose __angularMigration with only Angular-specific options.
   // This filters out known Panel schema properties, passing only the Angular options to migration handlers.
@@ -624,7 +572,6 @@ export function buildPanelKind(p: Panel): PanelKind {
   if (!autoMigrateFrom && Object.keys(originalOptions).length > 0) {
     autoMigrateFrom = p.type;
   }
-
   if (autoMigrateFrom) {
     options = {
       ...options,
@@ -634,7 +581,6 @@ export function buildPanelKind(p: Panel): PanelKind {
       },
     };
   }
-
   const panelKind: PanelKind = {
     kind: 'Panel',
     spec: {
@@ -677,7 +623,6 @@ export function buildPanelKind(p: Panel): PanelKind {
   };
   return panelKind;
 }
-
 function getPanelTransformations(transformations: DataTransformerConfig[]): TransformationKind[] {
   return transformations.map((t) => {
     return {
@@ -692,7 +637,6 @@ function getPanelTransformations(transformations: DataTransformerConfig[]): Tran
     };
   });
 }
-
 function getVariables(vars: TypedVariableModel[]): DashboardV2Spec['variables'] {
   const variables: DashboardV2Spec['variables'] = [];
   for (const v of vars) {
@@ -703,23 +647,20 @@ function getVariables(vars: TypedVariableModel[]): DashboardV2Spec['variables'] 
       skipUrlSync: Boolean(v.skipUrlSync),
       hide: transformVariableHideToEnum(v.hide),
     };
-
     let ds: DataSourceRef | undefined;
     let dsType: string | undefined;
-
     switch (v.type) {
       case 'query':
         let query = v.query || {};
-
         if (typeof query === 'string') {
-          console.warn(
+          structLog(
+            'warn',
             'Query variable query is a string which is deprecated in the schema v2. It should extend DataQuery'
           );
           query = {
             [LEGACY_STRING_VALUE_KEY]: query,
           };
         }
-
         const qv: QueryVariableKind = {
           kind: 'QueryVariable',
           spec: {
@@ -755,11 +696,9 @@ function getVariables(vars: TypedVariableModel[]): DashboardV2Spec['variables'] 
         break;
       case 'datasource':
         let pluginId = getDefaultDatasourceType();
-
         if (v.query && typeof v.query === 'string') {
           pluginId = v.query;
         }
-
         const dv: DatasourceVariableKind = {
           kind: 'DatasourceVariable',
           spec: {
@@ -802,7 +741,6 @@ function getVariables(vars: TypedVariableModel[]): DashboardV2Spec['variables'] 
       case 'adhoc':
         ds = v.datasource || getDefaultDatasource();
         dsType = ds.type ?? getDefaultDatasourceType();
-
         const av: AdhocVariableKind = {
           kind: 'AdhocVariable',
           group: dsType,
@@ -822,7 +760,6 @@ function getVariables(vars: TypedVariableModel[]): DashboardV2Spec['variables'] 
             allowCustomValue: v.allowCustomValue ?? true,
           },
         };
-
         variables.push(av);
         break;
       case 'constant':
@@ -878,7 +815,6 @@ function getVariables(vars: TypedVariableModel[]): DashboardV2Spec['variables'] 
       case 'groupby':
         ds = v.datasource || getDefaultDatasource();
         dsType = ds.type ?? getDefaultDatasourceType();
-
         const gb: GroupByVariableKind = {
           kind: 'GroupByVariable',
           group: dsType,
@@ -897,7 +833,6 @@ function getVariables(vars: TypedVariableModel[]): DashboardV2Spec['variables'] 
             multi: v.multi,
           },
         };
-
         variables.push(gb);
         break;
       case 'switch':
@@ -911,7 +846,6 @@ function getVariables(vars: TypedVariableModel[]): DashboardV2Spec['variables'] 
         // Current value should be a string (not array)
         const currentValueRaw = v.current?.value ?? disabledValue;
         const currentValue = Array.isArray(currentValueRaw) ? currentValueRaw[0] : currentValueRaw;
-
         const sw: SwitchVariableKind = {
           kind: 'SwitchVariable',
           spec: {
@@ -925,17 +859,15 @@ function getVariables(vars: TypedVariableModel[]): DashboardV2Spec['variables'] 
         break;
       default:
         // do not throw error, just log it
-        console.error(`Variable transformation not implemented: ${v.type}`);
+        structLog('error', `Variable transformation not implemented: ${v.type}`);
     }
   }
   return variables;
 }
-
 function getAnnotations(annotations: AnnotationQuery[]): DashboardV2Spec['annotations'] {
   return annotations.map((a) => {
     // Extract properties that are explicitly handled
     const { name, enable, hide, iconColor, builtIn, datasource, target, filter, mappings, ...legacyOptions } = a;
-
     const aq: AnnotationQueryKind = {
       kind: 'AnnotationQuery',
       spec: {
@@ -959,7 +891,6 @@ function getAnnotations(annotations: AnnotationQuery[]): DashboardV2Spec['annota
           },
         },
         ...(filter !== undefined && { filter }),
-
         // Include any additional properties as legacyOptions
         ...(Object.keys(legacyOptions).length > 0 && { legacyOptions }),
       },
@@ -967,10 +898,8 @@ function getAnnotations(annotations: AnnotationQuery[]): DashboardV2Spec['annota
     return aq;
   });
 }
-
 function getVariablesV1(vars: DashboardV2Spec['variables']): VariableModel[] {
   const variables: VariableModel[] = [];
-
   for (const v of vars) {
     const commonProperties = {
       name: v.spec.name,
@@ -980,7 +909,6 @@ function getVariablesV1(vars: DashboardV2Spec['variables']): VariableModel[] {
       hide: transformVariableHideToEnumV1(v.spec.hide),
       type: transformToV1VariableTypes(v),
     };
-
     switch (v.kind) {
       case 'QueryVariable':
         const qv: VariableModel = {
@@ -1075,7 +1003,6 @@ function getVariablesV1(vars: DashboardV2Spec['variables']): VariableModel[] {
           text: v.spec.current.value,
           value: v.spec.current.value,
         };
-
         const tv: VariableModel = {
           ...commonProperties,
           current: {
@@ -1138,26 +1065,21 @@ function getVariablesV1(vars: DashboardV2Spec['variables']): VariableModel[] {
         break;
       default:
         // do not throw error, just log it
-        console.error(`Variable transformation not implemented: ${v}`);
+        structLog('error', `Variable transformation not implemented: ${v}`);
     }
   }
   return variables;
 }
-
 interface LibraryPanelDTO extends Pick<Panel, 'libraryPanel' | 'id' | 'title' | 'gridPos' | 'type'> {}
-
 function getPanelsV1(
   panels: DashboardV2Spec['elements'],
   layout: DashboardV2Spec['layout']
 ): Array<Panel | LibraryPanelDTO> {
   const panelsV1: Array<Panel | LibraryPanelDTO | RowPanel> = [];
-
   let maxPanelId = 0;
-
   if (layout.kind !== 'GridLayout') {
     throw new Error('Cannot convert non-GridLayout layout to v1');
   }
-
   for (const item of layout.spec.items) {
     const panel = panels[item.spec.element.name];
     const v1Panel = transformV2PanelToV1Panel(panel, item);
@@ -1166,7 +1088,6 @@ function getPanelsV1(
       maxPanelId = v1Panel.id ?? 0;
     }
   }
-
   // Update row panel ids to be unique
   for (const panel of panelsV1) {
     if (panel.type === 'row' && panel.id === -1) {
@@ -1175,7 +1096,6 @@ function getPanelsV1(
   }
   return panelsV1;
 }
-
 function transformV2PanelToV1Panel(
   p: PanelKind | LibraryPanelKind,
   layoutElement: GridLayoutItemKind,
@@ -1254,7 +1174,6 @@ function transformV2PanelToV1Panel(
     throw new Error(`Unknown element kind: ${p}`);
   }
 }
-
 export function transformMappingsToV1(fieldConfig: FieldConfigSource): FieldConfigSourceV1 {
   const getThresholdsMode = (mode: ThresholdsMode): ThresholdsModeV1 => {
     switch (mode) {
@@ -1266,11 +1185,9 @@ export function transformMappingsToV1(fieldConfig: FieldConfigSource): FieldConf
         return ThresholdsModeV1.Absolute;
     }
   };
-
   const transformedDefaults: any = {
     ...fieldConfig.defaults,
   };
-
   if (fieldConfig.defaults.mappings && fieldConfig.defaults.mappings.length > 0) {
     transformedDefaults.mappings = fieldConfig.defaults.mappings.flatMap((mapping) => {
       switch (mapping.type) {
@@ -1308,27 +1225,23 @@ export function transformMappingsToV1(fieldConfig: FieldConfigSource): FieldConf
       }
     });
   }
-
   if (fieldConfig.defaults.thresholds) {
     transformedDefaults.thresholds = {
       ...fieldConfig.defaults.thresholds,
       mode: getThresholdsMode(fieldConfig.defaults.thresholds.mode),
     };
   }
-
   if (fieldConfig.defaults.color?.mode) {
     transformedDefaults.color = {
       ...fieldConfig.defaults.color,
       mode: colorIdToEnumv1(fieldConfig.defaults.color.mode),
     };
   }
-
   return {
     ...fieldConfig,
     defaults: transformedDefaults,
   };
 }
-
 function colorIdToEnumv1(colorId: FieldColorModeId): FieldColorModeIdV1 {
   switch (colorId) {
     case 'thresholds':
@@ -1375,7 +1288,6 @@ function colorIdToEnumv1(colorId: FieldColorModeId): FieldColorModeIdV1 {
       return FieldColorModeIdV1.Thresholds;
   }
 }
-
 function transformSpecialValueMatchToV1(match: SpecialValueMatch): SpecialValueMatchV1 | undefined {
   switch (match) {
     case 'true':
@@ -1391,11 +1303,10 @@ function transformSpecialValueMatchToV1(match: SpecialValueMatch): SpecialValueM
     case 'empty':
       return SpecialValueMatchV1.Empty;
     default:
-      console.warn(`Skipping special value mapping with unknown match type: "${match}"`);
+      structLog('warn', `Skipping special value mapping with unknown match type: "${match}"`);
       return undefined;
   }
 }
-
 function transformToV1VariableTypes(variable: TypedVariableModelV2): VariableType {
   switch (variable.kind) {
     case 'QueryVariable':
@@ -1420,10 +1331,8 @@ function transformToV1VariableTypes(variable: TypedVariableModelV2): VariableTyp
       throw new Error(`Unknown variable type: ${variable}`);
   }
 }
-
 export function transformDashboardV2SpecToV1(spec: DashboardV2Spec, metadata: ObjectMeta): DashboardDataDTO {
   const annotations = (spec.annotations ?? []).map(transformV2ToV1AnnotationQuery);
-
   const gnetId = metadata.annotations?.[AnnoKeyDashboardGnetId];
   const variables = getVariablesV1(spec.variables ?? []);
   const panels = getPanelsV1(spec.elements, spec.layout);
@@ -1460,24 +1369,20 @@ export function transformDashboardV2SpecToV1(spec: DashboardV2Spec, metadata: Ob
     templating: { list: variables },
   };
 }
-
 export function transformAnnotationMappingsV1ToV2(
   mappings: AnnotationQuery['mappings']
 ): AnnotationQueryKind['spec']['mappings'] {
   if (!mappings) {
     return {};
   }
-
   return Object.fromEntries(
     Object.entries(mappings).map(([key, value]) => {
       if (typeof value === 'string') {
         return [key, { source: 'field', value }];
       }
-
       if (typeof value === 'object') {
         return [key, value.source ? value : { source: 'field', ...value }];
       }
-
       return [key, value];
     })
   );

--- a/public/app/features/dashboard/components/DashExportModal/DashboardExporter.ts
+++ b/public/app/features/dashboard/components/DashExportModal/DashboardExporter.ts
@@ -1,5 +1,5 @@
+import { structLog } from '@grafana/data';
 import { defaults, each, sortBy } from 'lodash';
-
 import { type DataSourceRef, type VariableOption, VariableRefresh } from '@grafana/data';
 import { getDataSourceSrv } from '@grafana/runtime';
 import { getPanelPluginMeta } from '@grafana/runtime/internal';
@@ -7,18 +7,15 @@ import config from 'app/core/config';
 import { type PanelModel } from 'app/features/dashboard/state/PanelModel';
 import { getLibraryPanel } from 'app/features/library-panels/state/api';
 import { variableRegex } from 'app/features/variables/utils';
-
 import { isPanelModelLibraryPanel } from '../../../library-panels/guard';
 import { LibraryElementKind } from '../../../library-panels/types';
 import { type DashboardJson } from '../../../manage-dashboards/types';
 import { isConstant } from '../../../variables/guard';
 import { type DashboardModel } from '../../state/DashboardModel';
 import { type GridPos } from '../../state/PanelModel';
-
 export interface InputUsage {
   libraryPanels?: LibraryPanel[];
 }
-
 export interface LibraryPanel {
   name: string;
   uid: string;
@@ -31,7 +28,6 @@ export interface Input {
   description: string;
   usage?: InputUsage;
 }
-
 interface Requires {
   [key: string]: {
     type: string;
@@ -40,26 +36,22 @@ interface Requires {
     version: string;
   };
 }
-
 export interface ExternalDashboard {
   __inputs?: Input[];
   __elements?: Record<string, LibraryElementExport>;
   __requires?: Array<Requires[string]>;
   panels: Array<PanelModel | PanelWithExportableLibraryPanel>;
 }
-
 interface PanelWithExportableLibraryPanel {
   gridPos: GridPos;
   id: number;
   libraryPanel: LibraryPanel;
 }
-
 function isExportableLibraryPanel(
   p: PanelModel | PanelWithExportableLibraryPanel
 ): p is PanelWithExportableLibraryPanel {
   return Boolean(p.libraryPanel?.name && p.libraryPanel?.uid);
 }
-
 interface DataSources {
   [key: string]: {
     name: string;
@@ -71,14 +63,12 @@ interface DataSources {
     usage?: InputUsage;
   };
 }
-
 export interface LibraryElementExport {
   name: string;
   uid: string;
   model: any;
   kind: LibraryElementKind;
 }
-
 export class DashboardExporter {
   async makeExportable(dashboard: DashboardModel) {
     // clean up repeated rows and panels,
@@ -86,34 +76,28 @@ export class DashboardExporter {
     // so we need to undo this
     // this is pretty hacky and needs to be changed
     dashboard.cleanUpRepeats();
-
     const saveModel = dashboard.getSaveModelCloneOld();
-
     // undo repeat cleanup
     dashboard.processRepeats();
-
     const inputs: Input[] = [];
     const requires: Requires = {};
     const datasources: DataSources = {};
-    const variableLookup: { [key: string]: any } = {};
+    const variableLookup: {
+      [key: string]: any;
+    } = {};
     const libraryPanels: Map<string, LibraryElementExport> = new Map<string, LibraryElementExport>();
-
     for (const variable of saveModel.getVariables()) {
       variableLookup[variable.name] = variable;
     }
-
     const templateizeDatasourceUsage = (obj: any, fallback?: DataSourceRef) => {
       if (obj.datasource === undefined) {
         obj.datasource = fallback;
         return;
       }
-
       let datasource = obj.datasource;
       let datasourceVariable: any = null;
-
       const datasourceUid: string | undefined = datasource?.uid;
       const match = datasourceUid && variableRegex.exec(datasourceUid);
-
       // ignore data source properties that contain a variable
       if (match) {
         const varName = match[1] || match[2] || match[4];
@@ -122,14 +106,12 @@ export class DashboardExporter {
           datasource = datasourceVariable.current.value;
         }
       }
-
       return getDataSourceSrv()
         .get(datasource)
         .then((ds) => {
           if (ds.meta?.builtIn) {
             return;
           }
-
           // add data source type to require list
           requires['datasource' + ds.meta?.id] = {
             type: 'datasource',
@@ -137,16 +119,13 @@ export class DashboardExporter {
             name: ds.meta.name,
             version: ds.meta.info.version || '1.0.0',
           };
-
           // if used via variable we can skip templatizing usage
           if (datasourceVariable) {
             return;
           }
-
           const libraryPanel = obj.libraryPanel;
           const libraryPanelSuffix = !!libraryPanel ? '-for-library-panel' : '';
           let refName = 'DS_' + ds.name.replace(' ', '_').toUpperCase() + libraryPanelSuffix.toUpperCase();
-
           datasources[refName] = {
             name: refName,
             label: ds.name,
@@ -156,30 +135,24 @@ export class DashboardExporter {
             pluginName: ds.meta?.name,
             usage: datasources[refName]?.usage,
           };
-
           if (!!libraryPanel) {
             const libPanels = datasources[refName]?.usage?.libraryPanels || [];
             libPanels.push({ name: libraryPanel.name, uid: libraryPanel.uid });
-
             datasources[refName].usage = {
               libraryPanels: libPanels,
             };
           }
-
           obj.datasource = { type: ds.meta.id, uid: '${' + refName + '}' };
         });
     };
-
     const processPanel = async (panel: PanelModel) => {
       if (panel.type !== 'row') {
         await templateizeDatasourceUsage(panel);
-
         if (panel.targets) {
           for (const target of panel.targets) {
             await templateizeDatasourceUsage(target, panel.datasource!);
           }
         }
-
         const panelDef = await getPanelPluginMeta(panel.type);
         if (panelDef) {
           requires['panel' + panelDef.id] = {
@@ -191,7 +164,6 @@ export class DashboardExporter {
         }
       }
     };
-
     const processLibraryPanels = async (panel: PanelModel) => {
       if (isPanelModelLibraryPanel(panel)) {
         const { name, uid } = panel.libraryPanel;
@@ -200,21 +172,17 @@ export class DashboardExporter {
           const libPanel = await getLibraryPanel(uid, true);
           model = libPanel.model;
         }
-
         await templateizeDatasourceUsage(model);
-
         const { gridPos, id, ...rest } = model as any;
         if (!libraryPanels.has(uid)) {
           libraryPanels.set(uid, { name, uid, kind: LibraryElementKind.Panel, model: rest });
         }
       }
     };
-
     try {
       // check up panel data sources
       for (const panel of saveModel.panels) {
         await processPanel(panel);
-
         // handle collapsed rows
         if (panel.collapsed !== undefined && panel.collapsed === true && panel.panels) {
           for (const rowPanel of panel.panels) {
@@ -222,7 +190,6 @@ export class DashboardExporter {
           }
         }
       }
-
       // templatize template vars
       for (const variable of saveModel.getVariables()) {
         if (variable.type === 'query') {
@@ -235,12 +202,10 @@ export class DashboardExporter {
           variable.current = {};
         }
       }
-
       // templatize annotations vars
       for (const annotationDef of saveModel.annotations.list) {
         await templateizeDatasourceUsage(annotationDef);
       }
-
       // add grafana version
       requires['grafana'] = {
         type: 'grafana',
@@ -248,7 +213,6 @@ export class DashboardExporter {
         name: 'Grafana',
         version: config.buildInfo.version,
       };
-
       // we need to process all panels again after all the promises are resolved
       // so all data sources, variables and targets have been templateized when we process library panels
       for (const panel of saveModel.panels) {
@@ -259,11 +223,9 @@ export class DashboardExporter {
           }
         }
       }
-
       each(datasources, (value: any) => {
         inputs.push(value);
       });
-
       // templatize constants
       for (const variable of saveModel.getVariables()) {
         if (isConstant(variable)) {
@@ -285,7 +247,6 @@ export class DashboardExporter {
           variable.options = [variable.current];
         }
       }
-
       const __elements = [...libraryPanels.entries()].reduce<Record<string, LibraryElementExport>>(
         (prev, [curKey, curLibPanel]) => {
           prev[curKey] = curLibPanel;
@@ -293,7 +254,6 @@ export class DashboardExporter {
         },
         {}
       );
-
       // make inputs and requires a top thing
       const newObj: DashboardJson = defaults(
         {
@@ -303,7 +263,6 @@ export class DashboardExporter {
         },
         saveModel
       );
-
       // Remove extraneous props from library panels
       for (let i = 0; i < newObj.panels.length; i++) {
         const libPanel = newObj.panels[i];
@@ -315,10 +274,9 @@ export class DashboardExporter {
           };
         }
       }
-
       return newObj;
     } catch (err) {
-      console.error('Export failed:', err);
+      structLog('error', 'Export failed:', err);
       return {
         error: err,
       };

--- a/public/app/features/dashboard/components/DashboardSettings/VersionsSettings.tsx
+++ b/public/app/features/dashboard/components/DashboardSettings/VersionsSettings.tsx
@@ -1,6 +1,6 @@
+import { structLog } from '@grafana/data';
 import { PureComponent } from 'react';
 import * as React from 'react';
-
 import { Spinner, Stack } from '@grafana/ui';
 import { Page } from 'app/core/components/Page/Page';
 import { type Resource } from 'app/features/apiserver/types';
@@ -12,28 +12,25 @@ import {
 } from 'app/features/dashboard/types/revisionModels';
 import { VersionsHistoryButtons } from 'app/features/dashboard-scene/settings/version-history/VersionHistoryButtons';
 import { VersionHistoryHeader } from 'app/features/dashboard-scene/settings/version-history/VersionHistoryHeader';
-
 import { VersionHistoryComparison } from '../VersionHistory/VersionHistoryComparison';
 import { VersionHistoryTable } from '../VersionHistory/VersionHistoryTable';
-
 import { type SettingsPageProps } from './types';
-
 interface Props extends SettingsPageProps {}
-
 type State = {
   isLoading: boolean;
   isAppending: boolean;
   versions: DecoratedRevisionModel[];
   viewMode: 'list' | 'compare';
-  diffData: { lhs: object; rhs: object };
+  diffData: {
+    lhs: object;
+    rhs: object;
+  };
   newInfo?: DecoratedRevisionModel;
   baseInfo?: DecoratedRevisionModel;
   isNewLatest: boolean;
 };
-
 export class VersionsSettings extends PureComponent<Props, State> {
   continueToken: string;
-
   constructor(props: Props) {
     super(props);
     this.continueToken = '';
@@ -46,18 +43,14 @@ export class VersionsSettings extends PureComponent<Props, State> {
       diffData: { lhs: {}, rhs: {} },
     };
   }
-
   componentDidMount() {
     this.getVersions();
   }
-
   getVersions = (append = false) => {
     this.setState({ isAppending: append });
-
     const options = append
       ? { limit: VERSIONS_FETCH_LIMIT, continueToken: this.continueToken }
       : { limit: VERSIONS_FETCH_LIMIT };
-
     getDashboardAPI()
       .then(async (api) => {
         const result = await api.listDashboardHistory(this.props.dashboard.uid, options);
@@ -69,10 +62,9 @@ export class VersionsSettings extends PureComponent<Props, State> {
         // Update the continueToken for the next request, if available
         this.continueToken = result.metadata.continue ?? '';
       })
-      .catch((err) => console.log(err))
+      .catch((err) => structLog('log', err))
       .finally(() => this.setState({ isAppending: false }));
   };
-
   transformToRevisionModels(items: Array<Resource<unknown>>): RevisionModel[] {
     return items.map(
       (item): RevisionModel => ({
@@ -88,12 +80,10 @@ export class VersionsSettings extends PureComponent<Props, State> {
       })
     );
   }
-
   getDiff = () => {
     const selectedVersions = this.state.versions.filter((version) => version.checked);
     const [newInfo, baseInfo] = selectedVersions;
     const isNewLatest = newInfo.version === this.props.dashboard.version;
-
     // Use the already-loaded data from listDashboardHistory - no need for another API call
     this.setState({
       baseInfo,
@@ -104,7 +94,6 @@ export class VersionsSettings extends PureComponent<Props, State> {
       diffData: { lhs: baseInfo.data, rhs: newInfo.data },
     });
   };
-
   decorateVersions = (versions: RevisionModel[]) =>
     versions.map((version) => ({
       ...version,
@@ -112,7 +101,6 @@ export class VersionsSettings extends PureComponent<Props, State> {
       ageString: this.props.dashboard.getRelativeTime(version.created),
       checked: false,
     }));
-
   isLastPage() {
     return (
       this.state.versions.find((rev) => rev.version === 1) ||
@@ -120,7 +108,6 @@ export class VersionsSettings extends PureComponent<Props, State> {
       this.continueToken === ''
     );
   }
-
   onCheck = (ev: React.FormEvent<HTMLInputElement>, versionId: number) => {
     this.setState({
       versions: this.state.versions.map((version) =>
@@ -128,7 +115,6 @@ export class VersionsSettings extends PureComponent<Props, State> {
       ),
     });
   };
-
   reset = () => {
     this.continueToken = '';
     this.setState({
@@ -140,14 +126,12 @@ export class VersionsSettings extends PureComponent<Props, State> {
       viewMode: 'list',
     });
   };
-
   render() {
     const { versions, viewMode, baseInfo, newInfo, isNewLatest, isLoading, diffData } = this.state;
     const canCompare = versions.filter((version) => version.checked).length === 2;
     const showButtons = versions.length > 1;
     const hasMore = versions.length >= VERSIONS_FETCH_LIMIT;
     const pageNav = this.props.sectionNav.node.parentItem;
-
     if (viewMode === 'compare') {
       return (
         <Page navModel={this.props.sectionNav} pageNav={pageNav}>
@@ -170,7 +154,6 @@ export class VersionsSettings extends PureComponent<Props, State> {
         </Page>
       );
     }
-
     return (
       <Page navModel={this.props.sectionNav} pageNav={pageNav}>
         {isLoading ? (
@@ -192,7 +175,6 @@ export class VersionsSettings extends PureComponent<Props, State> {
     );
   }
 }
-
 export const VersionsHistorySpinner = ({ msg }: { msg: string }) => (
   <Stack>
     <Spinner />

--- a/public/app/features/dashboard/components/GenAI/hooks.ts
+++ b/public/app/features/dashboard/components/GenAI/hooks.ts
@@ -1,40 +1,32 @@
+import { structLog } from '@grafana/data';
 import { type Dispatch, type SetStateAction, useCallback, useEffect, useState } from 'react';
 import { useAsync } from 'react-use';
 import { type Subscription } from 'rxjs';
-
 import { llm } from '@grafana/llm';
 import { createMonitoringLogger } from '@grafana/runtime';
 import { useAppNotification } from 'app/core/copy/appNotification';
-
 import { DEFAULT_LLM_MODEL, isLLMPluginEnabled } from './utils';
-
 // Declared instead of imported from utils to make this hook modular
 // Ideally we will want to move the hook itself to a different scope later.
 type Message = llm.Message;
-
 const genAILogger = createMonitoringLogger('features.dashboards.genai');
-
 export enum StreamStatus {
   IDLE = 'idle',
   GENERATING = 'generating',
   COMPLETED = 'completed',
 }
-
 export const TIMEOUT = 10000; // 10 seconds
-
 interface Options {
   model: string;
   temperature: number;
   onResponse?: (response: string) => void;
   timeout?: number;
 }
-
 const defaultOptions = {
   model: DEFAULT_LLM_MODEL,
   temperature: 1,
   timeout: TIMEOUT,
 };
-
 interface UseLLMStreamResponse {
   setMessages: Dispatch<SetStateAction<Message[]>>;
   stopGeneration: () => void;
@@ -47,13 +39,11 @@ interface UseLLMStreamResponse {
     stream?: Subscription;
   };
 }
-
 // TODO: Add tests
 export function useLLMStream(options: Options = defaultOptions): UseLLMStreamResponse {
   const { model, temperature, onResponse, timeout } = { ...defaultOptions, ...options };
   // The messages array to send to the LLM, updated when the button is clicked.
   const [messages, setMessages] = useState<Message[]>([]);
-
   // The latest reply from the LLM.
   const [reply, setReply] = useState('');
   const [streamStatus, setStreamStatus] = useState<StreamStatus>(StreamStatus.IDLE);
@@ -61,7 +51,6 @@ export function useLLMStream(options: Options = defaultOptions): UseLLMStreamRes
   const { error: notifyError } = useAppNotification();
   // Accumulate response and it will only update the state of the attatched component when the stream is completed.
   let partialReply = '';
-
   const onError = useCallback(
     (e: Error) => {
       setStreamStatus(StreamStatus.IDLE);
@@ -71,28 +60,24 @@ export function useLLMStream(options: Options = defaultOptions): UseLLMStreamRes
         'Failed to generate content using LLM',
         'Please try again or if the problem persists, contact your organization admin.'
       );
-      console.error(e);
+      structLog('error', e);
       genAILogger.logError(e, { messages: JSON.stringify(messages), model, temperature: String(temperature) });
     },
     [messages, model, temperature, notifyError]
   );
-
   useEffect(() => {
     if (messages.length > 0) {
       setReply('');
     }
   }, [messages]);
-
   const { error: enabledError, value: enabled } = useAsync(
     async () => await isLLMPluginEnabled(),
     [isLLMPluginEnabled]
   );
-
   const { error: asyncError, value } = useAsync(async () => {
     if (!enabled || !messages.length) {
       return { enabled };
     }
-
     setStreamStatus(StreamStatus.GENERATING);
     setError(undefined);
     // Stream the completions. Each element is the next stream chunk.
@@ -130,14 +115,12 @@ export function useLLMStream(options: Options = defaultOptions): UseLLMStreamRes
       }),
     };
   }, [messages, enabled]);
-
   // Unsubscribe from the stream when the component unmounts.
   useEffect(() => {
     return () => {
       value?.stream?.unsubscribe();
     };
   }, [value]);
-
   // Unsubscribe from the stream when user stops the generation.
   const stopGeneration = useCallback(() => {
     value?.stream?.unsubscribe();
@@ -145,7 +128,6 @@ export function useLLMStream(options: Options = defaultOptions): UseLLMStreamRes
     setError(undefined);
     setMessages([]);
   }, [value]);
-
   // If the stream is generating and we haven't received a reply, it times out.
   useEffect(() => {
     let timeoutId: NodeJS.Timeout | undefined;
@@ -154,16 +136,13 @@ export function useLLMStream(options: Options = defaultOptions): UseLLMStreamRes
         onError(new Error(`LLM stream timed out after ${timeout}ms`));
       }, timeout);
     }
-
     return () => {
       clearTimeout(timeoutId);
     };
   }, [streamStatus, reply, onError, timeout]);
-
   if (asyncError || enabledError) {
     setError(asyncError || enabledError);
   }
-
   return {
     setMessages,
     stopGeneration,

--- a/public/app/features/dashboard/components/HelpWizard/SupportSnapshotService.ts
+++ b/public/app/features/dashboard/components/HelpWizard/SupportSnapshotService.ts
@@ -1,18 +1,15 @@
+import { structLog } from '@grafana/data';
 import saveAs from 'file-saver';
-
 import { dateTimeFormat, formattedValueToString, getValueFormat, type SelectableValue } from '@grafana/data';
 import { t } from '@grafana/i18n';
 import { type SceneObject } from '@grafana/scenes';
 import { StateManagerBase } from 'app/core/services/StateManagerBase';
 import { type Randomize } from 'app/features/dashboard-scene/inspect/HelpWizard/randomizer';
 import { createDashboardSceneFromDashboardModel } from 'app/features/dashboard-scene/serialization/transformSaveModelToScene';
-
 import { getTimeSrv } from '../../services/TimeSrv';
 import { DashboardModel } from '../../state/DashboardModel';
 import { type PanelModel } from '../../state/PanelModel';
-
 import { getDebugDashboard, getGithubMarkdown } from './utils';
-
 interface SupportSnapshotState {
   currentTab: SnapshotTab;
   showMessage: ShowMessage;
@@ -28,23 +25,19 @@ interface SupportSnapshotState {
   };
   panel: PanelModel;
   panelTitle: string;
-
   // eslint-disable-next-line
   snapshot?: any;
   snapshotUpdate: number;
   scene?: SceneObject;
 }
-
 export enum SnapshotTab {
   Support,
   Data,
 }
-
 export enum ShowMessage {
   PanelSnapshot,
   GithubComment,
 }
-
 export class SupportSnapshotService extends StateManagerBase<SupportSnapshotState> {
   constructor(panel: PanelModel) {
     super({
@@ -73,39 +66,31 @@ export class SupportSnapshotService extends StateManagerBase<SupportSnapshotStat
       ],
     });
   }
-
   async buildDebugDashboard() {
     const { panel, randomize, snapshotUpdate } = this.state;
     const snapshot = await getDebugDashboard(panel, randomize, getTimeSrv().timeRange());
     const snapshotText = JSON.stringify(snapshot, null, 2);
     const markdownText = getGithubMarkdown(panel, snapshotText);
     const snapshotSize = formattedValueToString(getValueFormat('bytes')(snapshotText?.length ?? 0));
-
     let scene: SceneObject | undefined = undefined;
-
     try {
       const oldModel = new DashboardModel(snapshot, { isEmbedded: true });
       const dash = createDashboardSceneFromDashboardModel(oldModel, snapshot);
       scene = dash.state.body; // skip the wrappers
     } catch (ex) {
-      console.log('Error creating scene:', ex);
+      structLog('log', 'Error creating scene:', ex);
     }
-
     this.setState({ snapshot, snapshotText, markdownText, snapshotSize, snapshotUpdate: snapshotUpdate + 1, scene });
   }
-
   onCurrentTabChange = (value: SnapshotTab) => {
     this.setState({ currentTab: value });
   };
-
   onShowMessageChange = (value: SelectableValue<ShowMessage>) => {
     this.setState({ showMessage: value.value! });
   };
-
   onGetMarkdownForClipboard = () => {
     const { markdownText } = this.state;
     const maxLen = Math.pow(1024, 2) * 1.5; // 1.5MB
-
     if (markdownText.length > maxLen) {
       this.setState({
         error: {
@@ -113,13 +98,10 @@ export class SupportSnapshotService extends StateManagerBase<SupportSnapshotStat
           message: 'Snapshot is too large, consider download and attaching a file instead',
         },
       });
-
       return '';
     }
-
     return markdownText;
   };
-
   onDownloadDashboard = () => {
     const { snapshotText, panelTitle } = this.state;
     const blob = new Blob([snapshotText], {
@@ -128,11 +110,9 @@ export class SupportSnapshotService extends StateManagerBase<SupportSnapshotStat
     const fileName = `debug-${panelTitle}-${dateTimeFormat(new Date())}.json.txt`;
     saveAs(blob, fileName);
   };
-
   onSetSnapshotText = (snapshotText: string) => {
     this.setState({ snapshotText });
   };
-
   onToggleRandomize = (k: keyof Randomize) => {
     const { randomize } = this.state;
     this.setState({ randomize: { ...randomize, [k]: !randomize[k] } });

--- a/public/app/features/dashboard/components/PanelEditor/state/actions.ts
+++ b/public/app/features/dashboard/components/PanelEditor/state/actions.ts
@@ -1,14 +1,12 @@
+import { structLog } from '@grafana/data';
 import { pick } from 'lodash';
-
 import { store } from '@grafana/data';
 import { removePanel } from 'app/features/dashboard/utils/panel';
 import { cleanUpPanelState } from 'app/features/panel/state/actions';
 import { panelModelAndPluginReady } from 'app/features/panel/state/reducers';
 import { type ThunkResult } from 'app/types/store';
-
 import { type DashboardModel } from '../../../state/DashboardModel';
 import { type PanelModel } from '../../../state/PanelModel';
-
 import {
   closeEditor,
   PANEL_EDITOR_UI_STATE_STORAGE_KEY,
@@ -17,11 +15,9 @@ import {
   setPanelEditorUIState,
   updateEditorInitState,
 } from './reducers';
-
 export function initPanelEditor(sourcePanel: PanelModel, dashboard: DashboardModel): ThunkResult<void> {
   return async (dispatch) => {
     const panel = dashboard.initEditPanel(sourcePanel);
-
     dispatch(
       updateEditorInitState({
         panel,
@@ -30,7 +26,6 @@ export function initPanelEditor(sourcePanel: PanelModel, dashboard: DashboardMod
     );
   };
 }
-
 export function discardPanelChanges(): ThunkResult<void> {
   return async (dispatch, getStore) => {
     const { getPanel } = getStore().panelEditor;
@@ -38,7 +33,6 @@ export function discardPanelChanges(): ThunkResult<void> {
     dispatch(setDiscardChanges(true));
   };
 }
-
 export function updateDuplicateLibraryPanels(
   modifiedPanel: PanelModel,
   dashboard: DashboardModel | null
@@ -47,37 +41,30 @@ export function updateDuplicateLibraryPanels(
     if (modifiedPanel.libraryPanel?.uid === undefined || !dashboard) {
       return;
     }
-
     const modifiedSaveModel = modifiedPanel.getSaveModel();
     for (const panel of dashboard.panels) {
       if (skipPanelUpdate(modifiedPanel, panel)) {
         continue;
       }
-
       panel.restoreModel({
         ...modifiedSaveModel,
         ...pick(panel, 'gridPos', 'id'),
       });
-
       // Loaded plugin is not included in the persisted properties
       // So is not handled by restoreModel
       const pluginChanged = panel.plugin?.meta.id !== modifiedPanel.plugin?.meta.id;
       panel.plugin = modifiedPanel.plugin;
       panel.configRev++;
-
       if (pluginChanged) {
         panel.generateNewKey();
-
         dispatch(panelModelAndPluginReady({ key: panel.key, plugin: panel.plugin! }));
       }
-
       // Resend last query result on source panel query runner
       // But do this after the panel edit editor exit process has completed
       setTimeout(() => {
         panel.getQueryRunner().useLastResultFrom(modifiedPanel.getQueryRunner());
       }, 20);
     }
-
     if (modifiedPanel.repeat) {
       // We skip any repeated library panels so we need to update them by calling processRepeats
       // But do this after the panel edit editor exit process has completed
@@ -85,67 +72,53 @@ export function updateDuplicateLibraryPanels(
     }
   };
 }
-
 export function skipPanelUpdate(modifiedPanel: PanelModel, panelToUpdate: PanelModel): boolean {
   // don't update library panels that aren't of the same type
   if (panelToUpdate.libraryPanel?.uid !== modifiedPanel.libraryPanel!.uid) {
     return true;
   }
-
   // don't update the modifiedPanel twice
   if (panelToUpdate.id && panelToUpdate.id === modifiedPanel.id) {
     return true;
   }
-
   // don't update library panels that are repeated
   if (panelToUpdate.repeatPanelId) {
     return true;
   }
-
   return false;
 }
-
 export function exitPanelEditor(): ThunkResult<void> {
   return async (dispatch, getStore) => {
     const dashboard = getStore().dashboard.getModel();
     const { getPanel, getSourcePanel, shouldDiscardChanges } = getStore().panelEditor;
     const panel = getPanel();
-
     if (dashboard) {
       dashboard.exitPanelEditor();
     }
-
     const sourcePanel = getSourcePanel();
     if (hasPanelChangedInPanelEdit(panel) && !shouldDiscardChanges) {
       const modifiedSaveModel = panel.getSaveModel();
       const panelTypeChanged = sourcePanel.type !== panel.type;
-
       dispatch(updateDuplicateLibraryPanels(panel, dashboard));
-
       sourcePanel.restoreModel(modifiedSaveModel);
       sourcePanel.configRev++; // force check the configs
-
       if (panelTypeChanged) {
         // Loaded plugin is not included in the persisted properties so is not handled by restoreModel
         sourcePanel.plugin = panel.plugin;
         sourcePanel.generateNewKey();
-
         await dispatch(panelModelAndPluginReady({ key: sourcePanel.key, plugin: panel.plugin! }));
       }
-
       // Resend last query result on source panel query runner
       // But do this after the panel edit editor exit process has completed
       setTimeout(() => {
         sourcePanel.getQueryRunner().useLastResultFrom(panel.getQueryRunner());
         sourcePanel.render();
-
         // If all changes where saved then reset configRev after applying changes
         if (panel.hasSavedPanelEditChange && !panel.hasChanged) {
           sourcePanel.configRev = 0;
         }
       }, 20);
     }
-
     // A new panel is only new until the first time we exit the panel editor
     if (sourcePanel.isNew) {
       if (!shouldDiscardChanges) {
@@ -154,16 +127,13 @@ export function exitPanelEditor(): ThunkResult<void> {
         dashboard && removePanel(dashboard, sourcePanel, true);
       }
     }
-
     dispatch(cleanUpPanelState(panel.key));
     dispatch(closeEditor());
   };
 }
-
 function hasPanelChangedInPanelEdit(panel: PanelModel) {
   return panel.hasChanged || panel.hasSavedPanelEditChange;
 }
-
 export function updatePanelEditorUIState(uiState: Partial<PanelEditorUIState>): ThunkResult<void> {
   return (dispatch, getStore) => {
     const nextState = { ...getStore().panelEditor.ui, ...uiState };
@@ -171,7 +141,7 @@ export function updatePanelEditorUIState(uiState: Partial<PanelEditorUIState>): 
     try {
       store.setObject(PANEL_EDITOR_UI_STATE_STORAGE_KEY, nextState);
     } catch (error) {
-      console.error(error);
+      structLog('error', error);
     }
   };
 }

--- a/public/app/features/dashboard/dashgrid/DashboardGrid.tsx
+++ b/public/app/features/dashboard/dashgrid/DashboardGrid.tsx
@@ -1,26 +1,22 @@
+import { structLog } from '@grafana/data';
 import classNames from 'classnames';
 import { PureComponent, type CSSProperties } from 'react';
 import * as React from 'react';
 import ReactGridLayout, { type ItemCallback } from 'react-grid-layout';
 import { Subscription } from 'rxjs';
-
 import { config } from '@grafana/runtime';
 import { appEvents } from 'app/core/app_events';
 import { GRID_CELL_HEIGHT, GRID_CELL_VMARGIN, GRID_COLUMN_COUNT } from 'app/core/constants';
 import { contextSrv } from 'app/core/services/context_srv';
 import { VariablesChanged } from 'app/features/variables/types';
 import { DashboardPanelsChangedEvent } from 'app/types/events';
-
 import { AddLibraryPanelWidget } from '../components/AddLibraryPanelWidget/AddLibraryPanelWidget';
 import { DashboardRow } from '../components/DashboardRow/DashboardRow';
 import { type DashboardModel } from '../state/DashboardModel';
 import { type GridPos, type PanelModel } from '../state/PanelModel';
-
 import DashboardEmpty from './DashboardEmpty/DashboardEmpty';
 import { DashboardPanel } from './DashboardPanel';
-
 export const PANEL_FILTER_VARIABLE = 'systemPanelFilterVar';
-
 export interface Props {
   dashboard: DashboardModel;
   isEditable: boolean;
@@ -28,14 +24,14 @@ export interface Props {
   viewPanel: PanelModel | null;
   hidePanelMenus?: boolean;
 }
-
 interface State {
   panelFilter?: RegExp;
   width: number;
 }
-
 export class DashboardGrid extends PureComponent<Props, State> {
-  private panelMap: { [key: string]: PanelModel } = {};
+  private panelMap: {
+    [key: string]: PanelModel;
+  } = {};
   private eventSubs = new Subscription();
   private windowHeight = 1200;
   private windowWidth = 1920;
@@ -43,7 +39,6 @@ export class DashboardGrid extends PureComponent<Props, State> {
   /** Used to keep track of mobile panel layout position */
   private lastPanelBottom = 0;
   private isLayoutInitialized = false;
-
   constructor(props: Props) {
     super(props);
     this.state = {
@@ -51,10 +46,8 @@ export class DashboardGrid extends PureComponent<Props, State> {
       width: document.body.clientWidth, // initial very rough estimate
     };
   }
-
   componentDidMount() {
     const { dashboard } = this.props;
-
     if (config.featureToggles.panelFilterVariable) {
       // If panel filter variable is set on load then
       // update state to filter panels
@@ -66,7 +59,6 @@ export class DashboardGrid extends PureComponent<Props, State> {
           break;
         }
       }
-
       this.eventSubs.add(
         appEvents.subscribe(VariablesChanged, (e) => {
           if (e.payload.variable?.id === PANEL_FILTER_VARIABLE) {
@@ -80,14 +72,11 @@ export class DashboardGrid extends PureComponent<Props, State> {
         })
       );
     }
-
     this.eventSubs.add(dashboard.events.subscribe(DashboardPanelsChangedEvent, this.triggerForceUpdate));
   }
-
   componentWillUnmount() {
     this.eventSubs.unsubscribe();
   }
-
   setPanelFilter(regex: string) {
     // Only set the panels filter if the systemPanelFilterVar variable
     // is a non-empty string
@@ -95,17 +84,14 @@ export class DashboardGrid extends PureComponent<Props, State> {
     if (regex.length > 0) {
       panelFilter = new RegExp(regex, 'i');
     }
-
     this.setState({
       panelFilter: panelFilter,
     });
   }
-
   buildLayout() {
     const layout: ReactGridLayout.Layout[] = [];
     this.panelMap = {};
     const { panelFilter } = this.state;
-
     let count = 0;
     for (const panel of this.props.dashboard.panels) {
       if (!panel.key) {
@@ -113,12 +99,10 @@ export class DashboardGrid extends PureComponent<Props, State> {
       }
       panel.title = panel.title?.substring(0, 5000);
       this.panelMap[panel.key] = panel;
-
       if (!panel.gridPos) {
-        console.log('panel without gridpos');
+        structLog('log', 'panel without gridpos');
         continue;
       }
-
       const panelPos: ReactGridLayout.Layout = {
         i: panel.key,
         x: panel.gridPos.x,
@@ -126,14 +110,12 @@ export class DashboardGrid extends PureComponent<Props, State> {
         w: panel.gridPos.w,
         h: panel.gridPos.h,
       };
-
       if (panel.type === 'row') {
         panelPos.w = GRID_COLUMN_COUNT;
         panelPos.h = 1;
         panelPos.isResizable = false;
         panelPos.isDraggable = panel.collapsed;
       }
-
       if (!panelFilter) {
         layout.push(panelPos);
       } else {
@@ -147,10 +129,8 @@ export class DashboardGrid extends PureComponent<Props, State> {
         }
       }
     }
-
     return layout;
   }
-
   onLayoutChange = (newLayout: ReactGridLayout.Layout[]) => {
     if (this.state.panelFilter) {
       return;
@@ -158,39 +138,36 @@ export class DashboardGrid extends PureComponent<Props, State> {
     for (const newPos of newLayout) {
       this.panelMap[newPos.i!].updateGridPos(newPos, this.isLayoutInitialized);
     }
-
     if (this.isLayoutInitialized) {
       this.isLayoutInitialized = true;
     }
-
     this.props.dashboard.sortPanelsByGridPos();
     this.forceUpdate();
   };
-
   triggerForceUpdate = () => {
     this.forceUpdate();
   };
-
   updateGridPos = (item: ReactGridLayout.Layout, layout: ReactGridLayout.Layout[]) => {
     this.panelMap[item.i!].updateGridPos(item);
   };
-
   onResize: ItemCallback = (layout, oldItem, newItem) => {
     const panel = this.panelMap[newItem.i!];
     panel.updateGridPos(newItem);
   };
-
   onResizeStop: ItemCallback = (layout, oldItem, newItem) => {
     this.updateGridPos(newItem, layout);
   };
-
   onDragStop: ItemCallback = (layout, oldItem, newItem) => {
     this.updateGridPos(newItem, layout);
   };
-
-  getPanelScreenPos(panel: PanelModel, gridWidth: number): { top: number; bottom: number } {
+  getPanelScreenPos(
+    panel: PanelModel,
+    gridWidth: number
+  ): {
+    top: number;
+    bottom: number;
+  } {
     let top = 0;
-
     // mobile layout
     if (gridWidth < config.theme2.breakpoints.values.md) {
       // In mobile layout panels are stacked so we just add the panel vertical margin to the last panel bottom position
@@ -199,19 +176,14 @@ export class DashboardGrid extends PureComponent<Props, State> {
       // For top position we need to add back the vertical margin removed by translateGridHeightToScreenHeight
       top = translateGridHeightToScreenHeight(panel.gridPos.y) + GRID_CELL_VMARGIN;
     }
-
     this.lastPanelBottom = top + translateGridHeightToScreenHeight(panel.gridPos.h);
-
     return { top, bottom: this.lastPanelBottom };
   }
-
   renderPanels(gridWidth: number, isDashboardDraggable: boolean) {
     const { panelFilter } = this.state;
     const panelElements = [];
-
     // Reset last panel bottom
     this.lastPanelBottom = 0;
-
     // This is to avoid layout re-flows, accessing window.innerHeight can trigger re-flow
     // We assume here that if width change height might have changed as well
     if (this.gridWidth !== gridWidth) {
@@ -219,10 +191,8 @@ export class DashboardGrid extends PureComponent<Props, State> {
       this.windowWidth = window.innerWidth;
       this.gridWidth = gridWidth;
     }
-
     for (const panel of this.props.dashboard.panels) {
       const panelClasses = classNames({ 'react-grid-item--fullscreen': panel.isViewing });
-
       const p = (
         <GrafanaGridItem
           key={panel.key}
@@ -239,7 +209,6 @@ export class DashboardGrid extends PureComponent<Props, State> {
           }}
         </GrafanaGridItem>
       );
-
       if (!panelFilter) {
         panelElements.push(p);
       } else {
@@ -248,19 +217,15 @@ export class DashboardGrid extends PureComponent<Props, State> {
         }
       }
     }
-
     return panelElements;
   }
-
   renderPanel(panel: PanelModel, width: number, height: number, isDraggable: boolean) {
     if (panel.type === 'row') {
       return <DashboardRow key={panel.key} panel={panel} dashboard={this.props.dashboard} />;
     }
-
     if (panel.type === 'add-library-panel') {
       return <AddLibraryPanelWidget key={panel.key} panel={panel} dashboard={this.props.dashboard} />;
     }
-
     return (
       <DashboardPanel
         key={panel.key}
@@ -276,7 +241,6 @@ export class DashboardGrid extends PureComponent<Props, State> {
       />
     );
   }
-
   /**
    * Without this hack the move animations are triggered on initial load and all panels fly into position.
    * This can be quite distracting and make the dashboard appear to less snappy.
@@ -288,7 +252,6 @@ export class DashboardGrid extends PureComponent<Props, State> {
       }, 50);
     }
   };
-
   private resizeObserver?: ResizeObserver;
   private rootEl: HTMLDivElement | null = null;
   onMeasureRef = (rootEl: HTMLDivElement | null) => {
@@ -298,27 +261,21 @@ export class DashboardGrid extends PureComponent<Props, State> {
       }
       return;
     }
-
     this.rootEl = rootEl;
     this.resizeObserver = new ResizeObserver((entries) => {
       entries.forEach((entry) => {
         this.setState({ width: entry.contentRect.width });
       });
     });
-
     this.resizeObserver.observe(rootEl);
   };
-
   render() {
     const { isEditable, dashboard } = this.props;
     const { width } = this.state;
-
     if (dashboard.panels.length === 0) {
       return <DashboardEmpty dashboard={dashboard} canCreate={isEditable} />;
     }
-
     const draggable = width <= config.theme2.breakpoints.values.md ? false : isEditable;
-
     // pos: rel + z-index is required to create a new stacking context to contain
     // the escalating z-indexes of the panels
     return (
@@ -356,7 +313,6 @@ export class DashboardGrid extends PureComponent<Props, State> {
     );
   }
 }
-
 interface GrafanaGridItemProps extends React.HTMLAttributes<HTMLDivElement> {
   gridWidth?: number;
   gridPos?: GridPos;
@@ -365,7 +321,6 @@ interface GrafanaGridItemProps extends React.HTMLAttributes<HTMLDivElement> {
   windowWidth: number;
   children: any; // eslint-disable-line @typescript-eslint/no-explicit-any
 }
-
 /**
  * A hacky way to intercept the react-layout-grid item dimensions and pass them to DashboardPanel
  */
@@ -373,10 +328,8 @@ const GrafanaGridItem = React.forwardRef<HTMLDivElement, GrafanaGridItemProps>((
   const theme = config.theme2;
   let width = 100;
   let height = 100;
-
   const { gridWidth, gridPos, isViewing, windowHeight, windowWidth, ...divProps } = props;
   const style: CSSProperties = props.style ?? {};
-
   if (isViewing) {
     // In fullscreen view mode a single panel take up full width & 85% height
     width = gridWidth!;
@@ -401,7 +354,6 @@ const GrafanaGridItem = React.forwardRef<HTMLDivElement, GrafanaGridItemProps>((
       }
     }
   }
-
   // props.children[0] is our main children. RGL adds the drag handle at props.children[1]
   return (
     <div {...divProps} style={{ ...divProps.style }} ref={ref}>
@@ -410,12 +362,10 @@ const GrafanaGridItem = React.forwardRef<HTMLDivElement, GrafanaGridItemProps>((
     </div>
   );
 });
-
 /**
  * This translates grid height dimensions to real pixels
  */
 function translateGridHeightToScreenHeight(gridHeight: number): number {
   return gridHeight * (GRID_CELL_HEIGHT + GRID_CELL_VMARGIN) - GRID_CELL_VMARGIN;
 }
-
 GrafanaGridItem.displayName = 'GridItemWithDimensions';

--- a/public/app/features/dashboard/dashgrid/DashboardLibrary/DashboardCard.tsx
+++ b/public/app/features/dashboard/dashgrid/DashboardLibrary/DashboardCard.tsx
@@ -1,7 +1,7 @@
+import { structLog } from '@grafana/data';
 import { css, cx } from '@emotion/css';
 import { useMemo } from 'react';
 import Skeleton from 'react-loading-skeleton';
-
 import { createAssistantContextItem, useAssistant } from '@grafana/assistant';
 import { type GrafanaTheme2 } from '@grafana/data';
 import { t, Trans } from '@grafana/i18n';
@@ -9,11 +9,9 @@ import { config } from '@grafana/runtime';
 import { Badge, Box, Button, Card, IconButton, Text, TextLink, Tooltip, useStyles2 } from '@grafana/ui';
 import { attachSkeleton, type SkeletonComponent } from '@grafana/ui/unstable';
 import { type PluginDashboard } from 'app/types/plugins';
-
 import { CompatibilityBadge, type CompatibilityState } from './CompatibilityBadge';
 import { type GnetDashboard } from './types';
 import { buildAssistantPrompt, buildTemplateContextData, buildTemplateContextTitle } from './utils/assistantHelpers';
-
 interface Details {
   id: string;
   datasource: string;
@@ -22,7 +20,6 @@ interface Details {
   lastUpdate: string;
   grafanaComUrl?: string;
 }
-
 interface Props {
   title: string;
   imageUrl?: string;
@@ -44,7 +41,6 @@ interface Props {
   /** Whether to show the "Customize with assistant" button (caller must check relevant feature flags) */
   showAssistantButton?: boolean;
 }
-
 function DashboardCardComponent({
   title,
   imageUrl,
@@ -64,15 +60,12 @@ function DashboardCardComponent({
 }: Props) {
   const styles = useStyles2(getStyles);
   const isCompatibilityAppEnabled = config.featureToggles.dashboardValidatorApp;
-
   const detailsButton = details && (
     <Tooltip interactive={true} content={<DetailsTooltipContent details={details} />} placement="right">
       <IconButton name="info-circle" size="md" aria-label={t('dashboard-library.card.details-tooltip', 'Details')} />
     </Tooltip>
   );
-
   const { isAvailable: assistantAvailable, openAssistant } = useAssistant();
-
   // Create structured context item with template metadata for the Assistant
   const templateContext = useMemo(
     () =>
@@ -83,7 +76,6 @@ function DashboardCardComponent({
       }),
     [dashboard, kind]
   );
-
   const onUseAssistantClick = () => {
     if (assistantAvailable) {
       openAssistant?.({
@@ -98,9 +90,7 @@ function DashboardCardComponent({
       onClick?.(true);
     }
   };
-
   const hasCompatActions = isCompatibilityAppEnabled && showCompatibilityBadge && onCompatibilityCheck;
-
   return (
     <Card className={styles.card} noMargin>
       <Card.Heading className={styles.title}>
@@ -120,7 +110,7 @@ function DashboardCardComponent({
               kind === 'suggested_dashboard' ? styles.thumbnailCoverImage : styles.thumbnailContainImage
             )}
             onError={(e) => {
-              console.error('Failed to load image for:', title, 'URL:', imageUrl);
+              structLog('error', 'Failed to load image for:', title, 'URL:', imageUrl);
               e.currentTarget.style.display = 'none';
             }}
           />
@@ -200,7 +190,6 @@ function DashboardCardComponent({
     </Card>
   );
 }
-
 function DetailsTooltipContent({ details }: { details: Details }) {
   const Section = ({ label, value }: { label: string; value: string }) => {
     return (
@@ -212,7 +201,6 @@ function DetailsTooltipContent({ details }: { details: Details }) {
       </Box>
     );
   };
-
   return (
     <Box display="flex">
       <Box display="flex" direction="column" gap={1} width={{ xs: 'auto', md: 340 }}>
@@ -244,7 +232,6 @@ function DetailsTooltipContent({ details }: { details: Details }) {
     </Box>
   );
 }
-
 function getStyles(theme: GrafanaTheme2) {
   const thumbnailOverlay = css({
     position: 'absolute',
@@ -261,7 +248,6 @@ function getStyles(theme: GrafanaTheme2) {
       transition: 'opacity 0.15s ease',
     },
   });
-
   return {
     card: css({
       gridTemplateAreas: `
@@ -428,11 +414,9 @@ function getStyles(theme: GrafanaTheme2) {
     }),
   };
 }
-
 interface DashboardCardSkeletonProps {
   showCompatibilityBadge?: boolean;
 }
-
 const DashboardCardSkeleton: SkeletonComponent<DashboardCardSkeletonProps> = ({
   rootProps,
   showCompatibilityBadge,
@@ -447,7 +431,6 @@ const DashboardCardSkeleton: SkeletonComponent<DashboardCardSkeletonProps> = ({
     </div>
   );
 };
-
 const getSkeletonStyles = (theme: GrafanaTheme2) => ({
   card: css({
     width: '350px',
@@ -469,5 +452,4 @@ const getSkeletonStyles = (theme: GrafanaTheme2) => ({
     lineHeight: 1,
   }),
 });
-
 export const DashboardCard = attachSkeleton(DashboardCardComponent, DashboardCardSkeleton);

--- a/public/app/features/dashboard/dashgrid/DashboardLibrary/SuggestedDashboardsList/SuggestedDashboardsList.tsx
+++ b/public/app/features/dashboard/dashgrid/DashboardLibrary/SuggestedDashboardsList/SuggestedDashboardsList.tsx
@@ -1,14 +1,13 @@
+import { structLog } from '@grafana/data';
 import { css } from '@emotion/css';
 import { useBooleanFlagValue } from '@openfeature/react-sdk';
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { useAsyncFn, useDebounce } from 'react-use';
-
 import { type GrafanaTheme2 } from '@grafana/data';
 import { t } from '@grafana/i18n';
 import { config, getDataSourceSrv, isFetchError, locationService } from '@grafana/runtime';
 import { FilterInput, Grid, Pagination, Stack, useStyles2 } from '@grafana/ui';
 import { type PluginDashboard } from 'app/types/plugins';
-
 import { DASHBOARD_LIBRARY_ROUTES } from '../../types';
 import { type CompatibilityState } from '../CompatibilityBadge';
 import { DashboardCard } from '../DashboardCard';
@@ -21,17 +20,14 @@ import { DashboardLibraryInteractions, SuggestedDashboardInteractions } from '..
 import { type GnetDashboard } from '../types';
 import { onUseCommunityDashboard, interpolateDashboardForCompatibilityCheck } from '../utils/communityDashboardHelpers';
 import { getPageSlice } from '../utils/suggestedDashboardHelpers';
-
 import { DashboardResultsGrid } from './DashboardResultsGrid';
 import { EmptyResults } from './EmptyResults';
 import { ListHeader } from './ListHeader';
-
 const SEARCH_DEBOUNCE_MS = 500;
 const DEFAULT_SORT_ORDER = 'downloads';
 const DEFAULT_SORT_DIRECTION = 'desc' as const;
 const INCLUDE_LOGO = true;
 const INCLUDE_SCREENSHOTS = true;
-
 interface SuggestedDashboardsListProps {
   provisionedDashboards: PluginDashboard[];
   communityDashboards: GnetDashboard[];
@@ -44,7 +40,6 @@ interface SuggestedDashboardsListProps {
   onShowMapping: (context: MappingContext) => void;
   onDismiss: () => void;
 }
-
 interface CommunityCache {
   searchQuery: string;
   items: Array<GnetDashboard | undefined>;
@@ -53,7 +48,6 @@ interface CommunityCache {
   /** Exact count of community items on the last API page (once fetched). */
   lastPageItemCount?: number;
 }
-
 export const SuggestedDashboardsList = ({
   provisionedDashboards,
   communityDashboards,
@@ -76,9 +70,7 @@ export const SuggestedDashboardsList = ({
   const hasTrackedLoaded = useRef(false);
   const hasAutoCheckedRef = useRef(false);
   const isCompatibilityAppEnabled = config.featureToggles.dashboardValidatorApp;
-
   const [compatibilityMap, setCompatibilityMap] = useState<Map<number, CompatibilityState>>(new Map());
-
   // Community cache state — initialized with pre-fetched page 1 data from the loader
   const [communityCache, setCommunityCache] = useState<CommunityCache>(() => ({
     searchQuery: '',
@@ -88,7 +80,6 @@ export const SuggestedDashboardsList = ({
     // Use persisted value from the module cache, or infer when there's only one page
     lastPageItemCount: initialLastPageItemCount ?? (communityTotalPages <= 1 ? communityDashboards.length : undefined),
   }));
-
   // Filter provisioned dashboards client-side
   const filteredProvisioned = useMemo(() => {
     if (!debouncedSearchQuery.trim()) {
@@ -99,13 +90,11 @@ export const SuggestedDashboardsList = ({
       (d) => d.title.toLowerCase().includes(query) || (d.description ?? '').toLowerCase().includes(query)
     );
   }, [provisionedDashboards, debouncedSearchQuery]);
-
   // Debounce search — updates debouncedSearchQuery and resets cache after delay
   useDebounce(
     () => {
       setDebouncedSearchQuery(searchQuery);
       setCurrentPage(1);
-
       // Clear community cache when search changes
       if (searchQuery.trim()) {
         setCommunityCache({
@@ -130,13 +119,11 @@ export const SuggestedDashboardsList = ({
     SEARCH_DEBOUNCE_MS,
     [searchQuery, communityDashboards, communityTotalPages]
   );
-
   // Calculate pagination slices for the merged provisioned + community list
   const { totalPages, provisionedSlice, communityNeededCount, communityStartIndex, communitySlice } = useMemo(
     () => getPageSlice({ currentPage, pageSize: PAGE_SIZE, filteredProvisioned, communityCache }),
     [currentPage, filteredProvisioned, communityCache]
   );
-
   // Auto-correct currentPage if it exceeds totalPages (e.g. after fetching the
   // last API page reveals fewer items than estimated)
   useEffect(() => {
@@ -144,13 +131,11 @@ export const SuggestedDashboardsList = ({
       setCurrentPage(totalPages);
     }
   }, [currentPage, totalPages]);
-
   // Fetch community pages as needed
   useEffect(() => {
     if (communityNeededCount <= 0 || !datasourceType || isDashboardsLoading) {
       return;
     }
-
     // The loader pre-fetches page 1, but the cache may not have it yet (useState
     // initializer ran when the prop was still empty). Sync it from the prop to
     // avoid a duplicate fetch — this triggers a re-render and the effect re-runs
@@ -166,7 +151,6 @@ export const SuggestedDashboardsList = ({
       });
       return;
     }
-
     const fetchNeeded = async () => {
       // Community items are fetched in pages of PAGE_SIZE from the API.
       // communityStartIndex is the offset into the flat community list (e.g. 8 means "start at the 9th community item").
@@ -176,20 +160,16 @@ export const SuggestedDashboardsList = ({
       // The last item we need is at (communityStartIndex + communityNeededCount - 1).
       // We find which API page contains that last item to know the full range of pages to fetch.
       const lastApiPage = Math.floor((communityStartIndex + communityNeededCount - 1) / PAGE_SIZE) + 1;
-
       const pagesToFetch: number[] = [];
       for (let p = firstApiPage; p <= lastApiPage; p++) {
         if (!communityCache.cachedPages.has(p)) {
           pagesToFetch.push(p);
         }
       }
-
       if (pagesToFetch.length === 0) {
         return;
       }
-
       setIsCommunityLoading(true);
-
       try {
         const responses = await Promise.all(
           pagesToFetch.map((page) =>
@@ -205,15 +185,12 @@ export const SuggestedDashboardsList = ({
             })
           )
         );
-
         let totalFetched = 0;
-
         setCommunityCache((prev) => {
           const newItems = [...prev.items];
           const newCachedPages = new Set(prev.cachedPages);
           let totalApiPages = prev.totalApiPages;
           let lastPageItemCount = prev.lastPageItemCount;
-
           // Place each page's items at their correct offset in the sparse items array
           responses.forEach((response, idx) => {
             const page = pagesToFetch[idx];
@@ -224,7 +201,6 @@ export const SuggestedDashboardsList = ({
             newCachedPages.add(page);
             totalFetched += response.items.length;
             totalApiPages = response.pages;
-
             // When we fetch the last API page, record its exact item count
             // so we can compute an accurate total instead of overestimating
             if (page === response.pages) {
@@ -232,7 +208,6 @@ export const SuggestedDashboardsList = ({
               onLastPageItemCount?.(response.items.length);
             }
           });
-
           return {
             ...prev,
             items: newItems,
@@ -241,7 +216,6 @@ export const SuggestedDashboardsList = ({
             lastPageItemCount,
           };
         });
-
         if (debouncedSearchQuery.trim()) {
           DashboardLibraryInteractions.searchPerformed({
             datasourceTypes: [datasourceType],
@@ -252,12 +226,11 @@ export const SuggestedDashboardsList = ({
           });
         }
       } catch (err) {
-        console.error('Error loading community dashboards', err);
+        structLog('error', 'Error loading community dashboards', err);
       } finally {
         setIsCommunityLoading(false);
       }
     };
-
     fetchNeeded();
   }, [
     currentPage,
@@ -274,7 +247,6 @@ export const SuggestedDashboardsList = ({
     sourceEntryPoint,
     eventLocation,
   ]);
-
   // Track analytics on first load
   useEffect(() => {
     if (
@@ -289,7 +261,6 @@ export const SuggestedDashboardsList = ({
       if (communityDashboards.length > 0) {
         contentKinds.push(CONTENT_KINDS.COMMUNITY_DASHBOARD);
       }
-
       SuggestedDashboardInteractions.loaded({
         numberOfItems: provisionedDashboards.length + communityDashboards.length,
         contentKinds,
@@ -307,7 +278,6 @@ export const SuggestedDashboardsList = ({
     sourceEntryPoint,
     eventLocation,
   ]);
-
   // Provisioned dashboard click handler
   const onClickProvisionedDashboard = (dashboard: PluginDashboard, customizeWithAssistant?: boolean) => {
     SuggestedDashboardInteractions.itemClicked({
@@ -320,7 +290,6 @@ export const SuggestedDashboardsList = ({
       discoveryMethod: debouncedSearchQuery.trim() ? DISCOVERY_METHODS.SEARCH : DISCOVERY_METHODS.BROWSE,
       action: customizeWithAssistant ? 'assistant' : 'use_dashboard',
     });
-
     const params = new URLSearchParams({
       datasource: datasourceUid || '',
       title: dashboard.title || 'Template',
@@ -333,15 +302,12 @@ export const SuggestedDashboardsList = ({
       eventLocation,
       contentKind: CONTENT_KINDS.DATASOURCE_DASHBOARD,
     });
-
     if (customizeWithAssistant) {
       params.set('assistantSource', 'assistant_button');
     }
-
     const templateUrl = `${DASHBOARD_LIBRARY_ROUTES.Template}?${params.toString()}`;
     locationService.push(templateUrl);
   };
-
   // Community dashboard click handler
   const [{ error: isPreviewDashboardError }, onClickCommunityDashboard] = useAsyncFn(
     async (dashboard: GnetDashboard, customizeWithAssistant?: boolean) => {
@@ -355,7 +321,6 @@ export const SuggestedDashboardsList = ({
         discoveryMethod: debouncedSearchQuery.trim() ? DISCOVERY_METHODS.SEARCH : DISCOVERY_METHODS.BROWSE,
         action: customizeWithAssistant ? 'assistant' : 'use_dashboard',
       });
-
       await onUseCommunityDashboard({
         dashboard,
         datasourceUid: datasourceUid || '',
@@ -367,15 +332,12 @@ export const SuggestedDashboardsList = ({
     },
     [datasourceType, datasourceUid, debouncedSearchQuery, onShowMapping, sourceEntryPoint, eventLocation]
   );
-
   // Compatibility check handler
   const onCheckCompatibility = async (dashboard: GnetDashboard, triggerMethod: 'manual' | 'auto_initial_load') => {
     if (!datasourceUid || !datasourceType) {
       return;
     }
-
     setCompatibilityMap((prev) => new Map(prev).set(dashboard.id, { status: 'loading' }));
-
     DashboardLibraryInteractions.compatibilityCheckTriggered({
       dashboardId: String(dashboard.id),
       dashboardTitle: dashboard.name,
@@ -384,10 +346,8 @@ export const SuggestedDashboardsList = ({
       eventLocation,
       sourceEntryPoint,
     });
-
     try {
       const interpolatedDashboard = await interpolateDashboardForCompatibilityCheck(dashboard.id, datasourceUid);
-
       const result = await checkDashboardCompatibility(interpolatedDashboard, [
         {
           uid: datasourceUid,
@@ -395,12 +355,10 @@ export const SuggestedDashboardsList = ({
           name: getDataSourceSrv().getInstanceSettings(datasourceUid)?.name ?? '',
         },
       ]);
-
       const dsResult = result.datasourceResults[0];
       const score = Math.round(dsResult.compatibilityScore * 100);
       const metricsFound = dsResult.foundMetrics;
       const metricsTotal = dsResult.totalMetrics;
-
       setCompatibilityMap((prev) =>
         new Map(prev).set(dashboard.id, {
           status: 'success',
@@ -409,7 +367,6 @@ export const SuggestedDashboardsList = ({
           metricsTotal,
         })
       );
-
       DashboardLibraryInteractions.compatibilityCheckCompleted({
         dashboardId: String(dashboard.id),
         dashboardTitle: dashboard.name,
@@ -422,11 +379,9 @@ export const SuggestedDashboardsList = ({
         sourceEntryPoint,
       });
     } catch (err) {
-      console.error('Error checking dashboard compatibility:', err);
-
+      structLog('error', 'Error checking dashboard compatibility:', err);
       const errorMessage = isFetchError(err) ? err.data?.message : 'Failed to check compatibility';
       const errorCode = isFetchError(err) ? err.data?.code : undefined;
-
       setCompatibilityMap((prev) =>
         new Map(prev).set(dashboard.id, {
           status: 'error',
@@ -436,7 +391,6 @@ export const SuggestedDashboardsList = ({
       );
     }
   };
-
   // Auto-trigger compatibility checks on initial load for Prometheus
   useEffect(() => {
     if (
@@ -462,10 +416,8 @@ export const SuggestedDashboardsList = ({
     isCompatibilityAppEnabled,
     debouncedSearchQuery,
   ]);
-
   const showLoading = isDashboardsLoading || isCommunityLoading;
   const hasNoResults = !showLoading && provisionedSlice.length === 0 && communitySlice.length === 0;
-
   const onCreateFromScratch = () => {
     DashboardLibraryInteractions.createFromScratchClicked({
       eventLocation,
@@ -473,7 +425,6 @@ export const SuggestedDashboardsList = ({
     onDismiss();
     locationService.push('/dashboard/new');
   };
-
   return (
     <Stack direction="column" gap={2} height="100%">
       <ListHeader error={isPreviewDashboardError} onCreateFromScratch={onCreateFromScratch} />
@@ -526,7 +477,6 @@ export const SuggestedDashboardsList = ({
     </Stack>
   );
 };
-
 function getStyles(theme: GrafanaTheme2) {
   return {
     resultsContainer: css({

--- a/public/app/features/dashboard/dashgrid/DashboardLibrary/TemplateDashboardModal.tsx
+++ b/public/app/features/dashboard/dashgrid/DashboardLibrary/TemplateDashboardModal.tsx
@@ -1,14 +1,13 @@
+import { structLog } from '@grafana/data';
 import { css } from '@emotion/css';
 import { useBooleanFlagValue } from '@openfeature/react-sdk';
 import { useEffect } from 'react';
 import { useSearchParams } from 'react-router-dom-v5-compat';
 import { useAsync } from 'react-use';
-
 import { type GrafanaTheme2 } from '@grafana/data';
 import { t, Trans } from '@grafana/i18n';
 import { getBackendSrv, getDataSourceSrv, locationService } from '@grafana/runtime';
 import { Box, Grid, Modal, Text, useStyles2 } from '@grafana/ui';
-
 import { DashboardCard } from './DashboardCard';
 import { NewTemplateDashboardInteractions } from './analytics/main';
 import {
@@ -21,13 +20,11 @@ import {
 import { TemplateDashboardInteractions } from './interactions';
 import { type GnetDashboard, type GnetDashboardsResponse, type Link } from './types';
 import { getTemplateDashboardUrl } from './utils/templateDashboardHelpers';
-
 const SourceEntryPointMap: Record<string, SourceEntryPoint> = {
   quickAdd: TemplateDashboardSourceEntryPoint.QUICK_ADD_BUTTON,
   commandPalette: TemplateDashboardSourceEntryPoint.COMMAND_PALETTE,
   createNewButton: TemplateDashboardSourceEntryPoint.BROWSE_DASHBOARDS_PAGE,
 };
-
 export const TemplateDashboardModal = () => {
   const [searchParams, setSearchParams] = useSearchParams();
   const isOpen = searchParams.get('templateDashboards') === 'true';
@@ -38,16 +35,12 @@ export const TemplateDashboardModal = () => {
     false
   );
   const isAnalyticsFrameworkEnabled = useBooleanFlagValue('analyticsFramework', true);
-
   const testDataSource = getDataSourceSrv().getList({ type: 'grafana-testdata-datasource' })[0];
-
   const styles = useStyles2(getStyles);
-
   const onClose = () => {
     searchParams.delete('templateDashboards');
     setSearchParams(searchParams);
   };
-
   const onPreviewDashboardClick = async (dashboard: GnetDashboard, customizeWithAssistant = false) => {
     const sourceEntryPoint = SourceEntryPointMap[entryPoint] || 'unknown';
     isAnalyticsFrameworkEnabled
@@ -71,7 +64,6 @@ export const TemplateDashboardModal = () => {
           discoveryMethod: DISCOVERY_METHODS.BROWSE,
           action: customizeWithAssistant ? 'assistant' : 'view_template',
         });
-
     const templateUrl = getTemplateDashboardUrl(
       dashboard,
       sourceEntryPoint,
@@ -79,12 +71,10 @@ export const TemplateDashboardModal = () => {
     );
     locationService.push(templateUrl);
   };
-
   const { value: dashboards = [], loading } = useAsync(async () => {
     if (!isOpen) {
       return [];
     }
-
     try {
       const response = await getBackendSrv().get<GnetDashboardsResponse>(
         `/api/gnet/dashboards?orgSlug=raintank&categorySlug=templates&includeScreenshots=true`,
@@ -94,14 +84,12 @@ export const TemplateDashboardModal = () => {
           showErrorAlert: false,
         }
       );
-
       return response.items;
     } catch (error) {
-      console.error('Error loading template dashboards ', error);
+      structLog('error', 'Error loading template dashboards ', error);
       return [];
     }
   }, [isOpen]);
-
   useEffect(() => {
     if (isOpen && !loading && dashboards.length > 0) {
       isAnalyticsFrameworkEnabled
@@ -121,11 +109,9 @@ export const TemplateDashboardModal = () => {
           });
     }
   }, [isOpen, dashboards, entryPoint, testDataSource?.type, loading, isAnalyticsFrameworkEnabled]);
-
   if (!testDataSource || (dashboards.length === 0 && !loading)) {
     return null;
   }
-
   return (
     <Modal
       isOpen={isOpen}
@@ -155,7 +141,6 @@ export const TemplateDashboardModal = () => {
             : dashboards?.map((dashboard) => {
                 const thumbnail = dashboard.screenshots?.[0]?.links.find((l: Link) => l.rel === 'image')?.href ?? '';
                 const thumbnailUrl = thumbnail ? `/api/gnet${thumbnail}` : '';
-
                 return (
                   <DashboardCard
                     key={dashboard.id}
@@ -178,7 +163,6 @@ export const TemplateDashboardModal = () => {
     </Modal>
   );
 };
-
 function getStyles(theme: GrafanaTheme2) {
   return {
     modal: css({

--- a/public/app/features/dashboard/dashgrid/DashboardLibrary/api/compatibilityApi.ts
+++ b/public/app/features/dashboard/dashgrid/DashboardLibrary/api/compatibilityApi.ts
@@ -1,7 +1,7 @@
+import { structLog } from '@grafana/data';
 import { getAPINamespace } from '@grafana/api-clients';
 import { getBackendSrv } from '@grafana/runtime';
 import { type DashboardJson } from 'app/features/manage-dashboards/types';
-
 /**
  * Represents a datasource mapping for compatibility checking.
  * Maps dashboard datasource references to actual datasource instances.
@@ -14,7 +14,6 @@ export interface DatasourceMapping {
   /** Optional human-readable name for display */
   name?: string;
 }
-
 /**
  * Request body for dashboard compatibility check API call
  */
@@ -24,7 +23,6 @@ export interface CheckCompatibilityRequest {
   /** Array of datasource mappings to check compatibility against */
   datasourceMappings: DatasourceMapping[];
 }
-
 /**
  * Breakdown of compatibility metrics for a single query within a panel
  */
@@ -46,7 +44,6 @@ export interface QueryBreakdown {
   /** Optional error message for queries that failed to parse */
   parseError?: string;
 }
-
 /**
  * Compatibility check result for a single datasource
  */
@@ -72,7 +69,6 @@ export interface DatasourceResult {
   /** Detailed breakdown of compatibility per query */
   queryBreakdown: QueryBreakdown[];
 }
-
 /**
  * Overall compatibility check result
  */
@@ -82,7 +78,6 @@ export interface CompatibilityCheckResult {
   /** Results for each datasource checked */
   datasourceResults: DatasourceResult[];
 }
-
 /**
  * Checks dashboard compatibility with specified datasources.
  *
@@ -116,13 +111,11 @@ export async function checkDashboardCompatibility(
   // Get namespace from global config (typically 'default' in development)
   // This follows Kubernetes API convention for Grafana app plugins
   const namespace = getAPINamespace();
-
   // Build request body matching backend schema
   const requestBody: CheckCompatibilityRequest = {
     dashboardJson,
     datasourceMappings,
   };
-
   try {
     // Make POST request to the dashboard validator app's /check endpoint
     // Following Kubernetes API path convention: /apis/{group}/{version}/namespaces/{namespace}/{resource}
@@ -134,12 +127,10 @@ export async function checkDashboardCompatibility(
         showErrorAlert: false,
       }
     );
-
     return response;
   } catch (error) {
     // Log error for debugging
-    console.error('Dashboard compatibility check failed:', error);
-
+    structLog('error', 'Dashboard compatibility check failed:', error);
     // Re-throw original error for caller to handle
     throw error;
   }

--- a/public/app/features/dashboard/dashgrid/DashboardLibrary/api/dashboardLibraryApi.ts
+++ b/public/app/features/dashboard/dashgrid/DashboardLibrary/api/dashboardLibraryApi.ts
@@ -1,9 +1,8 @@
+import { structLog } from '@grafana/data';
 import { getBackendSrv, logInfo, logWarning } from '@grafana/runtime';
 import { type DashboardJson } from 'app/features/manage-dashboards/types';
 import { type PluginDashboard } from 'app/types/plugins';
-
 import { type GnetDashboard, type GnetDashboardsResponse, type Link } from '../types';
-
 /**
  * Panel types that are known to allow JavaScript code execution.
  * These panels are filtered out due to security concerns.
@@ -16,7 +15,6 @@ const UNSAFE_PANEL_TYPE_SLUGS = [
   'volkovlabs-echarts-panel',
   'volkovlabs-form-panel',
 ];
-
 /**
  * Parameters for fetching community dashboards from Grafana.com
  */
@@ -30,7 +28,6 @@ export interface FetchCommunityDashboardsParams {
   dataSourceSlugIn?: string;
   filter?: string;
 }
-
 /**
  * Dependency item from Grafana.com dashboard API
  */
@@ -41,7 +38,6 @@ export interface GnetDashboardDependency {
   pluginVersion?: string;
   [key: string]: unknown;
 }
-
 /**
  * Response from the Gnet API when fetching a single dashboard
  */
@@ -55,7 +51,6 @@ export interface GnetDashboardResponse {
   };
   [key: string]: unknown;
 }
-
 /**
  * Fetch community dashboards from Grafana.com
  */
@@ -71,18 +66,15 @@ export async function fetchCommunityDashboards(
     includeScreenshots: params.includeScreenshots ? 'true' : 'false',
     includePanelTypeSlugs: 'true',
   });
-
   if (params.dataSourceSlugIn) {
     searchParams.append('dataSourceSlugIn', params.dataSourceSlugIn);
   }
   if (params.filter) {
     searchParams.append('filter', params.filter);
   }
-
   const result = await getBackendSrv().get(`/api/gnet/dashboards?${searchParams}`, undefined, undefined, {
     showErrorAlert: false,
   });
-
   if (result && Array.isArray(result.items)) {
     logInfo('Fetched community dashboards', {
       searchParams: searchParams.toString(),
@@ -91,32 +83,27 @@ export async function fetchCommunityDashboards(
       page: result.page,
       pages: result.pages,
     });
-
     const dashboards = filterNonSafeDashboards(result.items, params.dataSourceSlugIn);
-
     return {
       page: result.page || params.page,
       pages: result.pages || 1,
       items: dashboards,
     };
   }
-
   // Fallback for unexpected response format
-  console.warn('Unexpected API response format from Grafana.com:', result);
+  structLog('warn', 'Unexpected API response format from Grafana.com:', result);
   return {
     page: params.page,
     pages: 1,
     items: [],
   };
 }
-
 /**
  * Fetch a single community dashboard's full JSON from Grafana.com
  */
 export async function fetchCommunityDashboard(gnetId: number): Promise<GnetDashboardResponse> {
   return getBackendSrv().get(`/api/gnet/dashboards/${gnetId}`);
 }
-
 /**
  * Fetch provisioned dashboards for a datasource type
  */
@@ -127,27 +114,23 @@ export async function fetchProvisionedDashboards(datasourceType: string): Promis
     });
     return Array.isArray(dashboards) ? dashboards.filter((dashboard) => !dashboard.removed) : [];
   } catch (error) {
-    console.error('Error loading provisioned dashboards', error);
+    structLog('error', 'Error loading provisioned dashboards', error);
     return [];
   }
 }
-
 // We filter out dashboards with unsafe panel types that can execute JavaScript
 // They are previously ordered by downloads amount
 const filterNonSafeDashboards = (dashboards: GnetDashboard[], dataSourceType?: string): GnetDashboard[] => {
   let unsafeDashboardsCount = 0;
-
   const filteredDashboards = dashboards.filter((item: GnetDashboard) => {
     const unsafePanelTypes =
       item.panelTypeSlugs?.filter((slug: string) => UNSAFE_PANEL_TYPE_SLUGS.includes(slug)) ?? [];
-
     if (unsafePanelTypes.length > 0) {
       unsafeDashboardsCount++;
-
-      console.warn(
+      structLog(
+        'warn',
         `Community dashboard ${item.id} ${item.name} filtered out due to panel types ${item.panelTypeSlugs?.join(', ')} that can embed JavaScript`
       );
-
       logWarning('Community dashboard filtered out due to unsafe panel types', {
         dashboardId: item.id.toString(),
         dashboardName: item.name,
@@ -158,13 +141,11 @@ const filterNonSafeDashboards = (dashboards: GnetDashboard[], dataSourceType?: s
     }
     return true;
   });
-
   if (filteredDashboards.length === 0) {
     logWarning('No community dashboards found after safe filtering', {
       dataSourceType: dataSourceType ?? '',
       unsafeDashboardsCount: unsafeDashboardsCount.toString(),
     });
   }
-
   return filteredDashboards;
 };

--- a/public/app/features/dashboard/dashgrid/DashboardLibrary/utils/communityDashboardHelpers.ts
+++ b/public/app/features/dashboard/dashgrid/DashboardLibrary/utils/communityDashboardHelpers.ts
@@ -1,3 +1,4 @@
+import { structLog } from '@grafana/data';
 import { type PanelModel } from '@grafana/data';
 import { t } from '@grafana/i18n';
 import { getBackendSrv, locationService } from '@grafana/runtime';
@@ -5,7 +6,6 @@ import { createErrorNotification } from 'app/core/copy/appNotification';
 import { notifyApp } from 'app/core/reducers/appNotification';
 import { type DataSourceInput, type DashboardJson } from 'app/features/manage-dashboards/types';
 import { dispatch } from 'app/types/store';
-
 import { DASHBOARD_LIBRARY_ROUTES } from '../../types';
 import type { MappingContext } from '../SuggestedDashboardsModal';
 import { fetchCommunityDashboard, type GnetDashboardDependency } from '../api/dashboardLibraryApi';
@@ -17,16 +17,13 @@ import {
   type SourceEntryPoint,
 } from '../constants';
 import { type GnetDashboard, type Link } from '../types';
-
 import { type InputMapping, tryAutoMapDatasources, parseConstantInputs, isDataSourceInput } from './autoMapDatasources';
 import type { AssistantSource } from './templateDashboardHelpers';
-
 export const SEARCH_DEBOUNCE_MS = 500;
 export const DEFAULT_SORT_ORDER = 'downloads';
 export const DEFAULT_SORT_DIRECTION = 'desc';
 export const INCLUDE_LOGO = true;
 export const INCLUDE_SCREENSHOTS = true;
-
 /**
  * Extract thumbnail URL from dashboard screenshots
  */
@@ -34,7 +31,6 @@ export function getThumbnailUrl(dashboard: GnetDashboard): string {
   const thumbnail = dashboard.screenshots?.[0]?.links.find((l: Link) => l.rel === 'image')?.href ?? '';
   return thumbnail ? `/api/gnet${thumbnail}` : '';
 }
-
 /**
  * Extract logo URL from dashboard logos
  */
@@ -45,7 +41,6 @@ export function getLogoUrl(dashboard: GnetDashboard): string {
   }
   return '';
 }
-
 /**
  * Format date string for display
  */
@@ -56,14 +51,12 @@ export function formatDate(dateString?: string): string {
   const date = new Date(dateString);
   return date.toLocaleDateString(undefined, { year: 'numeric', month: 'short', day: 'numeric' });
 }
-
 /**
  * Build Grafana.com URL for a dashboard
  */
 export function buildGrafanaComUrl(dashboard: GnetDashboard): string {
   return `https://grafana.com/grafana/dashboards/${dashboard.id}-${dashboard.slug}/`;
 }
-
 /**
  * Build dashboard details object for display in card
  */
@@ -75,7 +68,6 @@ export interface DashboardDetails {
   lastUpdate: string;
   grafanaComUrl: string;
 }
-
 export function buildDashboardDetails(dashboard: GnetDashboard): DashboardDetails {
   return {
     id: String(dashboard.id),
@@ -86,7 +78,6 @@ export function buildDashboardDetails(dashboard: GnetDashboard): DashboardDetail
     grafanaComUrl: buildGrafanaComUrl(dashboard),
   };
 }
-
 /**
  * Navigate to dashboard template route with mappings
  */
@@ -112,22 +103,18 @@ export function navigateToTemplate(
     mappings: JSON.stringify(mappings),
     suggestedDashboardBanner: 'true',
   });
-
   // Add datasource types for tracking if available
   if (datasourceTypes && datasourceTypes.length > 0) {
     searchParams.set('datasourceTypes', JSON.stringify(datasourceTypes));
   }
-
   if (assistantSource) {
     searchParams.set('assistantSource', assistantSource);
   }
-
   locationService.push({
     pathname: DASHBOARD_LIBRARY_ROUTES.Template,
     search: searchParams.toString(),
   });
 }
-
 interface UseCommunityDashboardParams {
   dashboard: GnetDashboard;
   datasourceUid: string;
@@ -136,7 +123,6 @@ interface UseCommunityDashboardParams {
   onShowMapping?: (context: MappingContext) => void;
   assistantSource?: AssistantSource;
 }
-
 /**
  * Check if a panel contains JavaScript code using heuristic pattern matching.
  *
@@ -160,15 +146,13 @@ function canPanelContainJS(panel: PanelModel): boolean {
   // Create a copy of the panel without title and description, as they are already sanitized
   // This reduces false positives while still checking all other properties for JavaScript code
   const { title, description, ...panelWithoutSanitizedFields } = panel;
-
   let panelJson: string;
   try {
     panelJson = JSON.stringify(panelWithoutSanitizedFields);
   } catch (e) {
-    console.warn('Failed to stringify panel', e);
+    structLog('warn', 'Failed to stringify panel', e);
     return true;
   }
-
   // Patterns that indicate actual JavaScript code in values
   const valuePatterns = [
     /<script\b/i, // HTML script tags
@@ -182,7 +166,6 @@ function canPanelContainJS(panel: PanelModel): boolean {
     /\bsetTimeout\s*\(/i, // setTimeout calls
     /\bsetInterval\s*\(/i, // setInterval calls
   ];
-
   // Patterns for suspicious JSON keys that might indicate JS hooks
   const keyPatterns = [
     /"on[a-zA-Z]+"\s*:/, // Event handlers as keys (both camelCase and lowercase): "onClick": or "onclick":
@@ -193,33 +176,28 @@ function canPanelContainJS(panel: PanelModel): boolean {
     /"script"\s*:/i, // "script" as a JSON key
     /"handler"\s*:/i, // "handler" as a JSON key - common for event handlers
   ];
-
   const hasSuspiciousValue = valuePatterns.some((pattern) => {
     if (pattern.test(panelJson)) {
-      console.warn('Panel contains JavaScript code in value');
+      structLog('warn', 'Panel contains JavaScript code in value');
       return true;
     }
     return false;
   });
-
   const hasSuspiciousKey = keyPatterns.some((pattern) => {
     if (pattern.test(panelJson)) {
-      console.warn('Panel contains JavaScript code in key');
+      structLog('warn', 'Panel contains JavaScript code in key');
       return true;
     }
     return false;
   });
-
   return hasSuspiciousValue || hasSuspiciousKey;
 }
-
 function isPanelModel(panel: unknown): panel is PanelModel {
   if (!panel || typeof panel !== 'object') {
     return false;
   }
   return 'options' in panel && 'type' in panel;
 }
-
 /**
  * Check if a dashboard contains JavaScript code. This is not a perfect check, but good enough
  * Used as a second filter after the first filter of panel types (see api/dashboardLibraryApi.ts)
@@ -233,7 +211,6 @@ const canDashboardContainJS = (dashboard: DashboardJson): boolean => {
     return false;
   });
 };
-
 /**
  * Handles the flow when a user selects a community dashboard:
  * 1. Tracks analytics
@@ -256,31 +233,24 @@ export async function onUseCommunityDashboard({
     // Fetch full dashboard from Gcom, this is the JSON with __inputs
     const fullDashboard = await fetchCommunityDashboard(dashboard.id);
     const dashboardJson = fullDashboard.json;
-
     if (canDashboardContainJS(dashboardJson)) {
       throw new Error(`Community dashboard ${dashboard.id} "${dashboard.name}" might contain JavaScript code`);
     }
-
     // Parse datasource requirements from __inputs
     const dsInputs: DataSourceInput[] = dashboardJson.__inputs?.filter(isDataSourceInput) || [];
-
     // Extract datasource types for tracking purposes from dependencies
     const datasourceTypes =
       fullDashboard.dependencies?.items
         ?.filter((dep: GnetDashboardDependency) => dep.pluginTypeCode === 'datasource')
         .map((dep: GnetDashboardDependency) => dep.pluginSlug)
         .filter(Boolean) || [];
-
     // Parse constant inputs - these always need user review
     const constantInputs = parseConstantInputs(dashboardJson.__inputs || []);
-
     // Try auto-mapping datasources
     const mappingResult = tryAutoMapDatasources(dsInputs, datasourceUid);
-
     // Decide whether to show mapping form or navigate directly
     // Show mapping form if: (a) there are unmapped datasources OR (b) there are constants
     const needsMapping = mappingResult.unmappedDsInputs.length > 0 || constantInputs.length > 0;
-
     if (!needsMapping) {
       // No mapping needed - all datasources auto-mapped, no constants
       navigateToTemplate(
@@ -320,7 +290,7 @@ export async function onUseCommunityDashboard({
       }
     }
   } catch (err) {
-    console.error('Error loading community dashboard:', err);
+    structLog('error', 'Error loading community dashboard:', err);
     dispatch(
       notifyApp(
         createErrorNotification(t('dashboard-library.community-error-title', 'Error loading community dashboard'))
@@ -329,7 +299,6 @@ export async function onUseCommunityDashboard({
     throw err;
   }
 }
-
 /**
  * Interpolate a community dashboard for compatibility checking.
  *
@@ -348,13 +317,10 @@ export async function interpolateDashboardForCompatibilityCheck(
   // 1. Fetch full dashboard JSON from Grafana.com
   const gnetResponse = await fetchCommunityDashboard(dashboardId);
   const dashboardJson = gnetResponse.json;
-
   // 2. Extract datasource inputs from dashboard's __inputs array
   const dsInputs: DataSourceInput[] = dashboardJson.__inputs?.filter(isDataSourceInput) || [];
-
   // 3. Auto-map datasources using existing utility
   const mappingResult = tryAutoMapDatasources(dsInputs, datasourceUid);
-
   // 4. Check if auto-mapping was successful
   // Compatibility check requires all datasource variables to be resolved
   if (!mappingResult.allMapped) {
@@ -365,16 +331,13 @@ export async function interpolateDashboardForCompatibilityCheck(
       )
     );
   }
-
   // 5. Prepare inputs array for interpolation API
   const inputs: InputMapping[] = mappingResult.mappings;
-
   // 6. Call interpolation endpoint to replace template variables
   const interpolatedDashboard = await getBackendSrv().post<DashboardJson>('/api/dashboards/interpolate', {
     dashboard: dashboardJson,
     overwrite: true,
     inputs: inputs,
   });
-
   return interpolatedDashboard;
 }

--- a/public/app/features/dashboard/dashgrid/PanelStateWrapper.tsx
+++ b/public/app/features/dashboard/dashgrid/PanelStateWrapper.tsx
@@ -1,7 +1,7 @@
+import { structLog } from '@grafana/data';
 import { debounce } from 'lodash';
 import { PureComponent } from 'react';
 import { Subscription } from 'rxjs';
-
 import {
   type AbsoluteTimeRange,
   AnnotationChangeEvent,
@@ -43,22 +43,18 @@ import { onUpdatePanelSnapshotData } from 'app/plugins/datasource/grafana/utils'
 import { changeSeriesColorConfigFactory } from 'app/plugins/panel/timeseries/overrides/colorSeriesConfigFactory';
 import { dispatch } from 'app/store/store';
 import { RenderEvent } from 'app/types/events';
-
 import { getDashboardQueryRunner } from '../../query/state/DashboardQueryRunner/DashboardQueryRunner';
 import { getTimeSrv, type TimeSrv } from '../services/TimeSrv';
 import { type DashboardModel } from '../state/DashboardModel';
 import { type PanelModel } from '../state/PanelModel';
 import { getPanelChromeProps } from '../utils/getPanelChromeProps';
 import { loadSnapshotData } from '../utils/loadSnapshotData';
-
 import { PanelHeaderMenuWrapper } from './PanelHeader/PanelHeaderMenuWrapper';
 import { PanelLoadTimeMonitor } from './PanelLoadTimeMonitor';
 import { seriesVisibilityConfigFactory } from './SeriesVisibilityConfigFactory';
 import { liveTimer } from './liveTimer';
 import { PanelOptionsLogger } from './panelOptionsLogger';
-
 const DEFAULT_PLUGIN_ERROR = 'Error in plugin';
-
 export interface Props {
   panel: PanelModel;
   dashboard: DashboardModel;
@@ -73,7 +69,6 @@ export interface Props {
   timezone?: string;
   hideMenu?: boolean;
 }
-
 export interface State {
   isFirstLoad: boolean;
   renderCounter: number;
@@ -82,20 +77,16 @@ export interface State {
   data: PanelData;
   liveTime?: TimeRange;
 }
-
 export class PanelStateWrapper extends PureComponent<Props, State> {
   private readonly timeSrv: TimeSrv = getTimeSrv();
   private subs = new Subscription();
   private eventFilter: EventFilterOptions = { onlyLocal: true };
   private panelOptionsLogger: PanelOptionsLogger | undefined = undefined;
-
   constructor(props: Props) {
     super(props);
-
     // Can this eventBus be on PanelModel?  when we have more complex event filtering, that may be a better option
     const eventBus = props.dashboard.events.newScopedBus(`panel:${props.panel.id}`, this.eventFilter);
     this.debouncedSetPanelAttention = debounce(this.setPanelAttention.bind(this), 100);
-
     this.state = {
       isFirstLoad: true,
       renderCounter: 0,
@@ -120,24 +111,19 @@ export class PanelStateWrapper extends PureComponent<Props, State> {
       },
       data: this.getInitialPanelDataState(),
     };
-
     if (this.getPanelContextApp() === CoreApp.PanelEditor) {
       const panelInfo = {
         panelId: String(props.panel.id),
         panelType: props.panel.type,
         panelTitle: props.panel.title,
       };
-
       this.panelOptionsLogger = new PanelOptionsLogger(props.panel.getOptions(), props.panel.fieldConfig, panelInfo);
     }
   }
-
   // Due to a mutable panel model we get the sync settings via function that proactively reads from the model
   getSync = () => (this.props.isEditing ? DashboardCursorSync.Off : this.props.dashboard.graphTooltip);
-
   onInstanceStateChange = (value: unknown) => {
     this.props.onInstanceStateChange(value);
-
     this.setState({
       context: {
         ...this.state.context,
@@ -145,7 +131,6 @@ export class PanelStateWrapper extends PureComponent<Props, State> {
       },
     });
   };
-
   getPanelContextApp() {
     if (this.props.isEditing) {
       return CoreApp.PanelEditor;
@@ -153,18 +138,14 @@ export class PanelStateWrapper extends PureComponent<Props, State> {
     if (this.props.isViewing) {
       return CoreApp.PanelViewer;
     }
-
     return CoreApp.Dashboard;
   }
-
   onUpdateData = (frames: DataFrame[]): Promise<boolean> => {
     return onUpdatePanelSnapshotData(this.props.panel, frames);
   };
-
   onSeriesColorChange = (label: string, color: string) => {
     this.onFieldConfigChange(changeSeriesColorConfigFactory(label, color, this.props.panel.fieldConfig));
   };
-
   onSeriesVisibilityChange = (label: string | string[] | null, mode: SeriesVisibilityChangeMode) => {
     if (typeof label !== 'string') {
       return;
@@ -173,21 +154,17 @@ export class PanelStateWrapper extends PureComponent<Props, State> {
       seriesVisibilityConfigFactory(label, mode, this.props.panel.fieldConfig, this.state.data.series)
     );
   };
-
   onToggleLegendSort = (sortKey: string) => {
     const legendOptions: VizLegendOptions = this.props.panel.options.legend;
-
     // We don't want to do anything when legend options are not available
     if (!legendOptions) {
       return;
     }
-
     let sortDesc = legendOptions.sortDesc;
     let sortBy = legendOptions.sortBy;
     if (sortKey !== sortBy) {
       sortDesc = undefined;
     }
-
     // if already sort ascending, disable sorting
     if (sortDesc === false) {
       sortBy = undefined;
@@ -196,13 +173,11 @@ export class PanelStateWrapper extends PureComponent<Props, State> {
       sortDesc = !sortDesc;
       sortBy = sortKey;
     }
-
     this.onOptionsChange({
       ...this.props.panel.options,
       legend: { ...legendOptions, sortBy, sortDesc },
     });
   };
-
   getInitialPanelDataState(): PanelData {
     return {
       state: LoadingState.NotStarted,
@@ -210,16 +185,12 @@ export class PanelStateWrapper extends PureComponent<Props, State> {
       timeRange: getDefaultTimeRange(),
     };
   }
-
   componentDidMount() {
     const { panel, dashboard } = this.props;
-
     // Subscribe to panel events
     this.subs.add(panel.events.subscribe(RefreshEvent, this.onRefresh));
     this.subs.add(panel.events.subscribe(RenderEvent, this.onRender));
-
     dashboard.panelInitialized(this.props.panel);
-
     // Move snapshot data into the query response
     if (this.hasPanelSnapshot) {
       this.setState({
@@ -228,11 +199,9 @@ export class PanelStateWrapper extends PureComponent<Props, State> {
       });
       return;
     }
-
     if (!this.wantsQueryExecution) {
       this.setState({ isFirstLoad: false });
     }
-
     this.subs.add(
       panel
         .getQueryRunner()
@@ -241,35 +210,29 @@ export class PanelStateWrapper extends PureComponent<Props, State> {
           next: (data) => this.onDataUpdate(data),
         })
     );
-
     // Listen for live timer events
     liveTimer.listen(this);
   }
-
   componentWillUnmount() {
     this.subs.unsubscribe();
     liveTimer.remove(this);
   }
-
   liveTimeChanged(liveTime: TimeRange) {
     const { data } = this.state;
     if (data.timeRange) {
       const delta = liveTime.to.valueOf() - data.timeRange.to.valueOf();
       if (delta < 100) {
         // 10hz
-        console.log('Skip tick render', this.props.panel.title, delta);
+        structLog('log', 'Skip tick render', this.props.panel.title, delta);
         return;
       }
     }
     this.setState({ liveTime });
   }
-
   componentDidUpdate(prevProps: Props) {
     const { isInView, width, panel } = this.props;
     const { context } = this.state;
-
     const app = this.getPanelContextApp();
-
     if (context.app !== app) {
       this.setState({
         context: {
@@ -278,7 +241,6 @@ export class PanelStateWrapper extends PureComponent<Props, State> {
         },
       });
     }
-
     // View state has changed
     if (isInView !== prevProps.isInView) {
       if (isInView) {
@@ -288,28 +250,23 @@ export class PanelStateWrapper extends PureComponent<Props, State> {
         }
       }
     }
-
     // The timer depends on panel width
     if (width !== prevProps.width) {
       liveTimer.updateInterval(this);
     }
   }
-
   // Updates the response with information from the stream
   // The next is outside a react synthetic event so setState is not batched
   // So in this context we can only do a single call to setState
   onDataUpdate(data: PanelData) {
     const { dashboard, panel, plugin } = this.props;
-
     // Ignore this data update if we are now a non data panel
     if (plugin.meta.skipDataQuery) {
       this.setState({ data: this.getInitialPanelDataState() });
       return;
     }
-
     let { isFirstLoad } = this.state;
     let errorMessage: string | undefined;
-
     switch (data.state) {
       case LoadingState.Loading:
         // Skip updating state data if it is already in loading state
@@ -342,26 +299,20 @@ export class PanelStateWrapper extends PureComponent<Props, State> {
         }
         break;
     }
-
     this.setState({ isFirstLoad, errorMessage, data, liveTime: undefined });
   }
-
   onRefresh = () => {
     const { dashboard, panel, isInView, width } = this.props;
-
     if (!dashboard.snapshot && !isInView) {
       panel.refreshWhenInView = true;
       return;
     }
-
     const timeData = applyPanelTimeOverrides(panel, this.timeSrv.timeRange());
-
     // Issue Query
     if (this.wantsQueryExecution) {
       if (width < 0) {
         return;
       }
-
       panel.refreshWhenInView = false;
       panel.runAllPanelQueries({
         dashboardUID: dashboard.uid,
@@ -379,40 +330,31 @@ export class PanelStateWrapper extends PureComponent<Props, State> {
       });
     }
   };
-
   onRender = () => {
     const stateUpdate = { renderCounter: this.state.renderCounter + 1 };
     this.setState(stateUpdate);
   };
-
   onOptionsChange = (options: object) => {
     this.props.panel.updateOptions(options);
   };
-
   onFieldConfigChange = (config: FieldConfigSource) => {
     this.props.panel.updateFieldConfig(config);
   };
-
   logPanelChangesOnError() {
     this.panelOptionsLogger!.logChanges(this.props.panel.getOptions(), this.props.panel.fieldConfig);
   }
-
   onPanelError = (error: Error) => {
     if (this.getPanelContextApp() === CoreApp.PanelEditor) {
       this.logPanelChangesOnError();
     }
-
     const errorMessage = error.message || DEFAULT_PLUGIN_ERROR;
-
     if (this.state.errorMessage !== errorMessage) {
       this.setState({ errorMessage });
     }
   };
-
   onPanelErrorRecover = () => {
     this.setState({ errorMessage: undefined });
   };
-
   onAnnotationCreate = async (event: AnnotationEventUIModel) => {
     const isRegion = event.from !== event.to;
     const anno = {
@@ -428,13 +370,11 @@ export class PanelStateWrapper extends PureComponent<Props, State> {
     getDashboardQueryRunner().run({ dashboard: this.props.dashboard, range: this.timeSrv.timeRange() });
     this.state.context.eventBus.publish(new AnnotationChangeEvent(anno));
   };
-
   onAnnotationDelete = async (id: string) => {
     await annotationServer().delete({ id });
     getDashboardQueryRunner().run({ dashboard: this.props.dashboard, range: this.timeSrv.timeRange() });
     this.state.context.eventBus.publish(new AnnotationChangeEvent({ id }));
   };
-
   onAnnotationUpdate = async (event: AnnotationEventUIModel) => {
     const isRegion = event.from !== event.to;
     const anno = {
@@ -448,27 +388,22 @@ export class PanelStateWrapper extends PureComponent<Props, State> {
       text: event.description,
     };
     await annotationServer().update(anno);
-
     getDashboardQueryRunner().run({ dashboard: this.props.dashboard, range: this.timeSrv.timeRange() });
     this.state.context.eventBus.publish(new AnnotationChangeEvent(anno));
   };
-
   get hasPanelSnapshot() {
     const { panel } = this.props;
     return panel.snapshotData && panel.snapshotData.length;
   }
-
   get wantsQueryExecution() {
     return !(this.props.plugin.meta.skipDataQuery || this.hasPanelSnapshot);
   }
-
   onChangeTimeRange = (timeRange: AbsoluteTimeRange) => {
     this.timeSrv.setTime({
       from: toUtc(timeRange.from),
       to: toUtc(timeRange.to),
     });
   };
-
   shouldSignalRenderingCompleted(loadingState: LoadingState, pluginMeta: PanelPluginMeta) {
     return (
       loadingState === LoadingState.Done ||
@@ -477,7 +412,6 @@ export class PanelStateWrapper extends PureComponent<Props, State> {
       pluginMeta.skipDataQuery
     );
   }
-
   skipFirstRender(loadingState: LoadingState) {
     const { isFirstLoad } = this.state;
     return (
@@ -486,10 +420,8 @@ export class PanelStateWrapper extends PureComponent<Props, State> {
       (loadingState === LoadingState.Loading || loadingState === LoadingState.NotStarted)
     );
   }
-
   onAddAdHocFilter = (filter: AdHocFilterItem) => {
     const { key, value, operator } = filter;
-
     // When the datasource is null/undefined (for a default datasource), we use getInstanceSettings
     // to find the real datasource ref for the default datasource.
     const datasourceInstance = getDatasourceSrv().getInstanceSettings(this.props.panel.datasource);
@@ -497,34 +429,27 @@ export class PanelStateWrapper extends PureComponent<Props, State> {
     if (!datasourceRef) {
       return;
     }
-
     dispatch(applyFilterFromTable({ datasource: datasourceRef, key, operator, value }));
   };
-
   renderPanelContent(innerWidth: number, innerHeight: number) {
     const { panel, plugin, dashboard } = this.props;
     const { renderCounter, data } = this.state;
     const { state: loadingState } = data;
-
     // do not render component until we have first data
     if (this.skipFirstRender(loadingState)) {
       return null;
     }
-
     // This is only done to increase a counter that is used by backend
     // image rendering to know when to capture image
     if (this.shouldSignalRenderingCompleted(loadingState, plugin.meta)) {
       profiler.renderingCompleted();
     }
-
     const PanelComponent = plugin.panel!;
     const timeRange = this.state.liveTime ?? data.timeRange ?? this.timeSrv.timeRange();
     const panelOptions = panel.getOptions();
-
     // Update the event filter (dashboard settings may have changed)
     // Yes this is called ever render for a function that is triggered on every mouse move
     this.eventFilter.onlyLocal = dashboard.graphTooltip === 0;
-
     return (
       <>
         <PanelContextProvider value={this.state.context}>
@@ -555,28 +480,22 @@ export class PanelStateWrapper extends PureComponent<Props, State> {
       </>
     );
   }
-
   setPanelAttention() {
     appEvents.publish(new SetPanelAttentionEvent({ panelId: this.props.panel.id }));
   }
-
   debouncedSetPanelAttention() {}
-
   render() {
     const { dashboard, panel, width, height, plugin } = this.props;
     const { errorMessage, data } = this.state;
     const { transparent } = panel;
     const panelChromeProps = getPanelChromeProps({ ...this.props, data });
-
     // Shift the hover menu down if it's on the top row so it doesn't get clipped by topnav
     const hoverHeaderOffset = (panel.gridPos?.y ?? 0) === 0 ? -16 : undefined;
-
     const menu = (
       <div data-testid="panel-dropdown">
         <PanelHeaderMenuWrapper panel={panel} dashboard={dashboard} loadingState={data.state} />
       </div>
     );
-
     return (
       <PanelChrome
         width={width}

--- a/public/app/features/dashboard/services/DashboardAnalyticsAggregator.ts
+++ b/public/app/features/dashboard/services/DashboardAnalyticsAggregator.ts
@@ -1,6 +1,6 @@
+import { structLog } from '@grafana/data';
 import { logMeasurement, reportInteraction } from '@grafana/runtime';
 import { type performanceUtils } from '@grafana/scenes';
-
 import { SLOW_OPERATION_THRESHOLD_MS } from './performanceConstants';
 import {
   registerPerformanceObserver,
@@ -9,7 +9,6 @@ import {
   writePerformanceGroupLog,
   writePerformanceGroupEnd,
 } from './performanceUtils';
-
 /**
  * Panel metrics structure for analytics
  */
@@ -46,7 +45,6 @@ interface PanelAnalyticsMetrics {
     timestamp: number;
   }>;
 }
-
 /**
  * Aggregates Scene performance events into analytics-ready panel metrics
  */
@@ -54,66 +52,55 @@ export class DashboardAnalyticsAggregator implements performanceUtils.ScenePerfo
   private panelMetrics = new Map<string, PanelAnalyticsMetrics>();
   private dashboardUID = '';
   private dashboardTitle = '';
-
   public initialize(uid: string, title: string) {
     // Clear previous dashboard data and set new context
     this.panelMetrics.clear();
     this.dashboardUID = uid;
     this.dashboardTitle = title;
   }
-
   public destroy() {
     // Clear dashboard context
     this.panelMetrics.clear();
     this.dashboardUID = '';
     this.dashboardTitle = '';
   }
-
   /**
    * Clear all collected metrics (called on dashboard interaction start)
    */
   public clearMetrics() {
     this.panelMetrics.clear();
   }
-
   /**
    * Get aggregated panel metrics for analytics
    */
   public getPanelMetrics(): PanelAnalyticsMetrics[] {
     return Array.from(this.panelMetrics.values());
   }
-
   // Dashboard-level events (we don't need to track these for panel analytics)
   onDashboardInteractionStart = (data: performanceUtils.DashboardInteractionStartData): void => {
     // Clear metrics when new dashboard interaction starts
     this.clearMetrics();
   };
-
   onDashboardInteractionMilestone = (_data: performanceUtils.DashboardInteractionMilestoneData): void => {
     // No action needed for milestones in analytics
   };
-
   onDashboardInteractionComplete = (data: performanceUtils.DashboardInteractionCompleteData): void => {
     // Send analytics report for dashboard interaction completion
     this.sendAnalyticsReport(data);
   };
-
   // Panel-level events
   onPanelOperationStart = (data: performanceUtils.PanelPerformanceData): void => {
     // Start events don't need aggregation, just ensure panel exists
     this.ensurePanelExists(data.panelKey, data.panelId, data.pluginId, data.pluginVersion);
   };
-
   onPanelOperationComplete = (data: performanceUtils.PanelPerformanceData): void => {
     // Aggregate panel metrics without verbose logging (handled by ScenePerformanceLogger)
     const panel = this.panelMetrics.get(data.panelKey);
     if (!panel) {
-      console.warn('Panel not found for operation completion:', data.panelKey);
+      structLog('warn', 'Panel not found for operation completion:', data.panelKey);
       return;
     }
-
     const duration = data.duration || 0;
-
     switch (data.operation) {
       case 'fieldConfig':
         panel.totalFieldConfigTime += duration;
@@ -122,7 +109,6 @@ export class DashboardAnalyticsAggregator implements performanceUtils.ScenePerfo
           timestamp: data.timestamp,
         });
         break;
-
       case 'transform':
         panel.totalTransformationTime += duration;
         panel.transformationOperations.push({
@@ -132,7 +118,6 @@ export class DashboardAnalyticsAggregator implements performanceUtils.ScenePerfo
           success: data.metadata.success,
         });
         break;
-
       case 'query':
         panel.totalQueryTime += duration;
         panel.queryOperations.push({
@@ -141,7 +126,6 @@ export class DashboardAnalyticsAggregator implements performanceUtils.ScenePerfo
           queryType: data.metadata.queryType,
         });
         break;
-
       case 'render':
         panel.totalRenderTime += duration;
         panel.renderOperations.push({
@@ -149,22 +133,18 @@ export class DashboardAnalyticsAggregator implements performanceUtils.ScenePerfo
           timestamp: data.timestamp,
         });
         break;
-
       case 'plugin-load':
         panel.pluginLoadTime += duration;
         break;
     }
   };
-
   // Query-level events
   onQueryStart = (_data: performanceUtils.QueryPerformanceData): void => {
     // no-op
   };
-
   onQueryComplete = (_data: performanceUtils.QueryPerformanceData): void => {
     // no-op
   };
-
   /**
    * Ensure a panel exists in our tracking map
    */
@@ -195,13 +175,11 @@ export class DashboardAnalyticsAggregator implements performanceUtils.ScenePerfo
     }
     return panel;
   }
-
   /**
    * Send panel_render interactions for each panel with aggregated metrics
    */
   private sendPanelRenderInteractions(data: performanceUtils.DashboardInteractionCompleteData): void {
     const panelMetrics = this.getPanelMetrics();
-
     panelMetrics.forEach((panel) => {
       const totalPanelTime =
         panel.totalQueryTime +
@@ -209,7 +187,6 @@ export class DashboardAnalyticsAggregator implements performanceUtils.ScenePerfo
         panel.totalRenderTime +
         panel.totalFieldConfigTime +
         panel.pluginLoadTime;
-
       // logMeasurement requires numeric values in second parameter, metadata in third
       const measurementValues = {
         totalTime: Math.round(totalPanelTime * 10) / 10,
@@ -219,7 +196,6 @@ export class DashboardAnalyticsAggregator implements performanceUtils.ScenePerfo
         fieldConfigCount: panel.fieldConfigOperations.length,
         pluginLoadCount: panel.pluginLoadTime > 0 ? 1 : 0,
       };
-
       logMeasurement('panel_render', measurementValues, {
         panelKey: panel.panelKey,
         pluginId: panel.pluginId,
@@ -228,7 +204,6 @@ export class DashboardAnalyticsAggregator implements performanceUtils.ScenePerfo
       });
     });
   }
-
   /**
    * Send analytics report for dashboard interactions
    */
@@ -243,29 +218,23 @@ export class DashboardAnalyticsAggregator implements performanceUtils.ScenePerfo
       longFramesTotalTime: data.longFramesTotalTime,
       ...getPerformanceMemory(),
     };
-
     const panelMetrics = this.getPanelMetrics();
-
     this.logDashboardAnalyticsEvent(data, payload, panelMetrics);
-
     reportInteraction('dashboard_render', {
       interactionType: data.interactionType,
       uid: this.dashboardUID,
       operationId: data.operationId, // OperationId for correlating with panel_render interactions
       ...payload,
     });
-
     logMeasurement('dashboard_render', payload, {
       interactionType: data.interactionType,
       dashboard: this.dashboardUID,
       title: this.dashboardTitle,
       operationId: data.operationId, // OperationId for correlating with panel_render interactions
     });
-
     // Send individual panel_render interactions
     this.sendPanelRenderInteractions(data);
   }
-
   /**
    * Log dashboard analytics event with panel metrics and performance insights
    */
@@ -276,7 +245,6 @@ export class DashboardAnalyticsAggregator implements performanceUtils.ScenePerfo
   ): void {
     const panelCount = panelMetrics?.length || 0;
     const panelSummary = panelCount ? `${panelCount} panels analyzed` : 'No panel metrics';
-
     // Main analytics summary
     const slowPanelCount =
       panelMetrics?.filter(
@@ -284,12 +252,10 @@ export class DashboardAnalyticsAggregator implements performanceUtils.ScenePerfo
           p.totalQueryTime + p.totalTransformationTime + p.totalRenderTime + p.totalFieldConfigTime + p.pluginLoadTime >
           SLOW_OPERATION_THRESHOLD_MS
       ).length || 0;
-
     writePerformanceGroupStart(
       'DAA',
       `[ANALYTICS] ${data.interactionType} | ${panelSummary}${slowPanelCount > 0 ? ` | ${slowPanelCount} slow panels ⚠️` : ''}`
     );
-
     // Dashboard overview
     writePerformanceGroupLog('DAA', '📊 Dashboard (ms):', {
       duration: Math.round((data.duration || 0) * 10) / 10,
@@ -297,10 +263,8 @@ export class DashboardAnalyticsAggregator implements performanceUtils.ScenePerfo
       interactionType: data.interactionType,
       slowPanels: slowPanelCount,
     });
-
     // Analytics payload
     writePerformanceGroupLog('DAA', '📈 Analytics payload:', payload);
-
     // Individual collapsible panel logs with detailed breakdown
     if (panelMetrics && panelMetrics.length > 0) {
       panelMetrics.forEach((panel) => {
@@ -310,22 +274,18 @@ export class DashboardAnalyticsAggregator implements performanceUtils.ScenePerfo
           panel.totalRenderTime +
           panel.totalFieldConfigTime +
           panel.pluginLoadTime;
-
         const isSlowPanel = totalPanelTime > SLOW_OPERATION_THRESHOLD_MS;
         const slowWarning = isSlowPanel ? ' ⚠️ SLOW' : '';
-
         writePerformanceGroupStart(
           'DAA',
           `🎨 Panel ${panel.pluginId}-${panel.panelId}: ${totalPanelTime.toFixed(1)}ms total${slowWarning}`
         );
-
         writePerformanceGroupLog('DAA', '🔧 Plugin:', {
           id: panel.pluginId,
           version: panel.pluginVersion || 'unknown',
           panelId: panel.panelId,
           panelKey: panel.panelKey,
         });
-
         writePerformanceGroupLog('DAA', '⚡ Performance (ms):', {
           totalTime: Math.round(totalPanelTime * 10) / 10, // Round to 1 decimal
           isSlowPanel: isSlowPanel,
@@ -337,7 +297,6 @@ export class DashboardAnalyticsAggregator implements performanceUtils.ScenePerfo
             pluginLoad: Math.round(panel.pluginLoadTime * 10) / 10,
           },
         });
-
         if (panel.queryOperations.length > 0) {
           writePerformanceGroupLog('DAA', '📊 Queries:', {
             count: panel.queryOperations.length,
@@ -349,7 +308,6 @@ export class DashboardAnalyticsAggregator implements performanceUtils.ScenePerfo
             })),
           });
         }
-
         if (panel.transformationOperations.length > 0) {
           writePerformanceGroupLog('DAA', '🔄 Transformations:', {
             count: panel.transformationOperations.length,
@@ -362,7 +320,6 @@ export class DashboardAnalyticsAggregator implements performanceUtils.ScenePerfo
             })),
           });
         }
-
         if (panel.renderOperations.length > 0) {
           writePerformanceGroupLog('DAA', '🎨 Renders:', {
             count: panel.renderOperations.length,
@@ -373,7 +330,6 @@ export class DashboardAnalyticsAggregator implements performanceUtils.ScenePerfo
             })),
           });
         }
-
         if (panel.fieldConfigOperations.length > 0) {
           writePerformanceGroupLog('DAA', '⚙️ FieldConfigs:', {
             count: panel.fieldConfigOperations.length,
@@ -384,15 +340,12 @@ export class DashboardAnalyticsAggregator implements performanceUtils.ScenePerfo
             })),
           });
         }
-
         writePerformanceGroupEnd();
       });
     }
-
     // Panel render interactions summary
     if (panelMetrics && panelMetrics.length > 0) {
       writePerformanceGroupStart('DAA', `📤 Panel render interactions: ${panelMetrics.length} panels reported`);
-
       panelMetrics.forEach((panel) => {
         const totalPanelTime =
           panel.totalQueryTime +
@@ -400,9 +353,7 @@ export class DashboardAnalyticsAggregator implements performanceUtils.ScenePerfo
           panel.totalRenderTime +
           panel.totalFieldConfigTime +
           panel.pluginLoadTime;
-
         const isSlowPanel = totalPanelTime > SLOW_OPERATION_THRESHOLD_MS;
-
         writePerformanceGroupLog('DAA', `🎨 ${panel.pluginId}-${panel.panelId}:`, {
           totalTime: Math.round(totalPanelTime * 10) / 10,
           operations: {
@@ -416,27 +367,21 @@ export class DashboardAnalyticsAggregator implements performanceUtils.ScenePerfo
           ...(isSlowPanel && { warning: 'SLOW' }),
         });
       });
-
       writePerformanceGroupEnd();
     }
-
     writePerformanceGroupEnd();
   }
 }
-
 // Global singleton instance with lazy initialization
 let dashboardAnalyticsAggregator: DashboardAnalyticsAggregator | null = null;
-
 export function initializeDashboardAnalyticsAggregator(): DashboardAnalyticsAggregator {
   if (!dashboardAnalyticsAggregator) {
     dashboardAnalyticsAggregator = new DashboardAnalyticsAggregator();
-
     // Register as global performance observer
     registerPerformanceObserver(dashboardAnalyticsAggregator, 'DAA');
   }
   return dashboardAnalyticsAggregator;
 }
-
 export function getDashboardAnalyticsAggregator(): DashboardAnalyticsAggregator {
   return initializeDashboardAnalyticsAggregator();
 }

--- a/public/app/features/dashboard/services/DashboardLoaderSrv.ts
+++ b/public/app/features/dashboard/services/DashboardLoaderSrv.ts
@@ -1,7 +1,7 @@
+import { structLog } from '@grafana/data';
 import $ from 'jquery';
 import _, { isFunction } from 'lodash'; // eslint-disable-line lodash/import-scope
 import moment from 'moment'; // eslint-disable-line no-restricted-imports
-
 import { AppEvents, dateMath, type UrlQueryMap, type UrlQueryValue } from '@grafana/data';
 import { getBackendSrv, isFetchError, locationService } from '@grafana/runtime';
 import { type Spec as DashboardV2Spec } from '@grafana/schema/apis/dashboard.grafana.app/v2';
@@ -11,15 +11,12 @@ import kbn from 'app/core/utils/kbn';
 import { getDashboardScenePageStateManager } from 'app/features/dashboard-scene/pages/DashboardScenePageStateManager';
 import { getDatasourceSrv } from 'app/features/plugins/datasource_srv';
 import { type DashboardDTO } from 'app/types/dashboard';
-
 import { appEvents } from '../../../core/app_events';
 import { ResponseTransformers } from '../api/ResponseTransformers';
 import { getDashboardAPI } from '../api/dashboard_api';
 import { DashboardVersionError, type DashboardWithAccessInfo } from '../api/types';
-
 import { getDashboardSrv } from './DashboardSrv';
 import { getDashboardSnapshotSrv } from './SnapshotSrv';
-
 interface DashboardLoaderSrvLike<T> {
   loadDashboard(
     type: UrlQueryValue,
@@ -28,7 +25,6 @@ interface DashboardLoaderSrvLike<T> {
     params?: UrlQueryMap
   ): Promise<T>;
 }
-
 abstract class DashboardLoaderSrvBase<T> implements DashboardLoaderSrvLike<T> {
   abstract loadDashboard(
     type: UrlQueryValue,
@@ -36,12 +32,9 @@ abstract class DashboardLoaderSrvBase<T> implements DashboardLoaderSrvLike<T> {
     uid: string | undefined,
     params?: UrlQueryMap
   ): Promise<T>;
-
   abstract loadSnapshot(slug: string): Promise<T>;
-
   protected loadScriptedDashboard(file: string) {
     const url = 'public/dashboards/' + file.replace(/\.(?!js)/, '/') + '?' + new Date().getTime();
-
     return getBackendSrv()
       .get(url, undefined, undefined, { validatePath: true })
       .then(this.executeScript.bind(this))
@@ -58,7 +51,7 @@ abstract class DashboardLoaderSrvBase<T> implements DashboardLoaderSrvLike<T> {
           };
         },
         (err) => {
-          console.error('Script dashboard error ' + err);
+          structLog('error', 'Script dashboard error ' + err);
           appEvents.emit(AppEvents.alertError, [
             'Script Error',
             'Please make sure it exists and returns a valid dashboard',
@@ -67,7 +60,6 @@ abstract class DashboardLoaderSrvBase<T> implements DashboardLoaderSrvLike<T> {
         }
       );
   }
-
   private executeScript(result: any) {
     const services = {
       dashboardSrv: getDashboardSrv(),
@@ -98,7 +90,6 @@ abstract class DashboardLoaderSrvBase<T> implements DashboardLoaderSrvLike<T> {
       $,
       services
     );
-
     // Handle async dashboard scripts
     if (isFunction(scriptResult)) {
       return new Promise((resolve) => {
@@ -107,11 +98,9 @@ abstract class DashboardLoaderSrvBase<T> implements DashboardLoaderSrvLike<T> {
         });
       });
     }
-
     return { data: scriptResult };
   }
 }
-
 export class DashboardLoaderSrv extends DashboardLoaderSrvBase<DashboardDTO> {
   loadDashboard(
     type: UrlQueryValue,
@@ -121,7 +110,6 @@ export class DashboardLoaderSrv extends DashboardLoaderSrvBase<DashboardDTO> {
   ): Promise<DashboardDTO> {
     const stateManager = getDashboardScenePageStateManager('v1');
     let promise;
-
     if (type === 'script' && slug) {
       promise = this.loadScriptedDashboard(slug);
     } else if (type === 'snapshot' && slug) {
@@ -137,48 +125,38 @@ export class DashboardLoaderSrv extends DashboardLoaderSrvBase<DashboardDTO> {
           return Promise.resolve(cachedDashboard);
         }
       }
-
       promise = getDashboardAPI('v1').then(async (api) => {
         try {
           return await api.getDashboardDTO(uid, params);
         } catch (e) {
           if (isFetchError(e) && !(e instanceof DashboardVersionError)) {
-            console.error('Failed to load dashboard', e);
+            structLog('error', 'Failed to load dashboard', e);
             e.isHandled = true;
             if (e.status === 404) {
               appEvents.emit(AppEvents.alertError, ['Dashboard not found']);
             }
           }
-
           throw e;
         }
       });
     } else {
       throw new Error('Dashboard uid or slug required');
     }
-
     promise.then((result: DashboardDTO) => {
       impressionSrv.addDashboardImpression(result.dashboard.uid);
-
       return result;
     });
-
     return promise;
   }
-
   loadSnapshot(slug: string): Promise<DashboardDTO> {
     const promise = getDashboardSnapshotSrv().getSnapshot(slug);
-
     promise.then((result: DashboardDTO) => {
       impressionSrv.addDashboardImpression(result.dashboard.uid);
-
       return result;
     });
-
     return promise;
   }
 }
-
 export class DashboardLoaderSrvV2 extends DashboardLoaderSrvBase<DashboardWithAccessInfo<DashboardV2Spec>> {
   loadDashboard(
     type: UrlQueryValue,
@@ -188,7 +166,6 @@ export class DashboardLoaderSrvV2 extends DashboardLoaderSrvBase<DashboardWithAc
   ): Promise<DashboardWithAccessInfo<DashboardV2Spec>> {
     const stateManager = getDashboardScenePageStateManager('v2');
     let promise;
-
     if (type === 'script' && slug) {
       promise = this.loadScriptedDashboard(slug).then((r) => ResponseTransformers.ensureV2Response(r));
     } else if (type === 'public' && uid) {
@@ -202,52 +179,42 @@ export class DashboardLoaderSrvV2 extends DashboardLoaderSrvBase<DashboardWithAc
           return Promise.resolve(cachedDashboard);
         }
       }
-
       promise = getDashboardAPI('v2').then(async (api) => {
         try {
           return await api.getDashboardDTO(uid, params);
         } catch (e) {
           if (isFetchError(e) && !(e instanceof DashboardVersionError)) {
-            console.error('Failed to load dashboard', e);
+            structLog('error', 'Failed to load dashboard', e);
             e.isHandled = true;
             if (e.status === 404) {
               appEvents.emit(AppEvents.alertError, ['Dashboard not found']);
             }
           }
-
           throw e;
         }
       });
     } else {
       throw new Error('Dashboard uid or slug required');
     }
-
     promise.then((result: DashboardWithAccessInfo<DashboardV2Spec>) => {
       impressionSrv.addDashboardImpression(result.metadata.name);
       return result;
     });
-
     return promise;
   }
-
   loadSnapshot(slug: string): Promise<DashboardWithAccessInfo<DashboardV2Spec>> {
     const promise = getDashboardSnapshotSrv()
       .getSnapshot(slug)
       .then((r) => ResponseTransformers.ensureV2Response(r));
-
     promise.then((result: DashboardWithAccessInfo<DashboardV2Spec>) => {
       impressionSrv.addDashboardImpression(result.metadata.name);
-
       return result;
     });
-
     return promise;
   }
 }
-
 let dashboardLoaderSrv = new DashboardLoaderSrv();
 export { dashboardLoaderSrv };
-
 /** @internal
  * Used for tests only
  */
@@ -255,6 +222,5 @@ export const setDashboardLoaderSrv = (srv: DashboardLoaderSrv) => {
   if (process.env.NODE_ENV !== 'test') {
     throw new Error('dashboardLoaderSrv can be only overriden in test environment');
   }
-
   dashboardLoaderSrv = srv;
 };

--- a/public/app/features/dashboard/services/performanceUtils.ts
+++ b/public/app/features/dashboard/services/performanceUtils.ts
@@ -1,6 +1,6 @@
+import { structLog } from '@grafana/data';
 import { store } from '@grafana/data';
 import { performanceUtils, writePerformanceLog } from '@grafana/scenes';
-
 /**
  * Utility function to register a performance observer with the global tracker
  * Reduces duplication between ScenePerformanceLogger and DashboardAnalyticsAggregator
@@ -11,10 +11,8 @@ export function registerPerformanceObserver(
 ): void {
   const tracker = performanceUtils.getScenePerformanceTracker();
   tracker.addObserver(observer);
-
   writePerformanceLog(loggerName, 'Initialized globally and registered as performance observer');
 }
-
 /**
  * Chrome-specific performance.memory interface (non-standard)
  */
@@ -23,21 +21,18 @@ export interface PerformanceMemory {
   usedJSHeapSize: number;
   jsHeapSizeLimit: number;
 }
-
 /**
  * Extended Performance interface with Chrome's memory property
  */
 export interface PerformanceWithMemory extends Performance {
   memory?: PerformanceMemory;
 }
-
 /**
  * Type guard to check if performance has memory property (Chrome-specific)
  */
 function hasPerformanceMemory(perf: Performance): perf is PerformanceWithMemory {
   return 'memory' in perf;
 }
-
 /**
  * Safely get performance memory metrics (Chrome-specific, non-standard)
  * Returns zero values for browsers without performance.memory support
@@ -50,7 +45,6 @@ export function getPerformanceMemory(): PerformanceMemory {
       jsHeapSizeLimit: performance.memory?.jsHeapSizeLimit || 0,
     };
   }
-
   // Fallback for browsers without performance.memory
   return {
     totalJSHeapSize: 0,
@@ -58,7 +52,6 @@ export function getPerformanceMemory(): PerformanceMemory {
     jsHeapSizeLimit: 0,
   };
 }
-
 /**
  * Check if performance logging is enabled via localStorage
  */
@@ -68,7 +61,6 @@ function isPerformanceLoggingEnabled(): boolean {
   }
   return false;
 }
-
 /**
  * Write a collapsible performance log group (follows writePerformanceLog pattern)
  */
@@ -78,7 +70,6 @@ export function writePerformanceGroupStart(logger: string, message: string): voi
     console.groupCollapsed(`${logger}: ${message}`);
   }
 }
-
 /**
  * Write a performance log within a group (follows writePerformanceLog pattern)
  */
@@ -93,7 +84,6 @@ export function writePerformanceGroupLog(logger: string, message: string, data?:
     }
   }
 }
-
 /**
  * End a performance log group (follows writePerformanceLog pattern)
  */
@@ -103,7 +93,6 @@ export function writePerformanceGroupEnd(): void {
     console.groupEnd();
   }
 }
-
 /**
  * Safely creates a performance mark, ignoring errors if the Performance API is not available.
  */
@@ -117,10 +106,9 @@ export function createPerformanceMark(name: string, timestamp?: number): void {
       }
     }
   } catch (error) {
-    console.error(`❌ Failed to create performance mark: ${name}`, { timestamp, error });
+    structLog('error', `❌ Failed to create performance mark: ${name}`, { timestamp, error });
   }
 }
-
 /**
  * Safely creates a performance measure, ignoring errors if the Performance API is not available.
  */
@@ -134,6 +122,6 @@ export function createPerformanceMeasure(name: string, startMark: string, endMar
       }
     }
   } catch (error) {
-    console.error(`❌ Failed to create performance measure: ${name}`, { startMark, endMark, error });
+    structLog('error', `❌ Failed to create performance measure: ${name}`, { startMark, endMark, error });
   }
 }

--- a/public/app/features/dashboard/state/DashboardModel.ts
+++ b/public/app/features/dashboard/state/DashboardModel.ts
@@ -1,6 +1,6 @@
+import { structLog } from '@grafana/data';
 import { cloneDeep, defaults as _defaults, filter, indexOf, isEqual, map, maxBy, pull } from 'lodash';
 import { Subscription } from 'rxjs';
-
 import {
   type AnnotationQuery,
   type AppEvent,
@@ -34,7 +34,6 @@ import {
   RenderEvent,
   templateVariableValueUpdated,
 } from 'app/types/events';
-
 import { appEvents } from '../../../core/app_events';
 import { dispatch } from '../../../store/store';
 import {
@@ -46,26 +45,21 @@ import {
 import { isAllVariable } from '../../variables/utils';
 import { getTimeSrv } from '../services/TimeSrv';
 import { mergePanels, type PanelMergeInfo } from '../utils/panelMerge';
-
 import { DashboardMigrator } from './DashboardMigrator';
 import { PanelModel } from './PanelModel';
 import { type TimeModel } from './TimeModel';
 import { deleteScopeVars, isOnTheSameGridRow } from './utils';
-
 export interface CloneOptions {
   saveVariables?: boolean;
   saveTimerange?: boolean;
   message?: string;
 }
-
 export type DashboardLinkType = 'link' | 'dashboards';
-
 /** @experimental */
 export interface ScopeMeta {
   trait: string;
   groups: string[];
 }
-
 export class DashboardModel implements TimeModel {
   // TODO: use proper type and fix all the places where uid is set to null
   uid: any;
@@ -82,9 +76,13 @@ export class DashboardModel implements TimeModel {
   preload?: boolean;
   private originalTime: any;
   timepicker: any;
-  templating: { list: any[] };
+  templating: {
+    list: any[];
+  };
   private originalTemplating: any;
-  annotations: { list: AnnotationQuery[] };
+  annotations: {
+    list: AnnotationQuery[];
+  };
   refresh?: string;
   snapshot: any;
   schemaVersion: number;
@@ -102,17 +100,16 @@ export class DashboardModel implements TimeModel {
   private lastRefresh: number;
   private timeRangeUpdatedDuringEditOrView = false;
   private originalDashboard: Dashboard | null = null;
-
   // ------------------
   // not persisted
   // ------------------
-
   // repeat process cycles
   declare meta: DashboardMeta;
   events: EventBusExtended;
   private getVariablesFromState: GetVariables;
-
-  static nonPersistedProperties: { [str: string]: boolean } = {
+  static nonPersistedProperties: {
+    [str: string]: boolean;
+  } = {
     events: true,
     meta: true,
     panels: true, // needs special handling
@@ -130,7 +127,6 @@ export class DashboardModel implements TimeModel {
     timeRangeUpdatedDuringEditOrView: true,
     originalDashboard: true,
   };
-
   constructor(
     data: Dashboard,
     meta?: DashboardMeta,
@@ -173,10 +169,8 @@ export class DashboardModel implements TimeModel {
     this.originalDashboard = cloneDeep(data);
     this.originalTemplating = cloneDeep(this.templating);
     this.originalTime = cloneDeep(this.time);
-
     this.ensurePanelsHaveUniqueIds();
     this.formatDate = this.formatDate.bind(this);
-
     this.initMeta(meta);
     this.updateSchema(data, options?.targetSchemaVersion);
     this.addBuiltInAnnotationQuery();
@@ -192,13 +186,11 @@ export class DashboardModel implements TimeModel {
       appEvents.subscribe(VariablesChangedInUrl, this.variablesChangedInUrlHandler.bind(this))
     );
   }
-
   addBuiltInAnnotationQuery() {
     const found = this.annotations.list.some((item) => item.builtIn === 1);
     if (found) {
       return;
     }
-
     this.annotations.list.unshift({
       datasource: { uid: '-- Grafana --', type: 'grafana' },
       name: 'Annotations & Alerts',
@@ -209,29 +201,23 @@ export class DashboardModel implements TimeModel {
       builtIn: 1,
     });
   }
-
   private initMeta(meta?: DashboardMeta) {
     meta = meta || {};
-
     meta.canShare = meta.canShare !== false;
     meta.canSave = meta.canSave !== false;
     meta.canStar = meta.canStar !== false;
     meta.canEdit = meta.canEdit !== false;
     meta.canDelete = meta.canDelete !== false;
-
     meta.showSettings = meta.canEdit;
     meta.canMakeEditable = meta.canSave && !this.editable;
     meta.hasUnsavedFolderChange = false;
-
     if (!this.editable) {
       meta.canEdit = false;
       meta.canDelete = false;
       meta.canSave = false;
     }
-
     this.meta = meta;
   }
-
   /**
    * @deprecated Returns the wrong type please do not use
    */
@@ -240,46 +226,35 @@ export class DashboardModel implements TimeModel {
       saveVariables: true,
       saveTimerange: true,
     });
-
     // make clone
     let copy: any = {};
     for (const property in this) {
       if (DashboardModel.nonPersistedProperties[property] || !this.hasOwnProperty(property)) {
         continue;
       }
-
       copy[property] = cloneDeep(this[property]);
     }
-
     copy.templating = this.getTemplatingSaveModel(optionsWithDefaults);
-
     if (!optionsWithDefaults.saveTimerange) {
       copy.time = this.originalTime;
     }
-
     // get panel save models
     copy.panels = this.getPanelSaveModels();
-
     //  sort by keys
     copy = sortedDeepCloneWithoutNulls(copy);
     copy.getVariables = () => copy.templating.list;
-
     return copy;
   }
-
   /**
    * Returns the persisted save model (schema) of the dashboard
    */
   getSaveModelClone(options?: CloneOptions): Dashboard {
     const clone = this.getSaveModelCloneOld(options);
-
     // This is a bit messy / hacky but it's how we clean the model of any nulls / undefined / infinity
     const cloneJSON = JSON.stringify(clone);
     const cloneSafe = JSON.parse(cloneJSON);
-
     return cloneSafe;
   }
-
   /**
    * This will load a new dashboard, but keep existing panels unchanged
    *
@@ -301,7 +276,6 @@ export class DashboardModel implements TimeModel {
     }
     return info;
   }
-
   private getPanelSaveModels() {
     return this.panels
       .filter((panel) => this.isSnapshotTruthy() || !(panel.repeatPanelId || panel.repeatedByRow))
@@ -319,13 +293,11 @@ export class DashboardModel implements TimeModel {
             },
           };
         }
-
         // If we save while editing we should include the panel in edit mode instead of the
         // unmodified source panel
         if (this.panelInEdit && this.panelInEdit.id === panel.id) {
           return this.panelInEdit.getSaveModel();
         }
-
         return panel.getSaveModel();
       })
       .map((model) => {
@@ -335,7 +307,6 @@ export class DashboardModel implements TimeModel {
         // Clear any scopedVars from persisted mode. This cannot be part of getSaveModel as we need to be able to copy
         // panel models with preserved scopedVars, for example when going into edit mode.
         delete model.scopedVars;
-
         // Clear any repeated panels from collapsed rows
         if (model.type === 'row' && model.panels && model.panels.length > 0) {
           model.panels = model.panels
@@ -345,30 +316,24 @@ export class DashboardModel implements TimeModel {
               return model;
             });
         }
-
         return model;
       });
   }
-
   private getTemplatingSaveModel(options: CloneOptions) {
     const originalVariables = this.originalTemplating?.list ?? [];
     const currentVariables = this.getVariablesFromState(this.uid);
-
     const saveModels = currentVariables.map((variable) => {
       // Group by variables has no adapter. Use the model as-is. This is safe to do as in scenes from which dashboard can be serialised,
       // the variable model is provided through getVariablesCompatibility.
       const adapter = variableAdapters.getIfExists(variable.type);
       const variableSaveModel: any = adapter ? adapter.getSaveModel(variable, options.saveVariables) : variable;
-
       if (!options.saveVariables) {
         const original = originalVariables.find(
           ({ name, type }: any) => name === variable.name && type === variable.type
         );
-
         if (!original) {
           return variableSaveModel;
         }
-
         if (variable.type === 'adhoc') {
           variableSaveModel.filters = original.filters;
         } else {
@@ -376,36 +341,28 @@ export class DashboardModel implements TimeModel {
           variableSaveModel.options = original.options;
         }
       }
-
       return variableSaveModel;
     });
-
     const saveModelsWithoutNull = sortedDeepCloneWithoutNulls(saveModels);
     return { list: saveModelsWithoutNull };
   }
-
   timeRangeUpdated(timeRange: TimeRange) {
     this.events.publish(new TimeRangeUpdatedEvent(timeRange));
     dispatch(onTimeRangeUpdated(this.uid, timeRange));
-
     if (this.panelInEdit || this.panelInView) {
       this.timeRangeUpdatedDuringEditOrView = true;
     }
   }
-
   startRefresh(event: VariablesChangedEvent = { refreshAll: true, panelIds: [] }) {
     this.events.publish(new RefreshEvent());
     this.lastRefresh = Date.now();
-
     if (this.panelInEdit && (event.refreshAll || event.panelIds.includes(this.panelInEdit.id))) {
       this.panelInEdit.refresh();
       return;
     }
-
     const panelsToRefresh = this.panels.filter(
       (panel) => !this.otherPanelInFullscreen(panel) && (event.refreshAll || event.panelIds.includes(panel.id))
     );
-
     // We have to mark every panel as refreshWhenInView /before/ we actually refresh any
     // in case there is a shared query, as otherwise that might refresh before the source panel is
     // marked for refresh, preventing the panel from updating
@@ -414,59 +371,47 @@ export class DashboardModel implements TimeModel {
         panel.refreshWhenInView = true;
       }
     }
-
     for (const panel of panelsToRefresh) {
       panel.refresh();
     }
   }
-
   render() {
     this.events.publish(new RenderEvent());
     for (const panel of this.panels) {
       panel.render();
     }
   }
-
   panelInitialized(panel: PanelModel) {
     const lastResult = panel.getQueryRunner().getLastResult();
-
     if (!this.otherPanelInFullscreen(panel) && !lastResult) {
       panel.refresh();
     }
   }
-
   otherPanelInFullscreen(panel: PanelModel) {
     return (this.panelInEdit || this.panelInView) && !(panel.isViewing || panel.isEditing);
   }
-
   initEditPanel(sourcePanel: PanelModel): PanelModel {
     getTimeSrv().stopAutoRefresh();
     this.panelInEdit = sourcePanel.getEditClone();
     this.timeRangeUpdatedDuringEditOrView = false;
     return this.panelInEdit;
   }
-
   exitPanelEditor() {
     this.panelInEdit!.destroy();
     this.panelInEdit = undefined;
-
     getTimeSrv().resumeAutoRefresh();
-
     this.refreshIfPanelsAffectedByVariableChangeOrTimeRangeChanged();
   }
-
   initViewPanel(panel: PanelModel) {
     this.panelInView = panel;
     this.timeRangeUpdatedDuringEditOrView = false;
     panel.setIsViewing(true);
   }
-
   exitViewPanel(panel: PanelModel) {
     this.panelInView = undefined;
     panel.setIsViewing(false);
     this.refreshIfPanelsAffectedByVariableChangeOrTimeRangeChanged();
   }
-
   private refreshIfPanelsAffectedByVariableChangeOrTimeRangeChanged() {
     if (this.panelsAffectedByVariableChange || this.timeRangeUpdatedDuringEditOrView) {
       this.startRefresh({
@@ -477,7 +422,6 @@ export class DashboardModel implements TimeModel {
       this.timeRangeUpdatedDuringEditOrView = false;
     }
   }
-
   private ensurePanelsHaveUniqueIds() {
     const ids = new Set<number>();
     let nextPanelId = this.getNextPanelId();
@@ -488,12 +432,10 @@ export class DashboardModel implements TimeModel {
       ids.add(panel.id);
     }
   }
-
   private removeNullValuesFromVariables(templating: { list: VariableModel[] }) {
     if (!templating.list.length) {
       return templating;
     }
-
     for (const variable of templating.list) {
       if (variable.current) {
         // this is a safeguard for null value that breaks scenes dashboards.
@@ -510,21 +452,17 @@ export class DashboardModel implements TimeModel {
     }
     return templating;
   }
-
   private ensureListExist(data: any = {}) {
     data.list ??= [];
     return data;
   }
-
   getNextPanelId() {
     let max = 0;
-
     for (const panel of this.panelIterator()) {
       if (panel.id > max) {
         max = panel.id;
       }
     }
-
     // Also check panels in legacy rows (pre-v16 dashboard format)
     // This ensures unique IDs are assigned before the row upgrade migration runs
     for (const panel of this.rawPanelIterator()) {
@@ -532,21 +470,17 @@ export class DashboardModel implements TimeModel {
         max = panel.id;
       }
     }
-
     return max + 1;
   }
-
   *panelIterator() {
     for (const panel of this.panels) {
       yield panel;
-
       const rowPanels = panel.panels ?? [];
       for (const rowPanel of rowPanels) {
         yield rowPanel;
       }
     }
   }
-
   /**
    * Iterates over panels from the original raw dashboard data, including legacy rows.
    * This is needed to find panel IDs before row upgrade migration runs.
@@ -554,7 +488,6 @@ export class DashboardModel implements TimeModel {
   private *rawPanelIterator() {
     // @ts-expect-error - rows is a legacy property not included in the modern Dashboard schema
     const rows = this.originalDashboard?.rows;
-
     if (Array.isArray(rows)) {
       for (const row of rows) {
         const rowPanels = row?.panels;
@@ -566,54 +499,42 @@ export class DashboardModel implements TimeModel {
       }
     }
   }
-
   forEachPanel(callback: (panel: PanelModel, index: number) => void) {
     for (let i = 0; i < this.panels.length; i++) {
       callback(this.panels[i], i);
     }
   }
-
   getPanelById(id: number, includeCollapsed = false): PanelModel | null {
     if (this.panelInEdit && this.panelInEdit.id === id) {
       return this.panelInEdit;
     }
-
     if (includeCollapsed) {
       for (const panel of this.panelIterator()) {
         if (panel.id === id) {
           return panel;
         }
       }
-
       return null;
     } else {
       return this.panels.find((p) => p.id === id) ?? null;
     }
   }
-
   canEditPanel(panel?: PanelModel | null): boolean | undefined | null {
     return Boolean(this.meta.canEdit && panel && !panel.repeatPanelId && panel.type !== 'row');
   }
-
   canEditPanelById(id: number): boolean | undefined | null {
     return this.canEditPanel(this.getPanelById(id));
   }
-
   addPanel(panelData: any) {
     panelData.id = this.getNextPanelId();
-
     this.panels.unshift(new PanelModel(panelData));
-
     this.sortPanelsByGridPos();
-
     this.events.publish(new DashboardPanelsChangedEvent());
   }
-
   updateMeta(updates: Partial<DashboardMeta>) {
     this.meta = { ...this.meta, ...updates };
     this.events.publish(new DashboardMetaChangedEvent());
   }
-
   makeEditable() {
     this.editable = true;
     this.updateMeta({
@@ -622,7 +543,6 @@ export class DashboardModel implements TimeModel {
       canSave: true,
     });
   }
-
   sortPanelsByGridPos() {
     this.panels.sort((panelA, panelB) => {
       if (panelA.gridPos.y === panelB.gridPos.y) {
@@ -632,87 +552,68 @@ export class DashboardModel implements TimeModel {
       }
     });
   }
-
   clearUnsavedChanges(savedModel: Dashboard, options: CloneOptions) {
     for (const panel of this.panels) {
       panel.configRev = 0;
     }
-
     if (this.panelInEdit) {
       // Remember that we have a saved a change in panel editor so we apply it when leaving panel edit
       this.panelInEdit.hasSavedPanelEditChange = this.panelInEdit.configRev > 0;
       this.panelInEdit.configRev = 0;
     }
-
     this.originalDashboard = savedModel;
     this.originalTemplating = savedModel.templating;
-
     if (options.saveTimerange) {
       this.originalTime = savedModel.time;
     }
   }
-
   hasUnsavedChanges() {
     const changedPanel = this.panels.find((p) => p.hasChanged);
     return Boolean(changedPanel);
   }
-
   cleanUpRepeats() {
     if (this.isSnapshotTruthy() || !this.hasVariables()) {
       return;
     }
-
     // cleanup scopedVars
     deleteScopeVars(this.panels);
-
     const panelsToRemove = this.panels.filter((p) => (!p.repeat || p.repeatedByRow) && p.repeatPanelId);
-
     // remove panels
     pull(this.panels, ...panelsToRemove);
     panelsToRemove.map((p) => p.destroy());
     this.sortPanelsByGridPos();
   }
-
   processRepeats() {
     if (this.isSnapshotTruthy() || !this.hasVariables() || this.panelInView) {
       return;
     }
-
     this.cleanUpRepeats();
-
     for (let i = 0; i < this.panels.length; i++) {
       const panel = this.panels[i];
       if (panel.repeat) {
         this.repeatPanel(panel, i);
       }
     }
-
     this.sortPanelsByGridPos();
     this.events.publish(new DashboardPanelsChangedEvent());
   }
-
   cleanUpRowRepeats(rowPanels: PanelModel[]) {
     const panelIds = rowPanels.map((row) => row.id);
     // Remove repeated panels whose parent is in this row as these will be recreated later in processRowRepeats
     const panelsToRemove = rowPanels.filter((p) => !p.repeat && p.repeatPanelId && panelIds.includes(p.repeatPanelId));
-
     pull(rowPanels, ...panelsToRemove);
     pull(this.panels, ...panelsToRemove);
   }
-
   processRowRepeats(row: PanelModel) {
     if (this.isSnapshotTruthy() || !this.hasVariables()) {
       return;
     }
-
     let rowPanels = row.panels ?? [];
     if (!row.collapsed) {
       const rowPanelIndex = this.panels.findIndex((p) => p.id === row.id);
       rowPanels = this.getRowPanels(rowPanelIndex);
     }
-
     this.cleanUpRowRepeats(rowPanels);
-
     for (const panel of rowPanels) {
       if (panel.repeat) {
         const panelIndex = this.panels.findIndex((p) => p.id === panel.id);
@@ -720,31 +621,24 @@ export class DashboardModel implements TimeModel {
       }
     }
   }
-
   getPanelRepeatClone(sourcePanel: PanelModel, valueIndex: number, sourcePanelIndex: number) {
     // if first clone return source
     if (valueIndex === 0) {
       return sourcePanel;
     }
-
     const m = sourcePanel.getSaveModel();
     m.id = this.getNextPanelId();
     const clone = new PanelModel(m);
-
     // insert after source panel + value index
     this.panels.splice(sourcePanelIndex + valueIndex, 0, clone);
-
     clone.repeatPanelId = sourcePanel.id;
     clone.repeat = undefined;
-
     if (this.panelInView?.id === clone.id) {
       clone.setIsViewing(true);
       this.panelInView = clone;
     }
-
     return clone;
   }
-
   getRowRepeatClone(sourceRowPanel: PanelModel, valueIndex: number, sourcePanelIndex: number) {
     // if first clone, return source
     if (valueIndex === 0) {
@@ -752,57 +646,45 @@ export class DashboardModel implements TimeModel {
         const rowPanels = this.getRowPanels(sourcePanelIndex);
         sourceRowPanel.panels = rowPanels;
       }
-
       return sourceRowPanel;
     }
-
     const clone = new PanelModel(sourceRowPanel.getSaveModel());
     // for row clones we need to figure out panels under row to clone and where to insert clone
     let rowPanels: PanelModel[], insertPos: number;
     if (sourceRowPanel.collapsed) {
       rowPanels = cloneDeep(sourceRowPanel.panels) ?? [];
       clone.panels = rowPanels;
-
       // insert copied row after preceding row
       insertPos = sourcePanelIndex + valueIndex;
     } else {
       rowPanels = this.getRowPanels(sourcePanelIndex);
       clone.panels = rowPanels.map((panel) => panel.getSaveModel());
-
       // insert copied row after preceding row's panels
       insertPos = sourcePanelIndex + (rowPanels.length + 1) * valueIndex;
     }
     this.panels.splice(insertPos, 0, clone);
-
     this.updateRepeatedPanelIds(clone);
     return clone;
   }
-
   repeatPanel(panel: PanelModel, panelIndex: number) {
     const variable = this.getPanelRepeatVariable(panel);
     if (!variable) {
       return;
     }
-
     if (panel.type === 'row') {
       this.repeatRow(panel, panelIndex, variable);
       return;
     }
-
     const selectedOptions = this.getSelectedVariableOptions(variable);
-
     const maxPerRow = panel.maxPerRow || 4;
     let xPos = 0;
     let yPos = panel.gridPos.y;
-
     for (let index = 0; index < selectedOptions.length; index++) {
       const option = selectedOptions[index];
       let copy;
-
       copy = this.getPanelRepeatClone(panel, index, panelIndex);
       copy.scopedVars ??= {};
       copy.scopedVars[variable.name] = option;
-
       if (panel.repeatDirection === REPEAT_DIR_VERTICAL) {
         if (index > 0) {
           yPos += copy.gridPos.h;
@@ -814,9 +696,7 @@ export class DashboardModel implements TimeModel {
         copy.gridPos.w = Math.max(GRID_COLUMN_COUNT / selectedOptions.length, GRID_COLUMN_COUNT / maxPerRow);
         copy.gridPos.x = xPos;
         copy.gridPos.y = yPos;
-
         xPos += copy.gridPos.w;
-
         // handle overflow by pushing down one row
         if (xPos + copy.gridPos.w > GRID_COLUMN_COUNT) {
           xPos = 0;
@@ -824,7 +704,6 @@ export class DashboardModel implements TimeModel {
         }
       }
     }
-
     // Update gridPos for panels below
     const yOffset = yPos - panel.gridPos.y;
     if (yOffset > 0) {
@@ -833,25 +712,19 @@ export class DashboardModel implements TimeModel {
         if (isOnTheSameGridRow(panel, curPanel)) {
           continue;
         }
-
         curPanel.gridPos.y += yOffset;
       }
     }
   }
-
   repeatRow(panel: PanelModel, panelIndex: number, variable: TypedVariableModel) {
     const selectedOptions = this.getSelectedVariableOptions(variable);
-
     for (let optionIndex = 0; optionIndex < selectedOptions.length; optionIndex++) {
       const curOption = selectedOptions[optionIndex];
       const rowClone = this.getRowRepeatClone(panel, optionIndex, panelIndex);
-
       setScopedVars(rowClone, variable, curOption);
-
       const rowHeight = this.getRowHeight(rowClone);
       const panelsInRow = rowClone.panels || [];
       let panelBelowIndex;
-
       if (panel.collapsed) {
         // For a collapsed row, just copy its panels, set scoped vars and proper IDs
         for (const panelInRow of panelsInRow) {
@@ -860,7 +733,6 @@ export class DashboardModel implements TimeModel {
             this.updateRepeatedPanelIds(panelInRow, true);
           }
         }
-
         // push nth row clone's y-pos down by n
         rowClone.gridPos.y += optionIndex;
         panelBelowIndex = panelIndex + optionIndex + 1;
@@ -869,22 +741,18 @@ export class DashboardModel implements TimeModel {
         const insertPos = panelIndex + (panelsInRow.length + 1) * optionIndex + 1;
         panelsInRow.forEach((panelInRow, i) => {
           setScopedVars(panelInRow, variable, curOption);
-
           if (optionIndex > 0) {
             const panelInRowClone = new PanelModel(panelInRow);
             this.updateRepeatedPanelIds(panelInRowClone, true);
-
             // For exposed row, set correct grid y-position and add it to dashboard panels
             panelInRowClone.gridPos.y += rowHeight * optionIndex;
             this.panels.splice(insertPos + i, 0, panelInRowClone);
           }
         });
-
         rowClone.panels = [];
         rowClone.gridPos.y += rowHeight * optionIndex;
         panelBelowIndex = insertPos + panelsInRow.length;
       }
-
       // Update gridPos for panels below if we inserted more than 1 repeated row panel
       if (selectedOptions.length > 1) {
         for (const panel of this.panels.slice(panelBelowIndex)) {
@@ -893,20 +761,16 @@ export class DashboardModel implements TimeModel {
       }
     }
   }
-
   updateRepeatedPanelIds(panel: PanelModel, repeatedByRow?: boolean) {
     panel.repeatPanelId = panel.id;
     panel.id = this.getNextPanelId();
-
     if (repeatedByRow) {
       panel.repeatedByRow = true;
     } else {
       panel.repeat = undefined;
     }
-
     return panel;
   }
-
   getSelectedVariableOptions(variable: any) {
     let selectedOptions: any[];
     if (isAllVariable(variable)) {
@@ -916,7 +780,6 @@ export class DashboardModel implements TimeModel {
     }
     return selectedOptions;
   }
-
   getRowHeight(rowPanel: PanelModel): number {
     if (!rowPanel.panels || rowPanel.panels.length === 0) {
       return 0;
@@ -924,41 +787,33 @@ export class DashboardModel implements TimeModel {
       // A collapsed row will always have height 1
       return 1;
     }
-
     const maxYPos = maxBy(rowPanel.panels, ({ gridPos }) => gridPos.y + gridPos.h)!.gridPos;
     return maxYPos.y + maxYPos.h - rowPanel.gridPos.y;
   }
-
   removePanel(panel: PanelModel) {
     this.panels = this.panels.filter((item) => item !== panel);
     panel.destroy();
     this.events.publish(new DashboardPanelsChangedEvent());
   }
-
   removeRow(row: PanelModel, removePanels: boolean) {
     const needToggle = (!removePanels && row.collapsed) || (removePanels && !row.collapsed);
-
     if (needToggle) {
       this.toggleRow(row);
     }
-
     this.removePanel(row);
   }
-
   expandRows() {
     const collapsedRows = this.panels.filter((p) => p.type === 'row' && p.collapsed);
     for (const row of collapsedRows) {
       this.toggleRow(row);
     }
   }
-
   collapseRows() {
     const collapsedRows = this.panels.filter((p) => p.type === 'row' && !p.collapsed);
     for (const row of collapsedRows) {
       this.toggleRow(row);
     }
   }
-
   isSubMenuVisible() {
     return (
       this.links.length > 0 ||
@@ -966,27 +821,21 @@ export class DashboardModel implements TimeModel {
       this.annotations.list.some((annotation) => !annotation.hide)
     );
   }
-
   getPanelInfoById(panelId: number) {
     const panelIndex = this.panels.findIndex((p) => p.id === panelId);
     return panelIndex >= 0 ? { panel: this.panels[panelIndex], index: panelIndex } : null;
   }
-
   duplicatePanel(panel: PanelModel) {
     const newPanel = panel.getSaveModel();
     newPanel.id = this.getNextPanelId();
-
     delete newPanel.repeat;
     delete newPanel.repeatIteration;
     delete newPanel.repeatPanelId;
     delete newPanel.scopedVars;
-
     if (newPanel.alert) {
       delete newPanel.thresholds;
     }
-
     delete newPanel.alert;
-
     // does it fit to the right?
     if (panel.gridPos.x + panel.gridPos.w * 2 <= GRID_COLUMN_COUNT) {
       newPanel.gridPos.x += panel.gridPos.w;
@@ -994,18 +843,15 @@ export class DashboardModel implements TimeModel {
       // add below
       newPanel.gridPos.y += panel.gridPos.h;
     }
-
     this.addPanel(newPanel);
     return newPanel;
   }
-
   formatDate(date: DateTimeInput, format?: string) {
     return dateTimeFormat(date, {
       format,
       timeZone: this.getTimezone(),
     });
   }
-
   destroy() {
     this.appEventsSubscription.unsubscribe();
     this.events.removeAllListeners();
@@ -1013,48 +859,38 @@ export class DashboardModel implements TimeModel {
       panel.destroy();
     }
   }
-
   toggleRow(row: PanelModel) {
     const rowIndex = indexOf(this.panels, row);
-
     if (!row.collapsed) {
       const rowPanels = this.getRowPanels(rowIndex);
-
       // remove panels
       pull(this.panels, ...rowPanels);
       // save panel models inside row panel
       row.panels = rowPanels.map((panel: PanelModel) => panel.getSaveModel());
       row.collapsed = true;
-
       if (rowPanels.some((panel) => panel.hasChanged)) {
         row.configRev++;
       }
-
       // emit change event
       this.events.publish(new DashboardPanelsChangedEvent());
       return;
     }
-
     row.collapsed = false;
     const rowPanels = row.panels ?? [];
     const hasRepeat = rowPanels.some((p: PanelModel) => p.repeat);
-
     // This is set only for the row being repeated.
     const rowRepeatVariable = row.repeat;
-
     if (rowPanels.length > 0) {
       // Use first panel to figure out if it was moved or pushed
       // If the panel doesn't have gridPos.y, use the row gridPos.y instead.
       // This can happen for some generated dashboards.
       const firstPanelYPos = rowPanels[0].gridPos.y ?? row.gridPos.y;
       const yDiff = firstPanelYPos - (row.gridPos.y + row.gridPos.h);
-
       // start inserting after row
       let insertPos = rowIndex + 1;
       // y max will represent the bottom y pos after all panels have been added
       // needed to know home much panels below should be pushed down
       let yMax = row.gridPos.y;
-
       for (const panel of rowPanels) {
         // When expanding original row that's repeated, set scopedVars for repeated row panels.
         if (rowRepeatVariable) {
@@ -1078,87 +914,67 @@ export class DashboardModel implements TimeModel {
         insertPos += 1;
         yMax = Math.max(yMax, panel.gridPos.y + panel.gridPos.h);
       }
-
       const pushDownAmount = yMax - row.gridPos.y - 1;
-
       // push panels below down
       for (const panel of this.panels.slice(insertPos)) {
         panel.gridPos.y += pushDownAmount;
       }
-
       row.panels = [];
-
       if (hasRepeat) {
         this.processRowRepeats(row);
       }
     }
-
     // sort panels
     this.sortPanelsByGridPos();
-
     // emit change event
     this.events.publish(new DashboardPanelsChangedEvent());
   }
-
   /**
    * Will return all panels after rowIndex until it encounters another row
    */
   getRowPanels(rowIndex: number): PanelModel[] {
     const panelsBelowRow = this.panels.slice(rowIndex + 1);
     const nextRowIndex = panelsBelowRow.findIndex((p) => p.type === 'row');
-
     // Take all panels up to next row, or all panels if there are no other rows
     const rowPanels = panelsBelowRow.slice(0, nextRowIndex >= 0 ? nextRowIndex : this.panels.length);
-
     return rowPanels;
   }
-
   /** @deprecated */
   on<T>(event: AppEvent<T>, callback: (payload?: T) => void) {
-    console.log('DashboardModel.on is deprecated use events.subscribe');
+    structLog('log', 'DashboardModel.on is deprecated use events.subscribe');
     this.events.on(event, callback);
   }
-
   /** @deprecated */
   off<T>(event: AppEvent<T>, callback: (payload?: T) => void) {
-    console.log('DashboardModel.off is deprecated');
+    structLog('log', 'DashboardModel.off is deprecated');
     this.events.off(event, callback);
   }
-
   cycleGraphTooltip() {
     this.graphTooltip = (this.graphTooltip + 1) % 3;
   }
-
   sharedTooltipModeEnabled() {
     return this.graphTooltip > 0;
   }
-
   sharedCrosshairModeOnly() {
     return this.graphTooltip === 1;
   }
-
   getRelativeTime(date: DateTimeInput) {
     return dateTimeFormatTimeAgo(date, {
       timeZone: this.getTimezone(),
     });
   }
-
   isSnapshot() {
     return this.snapshot !== undefined;
   }
-
   getTimezone(): TimeZone {
     return this.timezone ? this.timezone : contextSrv?.user?.timezone;
   }
-
   private updateSchema(old: any, targetVersion?: number) {
     const migrator = new DashboardMigrator(this);
     migrator.updateSchema(old, targetVersion);
   }
-
   hasTimeChanged() {
     const { time, originalTime } = this;
-
     // Compare moment values vs strings values
     return !(
       isEqual(time, originalTime) ||
@@ -1166,61 +982,47 @@ export class DashboardModel implements TimeModel {
         isEqual(dateTime(time?.to), dateTime(originalTime?.to)))
     );
   }
-
   autoFitPanels(viewHeight: number, kioskMode?: UrlQueryValue) {
     const currentGridHeight = Math.max(...this.panels.map((panel) => panel.gridPos.h + panel.gridPos.y));
-
     const navbarHeight = 55;
     const margin = 20;
-
     let visibleHeight = viewHeight - navbarHeight - margin;
-
     // add back navbar height
     if (kioskMode) {
       visibleHeight += navbarHeight;
     }
-
     const visibleGridHeight = Math.floor(visibleHeight / (GRID_CELL_HEIGHT + GRID_CELL_VMARGIN));
     const scaleFactor = currentGridHeight / visibleGridHeight;
-
     for (const panel of this.panels) {
       panel.gridPos.y = Math.round(panel.gridPos.y / scaleFactor) || 1;
       panel.gridPos.h = Math.round(panel.gridPos.h / scaleFactor) || 1;
     }
   }
-
   templateVariableValueUpdated() {
     this.processRepeats();
     this.events.emit(templateVariableValueUpdated);
   }
-
   getPanelByUrlId(panelUrlId: string) {
     const panelId = parseInt(panelUrlId ?? '0', 10);
-
     // First try to find it in a collapsed row and exand it
     const collapsedPanels = this.panels.filter((p) => p.collapsed);
     for (const panel of collapsedPanels) {
       const hasPanel = panel.panels?.some((rp) => rp.id === panelId);
       hasPanel && this.toggleRow(panel);
     }
-
     return this.getPanelById(panelId);
   }
-
   toggleLegendsForAll() {
     const panelsWithLegends = this.panels.filter(isPanelWithLegend);
-
     // determine if more panels are displaying legends or not
     const onCount = panelsWithLegends.filter((panel) => panel.legend.show).length;
     const offCount = panelsWithLegends.length - onCount;
     const panelLegendsOn = onCount >= offCount;
-
     for (const panel of panelsWithLegends) {
       panel.legend.show = !panelLegendsOn;
       panel.render();
     }
   }
-
   toggleExemplarsForAll() {
     for (const panel of this.panels) {
       for (const target of panel.targets) {
@@ -1234,117 +1036,91 @@ export class DashboardModel implements TimeModel {
         ) {
           continue;
         }
-
         const promTarget = target as PromQuery;
         promTarget.exemplar = !promTarget.exemplar;
       }
     }
-
     this.startRefresh();
   }
-
   getVariables() {
     return this.getVariablesFromState(this.uid);
   }
-
   canEditAnnotations(dashboardUID?: string) {
     return !!this.meta.annotationsPermissions?.dashboard.canEdit;
   }
-
   canDeleteAnnotations(dashboardUID?: string) {
     return !!this.meta.annotationsPermissions?.dashboard.canDelete;
   }
-
   canAddAnnotations() {
     // When the builtin annotations are disabled, we should not add any in the UI
     const found = this.annotations.list.find((item) => item.builtIn === 1);
     if (found?.enable === false) {
       return false;
     }
-
     return Boolean(this.meta.annotationsPermissions?.dashboard.canAdd);
   }
-
   canEditDashboard() {
     return Boolean(this.meta.canEdit || this.meta.canMakeEditable);
   }
-
   canExecuteActions() {
     return this.canEditDashboard();
   }
-
   shouldUpdateDashboardPanelFromJSON(updatedPanel: PanelModel, panel: PanelModel) {
     const shouldUpdateGridPositionLayout = !isEqual(updatedPanel?.gridPos, panel?.gridPos);
     if (shouldUpdateGridPositionLayout) {
       this.events.publish(new DashboardPanelsChangedEvent());
     }
   }
-
   getDefaultTime() {
     return this.originalTime;
   }
-
   private getPanelRepeatVariable(panel: PanelModel) {
     return this.getVariablesFromState(this.uid).find((variable) => variable.name === panel.repeat);
   }
-
   private isSnapshotTruthy() {
     return this.snapshot;
   }
-
   private hasVariables() {
     return this.getVariablesFromState(this.uid).length > 0;
   }
-
   public hasVariablesChanged(): boolean {
     const originalVariables = this.originalTemplating?.list ?? [];
     const currentVariables = this.getTemplatingSaveModel({ saveVariables: true }).list;
-
     if (originalVariables.length !== currentVariables.length) {
       return false;
     }
-
     return !isEqual(currentVariables, originalVariables);
   }
-
   private variablesTimeRangeProcessDoneHandler(event: VariablesTimeRangeProcessDone) {
     const processRepeats = event.payload.variableIds.length > 0;
     this.variablesChangedHandler(new VariablesChanged({ panelIds: [], refreshAll: true }), processRepeats);
   }
-
   private variablesChangedHandler(event: VariablesChanged, processRepeats = true) {
     if (processRepeats) {
       this.processRepeats();
     }
-
     if (event.payload.refreshAll || getTimeSrv().isRefreshOutsideThreshold(this.lastRefresh)) {
       this.startRefresh({ refreshAll: true, panelIds: [] });
       return;
     }
-
     if (this.panelInEdit || this.panelInView) {
       this.panelsAffectedByVariableChange = event.payload.panelIds.filter(
         (id) => id !== (this.panelInEdit?.id ?? this.panelInView?.id)
       );
     }
-
     this.startRefresh(event.payload);
   }
-
   private variablesChangedInUrlHandler(event: VariablesChangedInUrl) {
     this.templateVariableValueUpdated();
     this.startRefresh(event.payload);
   }
-
   getOriginalDashboard() {
     return this.originalDashboard;
   }
 }
-
 function isPanelWithLegend(panel: PanelModel): panel is PanelModel & Pick<Required<PanelModel>, 'legend'> {
   return Boolean(panel.legend);
 }
-
 function setScopedVars(panel: PanelModel, variable: TypedVariableModel, variableOption: any) {
   panel.scopedVars ??= {};
   panel.scopedVars[variable.name] = variableOption;

--- a/public/app/features/dashboard/state/initDashboard.ts
+++ b/public/app/features/dashboard/state/initDashboard.ts
@@ -1,3 +1,4 @@
+import { structLog } from '@grafana/data';
 import { type DataQuery, locationUtil, setWeekStart, DashboardLoadedEvent, store } from '@grafana/data';
 import { t } from '@grafana/i18n';
 import { config, isFetchError, locationService } from '@grafana/runtime';
@@ -28,20 +29,16 @@ import {
   isRedirectResponse,
 } from 'app/types/dashboard';
 import { type StoreState, type ThunkDispatch, type ThunkResult } from 'app/types/store';
-
 import { contextSrv } from '../../../core/services/context_srv';
 import { createDashboardQueryRunner } from '../../query/state/DashboardQueryRunner/DashboardQueryRunner';
 import { initVariablesTransaction } from '../../variables/state/actions';
 import { getIfExistsLastKey } from '../../variables/state/selectors';
 import { trackDashboardLoaded } from '../utils/tracking';
-
 import { DashboardModel } from './DashboardModel';
 import { type PanelModel } from './PanelModel';
 import { emitDashboardViewEvent } from './analyticsProcessor';
 import { dashboardInitCompleted, dashboardInitFailed, dashboardInitFetching, dashboardInitServices } from './reducers';
-
 const INIT_DASHBOARD_MEASUREMENT = 'initDashboard';
-
 export interface InitDashboardArgs {
   urlUid?: string;
   urlSlug?: string;
@@ -53,7 +50,6 @@ export interface InitDashboardArgs {
   fixUrl: boolean;
   keybindingSrv: KeybindingSrv;
 }
-
 async function fetchDashboard(
   args: InitDashboardArgs,
   dispatch: ThunkDispatch,
@@ -64,21 +60,17 @@ async function fetchDashboard(
       case DashboardRoutes.Home: {
         const stateManager = getDashboardScenePageStateManager('v1');
         const cachedDashboard = stateManager.getDashboardFromCache(HOME_DASHBOARD_CACHE_KEY);
-
         if (cachedDashboard) {
           return cachedDashboard;
         }
-
         // load home dash
         const dashDTO = await backendSrv.get<DashboardDTO | HomeDashboardRedirectDTO>('/api/dashboards/home');
-
         // if user specified a custom home dashboard redirect to that
         if (isRedirectResponse(dashDTO)) {
           const newUrl = locationUtil.processRedirectUri(dashDTO.redirectUri, locationService.getLocation());
           locationService.replace(newUrl);
           return null;
         }
-
         // disable some actions on the default home dashboard
         dashDTO.meta.canSave = false;
         dashDTO.meta.canShare = false;
@@ -90,26 +82,23 @@ async function fetchDashboard(
       }
       case DashboardRoutes.Normal: {
         const dashDTO: DashboardDTO = await dashboardLoaderSrv.loadDashboard(args.urlType, args.urlSlug, args.urlUid);
-
         // only the folder API has information about ancestors
         // get parent folder (if it exists) and put it in the store
         // this will be used to populate the full breadcrumb trail
         if (dashDTO.meta.folderUid) {
           await updateNavModel(dashDTO.meta.folderUid);
         }
-
         if (args.fixUrl && dashDTO.meta.url && !playlistSrv.state.isPlaying) {
           // check if the current url is correct (might be old slug)
           const dashboardUrl = locationUtil.stripBaseFromUrl(dashDTO.meta.url);
           const currentPath = locationService.getLocation().pathname;
-
           if (dashboardUrl !== currentPath) {
             // Spread current location to persist search params used for navigation
             locationService.replace({
               ...locationService.getLocation(),
               pathname: dashboardUrl,
             });
-            console.log('not correct url correcting', dashboardUrl, currentPath);
+            structLog('log', 'not correct url correcting', dashboardUrl, currentPath);
           }
         }
         return dashDTO;
@@ -131,22 +120,24 @@ async function fetchDashboard(
     if (isFetchError(err) && err.cancelled) {
       return null;
     }
-
     dispatch(
       dashboardInitFailed({
         message: t('dashboard.fetch-dashboard.message.failed-to-fetch-dashboard', 'Failed to fetch dashboard'),
         error: err,
       })
     );
-    console.error(err);
+    structLog('error', err);
     return null;
   }
 }
-
 const getQueriesByDatasource = (
   panels: PanelModel[],
-  queries: { [datasourceId: string]: DataQuery[] } = {}
-): { [datasourceId: string]: DataQuery[] } => {
+  queries: {
+    [datasourceId: string]: DataQuery[];
+  } = {}
+): {
+  [datasourceId: string]: DataQuery[];
+} => {
   panels.forEach((panel) => {
     if (panel.panels) {
       getQueriesByDatasource(panel.panels, queries);
@@ -164,7 +155,6 @@ const getQueriesByDatasource = (
   });
   return queries;
 };
-
 /**
  * This action (or saga) does everything needed to bootstrap a dashboard & dashboard model.
  * First it handles the process of fetching the dashboard, correcting the url if required (causing redirects/url updates)
@@ -177,24 +167,18 @@ const getQueriesByDatasource = (
 export function initDashboard(args: InitDashboardArgs): ThunkResult<void> {
   return async (dispatch, getState) => {
     startMeasure(INIT_DASHBOARD_MEASUREMENT);
-
     // set fetching state
     dispatch(dashboardInitFetching());
-
     // fetch dashboard data
     const dashDTO = await fetchDashboard(args, dispatch, getState);
     const versionBeforeMigration = dashDTO?.dashboard?.version;
-
     // returns null if there was a redirect or error
     if (!dashDTO) {
       return;
     }
-
     addPanelsFromLocalStorage(dashDTO);
-
     // set initializing state
     dispatch(dashboardInitServices());
-
     // create model
     let dashboard: DashboardModel;
     try {
@@ -206,57 +190,45 @@ export function initDashboard(args: InitDashboardArgs): ThunkResult<void> {
           error: err,
         })
       );
-      console.error(err);
+      structLog('error', err);
       return;
     }
-
     // add missing orgId query param
     const storeState = getState();
     const queryParams = locationService.getSearchObject();
-
     if (!queryParams.orgId) {
       // TODO this is currently not possible with the LocationService API
       locationService.partial({ orgId: storeState.user.orgId }, true);
     }
-
     // init services
     const timeSrv: TimeSrv = getTimeSrv();
     const dashboardSrv: DashboardSrv = getDashboardSrv();
-
     // legacy srv state, we need this value updated for built-in annotations
     dashboardSrv.setCurrent(dashboard);
-
     timeSrv.init(dashboard);
-
     const dashboardUid = toStateKey(args.urlUid ?? dashboard.uid);
     // template values service needs to initialize completely before the rest of the dashboard can load
     await dispatch(initVariablesTransaction(dashboardUid, dashboard));
-
     // DashboardQueryRunner needs to run after all variables have been resolved so that any annotation query including a variable
     // will be correctly resolved
     const runner = createDashboardQueryRunner({ dashboard, timeSrv });
     runner.run({ dashboard, range: timeSrv.timeRange() });
-
     if (getIfExistsLastKey(getState()) !== dashboardUid) {
       // if a previous dashboard has slow running variable queries the batch uid will be the new one
       // but the args.urlUid will be the same as before initVariablesTransaction was called so then we can't continue initializing
       // the previous dashboard.
       return;
     }
-
     // If dashboard is in a different init phase it means it cancelled during service init
     if (getState().dashboard.initPhase !== DashboardInitPhase.Services) {
       return;
     }
-
     try {
       dashboard.processRepeats();
-
       // handle auto fix experimental feature
       if (queryParams.autofitpanels) {
         dashboard.autoFitPanels(window.innerHeight, queryParams.kiosk);
       }
-
       if (!config.publicDashboardAccessToken) {
         args.keybindingSrv.setupDashboardBindings(dashboard);
       }
@@ -264,26 +236,22 @@ export function initDashboard(args: InitDashboardArgs): ThunkResult<void> {
       if (err instanceof Error) {
         dispatch(notifyApp(createErrorNotification('Dashboard init failed', err)));
       }
-      console.error(err);
+      structLog('error', err);
     }
-
     // send open dashboard event
     if (args.routeName !== DashboardRoutes.New) {
       emitDashboardViewEvent(dashboard);
-
       // Listen for changes on the current dashboard
       dashboardWatcher.watch(dashboard.uid);
     } else {
       dashboardWatcher.leave();
     }
-
     // set week start
     if (dashboard.weekStart !== '' && dashboard.weekStart !== undefined) {
       setWeekStart(dashboard.weekStart);
     } else {
       setWeekStart(contextSrv.user.weekStart);
     }
-
     // Propagate an app-wide event about the dashboard being loaded
     appEvents.publish(
       new DashboardLoadedEvent({
@@ -294,15 +262,12 @@ export function initDashboard(args: InitDashboardArgs): ThunkResult<void> {
         queries: getQueriesByDatasource(dashboard.panels),
       })
     );
-
     const measure = stopMeasure(INIT_DASHBOARD_MEASUREMENT);
     trackDashboardLoaded(dashboard, measure?.duration, versionBeforeMigration);
-
     // yay we are done
     dispatch(dashboardInitCompleted(dashboard));
   };
 }
-
 function addPanelsFromLocalStorage(model: DashboardDTO) {
   // When creating new or adding panels to a dashboard from explore we load it from local storage
   const fromLS = store.getObject<DashboardDTO>(DASHBOARD_FROM_LS_KEY);
@@ -310,11 +275,9 @@ function addPanelsFromLocalStorage(model: DashboardDTO) {
     if (fromLS.dashboard.panels) {
       model.dashboard.panels = fromLS.dashboard.panels.concat(model.dashboard.panels);
     }
-
     if (fromLS.dashboard.time) {
       model.dashboard.time = fromLS.dashboard.time;
     }
-
     store.delete(DASHBOARD_FROM_LS_KEY);
   }
 }

--- a/public/app/features/dimensions/editors/FileUploader.tsx
+++ b/public/app/features/dimensions/editors/FileUploader.tsx
@@ -1,13 +1,11 @@
+import { structLog } from '@grafana/data';
 import { css } from '@emotion/css';
 import { type Dispatch, type SetStateAction, useState } from 'react';
-
 import { type GrafanaTheme2 } from '@grafana/data';
 import { Trans, t } from '@grafana/i18n';
 import { FileDropzone, useStyles2, Button, type DropzoneFile, Field } from '@grafana/ui';
 import { SanitizedSVG } from 'app/core/components/SVG/SanitizedSVG';
-
 import { MediaType } from '../types';
-
 interface Props {
   setFormData: Dispatch<SetStateAction<FormData>>;
   mediaType: MediaType;
@@ -20,7 +18,6 @@ interface ErrorResponse {
 }
 export function FileDropzoneCustomChildren({ secondaryText = 'Drag and drop here or browse' }) {
   const styles = useStyles2(getStyles);
-
   return (
     <div className={styles.iconWrapper}>
       <small className={styles.small}>{secondaryText}</small>
@@ -34,7 +31,6 @@ export const FileUploader = ({ mediaType, setFormData, setUpload, error }: Props
   const styles = useStyles2(getStyles);
   const [dropped, setDropped] = useState<boolean>(false);
   const [file, setFile] = useState<string>('');
-
   const Preview = () => (
     <Field label={t('dimensions.file-uploader.preview.label-preview', 'Preview')}>
       <div className={styles.iconPreview}>
@@ -43,13 +39,11 @@ export const FileUploader = ({ mediaType, setFormData, setUpload, error }: Props
       </div>
     </Field>
   );
-
   const onFileRemove = (file: DropzoneFile) => {
     fetch(`/api/storage/delete/upload/${file.file.name}`, {
       method: 'DELETE',
-    }).catch((error) => console.error('cannot delete file', error));
+    }).catch((error) => structLog('error', 'cannot delete file', error));
   };
-
   const acceptableFiles =
     mediaType === 'icon' ? { 'image/*': ['.svg', '.xml'] } : { 'image/*': ['.jpeg', '.png', '.gif', '.webp'] };
   return (
@@ -79,7 +73,6 @@ export const FileUploader = ({ mediaType, setFormData, setUpload, error }: Props
     </FileDropzone>
   );
 };
-
 function getStyles(theme: GrafanaTheme2, isDragActive?: boolean) {
   return {
     container: css({

--- a/public/app/features/dimensions/editors/ResourcePickerPopover.tsx
+++ b/public/app/features/dimensions/editors/ResourcePickerPopover.tsx
@@ -1,20 +1,17 @@
+import { structLog } from '@grafana/data';
 import { css } from '@emotion/css';
 import { useDialog } from '@react-aria/dialog';
 import { FocusScope } from '@react-aria/focus';
 import { useOverlay } from '@react-aria/overlays';
 import { useRef, useState } from 'react';
-
 import { type GrafanaTheme2 } from '@grafana/data';
 import { Trans } from '@grafana/i18n';
 import { config, getBackendSrv } from '@grafana/runtime';
 import { Button, useStyles2 } from '@grafana/ui';
-
 import { type MediaType, PickerTabType, type ResourceFolderName } from '../types';
-
 import { FileUploader } from './FileUploader';
 import { FolderPickerTab } from './FolderPickerTab';
 import { URLPickerTab } from './URLPickerTab';
-
 interface Props {
   value?: string; //img/icons/unicons/0-plus.svg
   onChange: (value?: string) => void;
@@ -23,34 +20,28 @@ interface Props {
   maxFiles?: number;
   hidePopper?: () => void;
 }
-
 interface ErrorResponse {
   message: string;
 }
 export const ResourcePickerPopover = (props: Props) => {
   const { value, onChange, mediaType, folderName, maxFiles, hidePopper } = props;
   const styles = useStyles2(getStyles);
-
   const onClose = () => {
     onChange(value);
     hidePopper?.();
   };
-
   const ref = useRef<HTMLElement>(null);
   const { dialogProps } = useDialog({}, ref);
   const { overlayProps } = useOverlay({ onClose, isDismissable: true, isOpen: true }, ref);
-
   const isURL = value && value.includes('://');
   const [newValue, setNewValue] = useState<string>(value ?? '');
   const [activePicker, setActivePicker] = useState<PickerTabType>(isURL ? PickerTabType.URL : PickerTabType.Folder);
   const [formData, setFormData] = useState<FormData>(new FormData());
   const [upload, setUpload] = useState<boolean>(false);
   const [error, setError] = useState<ErrorResponse>({ message: '' });
-
   const getTabClassName = (tabName: PickerTabType) => {
     return `${styles.resourcePickerPopoverTab} ${activePicker === tabName && styles.resourcePickerPopoverActiveTab}`;
   };
-
   const renderFolderPicker = () => (
     <FolderPickerTab
       value={value}
@@ -61,7 +52,6 @@ export const ResourcePickerPopover = (props: Props) => {
       maxFiles={maxFiles}
     />
   );
-
   const renderURLPicker = () => <URLPickerTab newValue={newValue} setNewValue={setNewValue} mediaType={mediaType} />;
   const renderUploader = () => (
     <FileUploader
@@ -84,7 +74,6 @@ export const ResourcePickerPopover = (props: Props) => {
         return renderFolderPicker();
     }
   };
-
   return (
     <FocusScope contain autoFocus restoreFocus>
       <section ref={ref} {...overlayProps} {...dialogProps}>
@@ -129,7 +118,7 @@ export const ResourcePickerPopover = (props: Props) => {
                           .then(() => onChange(`${config.appUrl}api/storage/read/${data.path}`))
                           .then(() => hidePopper?.());
                       })
-                      .catch((err) => console.error(err));
+                      .catch((err) => structLog('error', err));
                   } else {
                     onChange(newValue);
                     hidePopper?.();
@@ -145,7 +134,6 @@ export const ResourcePickerPopover = (props: Props) => {
     </FocusScope>
   );
 };
-
 const getStyles = (theme: GrafanaTheme2) => ({
   resourcePickerPopover: css({
     borderRadius: theme.shape.radius.default,
@@ -162,12 +150,10 @@ const getStyles = (theme: GrafanaTheme2) => ({
     fontSize: theme.typography.bodySmall.fontSize,
     cursor: 'pointer',
     border: 'none',
-
     '&:focus:not(:focus-visible)': {
       outline: 'none',
       boxShadow: 'none',
     },
-
     ':focus-visible': {
       position: 'relative',
     },

--- a/public/app/features/explore/Logs/LogsMetaRow.tsx
+++ b/public/app/features/explore/Logs/LogsMetaRow.tsx
@@ -1,7 +1,7 @@
+import { structLog } from '@grafana/data';
 import { css } from '@emotion/css';
 import { useBooleanFlagValue } from '@openfeature/react-sdk';
 import { memo } from 'react';
-
 import {
   LogsDedupStrategy,
   type LogsMetaItem,
@@ -15,14 +15,11 @@ import {
 import { Trans, t } from '@grafana/i18n';
 import { config, reportInteraction } from '@grafana/runtime';
 import { Button, Dropdown, Menu, ToolbarButton, useStyles2 } from '@grafana/ui';
-
 import { LogLabels, LogLabelsList, type Props as LogLabelsProps } from '../../logs/components/LogLabels';
 import { DownloadFormat, downloadLogs } from '../../logs/utils';
 import { MetaInfoText, type MetaItemProps } from '../MetaInfoText';
-
 import { type LogsVisualisationType } from './constants';
 import { SETTINGS_KEYS } from './utils/logs';
-
 const getStyles = () => ({
   metaContainer: css({
     flex: 1,
@@ -34,7 +31,6 @@ const getStyles = () => ({
     },
   }),
 });
-
 export type Props = {
   meta: LogsMetaItem[];
   dedupStrategy: LogsDedupStrategy;
@@ -45,7 +41,6 @@ export type Props = {
   defaultDisplayedFields: string[];
   visualisationType: LogsVisualisationType;
 };
-
 export const LogsMetaRow = memo(
   ({
     meta,
@@ -60,9 +55,7 @@ export const LogsMetaRow = memo(
     const style = useStyles2(getStyles);
     const logsPanelControlsEnabled = useBooleanFlagValue('logsPanelControls', true);
     const newLogsPanelEnabled = useBooleanFlagValue('newLogsPanel', true);
-
     const logsMetaItem: Array<LogsMetaItem | MetaItemProps> = [...meta];
-
     // Add deduplication info
     if (dedupStrategy !== LogsDedupStrategy.none) {
       logsMetaItem.push({
@@ -71,7 +64,6 @@ export const LogsMetaRow = memo(
         kind: LogsMetaKind.Number,
       });
     }
-
     // Add detected fields info
     if (
       visualisationType === 'logs' &&
@@ -93,7 +85,6 @@ export const LogsMetaRow = memo(
         }
       );
     }
-
     function download(format: DownloadFormat) {
       reportInteraction('grafana_logs_download_logs_clicked', {
         app: CoreApp.Explore,
@@ -102,7 +93,6 @@ export const LogsMetaRow = memo(
       });
       downloadLogs(format, logRows, meta);
     }
-
     const downloadMenu = (
       <Menu>
         {/* eslint-disable-next-line @grafana/i18n/no-untranslated-strings */}
@@ -113,17 +103,14 @@ export const LogsMetaRow = memo(
         <Menu.Item label="csv" onClick={() => download(DownloadFormat.CSV)} />
       </Menu>
     );
-
     const onCommonLabelsToggle = (state: boolean) => {
       store.set(SETTINGS_KEYS.commonLabels, state);
     };
-
     const commonLabelsProps = {
       onDisplayMaxToggle: onCommonLabelsToggle,
       displayMax: 3,
       displayAll: store.getBool(SETTINGS_KEYS.commonLabels, false),
     };
-
     return (
       <>
         {logsMetaItem && (
@@ -149,9 +136,7 @@ export const LogsMetaRow = memo(
     );
   }
 );
-
 LogsMetaRow.displayName = 'LogsMetaRow';
-
 function renderMetaItem(value: string | number | Labels, kind: LogsMetaKind, logLabelsProps: Partial<LogLabelsProps>) {
   if (typeof value === 'string' || typeof value === 'number') {
     return <>{value}</>;
@@ -162,6 +147,6 @@ function renderMetaItem(value: string | number | Labels, kind: LogsMetaKind, log
   if (kind === LogsMetaKind.Error) {
     return <span className="logs-meta-item__error">{value.toString()}</span>;
   }
-  console.error(`Meta type ${typeof value} ${value} not recognized.`);
+  structLog('error', `Meta type ${typeof value} ${value} not recognized.`);
   return <></>;
 }

--- a/public/app/features/explore/Logs/LogsTableWrap.tsx
+++ b/public/app/features/explore/Logs/LogsTableWrap.tsx
@@ -1,7 +1,7 @@
+import { structLog } from '@grafana/data';
 import { css } from '@emotion/css';
 import { Resizable, type ResizeCallback } from 're-resizable';
 import { useCallback, useEffect, useMemo, useState } from 'react';
-
 import {
   type AbsoluteTimeRange,
   type DataFrame,
@@ -24,10 +24,8 @@ import { getFieldSelectorWidth } from 'app/features/logs/components/fieldSelecto
 import { getSuggestedFieldsFromTable } from 'app/features/logs/components/fieldSelector/getSuggestedFieldsFromTable';
 import { reportInteractionOnce } from 'app/features/logs/components/panel/analytics';
 import { parseLogsFrame } from 'app/features/logs/logsFrame';
-
 import { LogsTable } from './LogsTable';
 import { SETTING_KEY_ROOT } from './utils/logs';
-
 interface Props {
   logsFrames: DataFrame[];
   width: number;
@@ -45,45 +43,35 @@ interface Props {
   absoluteRange?: AbsoluteTimeRange;
   logRows?: LogRowModel[];
 }
-
 type ActiveFieldMeta = {
   active: false;
   index: undefined; // if undefined the column is not selected
 };
-
 type InactiveFieldMeta = {
   active: true;
   index: number; // if undefined the column is not selected
 };
-
 type GenericMeta = {
   percentOfLinesWithLabel: number;
   type?: 'BODY_FIELD' | 'TIME_FIELD';
 };
-
 export type FieldNameMeta = (InactiveFieldMeta | ActiveFieldMeta) & GenericMeta;
-
 type FieldName = string;
 export type FieldNameMetaStore = Record<FieldName, FieldNameMeta>;
-
 export function LogsTableWrap(props: Props) {
   const { logsFrames, updatePanelState, panelState } = props;
   const propsColumns = panelState?.columns;
   // Save the normalized cardinality of each label
   const [columnsWithMeta, setColumnsWithMeta] = useState<FieldNameMetaStore | undefined>(undefined);
   const dragStyles = useStyles2(getDragStyles);
-
   // Filtered copy of columnsWithMeta that only includes matching results
   const [filteredColumnsWithMeta, setFilteredColumnsWithMeta] = useState<FieldNameMetaStore | undefined>(undefined);
-
   const height = getLogsTableHeight();
   const panelStateRefId = props?.panelState?.refId;
-
   // The current dataFrame containing the refId of the current query
   const [currentDataFrame, setCurrentDataFrame] = useState<DataFrame>(
     logsFrames.find((f) => f.refId === panelStateRefId) ?? logsFrames[0]
   );
-
   const getColumnsFromProps = useCallback(
     (fieldNames: FieldNameMetaStore) => {
       const previouslySelected = props.panelState?.columns;
@@ -99,9 +87,7 @@ export function LogsTableWrap(props: Props) {
     },
     [props.panelState?.columns]
   );
-
   const logsFrame = useMemo(() => parseLogsFrame(currentDataFrame), [currentDataFrame]);
-
   useEffect(() => {
     if (logsFrame?.timeField.name && logsFrame?.bodyField.name && !propsColumns) {
       const defaultColumns = { 0: logsFrame?.timeField.name ?? '', 1: logsFrame?.bodyField.name ?? '' };
@@ -112,7 +98,6 @@ export function LogsTableWrap(props: Props) {
       });
     }
   }, [logsFrame, propsColumns, updatePanelState]);
-
   /**
    * When logs frame updates (e.g. query|range changes), we need to set the selected frame to state
    */
@@ -122,7 +107,6 @@ export function LogsTableWrap(props: Props) {
       setCurrentDataFrame(newFrame);
     }
   }, [logsFrames, panelStateRefId]);
-
   /**
    * Keeps the filteredColumnsWithMeta state in sync with the columnsWithMeta state,
    * which can be updated by explore browser history state changes
@@ -144,7 +128,6 @@ export function LogsTableWrap(props: Props) {
       setFilteredColumnsWithMeta(newFiltered);
     }
   }, [columnsWithMeta, filteredColumnsWithMeta]);
-
   /**
    * when the query results change, we need to update the columnsWithMeta state
    * and reset any local search state
@@ -161,9 +144,7 @@ export function LogsTableWrap(props: Props) {
     const numberOfLogLines = currentDataFrame ? currentDataFrame.length : 0;
     const logsFrame = parseLogsFrame(currentDataFrame);
     const labels = logsFrame?.getLogFrameLabelsAsLabels();
-
     const otherFields = [];
-
     if (logsFrame) {
       otherFields.push(...logsFrame.extraFields.filter((field) => !field?.config?.custom?.hidden));
     }
@@ -176,13 +157,10 @@ export function LogsTableWrap(props: Props) {
     if (logsFrame?.timeField) {
       otherFields.push(logsFrame?.timeField);
     }
-
     // Use a map to dedupe labels and count their occurrences in the logs
     const labelCardinality = new Map<FieldName, FieldNameMeta>();
-
     // What the label state will look like
     let pendingLabelState: FieldNameMetaStore = {};
-
     // If we have labels and log lines
     if (labels?.length && numberOfLogLines) {
       // Iterate through all of Labels
@@ -214,10 +192,8 @@ export function LogsTableWrap(props: Props) {
           }
         });
       });
-
       // Converting the map to an object
       pendingLabelState = Object.fromEntries(labelCardinality);
-
       // Convert count to percent of log lines
       Object.keys(pendingLabelState).forEach((key) => {
         pendingLabelState[key].percentOfLinesWithLabel = normalize(
@@ -226,7 +202,6 @@ export function LogsTableWrap(props: Props) {
         );
       });
     }
-
     // Normalize the other fields
     otherFields.forEach((field) => {
       const isActive = pendingLabelState[field.name]?.active;
@@ -251,12 +226,9 @@ export function LogsTableWrap(props: Props) {
         };
       }
     });
-
     pendingLabelState = getColumnsFromProps(pendingLabelState);
-
     // Get all active columns
     const active = Object.keys(pendingLabelState).filter((key) => pendingLabelState[key].active);
-
     // If nothing is selected, then select the default columns
     if (active.length === 0) {
       if (logsFrame?.bodyField?.name) {
@@ -266,24 +238,23 @@ export function LogsTableWrap(props: Props) {
         pendingLabelState[logsFrame.timeField.name].active = true;
       }
     }
-
     if (logsFrame?.bodyField?.name && logsFrame?.timeField?.name) {
       pendingLabelState[logsFrame.bodyField.name].type = 'BODY_FIELD';
       pendingLabelState[logsFrame.timeField.name].type = 'TIME_FIELD';
     }
-
     setColumnsWithMeta(pendingLabelState);
-
     // The panel state is updated when the user interacts with the multi-select sidebar
   }, [currentDataFrame, getColumnsFromProps]);
-
   const [sidebarWidth, setSidebarWidth] = useState(getFieldSelectorWidth(SETTING_KEY_ROOT));
   const tableWidth = props.width - sidebarWidth;
-
   const styles = useStyles2(getStyles, height, sidebarWidth);
-
   const onSortByChange = useCallback(
-    (sortBy: Array<{ displayName: string; desc?: boolean }>) => {
+    (
+      sortBy: Array<{
+        displayName: string;
+        desc?: boolean;
+      }>
+    ) => {
       // Transform from Table format to URL format - only store the first sort column
       if (sortBy.length > 0) {
         // Defer the Redux dispatch to avoid updating ExploreActions during Table's render cycle
@@ -300,11 +271,9 @@ export function LogsTableWrap(props: Props) {
     },
     [updatePanelState]
   );
-
   if (!columnsWithMeta) {
     return null;
   }
-
   function columnFilterEvent(columnName: string) {
     if (columnsWithMeta) {
       const newState = !columnsWithMeta[columnName]?.active;
@@ -317,7 +286,6 @@ export function LogsTableWrap(props: Props) {
       reportInteraction('grafana_explore_logs_table_column_filter_clicked', event);
     }
   }
-
   const clearSelection = () => {
     const pendingLabelState = { ...columnsWithMeta };
     Object.keys(pendingLabelState).forEach((key) => {
@@ -333,21 +301,16 @@ export function LogsTableWrap(props: Props) {
     });
     setColumnsWithMeta(pendingLabelState);
   };
-
   const reorderColumn = (newColumns: string[]) => {
     const pendingLabelState = { ...columnsWithMeta };
-
     newColumns.forEach((key, index) => {
       pendingLabelState[key].index = index;
     });
-
     // Set local state
     setColumnsWithMeta(pendingLabelState);
-
     // Sync the explore state
     updateExploreState(pendingLabelState);
   };
-
   function updateExploreState(pendingLabelState: FieldNameMetaStore) {
     // Get all active columns and sort by index
     const newColumnsArray = Object.keys(pendingLabelState)
@@ -361,13 +324,11 @@ export function LogsTableWrap(props: Props) {
         }
         return 0;
       });
-
     const newColumns: Record<number, string> = Object.assign(
       {},
       // Get the keys of the object as an array
       newColumnsArray
     );
-
     const defaultColumns = { 0: logsFrame?.timeField.name ?? '', 1: logsFrame?.bodyField.name ?? '' };
     const newPanelState: ExploreLogsPanelState = {
       ...props.panelState,
@@ -377,21 +338,17 @@ export function LogsTableWrap(props: Props) {
       visualisationType: 'table',
       labelFieldName: logsFrame?.getLabelFieldName() ?? undefined,
     };
-
     // Update url state
     updatePanelState(newPanelState);
   }
-
   // Toggle a column on or off when the user interacts with an element in the multi-select sidebar
   const toggleColumn = (columnName: FieldName) => {
     if (!columnsWithMeta || !(columnName in columnsWithMeta)) {
-      console.warn('failed to get column', columnsWithMeta);
+      structLog('warn', 'failed to get column', columnsWithMeta);
       return;
     }
-
     const length = Object.keys(columnsWithMeta).filter((c) => columnsWithMeta[c].active).length;
     const isActive = !columnsWithMeta[columnName].active ? true : undefined;
-
     let pendingLabelState: FieldNameMetaStore;
     if (isActive) {
       pendingLabelState = {
@@ -412,13 +369,10 @@ export function LogsTableWrap(props: Props) {
         },
       };
     }
-
     // Analytics
     columnFilterEvent(columnName);
-
     // Set local state
     setColumnsWithMeta(pendingLabelState);
-
     // If user is currently filtering, update filtered state
     if (filteredColumnsWithMeta) {
       const active = !filteredColumnsWithMeta[columnName]?.active;
@@ -442,13 +396,10 @@ export function LogsTableWrap(props: Props) {
           },
         };
       }
-
       setFilteredColumnsWithMeta(pendingFilteredLabelState);
     }
-
     updateExploreState(pendingLabelState);
   };
-
   const onFrameSelectorChange = (value: SelectableValue<string>) => {
     const matchingDataFrame = logsFrames.find((frame) => frame.refId === value.value);
     if (matchingDataFrame) {
@@ -456,7 +407,6 @@ export function LogsTableWrap(props: Props) {
     }
     props.updatePanelState({ refId: value.value, labelFieldName: logsFrame?.getLabelFieldName() ?? undefined });
   };
-
   const getOnResize: ResizeCallback = (event, direction, ref) => {
     const newSidebarWidth = Number(ref.style.width.slice(0, -2));
     if (!isNaN(newSidebarWidth)) {
@@ -467,7 +417,6 @@ export function LogsTableWrap(props: Props) {
       });
     }
   };
-
   return (
     <>
       <div>
@@ -549,11 +498,9 @@ export function LogsTableWrap(props: Props) {
     </>
   );
 }
-
 const normalize = (value: number, total: number): number => {
   return Math.ceil((100 * value) / total);
 };
-
 function getStyles(theme: GrafanaTheme2, height: number, width: number) {
   return {
     wrapper: css({
@@ -578,7 +525,6 @@ function getStyles(theme: GrafanaTheme2, height: number, width: number) {
     }),
   };
 }
-
 export const getLogsTableHeight = () => {
   // Instead of making the height of the table based on the content (like in the table panel itself), let's try to use the vertical space that is available.
   // Since this table is in explore, we can expect the user to be running multiple queries that return disparate numbers of rows and labels in the same session

--- a/public/app/features/explore/Logs/utils/table/logsTable.ts
+++ b/public/app/features/explore/Logs/utils/table/logsTable.ts
@@ -1,7 +1,7 @@
+import { structLog } from '@grafana/data';
 import { type DataFrame, FieldType, getFieldDisplayName, LogsSortOrder } from '@grafana/data';
 import { type TableSortByFieldState } from '@grafana/schema/dist/esm/common/common.gen';
 import { LOGS_DATAPLANE_TIMESTAMP_NAME } from 'app/features/logs/logsFrame';
-
 function getDefaultSortBy(dataFrame: DataFrame | undefined, logsSortOrder: LogsSortOrder): TableSortByFieldState[] {
   const field = dataFrame?.fields.find((field) => field.type === FieldType.time);
   const timeFieldName = field ? getFieldDisplayName(field) : LOGS_DATAPLANE_TIMESTAMP_NAME;
@@ -12,7 +12,6 @@ function getDefaultSortBy(dataFrame: DataFrame | undefined, logsSortOrder: LogsS
     },
   ];
 }
-
 export const getDefaultTableSortBy = (
   tableSortByDefaultStringFromStorage: string,
   dataFrame: DataFrame | undefined,
@@ -34,9 +33,8 @@ export const getDefaultTableSortBy = (
         return parsed;
       }
     } catch (e) {
-      console.error('failed to parse table sort from local storage!', e);
+      structLog('error', 'failed to parse table sort from local storage!', e);
     }
   }
-
   return getDefaultSortBy(dataFrame, logsSortOrder);
 };

--- a/public/app/features/explore/PrometheusListView/utils/getRawPrometheusListItemsFromDataFrame.ts
+++ b/public/app/features/explore/PrometheusListView/utils/getRawPrometheusListItemsFromDataFrame.ts
@@ -1,11 +1,12 @@
+import { structLog } from '@grafana/data';
 import { type DataFrame, formattedValueToString } from '@grafana/data';
-
 import { type instantQueryRawVirtualizedListData } from '../RawListContainer';
-
-type instantQueryMetricList = { [index: string]: { [index: string]: instantQueryRawVirtualizedListData } };
-
+type instantQueryMetricList = {
+  [index: string]: {
+    [index: string]: instantQueryRawVirtualizedListData;
+  };
+};
 export const RawPrometheusListItemEmptyValue = ' ';
-
 /**
  * transform dataFrame to instantQueryRawVirtualizedListData
  * @param dataFrame
@@ -13,10 +14,8 @@ export const RawPrometheusListItemEmptyValue = ' ';
 export const getRawPrometheusListItemsFromDataFrame = (dataFrame: DataFrame): instantQueryRawVirtualizedListData[] => {
   const metricList: instantQueryMetricList = {};
   const outputList: instantQueryRawVirtualizedListData[] = [];
-
   // Filter out time
   const newFields = dataFrame.fields.filter((field) => !['Time'].includes(field.name));
-
   // Get name from each series
   let metricNames: string[] = newFields.find((field) => field.name === '__name__')?.values ?? [];
   if (!metricNames.length && newFields.length && newFields[0].values.length) {
@@ -24,17 +23,13 @@ export const getRawPrometheusListItemsFromDataFrame = (dataFrame: DataFrame): in
     // Matching the native prometheus UI which appears to only show the permutations of the first field in the query result.
     metricNames = Array(newFields[0].values.length).fill('');
   }
-
   // Get everything that isn't the name from each series
   const metricLabels = dataFrame.fields.filter((field) => !['__name__'].includes(field.name));
-
   metricNames.forEach(function (metric: string, i: number) {
     metricList[metric] = {};
     const formattedMetric: instantQueryRawVirtualizedListData = metricList[metric][i] ?? {};
-
     for (const field of metricLabels) {
       const label = field.name;
-
       if (label !== 'Time') {
         // Initialize the objects
         if (typeof field?.display === 'function') {
@@ -43,7 +38,6 @@ export const getRawPrometheusListItemsFromDataFrame = (dataFrame: DataFrame): in
             formattedMetric[label] = value.numeric.toString(10);
           } else {
             const stringValue = formattedValueToString(value);
-
             if (stringValue) {
               formattedMetric[label] = stringValue;
             } else if (label.includes('Value #')) {
@@ -51,16 +45,14 @@ export const getRawPrometheusListItemsFromDataFrame = (dataFrame: DataFrame): in
             }
           }
         } else {
-          console.warn('Field display method is missing!');
+          structLog('warn', 'Field display method is missing!');
         }
       }
     }
-
     outputList.push({
       ...formattedMetric,
       __name__: metric,
     });
   });
-
   return outputList;
 };

--- a/public/app/features/explore/QueryLibrary/OpenQueryLibraryExposedComponent.tsx
+++ b/public/app/features/explore/QueryLibrary/OpenQueryLibraryExposedComponent.tsx
@@ -1,12 +1,10 @@
+import { structLog } from '@grafana/data';
 import { useCallback } from 'react';
-
 import { t } from '@grafana/i18n';
 import { reportInteraction } from '@grafana/runtime';
 import { type DataQuery } from '@grafana/schema';
 import { ToolbarButton } from '@grafana/ui';
-
 import { useQueryLibraryContext } from './QueryLibraryContext';
-
 interface Props {
   className?: string;
   context?: string;
@@ -18,7 +16,6 @@ interface Props {
   onSelectQuery?(query: DataQuery): void;
   tooltip?: string;
 }
-
 /**
  * EXPOSED COMPONENT (stable): grafana/open-query-library/v1
  *
@@ -73,19 +70,17 @@ export const OpenQueryLibraryExposedComponent = ({
   tooltip = t('query-library.exposed-compoment.tooltip', 'Open Query Library'),
 }: Props) => {
   const { openDrawer, queryLibraryEnabled } = useQueryLibraryContext();
-
   const handleClick = useCallback(() => {
     const options = context ? { context } : undefined;
     openDrawer({ datasourceFilters, onSelectQuery, options, query });
     reportInteraction(`exposed_query_library-${onSelectQuery ? 'load-queries-open' : 'save-queries-open'}`);
   }, [context, datasourceFilters, onSelectQuery, openDrawer, query]);
-
   if (!queryLibraryEnabled) {
-    console.warn(
+    structLog(
+      'warn',
       '[OpenQueryLibraryExposedComponent]: Attempted to use unsupported exposed component. Query library is not enabled.'
     );
     return null;
   }
-
   return <ToolbarButton className={className} variant="canvas" icon={icon} onClick={handleClick} tooltip={tooltip} />;
 };

--- a/public/app/features/explore/TraceView/components/CriticalPath/index.tsx
+++ b/public/app/features/explore/TraceView/components/CriticalPath/index.tsx
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import { structLog } from '@grafana/data';
 import memoizeOne from 'memoize-one';
 
 import { type TraceSpan, type CriticalPathSection, type Trace } from '../types/trace';
@@ -103,8 +104,7 @@ function criticalPathForTrace(trace: Trace) {
       const sanitizedSpanMap = sanitizeOverFlowingChildren(refinedSpanMap);
       criticalPath = computeCriticalPath(sanitizedSpanMap, rootSpanId, criticalPath);
     } catch (error) {
-      /* eslint-disable no-console */
-      console.log('error while computing critical path for a trace', error);
+      structLog('log', 'error while computing critical path for a trace', error);
     }
   }
   return criticalPath;

--- a/public/app/features/explore/TraceView/components/ScrollManager.test.ts
+++ b/public/app/features/explore/TraceView/components/ScrollManager.test.ts
@@ -14,6 +14,7 @@
 
 jest.mock('./scroll-page');
 
+import * as grafanaData from '@grafana/data';
 import ScrollManager, { type Accessors } from './ScrollManager';
 import traceGenerator from './demo/trace-generators';
 import { scrollBy, scrollTo } from './scroll-page';
@@ -74,16 +75,13 @@ describe('ScrollManager', () => {
     });
 
     it('is a noop if an invalid rowPosition is returned by the accessors', () => {
-      // eslint-disable-next-line no-console
-      const oldWarn = console.warn;
-      // eslint-disable-next-line no-console
-      console.warn = () => {};
+      const structLogSpy = jest.spyOn(grafanaData, 'structLog').mockImplementation();
       manager._scrollPast(-2, 1);
+      expect(structLogSpy).toHaveBeenCalledWith('warn', 'Invalid row index');
+      structLogSpy.mockRestore();
       expect(jest.mocked(accessors.getRowPosition).mock.calls.length).toBe(1);
       expect(jest.mocked(accessors.getViewHeight).mock.calls.length).toBe(0);
       expect(jest.mocked(scrollTo).mock.calls.length).toBe(0);
-      // eslint-disable-next-line no-console
-      console.warn = oldWarn;
     });
 
     it('scrolls up with direction is `-1`', () => {

--- a/public/app/features/explore/TraceView/components/ScrollManager.tsx
+++ b/public/app/features/explore/TraceView/components/ScrollManager.tsx
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import { structLog } from '@grafana/data';
+
 import type TNil from './types/TNil';
 import { type TraceSpan, type TraceSpanReference, type Trace } from './types/trace';
 
@@ -105,8 +107,7 @@ export default class ScrollManager {
     const isUp = direction < 0;
     const position = xrs.getRowPosition(rowIndex);
     if (!position) {
-      // eslint-disable-next-line no-console
-      console.warn('Invalid row index');
+      structLog('warn', 'Invalid row index');
       return;
     }
     let { y } = position;

--- a/public/app/features/explore/TraceView/components/TraceTimelineViewer/ListView/index.tsx
+++ b/public/app/features/explore/TraceView/components/TraceTimelineViewer/ListView/index.tsx
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import { structLog } from '@grafana/data';
 import * as React from 'react';
 
 import type TNil from '../../types/TNil';
@@ -387,8 +388,7 @@ export default class ListView extends React.Component<TListViewProps> {
         // use `.getAttribute(...)` instead of `.dataset` for jest / JSDOM
         const itemKey = node.getAttribute('data-item-key');
         if (!itemKey) {
-          // eslint-disable-next-line no-console
-          console.warn('itemKey not found');
+          structLog('warn', 'itemKey not found');
           continue;
         }
         // measure the first child, if it's available, otherwise the node itself

--- a/public/app/features/explore/TraceView/components/model/link-patterns.tsx
+++ b/public/app/features/explore/TraceView/components/model/link-patterns.tsx
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import { structLog } from '@grafana/data';
 import { uniq as _uniq } from 'lodash';
 import memoize from 'lru-memoize';
 
@@ -111,8 +112,7 @@ export function processLinkPattern(pattern: any): ProcessedLinkPattern | null {
       parameters: _uniq(url.parameters.concat(text.parameters)),
     };
   } catch (error) {
-    // eslint-disable-next-line no-console
-    console.error(`Ignoring invalid link pattern: ${error}`, pattern);
+    structLog('error', `Ignoring invalid link pattern: ${error}`, pattern);
     return null;
   }
 }

--- a/public/app/features/explore/TraceView/components/model/transform-trace-data.tsx
+++ b/public/app/features/explore/TraceView/components/model/transform-trace-data.tsx
@@ -15,7 +15,7 @@
 import { isEqual as _isEqual } from 'lodash';
 
 // @ts-ignore
-import { type TraceKeyValuePair } from '@grafana/data';
+import { structLog, type TraceKeyValuePair } from '@grafana/data';
 
 import { getTraceSpanIdsAsTree } from '../selectors/trace';
 import { type TraceResponse, type Trace, type TraceSpan, type TraceProcess } from '../types/trace';
@@ -120,11 +120,9 @@ export default function transformTraceData(data: TraceResponse | undefined): Tra
     // make sure span IDs are unique
     const idCount = spanIdCounts.get(spanID);
     if (idCount != null) {
-      // eslint-disable-next-line no-console
-      console.warn(`Dupe spanID, ${idCount + 1} x ${spanID}`, span, spanMap.get(spanID));
+      structLog('warn', `Dupe spanID, ${idCount + 1} x ${spanID}`, span, spanMap.get(spanID));
       if (_isEqual(span, spanMap.get(spanID))) {
-        // eslint-disable-next-line no-console
-        console.warn('\t two spans with same ID have `isEqual(...) === true`');
+        structLog('warn', '\t two spans with same ID have `isEqual(...) === true`');
       }
       spanIdCounts.set(spanID, idCount + 1);
       spanID = `${spanID}_${idCount}`;

--- a/public/app/features/explore/TraceView/createSpanLink.tsx
+++ b/public/app/features/explore/TraceView/createSpanLink.tsx
@@ -1,3 +1,4 @@
+import { structLog } from '@grafana/data';
 import {
   type DataFrame,
   type DataLink,
@@ -25,13 +26,10 @@ import { getTemplateSrv } from '@grafana/runtime';
 import { type DataQuery } from '@grafana/schema';
 import { Icon } from '@grafana/ui';
 import { getDatasourceSrv } from 'app/features/plugins/datasource_srv';
-
 import { type LokiQuery } from '../../../plugins/datasource/loki/types';
 import { type ExploreFieldLinkModel, getFieldLinksForExplore, getVariableUsageInfo } from '../utils/links';
-
 import { type SpanLinkDef, type SpanLinkFunc, SpanLinkType } from './components/types/links';
 import { type Trace, type TraceSpan, type TraceSpanReference } from './components/types/trace';
-
 /**
  * This is a factory for the link creator. It returns the function mainly so it can return undefined in which case
  * the trace view won't create any links and to capture the datasource and split function making it easier to memoize
@@ -59,10 +57,8 @@ export function createSpanLinkFactory({
   if (!dataFrame) {
     return undefined;
   }
-
   let scopedVars = scopedVarsFromTrace(trace.duration, trace.traceName, trace.traceID);
   const hasLinks = dataFrame.fields.some((f) => Boolean(f.config.links?.length));
-
   const createSpanLinks = legacyCreateSpanLinkFactory(
     splitOpenFn,
     // We need this to make the types happy but for this branch of code it does not matter which field we supply.
@@ -74,10 +70,8 @@ export function createSpanLinkFactory({
     dataFrame,
     dataLinkPostProcessor
   );
-
   return function SpanLink(span: TraceSpan): SpanLinkDef[] | undefined {
     let spanLinks = createSpanLinks(span);
-
     if (hasLinks) {
       scopedVars = {
         ...scopedVars,
@@ -94,7 +88,6 @@ export function createSpanLinkFactory({
         const hasConfiguredPyroscopeDS = profilesDataSourceSettings?.type === 'grafana-pyroscope-datasource';
         const hasPyroscopeProfile = span.tags.some((tag) => tag.key === pyroscopeProfileIdTagKey);
         const shouldCreatePyroscopeLink = hasConfiguredPyroscopeDS && hasPyroscopeProfile;
-
         let links: ExploreFieldLinkModel[] = [];
         fields.forEach((field) => {
           const fieldLinksForExplore = getFieldLinksForExplore({
@@ -107,7 +100,6 @@ export function createSpanLinkFactory({
           });
           links = links.concat(fieldLinksForExplore);
         });
-
         const newSpanLinks: SpanLinkDef[] = links.map((link) => {
           return {
             title: link.title,
@@ -119,19 +111,16 @@ export function createSpanLinkFactory({
             target: link.target,
           };
         });
-
         spanLinks.push.apply(spanLinks, newSpanLinks);
       } catch (error) {
         // It's fairly easy to crash here for example if data source defines wrong interpolation in the data link
-        console.error(error);
+        structLog('error', error);
         return spanLinks;
       }
     }
-
     return spanLinks;
   };
 }
-
 /**
  * Default keys to use when there are no configured tags.
  */
@@ -145,7 +134,6 @@ const defaultKeys = formatDefaultKeys(['cluster', 'hostname', 'namespace', 'pod'
 export const defaultProfilingKeys = formatDefaultKeys(['service.name', 'service.namespace']);
 export const pyroscopeProfileIdTagKey = 'pyroscope.profile.id';
 export const feO11yTagKey = 'gf.feo11y.app.id';
-
 function legacyCreateSpanLinkFactory(
   splitOpenFn: SplitOpen,
   field: Field,
@@ -161,12 +149,10 @@ function legacyCreateSpanLinkFactory(
     logsDataSourceSettings = getDatasourceSrv().getInstanceSettings(traceToLogsOptions.datasourceUid);
   }
   const isSplunkDS = logsDataSourceSettings?.type === 'grafana-splunk-datasource';
-
   let metricsDataSourceSettings: DataSourceInstanceSettings<DataSourceJsonData> | undefined;
   if (traceToMetricsOptions?.datasourceUid) {
     metricsDataSourceSettings = getDatasourceSrv().getInstanceSettings(traceToMetricsOptions.datasourceUid);
   }
-
   return function SpanLink(span: TraceSpan): SpanLinkDef[] {
     scopedVars = {
       ...scopedVars,
@@ -175,7 +161,6 @@ function legacyCreateSpanLinkFactory(
     const links: SpanLinkDef[] = [];
     let query: DataQuery | undefined;
     let tags = '';
-
     // TODO: This should eventually move into specific data sources and added to the data frame as we no longer use the
     //  deprecated blob format and we can map the link easily in data frame.
     if (logsDataSourceSettings && traceToLogsOptions) {
@@ -211,7 +196,6 @@ function legacyCreateSpanLinkFactory(
           query = getQueryForVictoriaLogs(span, traceToLogsOptions, tags, customQuery);
           break;
       }
-
       // query can be false in case the simple UI tag mapping is used but none of them are present in the span.
       // For custom query, this is always defined and we check if the interpolation matched all variables later on.
       if (query) {
@@ -236,7 +220,6 @@ function legacyCreateSpanLinkFactory(
             ),
           },
         };
-
         scopedVars = {
           ...scopedVars,
           __tags: {
@@ -244,7 +227,6 @@ function legacyCreateSpanLinkFactory(
             value: tags,
           },
         };
-
         // Check if all variables are defined and don't show if they aren't. This is usually handled by the
         // getQueryFor* functions but this is for case of custom query supplied by the user.
         if (getVariableUsageInfo(dataLink.internal!.query, scopedVars).allVariablesDefined) {
@@ -257,7 +239,6 @@ function legacyCreateSpanLinkFactory(
             onClickFn: splitOpenFn,
             replaceVariables: getTemplateSrv().replace.bind(getTemplateSrv()),
           });
-
           link =
             (dataFrame &&
               dataLinkPostProcessor?.({
@@ -270,7 +251,6 @@ function legacyCreateSpanLinkFactory(
                 linkModel: link,
               })) ||
             link;
-
           links.push({
             href: link.href,
             linkModel: link,
@@ -291,7 +271,6 @@ function legacyCreateSpanLinkFactory(
         }
       }
     }
-
     // Get metrics links
     if (metricsDataSourceSettings && traceToMetricsOptions?.queries) {
       for (const query of traceToMetricsOptions.queries) {
@@ -310,12 +289,10 @@ function legacyCreateSpanLinkFactory(
             },
           },
         };
-
         const tagsToUse =
           traceToMetricsOptions.tags && traceToMetricsOptions.tags.length > 0
             ? traceToMetricsOptions.tags
             : defaultKeys;
-
         scopedVars = {
           ...scopedVars,
           __tags: {
@@ -323,7 +300,6 @@ function legacyCreateSpanLinkFactory(
             value: getFormattedTags(span, tagsToUse),
           },
         };
-
         const link = mapInternalLinkToExplore({
           link: dataLink,
           internalLink: dataLink.internal!,
@@ -340,7 +316,6 @@ function legacyCreateSpanLinkFactory(
           onClickFn: splitOpenFn,
           replaceVariables: getTemplateSrv().replace.bind(getTemplateSrv()),
         });
-
         links.push({
           title: query?.name,
           href: link.href,
@@ -359,7 +334,6 @@ function legacyCreateSpanLinkFactory(
         });
       }
     }
-
     // Get trace links
     if (span.references && createFocusSpanLink) {
       for (const reference of span.references) {
@@ -367,10 +341,8 @@ function legacyCreateSpanLinkFactory(
         if (reference.refType === 'CHILD_OF') {
           continue;
         }
-
         const link = createFocusSpanLink(reference.traceID, reference.spanID);
         const title = getReferenceTitle(reference);
-
         links!.push({
           href: link.href,
           linkModel: link,
@@ -382,12 +354,10 @@ function legacyCreateSpanLinkFactory(
         });
       }
     }
-
     if (span.subsidiarilyReferencedBy && createFocusSpanLink) {
       for (const reference of span.subsidiarilyReferencedBy) {
         const link = createFocusSpanLink(reference.traceID, reference.spanID);
         const title = getReferenceTitle(reference);
-
         links!.push({
           href: link.href,
           title,
@@ -398,7 +368,6 @@ function legacyCreateSpanLinkFactory(
         });
       }
     }
-
     // Get session links
     const feO11yLink = getLinkForFeO11y(span);
     if (feO11yLink) {
@@ -415,11 +384,9 @@ function legacyCreateSpanLinkFactory(
         type: SpanLinkType.Session,
       });
     }
-
     return links;
   };
 }
-
 const getReferenceTitle = (reference: TraceSpanReference) => {
   let title = reference.span ? reference.span.operationName : 'View linked span';
   if (reference.refType === 'EXTERNAL') {
@@ -427,7 +394,6 @@ const getReferenceTitle = (reference: TraceSpanReference) => {
   }
   return title;
 };
-
 function getQueryForLoki(
   span: TraceSpan,
   options: TraceToLogsOptionsV2,
@@ -435,15 +401,12 @@ function getQueryForLoki(
   customQuery?: string
 ): LokiQuery | undefined {
   const { filterByTraceID, filterBySpanID } = options;
-
   if (customQuery) {
     return { expr: customQuery, refId: '' };
   }
-
   if (!tags) {
     return undefined;
   }
-
   let expr = '{${__tags}}';
   if (filterByTraceID && span.traceID) {
     expr +=
@@ -453,22 +416,18 @@ function getQueryForLoki(
     expr +=
       ' | label_format log_line_contains_span_id=`{{ contains "${__span.spanId}" __line__  }}` | log_line_contains_span_id="true" or span_id="${__span.spanId}"';
   }
-
   return {
     expr: expr,
     refId: '',
   };
 }
-
 function getLinkForFeO11y(span: TraceSpan): string | undefined {
   const feO11yAppId = span.process.tags.find((tag) => tag.key === feO11yTagKey)?.value;
   const feO11ySessionId = span.tags.find((tag) => tag.key === 'session_id' || tag.key === 'session.id')?.value;
-
   return feO11yAppId && feO11ySessionId
     ? `/a/grafana-kowalski-app/apps/${feO11yAppId}/sessions/${feO11ySessionId}`
     : undefined;
 }
-
 // we do not have access to the dataquery type for opensearch,
 // so here is a minimal interface that handles both elasticsearch and opensearch.
 interface ElasticsearchOrOpensearchQuery extends DataQuery {
@@ -478,7 +437,6 @@ interface ElasticsearchOrOpensearchQuery extends DataQuery {
     type: 'logs';
   }>;
 }
-
 function getQueryForElasticsearchOrOpensearch(
   span: TraceSpan,
   options: TraceToLogsOptionsV2,
@@ -493,34 +451,27 @@ function getQueryForElasticsearchOrOpensearch(
       metrics: [{ id: '1', type: 'logs' }],
     };
   }
-
   let queryArr = [];
   if (filterBySpanID && span.spanID) {
     queryArr.push('"${__span.spanId}"');
   }
-
   if (filterByTraceID && span.traceID) {
     queryArr.push('"${__span.traceId}"');
   }
-
   if (tags) {
     queryArr.push('${__tags}');
   }
-
   return {
     query: queryArr.join(' AND '),
     refId: '',
     metrics: [{ id: '1', type: 'logs' }],
   };
 }
-
 function getQueryForSplunk(span: TraceSpan, options: TraceToLogsOptionsV2, tags: string, customQuery?: string) {
   const { filterByTraceID, filterBySpanID } = options;
-
   if (customQuery) {
     return { query: customQuery, refId: '' };
   }
-
   let query = '';
   if (tags) {
     query += '${__tags}';
@@ -531,13 +482,11 @@ function getQueryForSplunk(span: TraceSpan, options: TraceToLogsOptionsV2, tags:
   if (filterBySpanID && span.spanID) {
     query += ' "${__span.spanId}"';
   }
-
   return {
     query: query,
     refId: '',
   };
 }
-
 function getQueryForGoogleCloudLogging(
   span: TraceSpan,
   options: TraceToLogsOptionsV2,
@@ -545,59 +494,47 @@ function getQueryForGoogleCloudLogging(
   customQuery?: string
 ) {
   const { filterByTraceID, filterBySpanID } = options;
-
   if (customQuery) {
     return { query: customQuery, refId: '' };
   }
-
   let queryArr = [];
   if (filterBySpanID && span.spanID) {
     queryArr.push('"${__span.spanId}"');
   }
-
   if (filterByTraceID && span.traceID) {
     queryArr.push('"${__span.traceId}"');
   }
-
   if (tags) {
     queryArr.push('${__tags}');
   }
-
   return {
     query: queryArr.join(' AND '),
     refId: '',
   };
 }
-
 function getQueryForFalconLogScale(span: TraceSpan, options: TraceToLogsOptionsV2, tags: string, customQuery?: string) {
   const { filterByTraceID, filterBySpanID } = options;
-
   if (customQuery) {
     return {
       lsql: customQuery,
       refId: '',
     };
   }
-
   if (!tags) {
     return undefined;
   }
-
   let lsql = '${__tags}';
   if (filterByTraceID && span.traceID) {
     lsql += ' or "${__span.traceId}"';
   }
-
   if (filterBySpanID && span.spanID) {
     lsql += ' or "${__span.spanId}"';
   }
-
   return {
     lsql,
     refId: '',
   };
 }
-
 /**
  * Builds a LogsQL expression for victoria‑metrics‑logs‑datasource.
  * Uses := for exact‑match filters and joins parts with AND.
@@ -605,7 +542,6 @@ function getQueryForFalconLogScale(span: TraceSpan, options: TraceToLogsOptionsV
  */
 function getQueryForVictoriaLogs(span: TraceSpan, options: TraceToLogsOptionsV2, tags: string, customQuery?: string) {
   const { filterByTraceID, filterBySpanID } = options;
-
   // Custom user query has priority
   if (customQuery) {
     return {
@@ -613,9 +549,7 @@ function getQueryForVictoriaLogs(span: TraceSpan, options: TraceToLogsOptionsV2,
       refId: '',
     };
   }
-
   const parts: string[] = [];
-
   if (filterBySpanID && span.spanID) {
     parts.push('span_id:="${__span.spanId}"');
   }
@@ -625,18 +559,15 @@ function getQueryForVictoriaLogs(span: TraceSpan, options: TraceToLogsOptionsV2,
   if (tags) {
     parts.push('${__tags}');
   }
-
   // Nothing to match against – do not create the link
   if (!parts.length) {
     return undefined;
   }
-
   return {
     expr: parts.join(' AND '),
     refId: '',
   };
 }
-
 /**
  * Creates a string representing all the tags already formatted for use in the query. The tags are filtered so that
  * only intersection of tags that exist in a span and tags that you want are serialized into the string.
@@ -644,7 +575,13 @@ function getQueryForVictoriaLogs(span: TraceSpan, options: TraceToLogsOptionsV2,
 export function getFormattedTags(
   span: TraceSpan,
   tags: TraceToLogsTag[],
-  { labelValueSign = '=', joinBy = ', ' }: { labelValueSign?: string; joinBy?: string } = {}
+  {
+    labelValueSign = '=',
+    joinBy = ', ',
+  }: {
+    labelValueSign?: string;
+    joinBy?: string;
+  } = {}
 ) {
   // In order, try to use mapped tags -> tags -> default tags
   // Build tag portion of query
@@ -666,20 +603,21 @@ export function getFormattedTags(
     .filter((v) => Boolean(v))
     .join(joinBy);
 }
-
 /**
  * Gets a time range from the span.
  */
 function getTimeRangeFromSpan(
   span: TraceSpan,
-  timeShift: { startMs: number; endMs: number } = { startMs: 0, endMs: 0 },
+  timeShift: {
+    startMs: number;
+    endMs: number;
+  } = { startMs: 0, endMs: 0 },
   isSplunkDS = false,
   shouldCreatePyroscopeLink = false
 ): TimeRange {
   let adjustedStartTime = Math.floor(span.startTime / 1000 + timeShift.startMs);
   const spanEndMs = (span.startTime + span.duration) / 1000;
   let adjustedEndTime = Math.floor(spanEndMs + timeShift.endMs);
-
   // Splunk requires a time interval of >= 1s, rather than >=1ms like Loki timerange in below elseif block
   if (isSplunkDS && adjustedEndTime - adjustedStartTime < 1000) {
     adjustedEndTime = adjustedStartTime + 1000;
@@ -691,10 +629,8 @@ function getTimeRangeFromSpan(
     // We need end time to be later than start time
     adjustedEndTime++;
   }
-
   const to = dateTime(adjustedEndTime);
   const from = dateTime(adjustedStartTime);
-
   // Beware that public/app/features/explore/state/main.ts SplitOpen fn uses the range from here. No matter what is in the url.
   return {
     from,
@@ -705,7 +641,6 @@ function getTimeRangeFromSpan(
     },
   };
 }
-
 /**
  * Variables from trace that can be used in the query
  * @param trace
@@ -722,14 +657,12 @@ export function scopedVarsFromTrace(duration: number, name: string, traceId: str
     },
   };
 }
-
 /**
  * Variables from span that can be used in the query
  * @param span
  */
 export function scopedVarsFromSpan(span: TraceSpan): ScopedVars {
   const tags: ScopedVars = {};
-
   // We put all these tags together similar way we do for the __tags variable. This means there can be some overriding
   // of values if there is the same tag in both process tags and span tags.
   for (const tag of span.process.tags) {
@@ -738,7 +671,6 @@ export function scopedVarsFromSpan(span: TraceSpan): ScopedVars {
   for (const tag of span.tags) {
     tags[tag.key] = tag.value;
   }
-
   return {
     __span: {
       text: t('explore.scoped-vars-from-span.text.span', 'Span'),
@@ -752,7 +684,6 @@ export function scopedVarsFromSpan(span: TraceSpan): ScopedVars {
     },
   };
 }
-
 /**
  * Variables from tags that can be used in the query
  * @param span
@@ -762,13 +693,11 @@ export function scopedVarsFromTags(
   traceToProfilesOptions: TraceToProfilesOptions | undefined
 ): ScopedVars {
   let tags: ScopedVars = {};
-
   if (traceToProfilesOptions) {
     const profileTags =
       traceToProfilesOptions.tags && traceToProfilesOptions.tags.length > 0
         ? traceToProfilesOptions.tags
         : defaultProfilingKeys;
-
     tags = {
       __tags: {
         text: t('explore.scoped-vars-from-tags.text.tags', 'Tags'),
@@ -776,6 +705,5 @@ export function scopedVarsFromTags(
       },
     };
   }
-
   return tags;
 }

--- a/public/app/features/explore/hooks/useExplorePageContext.ts
+++ b/public/app/features/explore/hooks/useExplorePageContext.ts
@@ -1,36 +1,30 @@
+import { structLog } from '@grafana/data';
 import { useEffect } from 'react';
-
 import { createAssistantContextItem, type ChatContextItem, useProvidePageContext } from '@grafana/assistant';
 import { type DataSourceApi } from '@grafana/data';
 import { getDataSourceSrv } from '@grafana/runtime';
 import { type DataQuery } from '@grafana/schema';
 import { type ExploreItemState } from 'app/types/explore';
-
 export function useExplorePageContext(panes: Array<[string, ExploreItemState]>): void {
   const setContext = useProvidePageContext(/^\/explore/);
-
   useEffect(() => {
     setContext(buildContext(panes));
   }, [panes, setContext]);
 }
-
 function buildContext(panes: Array<[string, ExploreItemState]>): ChatContextItem[] {
   return panes.flatMap(([, pane]) => {
     const ds = pane.datasourceInstance;
     if (!ds) {
       return [];
     }
-
     // if `-- Mixed --` datasource, we add each data source individual
     if (ds.meta.mixed) {
       return buildMixedContext(pane.queries);
     }
-
     const matchingQueries = pane.queries.filter((q) => !q.datasource?.uid || q.datasource.uid === ds.uid);
     return buildDatasourceContext(ds.uid, ds.name, ds.meta?.info?.logos?.small, matchingQueries, ds);
   });
 }
-
 function buildMixedContext(queries: DataQuery[]): ChatContextItem[] {
   const grouped = new Map<string, DataQuery[]>();
   for (const query of queries) {
@@ -45,7 +39,6 @@ function buildMixedContext(queries: DataQuery[]): ChatContextItem[] {
       grouped.set(uid, [query]);
     }
   }
-
   const items: ChatContextItem[] = [];
   for (const [uid, dsQueries] of grouped) {
     const settings = getDataSourceSrv().getInstanceSettings(uid);
@@ -56,7 +49,6 @@ function buildMixedContext(queries: DataQuery[]): ChatContextItem[] {
   }
   return items;
 }
-
 function buildDatasourceContext(
   uid: string,
   name: string,
@@ -65,7 +57,6 @@ function buildDatasourceContext(
   ds?: DataSourceApi
 ): ChatContextItem[] {
   const items: ChatContextItem[] = [createAssistantContextItem('datasource', { datasourceUid: uid, img })];
-
   const nonEmptyQueries = queries.filter((q) => !isQueryEmpty(q, ds));
   if (nonEmptyQueries.length > 0) {
     items.push(
@@ -77,10 +68,8 @@ function buildDatasourceContext(
       })
     );
   }
-
   return items;
 }
-
 // maintain these field lists to avoid passing full query objects to the assistant.
 const EXPRESSION_FIELDS = new Set(['expr', 'expression', 'query', 'rawSql', 'rawQuery']);
 const METADATA_FIELDS = new Set([
@@ -93,25 +82,21 @@ const METADATA_FIELDS = new Set([
   'maxLines',
   'direction',
 ]);
-
 /** Safely calls ds.getQueryDisplayText, returning undefined if unavailable or on error. */
 function getDisplayText(query: DataQuery, ds?: DataSourceApi): string | undefined {
   try {
     return ds?.getQueryDisplayText?.(query);
   } catch (error) {
-    console.error(error);
+    structLog('error', error);
     return undefined;
   }
 }
-
 function summarizeQuery(query: DataQuery, ds?: DataSourceApi): Record<string, unknown> {
   const summary: Record<string, unknown> = { refId: query.refId };
-
   const displayText = getDisplayText(query, ds);
   if (displayText) {
     summary.expression = displayText;
   }
-
   for (const [key, value] of Object.entries(query)) {
     if (!summary.expression && EXPRESSION_FIELDS.has(key) && value) {
       summary.expression = value;
@@ -120,10 +105,8 @@ function summarizeQuery(query: DataQuery, ds?: DataSourceApi): Record<string, un
       summary[key] = value;
     }
   }
-
   return summary;
 }
-
 function isQueryEmpty(query: DataQuery, ds?: DataSourceApi): boolean {
   const displayText = getDisplayText(query, ds);
   if (displayText?.trim()) {

--- a/public/app/features/explore/state/correlations.ts
+++ b/public/app/features/explore/state/correlations.ts
@@ -1,5 +1,5 @@
+import { structLog } from '@grafana/data';
 import { Observable } from 'rxjs';
-
 import { type DataLinkTransformationConfig } from '@grafana/data';
 import { type CorrelationData, getDataSourceSrv, reportInteraction } from '@grafana/runtime';
 import { createErrorNotification } from 'app/core/copy/appNotification';
@@ -8,11 +8,9 @@ import { type CreateCorrelationParams } from 'app/features/correlations/types';
 import { createCorrelation, generateDefaultLabel, getCorrelationsFromStorage } from 'app/features/correlations/utils';
 import { store } from 'app/store/store';
 import { type ThunkResult } from 'app/types/store';
-
 import { saveCorrelationsAction } from './explorePane';
 import { splitClose } from './main';
 import { runQueries } from './query';
-
 /**
  * Creates an observable that emits correlations once they are loaded
  */
@@ -34,18 +32,15 @@ export const getCorrelations = (exploreId: string) => {
     }
   });
 };
-
 function reloadCorrelations(exploreId: string): ThunkResult<Promise<void>> {
   return async (dispatch, getState) => {
     const pane = getState().explore!.panes[exploreId]!;
-
     if (pane.datasourceInstance?.uid !== undefined) {
       const correlations = await getCorrelationsFromStorage(dispatch, pane.queries, pane.datasourceInstance.uid);
       dispatch(saveCorrelationsAction({ exploreId, correlations: correlations.correlations || [] }));
     }
   };
 }
-
 export function saveCurrentCorrelation(
   label?: string,
   description?: string,
@@ -64,12 +59,10 @@ export function saveCurrentCorrelation(
     const targetDataSourceRef = targetPane.datasourceInstance?.meta.mixed
       ? targetPane.queries[0].datasource
       : targetPane.datasourceInstance?.getRef();
-
     const [sourceDatasource, targetDatasource] = await Promise.all([
       getDataSourceSrv().get(sourceDatasourceRef),
       getDataSourceSrv().get(targetDataSourceRef),
     ]);
-
     if (sourceDatasource?.uid && targetDatasource?.uid && targetPane.correlationEditorHelperData?.resultField) {
       const correlation: CreateCorrelationParams = {
         sourceUID: sourceDatasource.uid,
@@ -95,7 +88,7 @@ export function saveCurrentCorrelation(
         })
         .catch((err) => {
           dispatch(notifyApp(createErrorNotification('Error creating correlation', err)));
-          console.error(err);
+          structLog('error', err);
         });
     }
   };

--- a/public/app/features/explore/state/query.ts
+++ b/public/app/features/explore/state/query.ts
@@ -1,9 +1,9 @@
+import { structLog } from '@grafana/data';
 import { type AnyAction, createAction, type PayloadAction } from '@reduxjs/toolkit';
 import deepEqual from 'fast-deep-equal';
 import { findLast, flatten, groupBy, head, map, mapValues, snakeCase, zipObject } from 'lodash';
 import { combineLatest, identity, type Observable, of, type SubscriptionLike, type Unsubscribable } from 'rxjs';
 import { mergeMap, throttleTime } from 'rxjs/operators';
-
 import {
   type AbsoluteTimeRange,
   type DataFrame,
@@ -48,7 +48,6 @@ import {
   type SupplementaryQueries,
 } from 'app/types/explore';
 import { createAsyncThunk, type StoreState, type ThunkDispatch, type ThunkResult } from 'app/types/store';
-
 import { createErrorNotification } from '../../../core/copy/appNotification';
 import { runRequest } from '../../query/state/runRequest';
 import { decorateData, decorateWithLogsResult } from '../utils/decorators';
@@ -57,14 +56,12 @@ import {
   storeSupplementaryQueryEnabled,
   supplementaryQueryTypes,
 } from '../utils/supplementaryQueries';
-
 import { getCorrelations } from './correlations';
 import { saveCorrelationsAction } from './explorePane';
 import { addHistoryItem, loadRichHistory } from './history';
 import { changeCorrelationEditorDetails } from './main';
 import { updateTime } from './time';
 import { createCacheKey, filterLogRowsByIndex, getCorrelationsData, getResultsFromCache } from './utils';
-
 /**
  * Derives from explore state if a given Explore pane is waiting for more data to be received
  */
@@ -80,7 +77,6 @@ export const selectIsWaitingForData = (exploreId: string) => {
       : false;
   };
 };
-
 /**
  * Adds a query row after the row with the given index.
  */
@@ -90,7 +86,6 @@ export interface AddQueryRowPayload {
   query: DataQuery;
 }
 export const addQueryRowAction = createAction<AddQueryRowPayload>('explore/addQueryRow');
-
 /**
  * Query change handler for the query row with the given index.
  * If `override` is reset the query modifications and run the queries. Use this to set queries via a link.
@@ -103,7 +98,6 @@ export interface ChangeQueriesPayload {
   };
 }
 export const changeQueriesAction = createAction<ChangeQueriesPayload>('explore/changeQueries');
-
 /**
  * Cancel running queries.
  */
@@ -111,67 +105,56 @@ export interface CancelQueriesPayload {
   exploreId: string;
 }
 export const cancelQueriesAction = createAction<CancelQueriesPayload>('explore/cancelQueries');
-
 export interface QueriesImportedPayload {
   exploreId: string;
   queries: DataQuery[];
 }
 export const queriesImportedAction = createAction<QueriesImportedPayload>('explore/queriesImported');
-
 export interface QueryStoreSubscriptionPayload {
   exploreId: string;
   querySubscription: Unsubscribable;
 }
-
 export const queryStoreSubscriptionAction = createAction<QueryStoreSubscriptionPayload>(
   'explore/queryStoreSubscription'
 );
-
 const setSupplementaryQueryEnabledAction = createAction<{
   exploreId: string;
   type: SupplementaryQueryType;
   enabled: boolean;
 }>('explore/setSupplementaryQueryEnabledAction');
-
 export interface StoreSupplementaryQueryDataProvider {
   exploreId: string;
   dataProvider?: Observable<DataQueryResponse>;
   type: SupplementaryQueryType;
 }
-
 export interface CleanSupplementaryQueryDataProvider {
   exploreId: string;
   type: SupplementaryQueryType;
 }
-
 /**
  * Stores available supplementary query data provider after running the query. Used internally by runQueries().
  */
 export const storeSupplementaryQueryDataProviderAction = createAction<StoreSupplementaryQueryDataProvider>(
   'explore/storeSupplementaryQueryDataProviderAction'
 );
-
 export const cleanSupplementaryQueryDataProviderAction = createAction<CleanSupplementaryQueryDataProvider>(
   'explore/cleanSupplementaryQueryDataProviderAction'
 );
-
-export const cleanSupplementaryQueryAction = createAction<{ exploreId: string; type: SupplementaryQueryType }>(
-  'explore/cleanSupplementaryQueryAction'
-);
-
+export const cleanSupplementaryQueryAction = createAction<{
+  exploreId: string;
+  type: SupplementaryQueryType;
+}>('explore/cleanSupplementaryQueryAction');
 export interface StoreSupplementaryQueryDataSubscriptionPayload {
   exploreId: string;
   dataSubscription?: SubscriptionLike;
   type: SupplementaryQueryType;
 }
-
 /**
  * Stores current logs volume subscription for given explore pane.
  */
 const storeSupplementaryQueryDataSubscriptionAction = createAction<StoreSupplementaryQueryDataSubscriptionPayload>(
   'explore/storeSupplementaryQueryDataSubscriptionAction'
 );
-
 /**
  * Stores data returned by the provider. Used internally by loadSupplementaryQueryData().
  */
@@ -180,13 +163,11 @@ const updateSupplementaryQueryDataAction = createAction<{
   type: SupplementaryQueryType;
   data: DataQueryResponse;
 }>('explore/updateSupplementaryQueryDataAction');
-
 export interface QueryEndedPayload {
   exploreId: string;
   response: ExplorePanelData;
 }
 export const queryStreamUpdatedAction = createAction<QueryEndedPayload>('explore/queryStreamUpdated');
-
 /**
  * Reset queries to the given queries. Any modifications will be discarded.
  */
@@ -195,19 +176,16 @@ export interface SetQueriesPayload {
   queries: DataQuery[];
 }
 export const setQueriesAction = createAction<SetQueriesPayload>('explore/setQueries');
-
 export interface ChangeLoadingStatePayload {
   exploreId: string;
   loadingState: LoadingState;
 }
 export const changeLoadingStateAction = createAction<ChangeLoadingStatePayload>('changeLoadingState');
-
 export interface SetPausedStatePayload {
   exploreId: string;
   isPaused: boolean;
 }
 export const setPausedStateAction = createAction<SetPausedStatePayload>('explore/setPausedState');
-
 export interface ClearLogsPayload {
   exploreId: string;
 }
@@ -221,7 +199,6 @@ export interface ScanStartPayload {
   exploreId: string;
 }
 export const scanStartAction = createAction<ScanStartPayload>('explore/scanStart');
-
 /**
  * Stop any scanning for more results.
  */
@@ -229,7 +206,6 @@ export interface ScanStopPayload {
   exploreId: string;
 }
 export const scanStopAction = createAction<ScanStopPayload>('explore/scanStop');
-
 /**
  * Adds query results to cache.
  * This is currently used to cache last 5 query results for log queries run from logs navigation (pagination).
@@ -240,7 +216,6 @@ export interface AddResultsToCachePayload {
   queryResponse: ExplorePanelData;
 }
 export const addResultsToCacheAction = createAction<AddResultsToCachePayload>('explore/addResultsToCache');
-
 /**
  *  Clears cache.
  */
@@ -248,7 +223,6 @@ export interface ClearCachePayload {
   exploreId: string;
 }
 export const clearCacheAction = createAction<ClearCachePayload>('explore/clearCache');
-
 /**
  * Adds a query row after the row with the given index.
  */
@@ -256,7 +230,6 @@ export function addQueryRow(exploreId: string, index: number): ThunkResult<Promi
   return async (dispatch, getState) => {
     const pane = getState().explore.panes[exploreId]!;
     let datasourceOverride = undefined;
-
     // if we are not in mixed mode, use root datasource
     if (!pane.datasourceInstance?.meta.mixed) {
       datasourceOverride = pane.datasourceInstance?.getRef();
@@ -264,9 +237,7 @@ export function addQueryRow(exploreId: string, index: number): ThunkResult<Promi
       // else try to get the datasource from the last query that defines one, falling back to the default datasource
       datasourceOverride = findLast(pane.queries, (query) => !!query.datasource)?.datasource || undefined;
     }
-
     const query = await generateEmptyQuery(pane.queries, index, datasourceOverride);
-
     dispatch(addQueryRowAction({ exploreId, index, query }));
   };
 }
@@ -277,12 +248,10 @@ export function cancelQueries(exploreId: string): ThunkResult<void> {
   return (dispatch, getState) => {
     dispatch(scanStopAction({ exploreId }));
     dispatch(cancelQueriesAction({ exploreId }));
-
     const supplementaryQueries = getState().explore.panes[exploreId]!.supplementaryQueries;
     // Cancel all data providers
     for (const type of supplementaryQueryTypes) {
       dispatch(cleanSupplementaryQueryDataProviderAction({ exploreId, type }));
-
       // And clear any incomplete data
       if (supplementaryQueries[type]?.data?.state !== LoadingState.Done) {
         dispatch(cleanSupplementaryQueryAction({ exploreId, type }));
@@ -290,14 +259,12 @@ export function cancelQueries(exploreId: string): ThunkResult<void> {
     }
   };
 }
-
 const addDatasourceToQueries = (datasource: DataSourceApi, queries: DataQuery[]) => {
   const dataSourceRef = datasource.getRef();
   return queries.map((query: DataQuery) => {
     return { ...query, datasource: dataSourceRef };
   });
 };
-
 const getImportableQueries = async (
   targetDataSource: DataSourceApi,
   sourceDataSource: DataSourceApi,
@@ -316,7 +283,6 @@ const getImportableQueries = async (
   // add new datasource to queries before returning
   return addDatasourceToQueries(targetDataSource, queriesOut);
 };
-
 export const changeQueries = createAsyncThunk<void, ChangeQueriesPayload>(
   'explore/changeQueries',
   async ({ queries, exploreId, options }, { getState, dispatch }) => {
@@ -326,11 +292,9 @@ export const changeQueries = createAsyncThunk<void, ChangeQueriesPayload>(
     const correlationDetails = getState().explore.correlationEditorDetails;
     const isCorrelationsEditorMode = correlationDetails?.editorMode || false;
     const isLeftPane = Object.keys(getState().explore.panes)[0] === exploreId;
-
     if (!isLeftPane && isCorrelationsEditorMode && !correlationDetails?.queryEditorDirty) {
       dispatch(changeCorrelationEditorDetails({ queryEditorDirty: true }));
     }
-
     for (const newQuery of queries) {
       for (const oldQuery of oldQueries) {
         if (newQuery.refId === oldQuery.refId && newQuery.datasource?.type !== oldQuery.datasource?.type) {
@@ -342,7 +306,6 @@ export const changeQueries = createAsyncThunk<void, ChangeQueriesPayload>(
             queriesImported = true;
           }
         }
-
         if (
           rootUID === MIXED_DATASOURCE_NAME &&
           newQuery.refId === oldQuery.refId &&
@@ -353,19 +316,16 @@ export const changeQueries = createAsyncThunk<void, ChangeQueriesPayload>(
         }
       }
     }
-
     // Importing queries changes the same state, therefore if we are importing queries we don't want to change the state again
     if (!queriesImported) {
       dispatch(changeQueriesAction({ queries, exploreId }));
     }
-
     // if we are removing a query we want to run the remaining ones
     if (queries.length < oldQueries.length) {
       dispatch(runQueries({ exploreId }));
     }
   }
 );
-
 /**
  * Import queries from previous datasource if possible eg Loki and Prometheus have similar query language so the
  * labels part can be reused to get similar data.
@@ -387,7 +347,6 @@ export const importQueries = (
       dispatch(queriesImportedAction({ exploreId, queries }));
       return;
     }
-
     let importedQueries = queries;
     // If going to mixed, keep queries with source datasource
     if (targetDataSource.uid === MIXED_DATASOURCE_NAME) {
@@ -415,32 +374,26 @@ export const importQueries = (
       }
       importedQueries = await getImportableQueries(targetDataSource, sourceDataSource, queriesStartArr);
     }
-
     // this will be the entire imported set, or the single imported query in an array
     let nextQueries = await ensureQueries(importedQueries, targetDataSource.getRef());
-
     if (singleQueryChangeRef !== undefined) {
       // if the query import didn't return a result, there was no ability to import between datasources. Create an empty query for the datasource
       if (importedQueries.length === 0) {
         const dsQuery = await generateEmptyQuery([], undefined, targetDataSource.getRef());
         importedQueries = [dsQuery];
       }
-
       // capture the single imported query, and copy the original set
       const updatedQueryIdx = queries.findIndex((query) => query.refId === singleQueryChangeRef);
       // for single query change, all areas that generate refId do not know about other queries, so just copy the existing refID to the new query
       const changedQuery = { ...nextQueries[0], refId: queries[updatedQueryIdx].refId };
       nextQueries = [...queries];
-
       // replace the changed query
       nextQueries[updatedQueryIdx] = changedQuery;
     }
-
     dispatch(queriesImportedAction({ exploreId, queries: nextQueries }));
     return nextQueries;
   };
 };
-
 /**
  * Action to modify a query given a datasource-specific modifier action.
  * @param exploreId Explore area
@@ -454,22 +407,17 @@ export function modifyQueries(
 ): ThunkResult<void> {
   return async (dispatch, getState) => {
     const state = getState().explore.panes[exploreId]!;
-
     const { queries } = state;
-
     const nextQueriesRaw = await Promise.all(queries.map((query) => modifier({ ...query }, modification)));
-
     const nextQueries = nextQueriesRaw.map((nextQuery, i) => {
       return generateNewKeyAndAddRefIdIfMissing(nextQuery, queries, i);
     });
-
     dispatch(setQueriesAction({ exploreId, queries: nextQueries }));
     if (!modification.preventSubmit) {
       dispatch(runQueries({ exploreId }));
     }
   };
 }
-
 function filterQuery(datasource: DataSourceApi, query: DataQuery) {
   if (datasource.filterQuery && !datasource.filterQuery(query)) {
     return undefined; // if filterQuery is implemented and returns false, do not use query
@@ -477,7 +425,6 @@ function filterQuery(datasource: DataSourceApi, query: DataQuery) {
     return query; // if filterQuery is not implemented or it is and returns true, use it
   }
 }
-
 async function handleHistory(
   dispatch: ThunkDispatch,
   state: ExploreState,
@@ -494,26 +441,22 @@ async function handleHistory(
       }
     })
   );
-
   const filteredQueries = filteredQueriesRes.filter((query): query is DataQuery => !!query);
-
   if (filteredQueries.length > 0) {
     /*
-  Always write to local storage. If query history is enabled, we will use local storage for autocomplete only (and want to hide errors)
-  If query history is disabled, we will use local storage for query history as well, and will want to show errors
-  */
+      Always write to local storage. If query history is enabled, we will use local storage for autocomplete only (and want to hide errors)
+      If query history is disabled, we will use local storage for query history as well, and will want to show errors
+      */
     dispatch(addHistoryItem(true, datasource.uid, datasource.name, filteredQueries, config.queryHistoryEnabled));
     if (config.queryHistoryEnabled) {
       // write to remote if flag enabled
       dispatch(addHistoryItem(false, datasource.uid, datasource.name, filteredQueries, false));
     }
-
     // Because filtering happens in the backend we cannot add a new entry without checking if it matches currently
     // used filters. Instead, we refresh the query history list.
     await dispatch(loadRichHistory());
   }
 }
-
 interface RunQueriesOptions {
   exploreId: string;
   preserveCache?: boolean;
@@ -528,20 +471,16 @@ export const runQueries = createAsyncThunk<void, RunQueriesOptions>(
     if (!getState().explore?.panes[exploreId]?.scanning) {
       dispatch(cancelQueries(exploreId));
     }
-
     const { defaultCorrelationEditorDatasource, scopedVars, showCorrelationEditorLinks } = await getCorrelationsData(
       getState(),
       exploreId
     );
     const correlations$ = getCorrelations(exploreId);
-
     dispatch(updateTime({ exploreId }));
-
     // We always want to clear cache unless we explicitly pass preserveCache parameter
     if (preserveCache !== true) {
       dispatch(clearCache(exploreId));
     }
-
     const exploreState = getState();
     const exploreItemState = exploreState.explore.panes[exploreId]!;
     const {
@@ -557,21 +496,16 @@ export const runQueries = createAsyncThunk<void, RunQueriesOptions>(
       cache,
       supplementaryQueries,
     } = exploreItemState;
-
     let newQuerySource: Observable<ExplorePanelData>;
     let newQuerySubscription: SubscriptionLike;
-
     const queries = exploreItemState.queries.map((query) => ({
       ...query,
       datasource: query.datasource || datasourceInstance?.getRef(),
     }));
-
     if (datasourceInstance != null) {
       handleHistory(dispatch, getState().explore, datasourceInstance, queries);
     }
-
     const cachedValue = getResultsFromCache(cache, absoluteRange);
-
     // If we have results saved in cache, we are going to use those results instead of running queries
     if (cachedValue) {
       newQuerySource = combineLatest([of(cachedValue), correlations$]).pipe(
@@ -587,23 +521,18 @@ export const runQueries = createAsyncThunk<void, RunQueriesOptions>(
           )
         )
       );
-
       newQuerySubscription = newQuerySource.subscribe((data) => {
         dispatch(queryStreamUpdatedAction({ exploreId, response: data }));
       });
-
       // If we don't have results saved in cache, run new queries
     } else {
       if (!hasNonEmptyQuery(queries) || !datasourceInstance) {
         return;
       }
-
       // Some datasource's query builders allow per-query interval limits,
       // but we're using the datasource interval limit for now
       const minInterval = datasourceInstance?.interval;
-
       stopQueryState(querySubscription);
-
       const queryOptions: QueryOptions = {
         minInterval,
         // maxDataPoints is used in:
@@ -615,7 +544,6 @@ export const runQueries = createAsyncThunk<void, RunQueriesOptions>(
         maxDataPoints: containerWidth,
         liveStreaming: live,
       };
-
       const timeZone = getTimeZone(getState().user);
       const transaction = buildQueryTransaction(
         exploreId,
@@ -626,9 +554,7 @@ export const runQueries = createAsyncThunk<void, RunQueriesOptions>(
         timeZone,
         scopedVars
       );
-
       dispatch(changeLoadingStateAction({ exploreId, loadingState: LoadingState.Loading }));
-
       newQuerySource = combineLatest([
         runRequest(datasourceInstance, transaction.request)
           // Simple throttle for live tailing, in case of > 1000 rows per interval we spend about 200ms on processing and
@@ -649,15 +575,13 @@ export const runQueries = createAsyncThunk<void, RunQueriesOptions>(
           )
         )
       );
-
       newQuerySubscription = newQuerySource.subscribe({
         next(data) {
           const exploreState = getState().explore.panes[exploreId];
           dispatch(queryStreamUpdatedAction({ exploreId, response: data }));
-
           // Keep scanning for results if this was the last scanning transaction
           if (exploreState!.scanning) {
-            console.log(data.series);
+            structLog('log', data.series);
             if (data.state === LoadingState.Done && data.series.length === 0) {
               const range = getShiftedTimeRange(-1, exploreState!.range);
               dispatch(updateTime({ exploreId, absoluteRange: range }));
@@ -671,7 +595,7 @@ export const runQueries = createAsyncThunk<void, RunQueriesOptions>(
         error(error) {
           dispatch(notifyApp(createErrorNotification('Query processing error', error)));
           dispatch(changeLoadingStateAction({ exploreId, loadingState: LoadingState.Error }));
-          console.error(error);
+          structLog('error', error);
         },
         complete() {
           // In case we don't get any response at all but the observable completed, make sure we stop loading state.
@@ -682,7 +606,6 @@ export const runQueries = createAsyncThunk<void, RunQueriesOptions>(
           }
         },
       });
-
       if (live) {
         for (const type of supplementaryQueryTypes) {
           dispatch(
@@ -707,11 +630,9 @@ export const runQueries = createAsyncThunk<void, RunQueriesOptions>(
         );
       }
     }
-
     dispatch(queryStoreSubscriptionAction({ exploreId, querySubscription: newQuerySubscription }));
   }
 );
-
 interface RunLoadMoreLogsQueriesOptions {
   exploreId: string;
   absoluteRange: AbsoluteTimeRange;
@@ -723,16 +644,13 @@ export const runLoadMoreLogsQueries = createAsyncThunk<void, RunLoadMoreLogsQuer
   'explore/runLoadMoreQueries',
   async ({ exploreId, absoluteRange }, { dispatch, getState }) => {
     dispatch(cancelQueries(exploreId));
-
     const { datasourceInstance, containerWidth, queryResponse } = getState().explore.panes[exploreId]!;
     const { defaultCorrelationEditorDatasource, scopedVars, showCorrelationEditorLinks } = await getCorrelationsData(
       getState(),
       exploreId
     );
     const correlations$ = getCorrelations(exploreId);
-
     let newQuerySource: Observable<ExplorePanelData>;
-
     const queries = queryResponse.logsResult?.queries || [];
     const logRefIds = queryResponse.logsFrames.map((frame) => frame.refId);
     const logQueries = queries
@@ -743,16 +661,13 @@ export const runLoadMoreLogsQueries = createAsyncThunk<void, RunLoadMoreLogsQuer
         refId: query.refId,
         supportingQueryType: SupportingQueryType.InfiniteScroll,
       }));
-
     if (!hasNonEmptyQuery(logQueries) || !datasourceInstance) {
       return;
     }
-
     const queryOptions: QueryOptions = {
       minInterval: datasourceInstance?.interval,
       maxDataPoints: containerWidth,
     };
-
     const timeZone = getTimeZone(getState().user);
     const range = getTimeRange(
       timeZone,
@@ -763,9 +678,7 @@ export const runLoadMoreLogsQueries = createAsyncThunk<void, RunLoadMoreLogsQuer
       getFiscalYearStartMonth(getState().user)
     );
     const transaction = buildQueryTransaction(exploreId, logQueries, queryOptions, range, false, timeZone, scopedVars);
-
     dispatch(changeLoadingStateAction({ exploreId, loadingState: LoadingState.Loading }));
-
     newQuerySource = combineLatest([runRequest(datasourceInstance, transaction.request), correlations$]).pipe(
       mergeMap(([data, correlations]) => {
         // For query splitting, otherwise duplicates results
@@ -785,7 +698,6 @@ export const runLoadMoreLogsQueries = createAsyncThunk<void, RunLoadMoreLogsQuer
         );
       })
     );
-
     newQuerySource.subscribe({
       next(data) {
         dispatch(queryStreamUpdatedAction({ exploreId, response: data }));
@@ -793,7 +705,7 @@ export const runLoadMoreLogsQueries = createAsyncThunk<void, RunLoadMoreLogsQuer
       error(error) {
         dispatch(notifyApp(createErrorNotification('Query processing error', error)));
         dispatch(changeLoadingStateAction({ exploreId, loadingState: LoadingState.Error }));
-        console.error(error);
+        structLog('error', error);
       },
       complete() {
         dispatch(changeLoadingStateAction({ exploreId, loadingState: LoadingState.Done }));
@@ -801,13 +713,13 @@ export const runLoadMoreLogsQueries = createAsyncThunk<void, RunLoadMoreLogsQuer
     });
   }
 );
-
 const groupDataQueries = async (datasources: DataQuery[], scopedVars: ScopedVars) => {
   const nonMixedDataSources = datasources.filter((t) => {
     return t.datasource?.uid !== MIXED_DATASOURCE_NAME;
   });
-  const sets: { [key: string]: DataQuery[] } = groupBy(nonMixedDataSources, 'datasource.uid');
-
+  const sets: {
+    [key: string]: DataQuery[];
+  } = groupBy(nonMixedDataSources, 'datasource.uid');
   return await Promise.all(
     Object.values(sets).map(async (targets) => {
       const datasource = await getDataSourceSrv().get(targets[0].datasource, scopedVars);
@@ -818,7 +730,6 @@ const groupDataQueries = async (datasources: DataQuery[], scopedVars: ScopedVars
     })
   );
 };
-
 type HandleSupplementaryQueriesOptions = {
   exploreId: string;
   transaction: QueryTransaction;
@@ -828,7 +739,6 @@ type HandleSupplementaryQueriesOptions = {
   queries: DataQuery[];
   absoluteRange: AbsoluteTimeRange;
 };
-
 const handleSupplementaryQueries = createAsyncThunk(
   'explore/handleSupplementaryQueries',
   async (
@@ -849,7 +759,6 @@ const handleSupplementaryQueries = createAsyncThunk(
     } else {
       groupedQueries = [{ datasource: datasourceInstance, targets: transaction.request.targets }];
     }
-
     for (const type of supplementaryQueryTypes) {
       // We always prepare provider, even is supplementary query is disabled because when the user
       // enables the query, we need to load the data, so we need the provider
@@ -862,7 +771,6 @@ const handleSupplementaryQueries = createAsyncThunk(
         },
         newQuerySource
       );
-
       if (dataProvider) {
         dispatch(
           storeSupplementaryQueryDataProviderAction({
@@ -871,7 +779,6 @@ const handleSupplementaryQueries = createAsyncThunk(
             dataProvider,
           })
         );
-
         if (!canReuseSupplementaryQueryData(supplementaryQueries[type].data, queries, absoluteRange)) {
           dispatch(cleanSupplementaryQueryAction({ exploreId, type }));
           if (supplementaryQueries[type].enabled) {
@@ -890,7 +797,6 @@ const handleSupplementaryQueries = createAsyncThunk(
     }
   }
 );
-
 /**
  * Checks if after changing the time range the existing data can be used to show supplementary query.
  * It can happen if queries are the same and new time range is within existing data time range.
@@ -903,9 +809,7 @@ function canReuseSupplementaryQueryData(
   if (!supplementaryQueryData) {
     return false;
   }
-
   const newQueriesByRefId = zipObject(map(newQueries, 'refId'), newQueries);
-
   const existingDataByRefId = mapValues(
     groupBy(
       supplementaryQueryData.data.map((dataFrame: DataFrame) => dataFrame.meta?.custom?.sourceQuery),
@@ -913,15 +817,12 @@ function canReuseSupplementaryQueryData(
     ),
     head
   );
-
   const allSupportZoomingIn = supplementaryQueryData.data.every((data: DataFrame) => {
     // If log volume is based on returned log lines (i.e. LogsVolumeType.Limited),
     // zooming in may return different results, so we don't want to reuse the data
     return data.meta?.custom?.logsVolumeType === LogsVolumeType.FullRange;
   });
-
   const allQueriesAreTheSame = deepEqual(newQueriesByRefId, existingDataByRefId);
-
   const allResultsHaveWiderRange = supplementaryQueryData.data.every((data: DataFrame) => {
     const dataRange = data.meta?.custom?.absoluteRange;
     // Only first data frame in the response may contain the absolute range
@@ -931,10 +832,8 @@ function canReuseSupplementaryQueryData(
     const hasWiderRange = dataRange && dataRange.from <= selectedTimeRange.from && selectedTimeRange.to <= dataRange.to;
     return hasWiderRange;
   });
-
   return allSupportZoomingIn && allQueriesAreTheSame && allResultsHaveWiderRange;
 }
-
 /**
  * Reset queries to the given queries. Any modifications will be discarded.
  * Use this action for clicks on query examples. Triggers a query run.
@@ -948,7 +847,6 @@ export function setQueries(exploreId: string, rawQueries: DataQuery[]): ThunkRes
     dispatch(runQueries({ exploreId }));
   };
 }
-
 /**
  * Start a scan for more results using the given scanner.
  * @param exploreId Explore area
@@ -965,26 +863,22 @@ export function scanStart(exploreId: string): ThunkResult<void> {
     dispatch(runQueries({ exploreId }));
   };
 }
-
 export function addResultsToCache(exploreId: string): ThunkResult<void> {
   return (dispatch, getState) => {
     const queryResponse = getState().explore.panes[exploreId]!.queryResponse;
     const absoluteRange = getState().explore.panes[exploreId]!.absoluteRange;
     const cacheKey = createCacheKey(absoluteRange);
-
     // Save results to cache only when all results received and loading is done
     if (queryResponse.state === LoadingState.Done) {
       dispatch(addResultsToCacheAction({ exploreId, cacheKey, queryResponse }));
     }
   };
 }
-
 export function clearCache(exploreId: string): ThunkResult<void> {
   return (dispatch, getState) => {
     dispatch(clearCacheAction({ exploreId }));
   };
 }
-
 /**
  * Initializes loading logs volume data and stores emitted value.
  */
@@ -992,7 +886,6 @@ export function loadSupplementaryQueryData(exploreId: string, type: Supplementar
   return (dispatch, getState) => {
     const { supplementaryQueries } = getState().explore.panes[exploreId]!;
     const dataProvider = supplementaryQueries[type].dataProvider;
-
     if (dataProvider) {
       const dataSubscription = dataProvider.subscribe({
         next: (supplementaryQueryData: DataQueryResponse) => {
@@ -1009,7 +902,6 @@ export function loadSupplementaryQueryData(exploreId: string, type: Supplementar
     }
   };
 }
-
 export function setSupplementaryQueryEnabled(
   exploreId: string,
   enabled: boolean,
@@ -1023,11 +915,9 @@ export function setSupplementaryQueryEnabled(
     }
   };
 }
-
 //
 // Reducer
 //
-
 // Redux Toolkit uses ImmerJs as part of their solution to ensure that state objects are not mutated.
 // ImmerJs has an autoFreeze option that freezes objects from change which means this reducer can't be migrated to createSlice
 // because the state would become frozen and during run time we would get errors because flot (Graph lib) would try to mutate
@@ -1037,30 +927,24 @@ export const queryReducer = (state: ExploreItemState, action: AnyAction): Explor
   if (addQueryRowAction.match(action)) {
     const { queries } = state;
     const { index, query } = action.payload;
-
     // Add to queries, which will cause a new row to be rendered
     const nextQueries = [...queries.slice(0, index + 1), { ...query }, ...queries.slice(index + 1)];
-
     return {
       ...state,
       queries: nextQueries,
       queryKeys: getQueryKeys(nextQueries),
     };
   }
-
   if (changeQueriesAction.match(action)) {
     const { queries } = action.payload;
-
     return {
       ...state,
       queriesChangedIndex: state.queriesChangedIndex + 1,
       queries,
     };
   }
-
   if (cancelQueriesAction.match(action)) {
     stopQueryState(state.querySubscription);
-
     return {
       ...state,
       // mark existing request as done (may be incomplete)
@@ -1074,7 +958,6 @@ export const queryReducer = (state: ExploreItemState, action: AnyAction): Explor
         : {}),
     };
   }
-
   if (setQueriesAction.match(action)) {
     const { queries } = action.payload;
     return {
@@ -1083,7 +966,6 @@ export const queryReducer = (state: ExploreItemState, action: AnyAction): Explor
       queryKeys: getQueryKeys(queries),
     };
   }
-
   if (queryStoreSubscriptionAction.match(action)) {
     const { querySubscription } = action.payload;
     return {
@@ -1091,7 +973,6 @@ export const queryReducer = (state: ExploreItemState, action: AnyAction): Explor
       querySubscription,
     };
   }
-
   if (setSupplementaryQueryEnabledAction.match(action)) {
     const { enabled, type } = action.payload;
     const { supplementaryQueries } = state;
@@ -1099,60 +980,49 @@ export const queryReducer = (state: ExploreItemState, action: AnyAction): Explor
     if (!enabled && dataSubscription) {
       dataSubscription.unsubscribe();
     }
-
     const nextSupplementaryQueries: SupplementaryQueries = {
       ...supplementaryQueries,
       // NOTE: the dataProvider is not cleared, we may need it later,
       // if the user re-enables the supplementary query
       [type]: { ...supplementaryQueries[type], enabled, data: undefined },
     };
-
     return {
       ...state,
       supplementaryQueries: nextSupplementaryQueries,
     };
   }
-
   if (storeSupplementaryQueryDataProviderAction.match(action)) {
     const { dataProvider, type } = action.payload;
     const { supplementaryQueries } = state;
     const supplementaryQuery = supplementaryQueries[type];
-
     if (supplementaryQuery?.dataSubscription) {
       supplementaryQuery.dataSubscription.unsubscribe();
     }
-
     const nextSupplementaryQueries = {
       ...supplementaryQueries,
       [type]: { ...supplementaryQuery, dataProvider, dataSubscription: undefined },
     };
-
     return {
       ...state,
       supplementaryQueries: nextSupplementaryQueries,
     };
   }
-
   if (cleanSupplementaryQueryDataProviderAction.match(action)) {
     const { type } = action.payload;
     const { supplementaryQueries } = state;
     const supplementaryQuery = supplementaryQueries[type];
-
     if (supplementaryQuery?.dataSubscription) {
       supplementaryQuery.dataSubscription.unsubscribe();
     }
-
     const nextSupplementaryQueries = {
       ...supplementaryQueries,
       [type]: { ...supplementaryQuery, dataProvider: undefined, dataSubscription: undefined },
     };
-
     return {
       ...state,
       supplementaryQueries: nextSupplementaryQueries,
     };
   }
-
   if (cleanSupplementaryQueryAction.match(action)) {
     const { type } = action.payload;
     const { supplementaryQueries } = state;
@@ -1165,41 +1035,33 @@ export const queryReducer = (state: ExploreItemState, action: AnyAction): Explor
       supplementaryQueries: nextSupplementaryQueries,
     };
   }
-
   if (storeSupplementaryQueryDataSubscriptionAction.match(action)) {
     const { dataSubscription, type } = action.payload;
-
     const { supplementaryQueries } = state;
     const nextSupplementaryQueries = {
       ...supplementaryQueries,
       [type]: { ...supplementaryQueries[type], dataSubscription },
     };
-
     return {
       ...state,
       supplementaryQueries: nextSupplementaryQueries,
     };
   }
-
   if (updateSupplementaryQueryDataAction.match(action)) {
     let { data, type } = action.payload;
     const { supplementaryQueries } = state;
-
     const nextSupplementaryQueries = {
       ...supplementaryQueries,
       [type]: { ...supplementaryQueries[type], data },
     };
-
     return {
       ...state,
       supplementaryQueries: nextSupplementaryQueries,
     };
   }
-
   if (queryStreamUpdatedAction.match(action)) {
     return processQueryResponse(state, action);
   }
-
   if (queriesImportedAction.match(action)) {
     const { queries } = action.payload;
     return {
@@ -1208,7 +1070,6 @@ export const queryReducer = (state: ExploreItemState, action: AnyAction): Explor
       queryKeys: getQueryKeys(queries),
     };
   }
-
   if (changeLoadingStateAction.match(action)) {
     const { loadingState } = action.payload;
     return {
@@ -1219,7 +1080,6 @@ export const queryReducer = (state: ExploreItemState, action: AnyAction): Explor
       },
     };
   }
-
   if (setPausedStateAction.match(action)) {
     const { isPaused } = action.payload;
     return {
@@ -1227,11 +1087,9 @@ export const queryReducer = (state: ExploreItemState, action: AnyAction): Explor
       isPaused: isPaused,
     };
   }
-
   if (scanStartAction.match(action)) {
     return { ...state, scanning: true };
   }
-
   if (scanStopAction.match(action)) {
     return {
       ...state,
@@ -1239,33 +1097,27 @@ export const queryReducer = (state: ExploreItemState, action: AnyAction): Explor
       scanRange: undefined,
     };
   }
-
   if (addResultsToCacheAction.match(action)) {
     const CACHE_LIMIT = 5;
     const { cache } = state;
     const { queryResponse, cacheKey } = action.payload;
-
     let newCache = [...cache];
     const isDuplicateKey = newCache.some((c) => c.key === cacheKey);
-
     if (!isDuplicateKey) {
       const newCacheItem = { key: cacheKey, value: queryResponse };
       newCache = [newCacheItem, ...newCache].slice(0, CACHE_LIMIT);
     }
-
     return {
       ...state,
       cache: newCache,
     };
   }
-
   if (clearCacheAction.match(action)) {
     return {
       ...state,
       cache: [],
     };
   }
-
   if (clearLogs.match(action)) {
     if (!state.logsResult) {
       return {
@@ -1273,7 +1125,6 @@ export const queryReducer = (state: ExploreItemState, action: AnyAction): Explor
         clearedAtIndex: null,
       };
     }
-
     // When in loading state, clear logs and set clearedAtIndex as null.
     // Initially loaded logs will be fully replaced by incoming streamed logs, which may have a different length.
     if (state.queryResponse.state === LoadingState.Loading) {
@@ -1286,11 +1137,9 @@ export const queryReducer = (state: ExploreItemState, action: AnyAction): Explor
         },
       };
     }
-
     const lastItemIndex = state.clearedAtIndex
       ? state.clearedAtIndex + state.logsResult.rows.length
       : state.logsResult.rows.length - 1;
-
     return {
       ...state,
       clearedAtIndex: lastItemIndex,
@@ -1300,10 +1149,8 @@ export const queryReducer = (state: ExploreItemState, action: AnyAction): Explor
       },
     };
   }
-
   return state;
 };
-
 const processQueryResponse = (state: ExploreItemState, action: PayloadAction<QueryEndedPayload>): ExploreItemState => {
   const { response } = action.payload;
   const {
@@ -1319,17 +1166,14 @@ const processQueryResponse = (state: ExploreItemState, action: PayloadAction<Que
     rawPrometheusFrames,
     customFrames,
   } = response;
-
   if (error) {
     if (error.type === DataQueryErrorType.Timeout || error.type === DataQueryErrorType.Cancelled) {
       return { ...state };
     }
   }
-
   if (!request) {
     return { ...state };
   }
-
   return {
     ...state,
     queriesChangedIndexAtRun: state.queriesChangedIndex,

--- a/public/app/features/explore/state/utils.ts
+++ b/public/app/features/explore/state/utils.ts
@@ -1,5 +1,5 @@
+import { structLog } from '@grafana/data';
 import { uniq } from 'lodash';
-
 import {
   type AbsoluteTimeRange,
   type DataSourceApi,
@@ -28,20 +28,15 @@ import { SortOrder } from 'app/core/utils/richHistoryTypes';
 import { MIXED_DATASOURCE_NAME } from 'app/plugins/datasource/mixed/MixedDataSource';
 import { type ExploreItemState, type ExplorePanelData, type RichHistoryQuery } from 'app/types/explore';
 import { type StoreState } from 'app/types/store';
-
 import { setLastUsedDatasourceUID } from '../../../core/utils/explore';
 import { getDatasourceSrv } from '../../plugins/datasource_srv';
 import { loadSupplementaryQueries } from '../utils/supplementaryQueries';
-
 import { DEFAULT_RANGE } from './constants';
-
 export const MAX_HISTORY_AUTOCOMPLETE_ITEMS = 100;
-
 const GRAPH_STYLE_KEY = 'grafana.explore.style.graph';
 export const storeGraphStyle = (graphStyle: string): void => {
   store.set(GRAPH_STYLE_KEY, graphStyle);
 };
-
 /**
  * Returns a fresh Explore area state
  */
@@ -80,7 +75,6 @@ export const makeExplorePaneState = (overrides?: Partial<ExploreItemState>): Exp
   queriesChangedIndexAtRun: 0,
   ...overrides,
 });
-
 export const createEmptyQueryResponse = (): ExplorePanelData => ({
   state: LoadingState.NotStarted,
   series: [],
@@ -98,11 +92,13 @@ export const createEmptyQueryResponse = (): ExplorePanelData => ({
   logsResult: null,
   tableResult: null,
 });
-
 export async function loadAndInitDatasource(
   orgId: number,
   datasource: DataSourceRef | string
-): Promise<{ history: HistoryItem[]; instance: DataSourceApi }> {
+): Promise<{
+  history: HistoryItem[];
+  instance: DataSourceApi;
+}> {
   let instance: DataSourceApi<DataQuery, DataSourceJsonData, {}>;
   try {
     // let datasource be a ref if we have the info, otherwise a name or uid will do for lookup
@@ -118,21 +114,17 @@ export async function loadAndInitDatasource(
       instance.init();
     } catch (err) {
       // TODO: should probably be handled better
-      console.error(err);
+      structLog('error', err);
     }
   }
-
   let history: HistoryItem[] = [];
-
   const localStorageHistory = getLocalRichHistoryStorage();
-
   const historyResults = await localStorageHistory.getRichHistory({
     search: '',
     sortOrder: SortOrder.Ascending,
     datasourceFilters: [instance.name],
     starred: false,
   });
-
   // first, fill autocomplete with query history for that datasource
   if ((historyResults.total || 0) > 0) {
     historyResults.richHistory.forEach((historyResult: RichHistoryQuery) => {
@@ -141,7 +133,6 @@ export async function loadAndInitDatasource(
       });
     });
   }
-
   if (history.length < MAX_HISTORY_AUTOCOMPLETE_ITEMS) {
     // check the last 100 mixed history results seperately
     const historyMixedResults = await localStorageHistory.getRichHistory({
@@ -150,7 +141,6 @@ export async function loadAndInitDatasource(
       datasourceFilters: [MIXED_DATASOURCE_NAME],
       starred: false,
     });
-
     if ((historyMixedResults.total || 0) > 0) {
       // second, fill autocomplete with queries for that datasource used in Mixed scenarios
       historyMixedResults.richHistory.forEach((historyResult: RichHistoryQuery) => {
@@ -162,36 +152,33 @@ export async function loadAndInitDatasource(
       });
     }
   }
-
   // finally, add any legacy local storage history that might exist. To be removed in Grafana 12 #83309
   if (history.length < MAX_HISTORY_AUTOCOMPLETE_ITEMS) {
     const historyKey = `grafana.explore.history.${instance.meta?.id}`;
     history = [...history, ...store.getObject<HistoryItem[]>(historyKey, [])];
   }
-
   if (history.length > MAX_HISTORY_AUTOCOMPLETE_ITEMS) {
     history.length = MAX_HISTORY_AUTOCOMPLETE_ITEMS;
   }
-
   // Save last-used datasource
   setLastUsedDatasourceUID(orgId, instance.uid);
   return { history: history, instance };
 }
-
 export function createCacheKey(absRange: AbsoluteTimeRange) {
   const params = {
     from: absRange.from,
     to: absRange.to,
   };
-
   const cacheKey = Object.entries(params)
     .map(([k, v]) => `${encodeURIComponent(k)}=${encodeURIComponent(v.toString())}`)
     .join('&');
   return cacheKey;
 }
-
 export function getResultsFromCache(
-  cache: Array<{ key: string; value: PanelData }>,
+  cache: Array<{
+    key: string;
+    value: PanelData;
+  }>,
   absoluteRange: AbsoluteTimeRange
 ): PanelData | undefined {
   const cacheKey = createCacheKey(absoluteRange);
@@ -199,7 +186,6 @@ export function getResultsFromCache(
   const cacheValue = cacheIdx >= 0 ? cache[cacheIdx].value : undefined;
   return cacheValue;
 }
-
 export function getRange(raw: RawTimeRange, timeZone: TimeZone): TimeRange {
   return {
     from: dateMath.parse(raw.from, false, timeZone)!,
@@ -207,7 +193,6 @@ export function getRange(raw: RawTimeRange, timeZone: TimeZone): TimeRange {
     raw,
   };
 }
-
 export function fromURLRange(range: URLRange): RawTimeRange {
   let rawTimeRange: RawTimeRange = DEFAULT_RANGE;
   let parsedRange = {
@@ -219,23 +204,18 @@ export function fromURLRange(range: URLRange): RawTimeRange {
   }
   return rawTimeRange;
 }
-
 function parseRawTime(urlRangeValue: URLRangeValue | DateTime): TimeFragment | null {
   if (urlRangeValue === null) {
     return null;
   }
-
   if (isDateTime(urlRangeValue)) {
     return urlRangeValue;
   }
-
   if (typeof urlRangeValue !== 'string') {
     return null;
   }
-
   // it can only be a string now
   const value = urlRangeValue;
-
   if (value.indexOf('now') !== -1) {
     return value;
   }
@@ -249,22 +229,18 @@ function parseRawTime(urlRangeValue: URLRangeValue | DateTime): TimeFragment | n
   if (value.length === 19) {
     return toUtc(value, 'YYYY-MM-DD HH:mm:ss');
   }
-
   // This should handle cases where value is an epoch time as string
   if (value.match(/^\d+$/)) {
     const epoch = parseInt(value, 10);
     return toUtc(epoch);
   }
-
   // This should handle ISO strings
   const time = toUtc(value);
   if (time.isValid()) {
     return time;
   }
-
   return null;
 }
-
 export const filterLogRowsByIndex = (
   clearedAtIndex: ExploreItemState['clearedAtIndex'],
   logRows?: LogRowModel[]
@@ -272,15 +248,12 @@ export const filterLogRowsByIndex = (
   if (!logRows) {
     return [];
   }
-
   if (clearedAtIndex) {
     const filteredRows = logRows.slice(clearedAtIndex + 1);
     return filteredRows;
   }
-
   return logRows;
 };
-
 export const getDatasourceUIDs = (datasourceUID: string, queries: DataQuery[]): string[] => {
   if (datasourceUID === MIXED_DATASOURCE_NAME) {
     return uniq(queries.map((query) => query.datasource?.uid).filter((uid): uid is string => !!uid));
@@ -288,23 +261,19 @@ export const getDatasourceUIDs = (datasourceUID: string, queries: DataQuery[]): 
     return [datasourceUID];
   }
 };
-
 export async function getCorrelationsData(state: StoreState, exploreId: string) {
   const correlationEditorHelperData = state.explore.panes[exploreId]!.correlationEditorHelperData;
-
   const isCorrelationEditorMode = state.explore.correlationEditorDetails?.editorMode || false;
   const isLeftPane = Object.keys(state.explore.panes)[0] === exploreId;
   const showCorrelationEditorLinks = isCorrelationEditorMode && isLeftPane;
   const defaultCorrelationEditorDatasource = showCorrelationEditorLinks ? await getDataSourceSrv().get() : undefined;
   const interpolateCorrelationHelperVars =
     isCorrelationEditorMode && !isLeftPane && correlationEditorHelperData !== undefined;
-
   let scopedVars: ScopedVars = {};
   if (interpolateCorrelationHelperVars && correlationEditorHelperData !== undefined) {
     Object.entries(correlationEditorHelperData?.vars).forEach((variable) => {
       scopedVars[variable[0]] = { value: variable[1] };
     });
   }
-
   return { defaultCorrelationEditorDatasource, scopedVars, showCorrelationEditorLinks };
 }

--- a/public/app/features/expressions/components/QueryToolbox.tsx
+++ b/public/app/features/expressions/components/QueryToolbox.tsx
@@ -1,50 +1,39 @@
+import { structLog } from '@grafana/data';
 import { css } from '@emotion/css';
 import { useCallback, useEffect, useRef, useState, type JSX } from 'react';
-
 import { type GrafanaTheme2 } from '@grafana/data';
 import { t } from '@grafana/i18n';
 import { IconButton, useStyles2, Stack, InlineToast, Tooltip, Icon } from '@grafana/ui';
-
 import { type SqlExpressionQuery } from '../types';
-
 interface QueryToolboxProps {
   onFormatCode?: () => void;
   onExpand?: (isExpanded: boolean) => void;
   isExpanded?: boolean;
   query: SqlExpressionQuery;
 }
-
 const SHOW_SUCCESS_DURATION = 2 * 1000;
-
 export const QueryToolbox = ({ onFormatCode, onExpand, isExpanded, query }: QueryToolboxProps): JSX.Element => {
   const styles = useStyles2(getStyles);
-
   const [showCopySuccess, setShowCopySuccess] = useState(false);
   const buttonRef = useRef<HTMLButtonElement>(null);
-
   useEffect(() => {
     if (!showCopySuccess) {
       return;
     }
-
     const timeoutId = setTimeout(() => {
       setShowCopySuccess(false);
     }, SHOW_SUCCESS_DURATION);
-
     return () => clearTimeout(timeoutId);
   }, [showCopySuccess]);
-
   const copyTextCallback = useCallback(async () => {
     try {
       await navigator.clipboard.writeText(query.expression ?? '');
       setShowCopySuccess(true);
     } catch (e) {
-      console.error(e);
+      structLog('error', e);
     }
   }, [query.expression]);
-
   const copiedText = t('clipboard-button.inline-toast.success', 'Copied');
-
   return (
     <div className={styles.container}>
       <Stack alignItems="center" direction="row" gap={1}>
@@ -90,7 +79,6 @@ export const QueryToolbox = ({ onFormatCode, onExpand, isExpanded, query }: Quer
     </div>
   );
 };
-
 const getStyles = (theme: GrafanaTheme2) => ({
   container: css({
     border: `1px solid ${theme.colors.border.medium}`,

--- a/public/app/features/geo/gazetteer/gazetteer.ts
+++ b/public/app/features/geo/gazetteer/gazetteer.ts
@@ -1,20 +1,16 @@
+import { structLog } from '@grafana/data';
 import { getCenter } from 'ol/extent';
 import { type Geometry, Point } from 'ol/geom';
-
 import { type DataFrame, type Field, FieldType, type KeyValue, toDataFrame } from '@grafana/data';
-
 import { frameFromGeoJSON } from '../format/geojson';
 import { pointFieldFromLonLat, pointFieldFromGeohash } from '../format/utils';
-
 import { loadWorldmapPoints } from './worldmap';
-
 export interface PlacenameInfo {
   point: () => Point | undefined; // lon, lat (WGS84)
   geometry: () => Geometry | undefined;
   frame?: DataFrame;
   index?: number;
 }
-
 export interface Gazetteer {
   path: string;
   error?: string;
@@ -23,12 +19,10 @@ export interface Gazetteer {
   frame?: () => DataFrame;
   count?: number;
 }
-
 // Without knowing the datatype pick a good lookup function
 export function loadGazetteer(path: string, data: any): Gazetteer {
   // try loading geojson
   let frame: DataFrame | undefined = undefined;
-
   if (Array.isArray(data)) {
     const first = data[0];
     // Check for legacy worldmap syntax
@@ -40,7 +34,6 @@ export function loadGazetteer(path: string, data: any): Gazetteer {
       frame = frameFromGeoJSON(data);
     }
   }
-
   if (!frame) {
     try {
       frame = toDataFrame(data);
@@ -53,11 +46,15 @@ export function loadGazetteer(path: string, data: any): Gazetteer {
       };
     }
   }
-
   return frameAsGazetter(frame, { path });
 }
-
-export function frameAsGazetter(frame: DataFrame, opts: { path: string; keys?: string[] }): Gazetteer {
+export function frameAsGazetter(
+  frame: DataFrame,
+  opts: {
+    path: string;
+    keys?: string[];
+  }
+): Gazetteer {
   const keys: Field[] = [];
   let geo: Field<Geometry | undefined> | undefined = undefined;
   let lat: Field | undefined = undefined;
@@ -75,25 +72,21 @@ export function frameAsGazetter(frame: DataFrame, opts: { path: string; keys?: s
       if (opts.keys && opts.keys.includes(f.name)) {
         keys.push(f);
       }
-
       const name = f.name.toUpperCase();
       switch (name) {
         case 'LAT':
         case 'LATITUTE':
           lat = f;
           break;
-
         case 'LON':
         case 'LNG':
         case 'LONG':
         case 'LONGITUE':
           lng = f;
           break;
-
         case 'GEOHASH':
           geohash = f;
           break;
-
         case 'ID':
         case 'UID':
         case 'KEY':
@@ -102,7 +95,6 @@ export function frameAsGazetter(frame: DataFrame, opts: { path: string; keys?: s
             keys.push(f);
           }
           break;
-
         default: {
           if (!opts.keys) {
             if (name.endsWith('_ID') || name.endsWith('_CODE')) {
@@ -113,14 +105,11 @@ export function frameAsGazetter(frame: DataFrame, opts: { path: string; keys?: s
       }
     }
   }
-
   // Use the first string field
   if (!keys.length && firstString) {
     keys.push(firstString);
   }
-
   let isPoint = false;
-
   // Create a geo field from lat+lng
   if (!geo) {
     if (geohash) {
@@ -133,7 +122,6 @@ export function frameAsGazetter(frame: DataFrame, opts: { path: string; keys?: s
   } else {
     isPoint = geo.values[0]?.getType() === 'Point';
   }
-
   const lookup = new Map<string, number>();
   keys.forEach((f) => {
     f.values.forEach((k, idx) => {
@@ -142,7 +130,6 @@ export function frameAsGazetter(frame: DataFrame, opts: { path: string; keys?: s
       lookup.set(str, idx);
     });
   });
-
   return {
     path: opts.path,
     find: (k) => {
@@ -177,11 +164,8 @@ export function frameAsGazetter(frame: DataFrame, opts: { path: string; keys?: s
     count: frame.length,
   };
 }
-
 const registry: KeyValue<Gazetteer> = {};
-
 export const COUNTRIES_GAZETTEER_PATH = `${window.__grafana_public_path__}build/gazetteer/countries.json`;
-
 /**
  * Given a path to a file return a cached lookup function
  */
@@ -190,7 +174,6 @@ export async function getGazetteer(path?: string): Promise<Gazetteer> {
   if (!path) {
     path = COUNTRIES_GAZETTEER_PATH;
   }
-
   let lookup = registry[path];
   if (!lookup) {
     try {
@@ -199,7 +182,7 @@ export async function getGazetteer(path?: string): Promise<Gazetteer> {
       const data = await response.json();
       lookup = loadGazetteer(path, data);
     } catch (err) {
-      console.warn('Error loading placename lookup', path, err);
+      structLog('warn', 'Error loading placename lookup', path, err);
       lookup = {
         path,
         error: 'Error loading URL',

--- a/public/app/features/inspector/InspectJSONTab.tsx
+++ b/public/app/features/inspector/InspectJSONTab.tsx
@@ -1,9 +1,9 @@
+import { structLog } from '@grafana/data';
 import { isEqual } from 'lodash';
 import { useState, useCallback, useMemo } from 'react';
 import { useAsync } from 'react-use';
 import AutoSizer from 'react-virtualized-auto-sizer';
 import { firstValueFrom } from 'rxjs';
-
 import { AppEvents, type PanelData, type SelectableValue, LoadingState } from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';
 import { Trans, t } from '@grafana/i18n';
@@ -12,27 +12,22 @@ import { Button, CodeEditor, Field, Select, useStyles2 } from '@grafana/ui';
 import { appEvents } from 'app/core/app_events';
 import { type DashboardModel } from 'app/features/dashboard/state/DashboardModel';
 import { type PanelModel } from 'app/features/dashboard/state/PanelModel';
-
 import { getPanelDataFrames } from '../dashboard/components/HelpWizard/utils';
 import { getPanelInspectorStyles2 } from '../inspector/styles';
 import { reportPanelInspectInteraction } from '../search/page/reporting';
-
 import { InspectTab } from './types';
 import { getPrettyJSON } from './utils/utils';
-
 enum ShowContent {
   PanelJSON = 'panel',
   PanelData = 'data',
   DataFrames = 'frames',
 }
-
 interface Props {
   onClose: () => void;
   dashboard?: DashboardModel;
   panel?: PanelModel;
   data?: PanelData;
 }
-
 export function InspectJSONTab({ panel, dashboard, data, onClose }: Props) {
   const options: Array<SelectableValue<ShowContent>> = useMemo(
     () => [
@@ -75,12 +70,10 @@ export function InspectJSONTab({ panel, dashboard, data, onClose }: Props) {
   }, [options, panel]);
   const [show, setShow] = useState(panel ? ShowContent.PanelJSON : ShowContent.DataFrames);
   const [text, setText] = useState('');
-
   useAsync(async () => {
     const v = await getJSONObject(show, panel, data);
     setText(getPrettyJSON(v));
   }, [show, panel, data]);
-
   const onApplyPanelModel = useCallback(() => {
     if (panel && dashboard && text) {
       try {
@@ -89,7 +82,6 @@ export function InspectJSONTab({ panel, dashboard, data, onClose }: Props) {
         } else {
           const updates = JSON.parse(text);
           dashboard.shouldUpdateDashboardPanelFromJSON(updates, panel);
-
           //Report relevant updates
           reportPanelInspectInteraction(InspectTab.JSON, 'apply', {
             panel_type_changed: panel.type !== updates.type,
@@ -97,31 +89,26 @@ export function InspectJSONTab({ panel, dashboard, data, onClose }: Props) {
             panel_grid_pos_changed: !isEqual(panel.gridPos, updates.gridPos),
             panel_targets_changed: !isEqual(panel.targets, updates.targets),
           });
-
           panel.restoreModel(updates);
           panel.configRev++;
           panel.refresh();
           appEvents.emit(AppEvents.alertSuccess, ['Panel model updated']);
         }
       } catch (err) {
-        console.error('Error applying updates', err);
+        structLog('error', 'Error applying updates', err);
         appEvents.emit(AppEvents.alertError, ['Invalid JSON text']);
       }
-
       onClose();
     }
   }, [panel, dashboard, onClose, text]);
-
   const onShowHelpWizard = useCallback(() => {
     reportPanelInspectInteraction(InspectTab.JSON, 'supportWizard');
     const queryParms = locationService.getSearch();
     queryParms.set('inspectTab', InspectTab.Help.toString());
     locationService.push('?' + queryParms.toString());
   }, []);
-
   const isPanelJSON = show === ShowContent.PanelJSON;
   const canEdit = dashboard && dashboard.meta.canEdit;
-
   return (
     <div className={styles.wrap}>
       <div className={styles.toolbar} data-testid={selectors.components.PanelInspector.Json.content}>
@@ -164,18 +151,14 @@ export function InspectJSONTab({ panel, dashboard, data, onClose }: Props) {
     </div>
   );
 }
-
 async function getJSONObject(show: ShowContent, panel?: PanelModel, data?: PanelData) {
   if (show === ShowContent.PanelData) {
     reportPanelInspectInteraction(InspectTab.JSON, 'panelData');
     return data;
   }
-
   if (show === ShowContent.DataFrames) {
     reportPanelInspectInteraction(InspectTab.JSON, 'dataFrame');
-
     let d = data;
-
     // do not include transforms and
     if (panel && data?.state === LoadingState.Done) {
       d = await firstValueFrom(
@@ -187,11 +170,9 @@ async function getJSONObject(show: ShowContent, panel?: PanelModel, data?: Panel
     }
     return getPanelDataFrames(d);
   }
-
   if (show === ShowContent.PanelJSON && panel) {
     reportPanelInspectInteraction(InspectTab.JSON, 'panelJSON');
     return panel!.getSaveModel();
   }
-
   return { note: t('dashboard.inspect-json.unknown', 'Unknown Object: {{show}}', { show }) };
 }

--- a/public/app/features/library-panels/components/LibraryPanelsView/actions.ts
+++ b/public/app/features/library-panels/components/LibraryPanelsView/actions.ts
@@ -1,14 +1,11 @@
+import { structLog } from '@grafana/data';
 import { type Action } from '@reduxjs/toolkit';
 import { type Dispatch } from 'react';
 import { from, merge, of, Subscription, timer } from 'rxjs';
 import { catchError, finalize, mapTo, mergeMap, share, takeUntil } from 'rxjs/operators';
-
 import { deleteLibraryPanel as apiDeleteLibraryPanel, getLibraryPanels } from '../../state/api';
-
 import { initialLibraryPanelsViewState, initSearch, searchCompleted } from './reducer';
-
 type SearchDispatchResult = (dispatch: Dispatch<Action>, abortController?: AbortController) => void;
-
 interface SearchArgs {
   perPage: number;
   page: number;
@@ -18,10 +15,8 @@ interface SearchArgs {
   folderFilterUIDs?: string[];
   currentPanelId?: string;
 }
-
 export function searchForLibraryPanels(args: SearchArgs): SearchDispatchResult {
   // Functions to support filtering out library panels per plugin type that have skipDataQuery set to true
-
   return function (dispatch, abortController) {
     const subscription = new Subscription();
     const dataObservable = from(
@@ -48,21 +43,17 @@ export function searchForLibraryPanels(args: SearchArgs): SearchDispatchResult {
         // Check if this is an aborted request - if so, silently ignore it
         const isAbortError =
           err.name === 'AbortError' || err.cancelled === true || err.statusText === 'Request was aborted';
-
         if (isAbortError) {
           return of(); // Silently ignore aborted requests
         }
-
         // For real errors, log and show error to user
-        console.error('Error fetching library panels:', err);
-
+        structLog('error', 'Error fetching library panels:', err);
         // Update state to show empty results
         return of(searchCompleted({ ...initialLibraryPanelsViewState, page: args.page, perPage: args.perPage }));
       }),
       finalize(() => subscription.unsubscribe()), // make sure we unsubscribe
       share()
     );
-
     subscription.add(
       // If 50ms without a response dispatch a loading state
       // mapTo will translate the timer event into a loading state
@@ -71,18 +62,16 @@ export function searchForLibraryPanels(args: SearchArgs): SearchDispatchResult {
     );
   };
 }
-
 export function deleteLibraryPanel(uid: string, args: SearchArgs) {
   return async function (dispatch: Dispatch<Action>) {
     try {
       await apiDeleteLibraryPanel(uid);
       searchForLibraryPanels(args)(dispatch);
     } catch (e) {
-      console.error(e);
+      structLog('error', e);
     }
   };
 }
-
 export function asyncDispatcher(dispatch: Dispatch<Action>) {
   return function (action: Action | SearchDispatchResult | Function, abortController?: AbortController) {
     if (action instanceof Function) {

--- a/public/app/features/live/centrifuge/LiveDataStream.test.ts
+++ b/public/app/features/live/centrifuge/LiveDataStream.test.ts
@@ -1,6 +1,7 @@
 import { mapValues } from 'lodash';
 import { type Observable, Subject, type Subscription, type Unsubscribable } from 'rxjs';
 
+import * as grafanaData from '@grafana/data';
 import {
   type DataFrameJSON,
   dataFrameToJSON,
@@ -123,7 +124,7 @@ describe('LiveDataStream', () => {
   jest.useFakeTimers();
 
   beforeEach(() => {
-    jest.spyOn(console, 'log').mockImplementation(jest.fn);
+    jest.spyOn(grafanaData, 'structLog').mockImplementation(jest.fn);
   });
 
   afterEach(() => {

--- a/public/app/features/live/centrifuge/LiveDataStream.ts
+++ b/public/app/features/live/centrifuge/LiveDataStream.ts
@@ -1,5 +1,5 @@
+import { structLog } from '@grafana/data';
 import { map, Observable, ReplaySubject, type Subject, type Subscriber, type Subscription } from 'rxjs';
-
 import {
   type DataFrameJSON,
   type DataQueryError,
@@ -19,33 +19,26 @@ import {
   type StreamingFrameOptions,
   toDataQueryError,
 } from '@grafana/runtime';
-
 import { StreamingResponseDataType } from '../data/utils';
-
 import { type DataStreamSubscriptionKey, type StreamingDataQueryResponse } from './service';
-
 const bufferIfNot =
   (canEmitObservable: Observable<boolean>) =>
   <T>(source: Observable<T>): Observable<T[]> => {
     return new Observable((subscriber: Subscriber<T[]>) => {
       let buffer: T[] = [];
       let canEmit = true;
-
       const emitBuffer = () => {
         subscriber.next(buffer);
         buffer = [];
       };
-
       const canEmitSub = canEmitObservable.subscribe({
         next: (val) => {
           canEmit = val;
-
           if (canEmit && buffer.length) {
             emitBuffer();
           }
         },
       });
-
       const sourceSub = source.subscribe({
         next(value) {
           if (canEmit) {
@@ -65,14 +58,12 @@ const bufferIfNot =
           subscriber.complete();
         },
       });
-
       return () => {
         sourceSub.unsubscribe();
         canEmitSub.unsubscribe();
       };
     });
   };
-
 export type DataStreamHandlerDeps<T> = {
   channelId: LiveChannelId;
   liveEventsObservable: Observable<LiveChannelEvent<T>>;
@@ -81,13 +72,11 @@ export type DataStreamHandlerDeps<T> = {
   defaultStreamingFrameOptions: Readonly<StreamingFrameOptions>;
   shutdownDelayInMs: number;
 };
-
 enum InternalStreamMessageType {
   Error,
   NewValuesSameSchema,
   ChangedSchema,
 }
-
 type InternalStreamMessageTypeToData = {
   [InternalStreamMessageType.Error]: {
     error: DataQueryError;
@@ -97,13 +86,11 @@ type InternalStreamMessageTypeToData = {
     values: unknown[][];
   };
 };
-
 type InternalStreamMessage<T = InternalStreamMessageType> = T extends InternalStreamMessageType
   ? {
       type: T;
     } & InternalStreamMessageTypeToData[T]
   : never;
-
 const reduceNewValuesSameSchemaMessages = (
   packets: Array<InternalStreamMessage<InternalStreamMessageType.NewValuesSameSchema>>
 ) => ({
@@ -120,18 +107,15 @@ const reduceNewValuesSameSchemaMessages = (
   }, []),
   type: InternalStreamMessageType.NewValuesSameSchema,
 });
-
 const filterMessages = <T extends InternalStreamMessageType>(
   packets: InternalStreamMessage[],
   type: T
 ): Array<InternalStreamMessage<T>> => packets.filter((p) => p.type === type) as Array<InternalStreamMessage<T>>;
-
 export class LiveDataStream<T = unknown> {
   private frameBuffer: StreamingDataFrame;
   private liveEventsSubscription: Subscription;
   private stream: Subject<InternalStreamMessage> = new ReplaySubject(1);
   private shutdownTimeoutId: ReturnType<typeof setTimeout> | undefined;
-
   constructor(private deps: DataStreamHandlerDeps<T>) {
     this.frameBuffer = StreamingDataFrame.empty(deps.defaultStreamingFrameOptions);
     this.liveEventsSubscription = deps.liveEventsObservable.subscribe({
@@ -140,39 +124,33 @@ export class LiveDataStream<T = unknown> {
       next: this.onNext,
     });
   }
-
   private shutdown = () => {
     this.stream.complete();
     this.liveEventsSubscription.unsubscribe();
     this.deps.onShutdown();
   };
-
   private shutdownIfNoSubscribers = () => {
     if (!this.stream.observed) {
       this.shutdown();
     }
   };
-
   private onError = (err: unknown) => {
-    console.log('LiveQuery [error]', { err }, this.deps.channelId);
+    structLog('log', 'LiveQuery [error]', { err }, this.deps.channelId);
     this.stream.next({
       type: InternalStreamMessageType.Error,
       error: toDataQueryError(err),
     });
     this.shutdown();
   };
-
   private onComplete = () => {
-    console.log('LiveQuery [complete]', this.deps.channelId);
+    structLog('log', 'LiveQuery [complete]', this.deps.channelId);
     this.shutdown();
   };
-
   private onNext = (evt: LiveChannelEvent) => {
     if (isLiveChannelMessageEvent(evt)) {
       this.process(evt.message);
       return;
     }
-
     const liveChannelStatusEvent = isLiveChannelStatusEvent(evt);
     if (liveChannelStatusEvent && evt.error) {
       const err = toDataQueryError(evt.error);
@@ -184,7 +162,6 @@ export class LiveDataStream<T = unknown> {
         },
       });
     }
-
     if (
       liveChannelStatusEvent &&
       (evt.state === LiveChannelConnectionState.Connected || evt.state === LiveChannelConnectionState.Pending) &&
@@ -193,10 +170,8 @@ export class LiveDataStream<T = unknown> {
       this.process(evt.message);
     }
   };
-
   private process = (msg: DataFrameJSON) => {
     const packetInfo = this.frameBuffer.push(msg);
-
     if (packetInfo.schemaChanged) {
       this.stream.next({
         type: InternalStreamMessageType.ChangedSchema,
@@ -208,40 +183,33 @@ export class LiveDataStream<T = unknown> {
       });
     }
   };
-
   private resizeBuffer = (bufferOptions: StreamingFrameOptions) => {
     if (bufferOptions && this.frameBuffer.needsResizing(bufferOptions)) {
       this.frameBuffer.resize(bufferOptions);
     }
   };
-
   private prepareInternalStreamForNewSubscription = (options: LiveDataStreamOptions): void => {
     if (!this.frameBuffer.hasAtLeastOnePacket() && options.frame) {
       // will skip initial frames from subsequent subscribers
       this.process(options.frame);
     }
   };
-
   private clearShutdownTimeout = () => {
     if (this.shutdownTimeoutId) {
       clearTimeout(this.shutdownTimeoutId);
       this.shutdownTimeoutId = undefined;
     }
   };
-
   get = (options: LiveDataStreamOptions, subKey: DataStreamSubscriptionKey): Observable<StreamingDataQueryResponse> => {
     this.clearShutdownTimeout();
     const buffer = getStreamingFrameOptions(options.buffer);
-
     this.resizeBuffer(buffer);
     this.prepareInternalStreamForNewSubscription(options);
-
     const shouldSendLastPacketOnly = options?.buffer?.action === StreamingFrameAction.Replace;
     const fieldsNamesFilter = options.filter?.fields;
     const dataNeedsFiltering = fieldsNamesFilter?.length;
     const fieldFilterPredicate = dataNeedsFiltering ? ({ name }: Field) => fieldsNamesFilter.includes(name) : undefined;
     let matchingFieldIndexes: number[] | undefined = undefined;
-
     const getFullFrameResponseData = <T>(
       messages: InternalStreamMessage[],
       error?: DataQueryError
@@ -249,7 +217,6 @@ export class LiveDataStream<T = unknown> {
       matchingFieldIndexes = fieldFilterPredicate
         ? this.frameBuffer.getMatchingFieldIndexes(fieldFilterPredicate)
         : undefined;
-
       if (!shouldSendLastPacketOnly) {
         return {
           key: subKey,
@@ -263,7 +230,6 @@ export class LiveDataStream<T = unknown> {
           error,
         };
       }
-
       if (error) {
         // send empty frame with error
         return {
@@ -278,9 +244,8 @@ export class LiveDataStream<T = unknown> {
           error,
         };
       }
-
       if (!messages.length) {
-        console.warn(`expected to find at least one non error message ${messages.map(({ type }) => type)}`);
+        structLog('warn', `expected to find at least one non error message ${messages.map(({ type }) => type)}`);
         // send empty frame
         return {
           key: subKey,
@@ -294,7 +259,6 @@ export class LiveDataStream<T = unknown> {
           error,
         };
       }
-
       return {
         key: subKey,
         state: LoadingState.Streaming,
@@ -309,7 +273,6 @@ export class LiveDataStream<T = unknown> {
         error,
       };
     };
-
     const getNewValuesSameSchemaResponseData = (
       messages: Array<InternalStreamMessage<InternalStreamMessageType.NewValuesSameSchema>>
     ): StreamingDataQueryResponse => {
@@ -318,9 +281,7 @@ export class LiveDataStream<T = unknown> {
         shouldSendLastPacketOnly && lastMessage
           ? lastMessage.values
           : reduceNewValuesSameSchemaMessages(messages).values;
-
       const filteredValues = matchingFieldIndexes ? values.filter((v, i) => matchingFieldIndexes?.includes(i)) : values;
-
       return {
         key: subKey,
         state: LoadingState.Streaming,
@@ -332,39 +293,32 @@ export class LiveDataStream<T = unknown> {
         ],
       };
     };
-
     let shouldSendFullFrame = true;
     const transformedInternalStream = this.stream.pipe(
       bufferIfNot(this.deps.subscriberReadiness),
       map((messages, i) => {
         const errors = filterMessages(messages, InternalStreamMessageType.Error);
         const lastError = errors.length ? errors[errors.length - 1].error : undefined;
-
         if (shouldSendFullFrame) {
           shouldSendFullFrame = false;
           return getFullFrameResponseData(messages, lastError);
         }
-
         if (errors.length) {
           // send the latest frame with the last error, discard everything else
           return getFullFrameResponseData(messages, lastError);
         }
-
         const schemaChanged = messages.some((n) => n.type === InternalStreamMessageType.ChangedSchema);
         if (schemaChanged) {
           // send the latest frame, discard intermediate appends
           return getFullFrameResponseData(messages, undefined);
         }
-
         const newValueSameSchemaMessages = filterMessages(messages, InternalStreamMessageType.NewValuesSameSchema);
         if (newValueSameSchemaMessages.length !== messages.length) {
-          console.warn(`unsupported message type ${messages.map(({ type }) => type)}`);
+          structLog('warn', `unsupported message type ${messages.map(({ type }) => type)}`);
         }
-
         return getNewValuesSameSchemaResponseData(newValueSameSchemaMessages);
       })
     );
-
     return new Observable<StreamingDataQueryResponse>((subscriber) => {
       const sub = transformedInternalStream.subscribe({
         next: (n) => {
@@ -377,7 +331,6 @@ export class LiveDataStream<T = unknown> {
           subscriber.complete();
         },
       });
-
       return () => {
         // TODO: potentially resize (downsize) the buffer on unsubscribe
         sub.unsubscribe();

--- a/public/app/features/live/centrifuge/channel.ts
+++ b/public/app/features/live/centrifuge/channel.ts
@@ -1,3 +1,4 @@
+import { structLog } from '@grafana/data';
 import {
   type Subscription,
   type JoinContext,
@@ -8,7 +9,6 @@ import {
   type UnsubscribedContext,
 } from 'centrifuge';
 import { Subject, of, Observable } from 'rxjs';
-
 import {
   type LiveChannelStatusEvent,
   type LiveChannelEvent,
@@ -19,26 +19,20 @@ import {
   type DataFrameJSON,
   isValidLiveChannelAddress,
 } from '@grafana/data';
-
 /**
  * Internal class that maps Centrifuge support to GrafanaLive
  */
 export class CentrifugeLiveChannel<T = any> {
   readonly currentStatus: LiveChannelStatusEvent;
-
   readonly opened = Date.now();
   readonly id: string;
   readonly addr: LiveChannelAddress;
-
   readonly stream = new Subject<LiveChannelEvent<T>>();
-
   // Hold on to the last header with schema
   lastMessageWithSchema?: DataFrameJSON;
-
   subscription?: Subscription;
   shutdownCallback?: () => void;
   initalized?: boolean;
-
   constructor(id: string, addr: LiveChannelAddress) {
     this.id = id;
     this.addr = addr;
@@ -53,27 +47,23 @@ export class CentrifugeLiveChannel<T = any> {
       this.currentStatus.error = 'invalid channel address';
     }
   }
-
   // This should only be called when centrifuge is connected
   initalize(): void {
     if (this.initalized) {
       throw new Error('Channel already initalized: ' + this.id);
     }
     this.initalized = true;
-
     this.subscription!.on('publication', (ctx: PublicationContext) => {
       try {
         if (ctx.data) {
           if (ctx.data.schema) {
             this.lastMessageWithSchema = ctx.data;
           }
-
           this.stream.next({
             type: LiveChannelEventType.Message,
             message: ctx.data,
           });
         }
-
         // Clear any error messages
         if (this.currentStatus.error) {
           this.currentStatus.timestamp = Date.now();
@@ -81,7 +71,7 @@ export class CentrifugeLiveChannel<T = any> {
           this.sendStatus();
         }
       } catch (err) {
-        console.log('publish error', this.addr, err);
+        structLog('log', 'publish error', this.addr, err);
         this.currentStatus.error = err;
         this.currentStatus.timestamp = Date.now();
         this.sendStatus();
@@ -96,7 +86,6 @@ export class CentrifugeLiveChannel<T = any> {
         this.currentStatus.timestamp = Date.now();
         this.currentStatus.state = LiveChannelConnectionState.Connected;
         delete this.currentStatus.error;
-
         if (ctx.data?.schema) {
           this.lastMessageWithSchema = ctx.data;
         }
@@ -122,7 +111,6 @@ export class CentrifugeLiveChannel<T = any> {
         this.stream.next({ type: LiveChannelEventType.Leave, user: ctx.info.user });
       });
   }
-
   private sendStatus(message?: unknown) {
     const copy = { ...this.currentStatus };
     if (message) {
@@ -130,14 +118,12 @@ export class CentrifugeLiveChannel<T = any> {
     }
     this.stream.next(copy);
   }
-
   disconnectIfNoListeners = () => {
     const count = this.stream.observers.length;
     if (count === 0) {
       this.disconnect();
     }
   };
-
   /**
    * Get the stream of events and
    */
@@ -148,14 +134,11 @@ export class CentrifugeLiveChannel<T = any> {
         // send just schema instead of schema+data to avoid having data gaps
         initialMessage.message = { schema: this.lastMessageWithSchema?.schema };
       }
-
       subscriber.next({ ...this.currentStatus, message: this.lastMessageWithSchema });
-
       const sub = this.stream.subscribe(subscriber);
       return () => {
         sub.unsubscribe();
         const count = this.stream.observers.length;
-
         // Wait 1/4 second to fully disconnect
         if (count === 0) {
           setTimeout(this.disconnectIfNoListeners, 250);
@@ -163,7 +146,6 @@ export class CentrifugeLiveChannel<T = any> {
       };
     });
   }
-
   /**
    * This is configured by the server when the config supports presence
    */
@@ -171,52 +153,42 @@ export class CentrifugeLiveChannel<T = any> {
     if (!this.subscription) {
       return Promise.reject('not subscribed');
     }
-
     return this.subscription!.presence().then((v) => {
       return {
         users: Object.keys(v.clients),
       };
     });
   }
-
   publish = (data: unknown) => this.subscription?.publish(data);
-
   /**
    * This will close and terminate all streams for this channel
    */
   disconnect() {
     this.currentStatus.state = LiveChannelConnectionState.Shutdown;
     this.currentStatus.timestamp = Date.now();
-
     if (this.subscription) {
       this.subscription.unsubscribe();
       this.subscription.removeAllListeners(); // they keep all listeners attached after unsubscribe
       this.subscription = undefined;
     }
-
     this.stream.complete();
-
     this.stream.next({ ...this.currentStatus });
     this.stream.complete();
-
     if (this.shutdownCallback) {
       this.shutdownCallback();
     }
   }
-
   shutdownWithError(err: string) {
     this.currentStatus.error = err;
     this.sendStatus();
     this.disconnect();
   }
 }
-
 export function getErrorChannel<TMessage>(msg: string, id: string, addr: LiveChannelAddress) {
   return {
     id,
     opened: Date.now(),
     addr,
-
     // return an error
     getStream: () =>
       of({
@@ -226,7 +198,6 @@ export function getErrorChannel<TMessage>(msg: string, id: string, addr: LiveCha
         state: LiveChannelConnectionState.Invalid,
         error: msg,
       }),
-
     // already disconnected
     disconnect: () => {},
   };

--- a/public/app/features/live/centrifuge/service.ts
+++ b/public/app/features/live/centrifuge/service.ts
@@ -1,3 +1,4 @@
+import { structLog } from '@grafana/data';
 import {
   Centrifuge,
   type ConnectedContext,
@@ -8,7 +9,6 @@ import {
   State,
 } from 'centrifuge';
 import { BehaviorSubject, type Observable, share, startWith } from 'rxjs';
-
 import {
   type DataQueryError,
   type DataQueryResponse,
@@ -28,12 +28,9 @@ import {
   type BackendDataSourceResponse,
   getBackendSrv,
 } from '@grafana/runtime';
-
 import { type StreamingResponseData } from '../data/utils';
-
 import { LiveDataStream } from './LiveDataStream';
 import { CentrifugeLiveChannel } from './channel';
-
 export type CentrifugeSrvDeps = {
   grafanaAuthToken: string | null;
   appUrl: string;
@@ -42,30 +39,26 @@ export type CentrifugeSrvDeps = {
   liveEnabled: boolean;
   dataStreamSubscriberReadiness: Observable<boolean>;
 };
-
-export type StreamingDataQueryResponse = Omit<DataQueryResponse, 'data'> & { data: [StreamingResponseData] };
-
+export type StreamingDataQueryResponse = Omit<DataQueryResponse, 'data'> & {
+  data: [StreamingResponseData];
+};
 export type CentrifugeSrv = Omit<GrafanaLiveSrv, 'getDataStream' | 'getQueryData'> & {
   getDataStream: (options: LiveDataStreamOptions) => Observable<StreamingDataQueryResponse>;
-  getQueryData: (
-    options: LiveQueryDataOptions
-  ) => Promise<
-    | { data: BackendDataSourceResponse | undefined }
+  getQueryData: (options: LiveQueryDataOptions) => Promise<
+    | {
+        data: BackendDataSourceResponse | undefined;
+      }
     | FetchResponse<BackendDataSourceResponse | undefined>
     | DataQueryError
   >;
 };
-
 export type DataStreamSubscriptionKey = string;
-
 const defaultStreamingFrameOptions: Readonly<StreamingFrameOptions> = {
   maxLength: 100,
   maxDelta: Infinity,
   action: StreamingFrameAction.Append,
 };
-
 const dataStreamShutdownDelayInMs = 5000;
-
 export class CentrifugeService implements CentrifugeSrv {
   readonly open = new Map<string, CentrifugeLiveChannel>();
   private readonly liveDataStreamByChannelId: Record<LiveChannelId, LiveDataStream> = {};
@@ -74,18 +67,14 @@ export class CentrifugeService implements CentrifugeSrv {
   readonly connectionBlocker: Promise<void>;
   private readonly dataStreamSubscriberReadiness: Observable<boolean>;
   private lastAuthCheck = 0;
-  private static CONNECTION_TIMEOUT_MS = 10_000;
-
+  private static CONNECTION_TIMEOUT_MS = 10000;
   constructor(private deps: CentrifugeSrvDeps) {
     this.dataStreamSubscriberReadiness = deps.dataStreamSubscriberReadiness.pipe(share(), startWith(true));
-
     let liveUrl = `${deps.appUrl.replace(/^http/, 'ws')}/api/live/ws`;
-
     const token = deps.grafanaAuthToken;
     if (token !== null && token !== '') {
       liveUrl += '?auth_token=' + token;
     }
-
     this.centrifuge = new Centrifuge(liveUrl, {
       timeout: 30000,
     });
@@ -104,7 +93,6 @@ export class CentrifugeService implements CentrifugeSrv {
       };
       this.centrifuge.addListener('connected', connectListener);
     });
-
     // Register global listeners
     this.centrifuge.on('connected', this.onConnect);
     this.centrifuge.on('connecting', this.onDisconnect);
@@ -112,23 +100,18 @@ export class CentrifugeService implements CentrifugeSrv {
     this.centrifuge.on('publication', this.onServerSideMessage);
     this.centrifuge.on('error', this.onError);
   }
-
   //----------------------------------------------------------
   // Internal functions
   //----------------------------------------------------------
-
   private onConnect = (context: ConnectedContext) => {
     this.connectionState.next(true);
   };
-
   private onDisconnect = (context: ConnectingContext | DisconnectedContext) => {
     this.connectionState.next(false);
   };
-
   private onServerSideMessage = (context: ServerPublicationContext) => {
-    console.log('Publication from server-side channel', context);
+    structLog('log', 'Publication from server-side channel', context);
   };
-
   private onError = (context: ErrorContext) => {
     /**
      * This is a workaround to handle the case where the authentication token
@@ -149,7 +132,6 @@ export class CentrifugeService implements CentrifugeSrv {
       }
     }
   };
-
   /**
    * Get a channel.  If the scope, namespace, or path is invalid, a shutdown
    * channel will be returned with an error state indicated in its status
@@ -160,7 +142,6 @@ export class CentrifugeService implements CentrifugeSrv {
     if (channel != null) {
       return channel;
     }
-
     channel = new CentrifugeLiveChannel(id, addr);
     if (channel.currentStatus.state === LiveChannelConnectionState.Invalid) {
       return channel;
@@ -171,15 +152,12 @@ export class CentrifugeService implements CentrifugeSrv {
       channel.shutdownWithError('Grafana Live is disabled');
       return channel;
     }
-
     channel.shutdownCallback = () => {
       this.open.delete(id);
-
       // without a call to `removeSubscription`, the subscription will remain in centrifuge's internal registry
       this.centrifuge.removeSubscription(this.centrifuge.getSubscription(id));
     };
     this.open.set(id, channel);
-
     // Initialize the channel in the background
     this.initChannel(channel).catch((err) => {
       if (channel) {
@@ -188,11 +166,9 @@ export class CentrifugeService implements CentrifugeSrv {
       }
       this.open.delete(id);
     });
-
     // return the not-yet initialized channel
     return channel;
   }
-
   private async initChannel(channel: CentrifugeLiveChannel): Promise<void> {
     if (this.centrifuge.state !== State.Connected) {
       // Wait for centrifuge to connect, but bail out after the timeout
@@ -212,36 +188,29 @@ export class CentrifugeService implements CentrifugeSrv {
     subscription.subscribe();
     return;
   }
-
   //----------------------------------------------------------
   // Exported functions
   //----------------------------------------------------------
-
   /**
    * Listen for changes to the connection state
    */
   getConnectionState = () => {
     return this.connectionState.asObservable();
   };
-
   /**
    * Watch for messages in a channel
    */
   getStream: CentrifugeSrv['getStream'] = <T>(address: LiveChannelAddress) => {
     return this.getChannel<T>(address).getStream();
   };
-
   private createSubscriptionKey = (options: LiveDataStreamOptions): DataStreamSubscriptionKey =>
     options.key ?? `xstr/${streamCounter++}`;
-
   private getLiveDataStream = (options: LiveDataStreamOptions): LiveDataStream => {
     const channelId = toLiveChannelId(options.addr);
     const existingStream = this.liveDataStreamByChannelId[channelId];
-
     if (existingStream) {
       return existingStream;
     }
-
     const channel = this.getChannel(options.addr);
     this.liveDataStreamByChannelId[channelId] = new LiveDataStream({
       channelId,
@@ -260,11 +229,9 @@ export class CentrifugeService implements CentrifugeSrv {
    */
   getDataStream: CentrifugeSrv['getDataStream'] = (options) => {
     const subscriptionKey = this.createSubscriptionKey(options);
-
     const stream = this.getLiveDataStream(options);
     return stream.get(options, subscriptionKey);
   };
-
   /**
    * Executes a query over the live websocket. Query response can contain live channels we can subscribe to for further updates
    *
@@ -276,7 +243,6 @@ export class CentrifugeService implements CentrifugeSrv {
     }
     return this.centrifuge.rpc('grafana.query', options.body);
   };
-
   /**
    * For channels that support presence, this will request the current state from the server.
    *
@@ -285,7 +251,6 @@ export class CentrifugeService implements CentrifugeSrv {
   getPresence: CentrifugeSrv['getPresence'] = (address) => {
     return this.getChannel(address).getPresence();
   };
-
   /**
    * Publish into a channel.
    */
@@ -293,6 +258,5 @@ export class CentrifugeService implements CentrifugeSrv {
     return this.getChannel(address).publish(data);
   };
 }
-
 // This is used to give a unique key for each stream.  The actual value does not matter
 let streamCounter = 0;

--- a/public/app/features/live/dashboard/dashboardWatcher.ts
+++ b/public/app/features/live/dashboard/dashboardWatcher.ts
@@ -1,6 +1,6 @@
+import { structLog } from '@grafana/data';
 import { type Unsubscribable } from 'rxjs';
 import { v4 as uuidv4 } from 'uuid';
-
 import {
   AppEvents,
   isLiveChannelMessageEvent,
@@ -13,20 +13,15 @@ import {
 import { getGrafanaLiveSrv, locationService } from '@grafana/runtime';
 import { appEvents } from 'app/core/app_events';
 import { contextSrv } from 'app/core/services/context_srv';
-
 import { ShowModalReactEvent } from '../../../types/events';
 import { getDashboardSrv } from '../../dashboard/services/DashboardSrv';
-
 import { DashboardChangedModal } from './DashboardChangedModal';
 import { type DashboardEvent, DashboardEventAction } from './types';
-
 // sessionId is not a security-sensitive value.
 // It is used for filtering out dashboard edit events from the same browsing session
 const sessionId = uuidv4();
-
 class DashboardWatcher {
   private static readonly IGNORE_SAVE_WINDOW_MS = 5000;
-
   channel?: LiveChannelAddress; // path to the channel
   uid?: string;
   ignoreSave = 0; // save any events until this time passes
@@ -34,17 +29,14 @@ class DashboardWatcher {
   lastEditing?: DashboardEvent;
   subscription?: Unsubscribable;
   hasSeenNotice?: boolean;
-
   setEditingState(state: boolean) {
     const changed = (this.editing = state);
     this.editing = state;
     this.hasSeenNotice = false;
-
     if (changed && contextSrv.isEditor) {
       this.sendEditingState();
     }
   }
-
   private sendEditingState() {
     const { channel, uid } = this;
     if (channel && uid) {
@@ -56,13 +48,11 @@ class DashboardWatcher {
       });
     }
   }
-
   watch(uid: string) {
     const live = getGrafanaLiveSrv();
     if (!live) {
       return;
     }
-
     // Check for changes
     if (uid !== this.uid) {
       this.channel = {
@@ -77,7 +67,6 @@ class DashboardWatcher {
       this.uid = uid;
     }
   }
-
   leave() {
     if (this.subscription) {
       this.subscription.unsubscribe();
@@ -85,12 +74,10 @@ class DashboardWatcher {
     this.subscription = undefined;
     this.uid = undefined;
   }
-
   // ignore the next 5 seconds of save events
   ignoreNextSave() {
     this.ignoreSave = Date.now() + DashboardWatcher.IGNORE_SAVE_WINDOW_MS;
   }
-
   getRecentEditingEvent() {
     if (this.lastEditing && this.lastEditing.timestamp) {
       const elapsed = Date.now() - this.lastEditing.timestamp;
@@ -100,19 +87,16 @@ class DashboardWatcher {
     }
     return this.lastEditing;
   }
-
   observer = {
     next: (event: LiveChannelEvent<DashboardEvent>) => {
       // Send the editing state when connection starts
       if (isLiveChannelStatusEvent(event) && this.editing && event.state === LiveChannelConnectionState.Connected) {
         this.sendEditingState();
       }
-
       if (isLiveChannelMessageEvent(event)) {
         if (event.message.sessionId === sessionId) {
           return; // skip internal messages
         }
-
         const { action, message } = event.message;
         switch (action) {
           case DashboardEventAction.EditingStarted:
@@ -124,21 +108,17 @@ class DashboardWatcher {
                 return;
               }
             }
-
             const dash = getDashboardSrv().getCurrent();
             if (dash?.uid !== event.message.uid) {
-              console.log('dashboard event for different dashboard?', event, dash);
+              structLog('log', 'dashboard event for different dashboard?', event, dash);
               return;
             }
-
             let showPopup = this.editing || dash.hasUnsavedChanges();
-
             // Dashboard could have unsaved changes but if user has already restored from a version
             // the reloadPage should be called below
             if (message?.includes('Restored from version')) {
               showPopup = false;
             }
-
             if (action === DashboardEventAction.Saved) {
               if (showPopup) {
                 appEvents.publish(
@@ -171,10 +151,8 @@ class DashboardWatcher {
       }
     },
   };
-
   reloadPage() {
     locationService.reload();
   }
 }
-
 export const dashboardWatcher = new DashboardWatcher();

--- a/public/app/features/live/live.test.ts
+++ b/public/app/features/live/live.test.ts
@@ -1,5 +1,6 @@
 import { Subject } from 'rxjs';
 
+import * as grafanaData from '@grafana/data';
 import { type DataQueryResponse, FieldType, LiveChannelScope, StreamingDataFrame } from '@grafana/data';
 import { type BackendSrv } from '@grafana/runtime';
 
@@ -116,7 +117,7 @@ describe('GrafanaLiveService', () => {
   });
 
   it('should return an empty frame if first message was not a full frame', async () => {
-    jest.spyOn(console, 'warn').mockImplementation(jest.fn);
+    const structLogSpy = jest.spyOn(grafanaData, 'structLog').mockImplementation(jest.fn);
     const dummySubject = new Subject<StreamingDataQueryResponse>();
     mockGetDataStream.mockReturnValueOnce(dummySubject);
 
@@ -142,6 +143,6 @@ describe('GrafanaLiveService', () => {
     const frame: StreamingDataFrame = response?.data[0];
     expect(frame).toBeInstanceOf(StreamingDataFrame);
     expect(frame.fields).toEqual([]);
-    expect(console.warn).toHaveBeenCalled();
+    expect(structLogSpy).toHaveBeenCalled();
   });
 });

--- a/public/app/features/live/live.ts
+++ b/public/app/features/live/live.ts
@@ -1,39 +1,32 @@
+import { structLog } from '@grafana/data';
 import { map } from 'rxjs';
-
 import { toLiveChannelId, StreamingDataFrame } from '@grafana/data';
 import { type BackendSrv, type GrafanaLiveSrv } from '@grafana/runtime';
-
 import { type CentrifugeSrv, type StreamingDataQueryResponse } from './centrifuge/service';
 import { isStreamingResponseData, StreamingResponseDataType } from './data/utils';
-
 type GrafanaLiveServiceDeps = {
   centrifugeSrv: CentrifugeSrv;
   backendSrv: BackendSrv;
 };
-
 export class GrafanaLiveService implements GrafanaLiveSrv {
   constructor(private deps: GrafanaLiveServiceDeps) {}
-
   /**
    * Listen for changes to the connection state
    */
   getConnectionState = () => {
     return this.deps.centrifugeSrv.getConnectionState();
   };
-
   /**
    * Connect to a channel and return results as DataFrames
    */
   getDataStream: GrafanaLiveSrv['getDataStream'] = (options) => {
     let buffer: StreamingDataFrame;
-
     const updateBuffer = (next: StreamingDataQueryResponse): void => {
       const data = next.data[0];
       if (!buffer && !isStreamingResponseData(data, StreamingResponseDataType.FullFrame)) {
-        console.warn(`expected first packet to contain a full frame, received ${data?.type}`);
+        structLog('warn', `expected first packet to contain a full frame, received ${data?.type}`);
         return;
       }
-
       switch (data.type) {
         case StreamingResponseDataType.FullFrame: {
           buffer = StreamingDataFrame.deserialize(data.frame);
@@ -45,7 +38,6 @@ export class GrafanaLiveService implements GrafanaLiveSrv {
         }
       }
     };
-
     return this.deps.centrifugeSrv.getDataStream(options).pipe(
       map((next) => {
         updateBuffer(next);
@@ -56,14 +48,12 @@ export class GrafanaLiveService implements GrafanaLiveSrv {
       })
     );
   };
-
   /**
    * Watch for messages in a channel
    */
   getStream: GrafanaLiveSrv['getStream'] = (address) => {
     return this.deps.centrifugeSrv.getStream(address);
   };
-
   /**
    * Publish into a channel
    *
@@ -73,13 +63,11 @@ export class GrafanaLiveService implements GrafanaLiveSrv {
     if (options?.useSocket) {
       return this.deps.centrifugeSrv.publish(address, data);
     }
-
     return this.deps.backendSrv.post(`api/live/publish`, {
       channel: toLiveChannelId(address), // orgId is from user
       data,
     });
   };
-
   /**
    * For channels that support presence, this will request the current state from the server.
    *

--- a/public/app/features/logs/components/ControlledLogsTable.tsx
+++ b/public/app/features/logs/components/ControlledLogsTable.tsx
@@ -1,16 +1,13 @@
+import { structLog } from '@grafana/data';
 import { css } from '@emotion/css';
 import { useMemo, useRef } from 'react';
-
 import { EventBusSrv, type GrafanaTheme2 } from '@grafana/data';
 import { useStyles2 } from '@grafana/ui';
-
 import { LogsTableWrap } from '../../explore/Logs/LogsTableWrap';
-
 import { type LogRowsComponentProps } from './ControlledLogRows';
 import { useLogListContext } from './panel/LogListContext';
 import { CONTROLS_WIDTH_EXPANDED, LogListControls } from './panel/LogListControls';
 import { LOG_LIST_CONTROLS_WIDTH } from './panel/virtualization';
-
 export const ControlledLogsTable = ({
   loading,
   loadMoreLogs,
@@ -34,17 +31,13 @@ export const ControlledLogsTable = ({
   const { sortOrder, controlsExpanded } = useLogListContext();
   const eventBus = useMemo(() => new EventBusSrv(), []);
   const ref = useRef(null);
-
   const styles = useStyles2(getStyles);
-
   if (!splitOpen || !width || !updatePanelState) {
-    console.error('<ControlledLogsTable>: Missing required props.');
+    structLog('error', '<ControlledLogsTable>: Missing required props.');
     return;
   }
-
   const tableWidthExpandedControls = width - (CONTROLS_WIDTH_EXPANDED + 12);
   const tableWidth = width - (LOG_LIST_CONTROLS_WIDTH + 12);
-
   return (
     <div ref={ref} className={styles.logRowsContainer}>
       <LogListControls eventBus={eventBus} visualisationType={visualisationType} />
@@ -71,7 +64,6 @@ export const ControlledLogsTable = ({
     </div>
   );
 };
-
 const getStyles = (theme: GrafanaTheme2) => {
   return {
     logRows: css({

--- a/public/app/features/logs/components/fieldSelector/LogListFieldSelector.tsx
+++ b/public/app/features/logs/components/fieldSelector/LogListFieldSelector.tsx
@@ -1,22 +1,19 @@
+import { structLog } from '@grafana/data';
 import { useBooleanFlagValue } from '@openfeature/react-sdk';
 import { Resizable, type ResizeCallback } from 're-resizable';
 import { useCallback, useLayoutEffect, useMemo, useState } from 'react';
-
 import { type DataFrame, store } from '@grafana/data';
 import { t } from '@grafana/i18n';
 import { reportInteraction } from '@grafana/runtime';
 import { getDragStyles, IconButton, useStyles2 } from '@grafana/ui';
-
 import { useLogListContext } from '../panel/LogListContext';
 import { reportInteractionOnce } from '../panel/analytics';
 import { type LogListModel } from '../panel/processing';
-
 import { FieldSelector, FIELD_SELECTOR_MIN_WIDTH, getDefaultFieldSelectorWidth } from './FieldSelector';
 import { getFieldSelectorWidth } from './fieldSelectorUtils';
 import { getFieldsWithStats } from './getFieldsWithStats';
 import { logsFieldSelectorWrapperStyles } from './styles';
 import { getSuggestedFieldsFromLogList } from './suggestedFields';
-
 /**
  * FieldSelector wrapper for the LogList visualization.
  */
@@ -25,7 +22,6 @@ interface LogListFieldSelectorProps {
   logs: LogListModel[];
   dataFrames: DataFrame[];
 }
-
 export const LogListFieldSelector = ({ containerElement, dataFrames, logs }: LogListFieldSelectorProps) => {
   const {
     displayedFields,
@@ -40,7 +36,6 @@ export const LogListFieldSelector = ({ containerElement, dataFrames, logs }: Log
   const [sidebarWidth, setSidebarWidth] = useState(getFieldSelectorWidth(logOptionsStorageKey));
   const otelLogsFormattingEnabled = useBooleanFlagValue('otelLogsFormatting', false);
   const dragStyles = useStyles2(getDragStyles);
-
   useLayoutEffect(() => {
     const observer = new ResizeObserver((entries: ResizeObserverEntry[]) => {
       if (entries.length) {
@@ -50,7 +45,6 @@ export const LogListFieldSelector = ({ containerElement, dataFrames, logs }: Log
     observer.observe(containerElement);
     return () => observer.disconnect();
   }, [containerElement]);
-
   const setSidebarWidthWrapper = useCallback(
     (width: number) => {
       setSidebarWidth(width);
@@ -60,7 +54,6 @@ export const LogListFieldSelector = ({ containerElement, dataFrames, logs }: Log
     },
     [logOptionsStorageKey]
   );
-
   const clearFields = useCallback(() => {
     setDisplayedFields?.([]);
     reportInteraction('logs_field_selector_clear_fields_clicked', {
@@ -68,14 +61,12 @@ export const LogListFieldSelector = ({ containerElement, dataFrames, logs }: Log
       mode: 'logs',
     });
   }, [displayedFields.length, setDisplayedFields]);
-
   const collapse = useCallback(() => {
     setSidebarWidthWrapper(FIELD_SELECTOR_MIN_WIDTH);
     reportInteraction('logs_field_selector_collapse_clicked', {
       mode: 'logs',
     });
   }, [setSidebarWidthWrapper]);
-
   const expand = useCallback(() => {
     const width = getFieldSelectorWidth(logOptionsStorageKey);
     setSidebarWidthWrapper(width < 2 * FIELD_SELECTOR_MIN_WIDTH ? getDefaultFieldSelectorWidth() : width);
@@ -83,7 +74,6 @@ export const LogListFieldSelector = ({ containerElement, dataFrames, logs }: Log
       mode: 'logs',
     });
   }, [logOptionsStorageKey, setSidebarWidthWrapper]);
-
   const handleResize: ResizeCallback = useCallback(
     (event, direction, ref) => {
       setSidebarWidthWrapper(ref.clientWidth);
@@ -93,7 +83,6 @@ export const LogListFieldSelector = ({ containerElement, dataFrames, logs }: Log
     },
     [setSidebarWidthWrapper]
   );
-
   const toggleField = useCallback(
     (name: string) => {
       if (displayedFields.includes(name)) {
@@ -104,19 +93,17 @@ export const LogListFieldSelector = ({ containerElement, dataFrames, logs }: Log
     },
     [displayedFields, onClickHideField, onClickShowField]
   );
-
   const toggleLevel = useCallback(() => {
     setShowLevel(!showLevel);
   }, [setShowLevel, showLevel]);
-
   const suggestedFields = useMemo(
     () => getSuggestedFieldsFromLogList(logs, displayedFields, [], otelLogsFormattingEnabled),
     [displayedFields, logs, otelLogsFormattingEnabled]
   );
   const fields = useMemo(() => getFieldsWithStats(dataFrames), [dataFrames]);
-
   if (!onClickShowField || !onClickHideField || !setDisplayedFields) {
-    console.warn(
+    structLog(
+      'warn',
       'LogListFieldSelector: Missing required props: onClickShowField, onClickHideField, setDisplayedFields'
     );
     return null;
@@ -124,7 +111,6 @@ export const LogListFieldSelector = ({ containerElement, dataFrames, logs }: Log
   if (sidebarHeight === 0) {
     return null;
   }
-
   return (
     <Resizable
       enable={{

--- a/public/app/features/logs/components/panel/grammar.ts
+++ b/public/app/features/logs/components/panel/grammar.ts
@@ -1,22 +1,18 @@
+import { structLog } from '@grafana/data';
 import { type Grammar } from 'prismjs';
-
 import { escapeRegex, parseFlags } from '@grafana/data';
-
 import { type LogListModel } from './processing';
-
 // The Logs grammar is used for highlight in the logs panel
 const logsGrammar: Grammar = {
   'log-token-key': /(\b|\B)[\w_]+(?=\s*=)/gi,
   'log-token-string': /"(?!:)([^'"])*?"(?!:)/g,
 };
-
 const tokensGrammar: Grammar = {
   'log-token-uuid': /[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}/g,
   'log-token-size': /(?:\b|")\d+\.{0,1}\d*\s*[kKmMGgtTPp]*[bB]{1}(?:"|\b)/g,
   'log-token-duration': /(?:\b)\d+(\.\d+)?(ns|µs|ms|s|m|h|d)(?:\b)/g,
   'log-token-method': /\b(GET|POST|PUT|DELETE|PATCH|HEAD|OPTIONS|TRACE|CONNECT)\b/g,
 };
-
 const jsonGrammar: Grammar = {
   'log-token-json-key': {
     pattern: /(^|[^\\])"(?:\\.|[^\\"\r\n])*"(?=\s*:)/,
@@ -31,7 +27,6 @@ const jsonGrammar: Grammar = {
   },
   'log-token-size': /-?\b\d+(?:\.\d+)?(?:e[+-]?\d+)?\b/i,
 };
-
 export const generateLogGrammar = (log: LogListModel) => {
   const labels = Object.keys(log.labels)
     .concat(log.fields.map((field) => field.keys[0]))
@@ -51,7 +46,6 @@ export const generateLogGrammar = (log: LogListModel) => {
     ...logsGrammar,
   };
 };
-
 export const generateTextMatchGrammar = (highlightWords: string[] | undefined = [], search?: string): Grammar => {
   /**
    * See:
@@ -64,17 +58,16 @@ export const generateTextMatchGrammar = (highlightWords: string[] | undefined = 
       try {
         return new RegExp(`(?:${cleaned})`, flags);
       } catch (e) {
-        console.error(`generateTextMatchGrammar: cannot generate regular expression from /${cleaned}/${flags}`, e);
+        structLog('error', `generateTextMatchGrammar: cannot generate regular expression from /${cleaned}/${flags}`, e);
       }
       return undefined;
     })
     .filter((expression) => expression !== undefined);
-
   if (search) {
     try {
       expressions.push(new RegExp(escapeRegex(search), 'gi'));
     } catch (e) {
-      console.error(`generateTextMatchGrammar: cannot generate regular expression from /${search}/gi`, e);
+      structLog('error', `generateTextMatchGrammar: cannot generate regular expression from /${search}/gi`, e);
     }
   }
   if (!expressions.length) {
@@ -84,7 +77,6 @@ export const generateTextMatchGrammar = (highlightWords: string[] | undefined = 
     'log-search-match': expressions,
   };
 };
-
 const cleanNeedle = (needle: string): string => {
   return needle.replace(/[[{(][\w,.\/:;<=>?:*+]+$/, '');
 };

--- a/public/app/features/logs/components/panel/panelState/getLogsPanelState.ts
+++ b/public/app/features/logs/components/panel/panelState/getLogsPanelState.ts
@@ -1,11 +1,10 @@
+import { structLog } from '@grafana/data';
 import { urlUtil } from '@grafana/data';
-
 interface LogsPermalinkUrlState {
   logs?: {
     id?: string;
   };
 }
-
 export function getLogsPanelState(): LogsPermalinkUrlState | undefined {
   const urlParams = urlUtil.getUrlSearchParams();
   const panelStateEncoded = urlParams?.panelState;
@@ -18,9 +17,8 @@ export function getLogsPanelState(): LogsPermalinkUrlState | undefined {
     try {
       return JSON.parse(panelStateEncoded[0]);
     } catch (e) {
-      console.error('error parsing logsPanelState', e);
+      structLog('error', 'error parsing logsPanelState', e);
     }
   }
-
   return undefined;
 }

--- a/public/app/features/logs/components/panel/virtualization.ts
+++ b/public/app/features/logs/components/panel/virtualization.ts
@@ -1,19 +1,14 @@
+import { structLog } from '@grafana/data';
 import ansicolor from 'ansicolor';
-
 import { BusEventWithPayload, type GrafanaTheme2 } from '@grafana/data';
-
 import { type LogLineTimestampResolution } from './LogLine';
 import { type LogListFontSize } from './LogList';
 import { type LogListModel } from './processing';
-
 export const LOG_LIST_MIN_WIDTH = 35 * 8;
 // Controls the space between fields in the log line, timestamp, level, displayed fields, and log line body
 export const FIELD_GAP_MULTIPLIER = 1.5;
-
 export const DEFAULT_LINE_HEIGHT = 22;
-
 export const LOG_LIST_CONTROLS_WIDTH = 35;
-
 export class LogLineVirtualization {
   private ctx: CanvasRenderingContext2D | null = null;
   private gridSize;
@@ -24,10 +19,8 @@ export class LogLineVirtualization {
   private logLineSizesMap: Map<string, number>;
   private spanElement = document.createElement('span');
   readonly fontSize: LogListFontSize;
-
   constructor(theme: GrafanaTheme2, fontSize: LogListFontSize) {
     this.fontSize = fontSize;
-
     let fontSizePx;
     if (fontSize === 'default') {
       fontSizePx = theme.typography.fontSize;
@@ -39,31 +32,24 @@ export class LogLineVirtualization {
           : parseInt(theme.typography.bodySmall.fontSize, 10);
       this.lineHeight = fontSizePx * theme.typography.bodySmall.lineHeight;
     }
-
     this.gridSize = theme.spacing.gridSize;
     this.paddingBottom = this.gridSize * 0.75;
     this.logLineSizesMap = new Map<string, number>();
     this.textWidthMap = new Map<number, number>();
-
     const font = `${fontSizePx}px ${theme.typography.fontFamilyMonospace}`;
     const letterSpacing = theme.typography.body.letterSpacing;
-
     this.initDOMmeasurement(font, letterSpacing);
     this.initCanvasMeasurement(font, letterSpacing);
     this.determineMeasurementMode();
   }
-
   getLineHeight = () => this.lineHeight;
   getGridSize = () => this.gridSize;
   getPaddingBottom = () => this.paddingBottom;
-
   getTruncationLineCount = () => Math.round(window.innerHeight / this.getLineHeight() / 1.5);
-
   getTruncationLength = (container: HTMLDivElement | null) => {
     const availableWidth = container ? getLogContainerWidth(container) : window.innerWidth;
     return (availableWidth / this.measureTextWidth('e')) * this.getTruncationLineCount();
   };
-
   determineMeasurementMode = () => {
     if (!this.ctx) {
       this.measurementMode = 'dom';
@@ -73,11 +59,10 @@ export class LogLineVirtualization {
     const domCharWidth = this.measureTextWidthWithDOM('e');
     const diff = domCharWidth - canvasCharWidth;
     if (diff >= 0.1) {
-      console.warn('Virtualized log list: falling back to DOM for measurement');
+      structLog('warn', 'Virtualized log list: falling back to DOM for measurement');
       this.measurementMode = 'dom';
     }
   };
-
   initCanvasMeasurement = (font: string, letterSpacing: string | undefined) => {
     const canvas = document.createElement('canvas');
     this.ctx = canvas.getContext('2d');
@@ -93,7 +78,6 @@ export class LogLineVirtualization {
       this.ctx.letterSpacing = letterSpacing;
     }
   };
-
   initDOMmeasurement = (font: string, letterSpacing: string | undefined) => {
     this.spanElement.style.font = font;
     this.spanElement.style.visibility = 'hidden';
@@ -103,42 +87,33 @@ export class LogLineVirtualization {
       this.spanElement.style.letterSpacing = letterSpacing;
     }
   };
-
   measureTextWidth = (text: string): number => {
     if (!this.ctx) {
       throw new Error(`Measuring context canvas is not initialized. Call init() before.`);
     }
     const key = text.length;
-
     const storedWidth = this.textWidthMap.get(key);
     if (storedWidth) {
       return storedWidth;
     }
-
     const width =
       this.measurementMode === 'canvas' ? this.ctx.measureText(text).width : this.measureTextWidthWithDOM(text);
     this.textWidthMap.set(key, width);
-
     return width;
   };
-
   measureTextWidthWithDOM = (text: string) => {
     this.spanElement.textContent = text;
-
     document.body.appendChild(this.spanElement);
     const width = this.spanElement.getBoundingClientRect().width;
     document.body.removeChild(this.spanElement);
-
     return width;
   };
-
   measureTextHeight = (text: string, maxWidth: number, beforeWidth = 0) => {
     let logLines = 0;
     const charWidth = this.measureTextWidth('e');
     let logLineCharsLength = Math.round(maxWidth / charWidth);
     const firstLineCharsLength = Math.floor((maxWidth - beforeWidth) / charWidth) - 2 * charWidth;
     const textLines = text.split('\n');
-
     // Skip unnecessary measurements
     if (textLines.length === 1 && text.length < firstLineCharsLength) {
       return {
@@ -146,7 +121,6 @@ export class LogLineVirtualization {
         height: this.getLineHeight() + this.paddingBottom,
       };
     }
-
     const availableWidth = maxWidth - beforeWidth;
     for (const textLine of textLines) {
       for (let start = 0; start < textLine.length; ) {
@@ -169,15 +143,12 @@ export class LogLineVirtualization {
         start += testLogLine.length;
       }
     }
-
     const height = logLines * this.getLineHeight() + this.paddingBottom;
-
     return {
       lines: logLines,
       height,
     };
   };
-
   calculateFieldDimensions = (
     logs: LogListModel[],
     displayedFields: string[] = [],
@@ -240,22 +211,18 @@ export class LogLineVirtualization {
     }
     return dimensions;
   };
-
   resetLogLineSizes = () => {
     this.logLineSizesMap = new Map<string, number>();
   };
-
   storeLogLineSize = (id: string, container: HTMLDivElement, height: number) => {
     const key = `${id}_${getLogContainerWidth(container)}_${this.fontSize}`;
     this.logLineSizesMap.set(key, height);
   };
-
   retrieveLogLineSize = (id: string, container: HTMLDivElement) => {
     const key = `${id}_${getLogContainerWidth(container)}_${this.fontSize}`;
     return this.logLineSizesMap.get(key);
   };
 }
-
 export interface DisplayOptions {
   hasLogsWithErrors?: boolean;
   hasSampledLogs?: boolean;
@@ -263,7 +230,6 @@ export interface DisplayOptions {
   showTime: boolean;
   wrap: boolean;
 }
-
 export function getLogLineSize(
   virtualization: LogLineVirtualization,
   logs: LogListModel[],
@@ -279,25 +245,20 @@ export function getLogLineSize(
   if (!logs[index]) {
     return virtualization.getLineHeight() + virtualization.getPaddingBottom();
   }
-
   const storedSize = virtualization.retrieveLogLineSize(logs[index].uid, container);
   if (storedSize) {
     return storedSize;
   }
-
   // Unwrapped logs always measure 1 line
   if (!wrap) {
     return virtualization.getLineHeight() + virtualization.getPaddingBottom();
   }
-
   const gap = virtualization.getGridSize() * FIELD_GAP_MULTIPLIER;
-
   // If a long line is collapsed, we show the line count + an extra line for the expand/collapse control
   logs[index].updateCollapsedState(displayedFields, container);
   if (logs[index].collapsed) {
     return (virtualization.getTruncationLineCount() + 1) * virtualization.getLineHeight();
   }
-
   let textToMeasure = '';
   const iconsGap = virtualization.getGridSize() * 0.5;
   let optionsWidth = 0;
@@ -325,18 +286,15 @@ export function getLogLineSize(
   if (!displayedFields.length) {
     textToMeasure += ansicolor.strip(logs[index].body);
   }
-
   const { height } = virtualization.measureTextHeight(textToMeasure, getLogContainerWidth(container), optionsWidth);
   // When the log is collapsed, add an extra line for the expand/collapse control
   return logs[index].collapsed === false ? height + virtualization.getLineHeight() : height;
 }
-
 export interface LogFieldDimension {
   internal?: boolean;
   field: string;
   width: number;
 }
-
 export function getLogLineDOMHeight(element: HTMLDivElement, calculatedHeight?: number): number | null {
   // Line overflows or is smaller than container
   let measuredHeight = element.scrollHeight;
@@ -344,38 +302,29 @@ export function getLogLineDOMHeight(element: HTMLDivElement, calculatedHeight?: 
   if (measuredHeight > 0 && measuredHeight !== height) {
     return measuredHeight;
   }
-
   // No overflow or undermeasurement
   return null;
 }
-
 const logLineMenuIconWidth = 24;
 const scrollBarWidth = getScrollbarWidth();
-
 export function getLogContainerWidth(container: HTMLDivElement) {
   return container.clientWidth - scrollBarWidth - logLineMenuIconWidth;
 }
-
 export function getScrollbarWidth() {
   const hiddenDiv = document.createElement('div');
-
   hiddenDiv.style.width = '100px';
   hiddenDiv.style.height = '100px';
   hiddenDiv.style.overflow = 'scroll';
   hiddenDiv.style.position = 'absolute';
   hiddenDiv.style.top = '-9999px';
-
   document.body.appendChild(hiddenDiv);
   const width = hiddenDiv.offsetWidth - hiddenDiv.clientWidth;
   document.body.removeChild(hiddenDiv);
-
   return width;
 }
-
 export interface ScrollToLogsEventPayload {
   scrollTo: 'top' | 'bottom' | string;
 }
-
 export class ScrollToLogsEvent extends BusEventWithPayload<ScrollToLogsEventPayload> {
   static type = 'logs-panel-scroll-to';
 }

--- a/public/app/features/logs/utils.ts
+++ b/public/app/features/logs/utils.ts
@@ -1,8 +1,8 @@
+import { structLog } from '@grafana/data';
 import saveAs from 'file-saver';
 import { countBy, chain } from 'lodash';
 import { type MouseEvent } from 'react';
 import { lastValueFrom, map, type Observable } from 'rxjs';
-
 import {
   LogLevel,
   type LogRowModel,
@@ -33,15 +33,12 @@ import {
 } from '@grafana/data';
 import { t } from '@grafana/i18n';
 import { getConfig } from 'app/core/config';
-
 import { getLogsExtractFields } from '../explore/Logs/LogsTable';
 import { downloadDataFrameAsCsv, downloadLogsModelAsTxt } from '../inspector/utils/download';
-
 import { LOG_LINE_BODY_FIELD_NAME } from './components/fieldSelector/logFields';
 import { getDataframeFields } from './components/logParser';
 import { type GetRowContextQueryFn } from './components/panel/LogLineMenu';
 import { DATAPLANE_LABELS_NAME, DATAPLANE_LABEL_TYPES_NAME, parseLogsFrame } from './logsFrame';
-
 /**
  * Returns the log level of a log line.
  * Parse the line for level words. If no level is found, it returns `LogLevel.unknown`.
@@ -54,11 +51,9 @@ export function getLogLevel(line: string): LogLevel {
   }
   let level = LogLevel.unknown;
   let currentIndex: number | undefined = undefined;
-
   for (const [key, value] of Object.entries(LogLevel)) {
     const regexp = new RegExp(`\\b${key}\\b`, 'i');
     const result = regexp.exec(line);
-
     if (result) {
       if (currentIndex === undefined || result.index < currentIndex) {
         level = value;
@@ -68,7 +63,6 @@ export function getLogLevel(line: string): LogLevel {
   }
   return level;
 }
-
 export function getLogLevelFromKey(key: string | number): LogLevel {
   // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
   const level = LogLevel[key.toString().toLowerCase() as keyof typeof LogLevel];
@@ -86,91 +80,77 @@ export function getLogLevelFromKey(key: string | number): LogLevel {
   } else if (typeof key === 'number') {
     return NumericLogLevel[key] || LogLevel.unknown;
   }
-
   return LogLevel.unknown;
 }
-
 export function calculateLogsLabelStats(rows: LogRowModel[], label: string): LogLabelStatsModel[] {
   // Consider only rows that have the given label
   const rowsWithLabel = rows.filter((row) => row.labels[label] !== undefined);
   const rowCount = rowsWithLabel.length;
-
   // Get label value counts for eligible rows
   const countsByValue = countBy(rowsWithLabel, (row) => row.labels[label]);
   return getSortedCounts(countsByValue, rowCount);
 }
-
 export function calculateStats(values: unknown[]): LogLabelStatsModel[] {
   const nonEmptyValues = values.filter((value) => value !== undefined && value !== null);
   const countsByValue = countBy(nonEmptyValues);
   return getSortedCounts(countsByValue, nonEmptyValues.length);
 }
-
-const getSortedCounts = (countsByValue: { [value: string]: number }, rowCount: number) => {
+const getSortedCounts = (
+  countsByValue: {
+    [value: string]: number;
+  },
+  rowCount: number
+) => {
   return chain(countsByValue)
     .map((count, value) => ({ count, value, proportion: count / rowCount }))
     .sortBy('count')
     .reverse()
     .value();
 };
-
 export const sortInAscendingOrder = (a: LogRowModel, b: LogRowModel) => {
   // compare milliseconds
   if (a.timeEpochMs < b.timeEpochMs) {
     return -1;
   }
-
   if (a.timeEpochMs > b.timeEpochMs) {
     return 1;
   }
-
   // if milliseconds are equal, compare nanoseconds
   if (a.timeEpochNs < b.timeEpochNs) {
     return -1;
   }
-
   if (a.timeEpochNs > b.timeEpochNs) {
     return 1;
   }
-
   return 0;
 };
-
 export const sortInDescendingOrder = (a: LogRowModel, b: LogRowModel) => {
   // compare milliseconds
   if (a.timeEpochMs > b.timeEpochMs) {
     return -1;
   }
-
   if (a.timeEpochMs < b.timeEpochMs) {
     return 1;
   }
-
   // if milliseconds are equal, compare nanoseconds
   if (a.timeEpochNs > b.timeEpochNs) {
     return -1;
   }
-
   if (a.timeEpochNs < b.timeEpochNs) {
     return 1;
   }
-
   return 0;
 };
-
 export const sortLogsResult = (logsResult: LogsModel | null, sortOrder: LogsSortOrder): LogsModel => {
   const rows = logsResult ? sortLogRows(logsResult.rows, sortOrder) : [];
   return logsResult ? { ...logsResult, rows } : { hasUniqueLabels: false, rows };
 };
-
 export const sortLogRows = (logRows: LogRowModel[], sortOrder: LogsSortOrder) =>
   sortOrder === LogsSortOrder.Ascending ? logRows.sort(sortInAscendingOrder) : logRows.sort(sortInDescendingOrder);
-
 // Currently supports only error condition in Loki logs
 export const checkLogsError = (logRow: LogRowModel): string | undefined => {
   return logRow.labels.__error__;
 };
-
 export const checkLogsSampled = (logRow: LogRowModel): string | undefined => {
   if (!logRow.labels.__adaptive_logs_sampled__) {
     return undefined;
@@ -179,10 +159,8 @@ export const checkLogsSampled = (logRow: LogRowModel): string | undefined => {
     ? 'Logs like this one have been dropped by Adaptive Logs'
     : `${logRow.labels.__adaptive_logs_sampled__}% of logs like this one have been dropped by Adaptive Logs`;
 };
-
 export const escapeUnescapedString = (string: string) =>
   string.replace(/\\r\\n|\\n|\\t|\\r/g, (match: string) => (match.slice(1) === 't' ? '\t' : '\n'));
-
 export function logRowsToReadableJson(logs: LogRowModel[], pickFields: string[] = []) {
   return logs.map((log) => {
     const fields = getDataframeFields(log).reduce<Record<string, string>>((acc, field) => {
@@ -190,16 +168,13 @@ export function logRowsToReadableJson(logs: LogRowModel[], pickFields: string[] 
       acc[key] = field.values[0];
       return acc;
     }, {});
-
     let logFields = {
       ...fields,
       ...log.labels,
     };
-
     if (pickFields.length) {
       logFields = Object.fromEntries(Object.entries(logFields).filter(([key]) => pickFields.includes(key)));
     }
-
     return {
       line: log.entry,
       timestamp: log.timeEpochNs,
@@ -208,10 +183,8 @@ export function logRowsToReadableJson(logs: LogRowModel[], pickFields: string[] 
     };
   });
 }
-
 export const getLogsVolumeMaximumRange = (dataFrames: DataFrame[]) => {
   let widestRange = { from: Infinity, to: -Infinity };
-
   dataFrames.forEach((dataFrame: DataFrame) => {
     const meta = dataFrame.meta?.custom || {};
     if (meta.absoluteRange?.from && meta.absoluteRange?.to) {
@@ -221,58 +194,56 @@ export const getLogsVolumeMaximumRange = (dataFrames: DataFrame[]) => {
       };
     }
   });
-
   return widestRange;
 };
-
 /**
  * Merge data frames by level and calculate maximum total value for all levels together
  */
-export const mergeLogsVolumeDataFrames = (dataFrames: DataFrame[]): { dataFrames: DataFrame[]; maximum: number } => {
+export const mergeLogsVolumeDataFrames = (
+  dataFrames: DataFrame[]
+): {
+  dataFrames: DataFrame[];
+  maximum: number;
+} => {
   if (dataFrames.length === 0) {
     throw new Error('Cannot aggregate data frames: there must be at least one data frame to aggregate');
   }
-
   // aggregate by level (to produce data frames)
   const aggregated: Record<string, Record<number, number>> = {};
-
   // aggregate totals to align Y axis when multiple log volumes are shown
   const totals: Record<number, number> = {};
   let maximumValue = -Infinity;
-
   const configs: Record<
     string,
-    { meta?: QueryResultMeta; valueFieldConfig: FieldConfig; timeFieldConfig: FieldConfig }
+    {
+      meta?: QueryResultMeta;
+      valueFieldConfig: FieldConfig;
+      timeFieldConfig: FieldConfig;
+    }
   > = {};
   let results: DataFrame[] = [];
-
   // collect and aggregate into aggregated object
   dataFrames.forEach((dataFrame) => {
     const { level, valueField, timeField } = getLogLevelInfo(dataFrame, dataFrames);
-
     if (!timeField || !valueField) {
       return;
     }
-
     configs[level] = {
       meta: dataFrame.meta,
       valueFieldConfig: valueField?.config ?? {},
       timeFieldConfig: timeField?.config ?? {},
     };
-
     for (let pointIndex = 0; pointIndex < dataFrame.length; pointIndex++) {
       const time: number = timeField.values[pointIndex];
       const value: number = valueField.values[pointIndex];
       aggregated[level] ??= {};
       aggregated[level][time] = (aggregated[level][time] || 0) + value;
-
       totals[time] = (totals[time] || 0) + value;
       if (totals[time] > maximumValue) {
         maximumValue = totals[time];
       }
     }
   });
-
   // convert aggregated into data frames
   Object.keys(aggregated).forEach((level) => {
     const levelDataFrame = new MutableDataFrame();
@@ -282,7 +253,6 @@ export const mergeLogsVolumeDataFrames = (dataFrames: DataFrame[]): { dataFrames
     levelDataFrame.meta = meta;
     levelDataFrame.addField({ name: 'Time', type: FieldType.time, config: timeFieldConfig });
     levelDataFrame.addField({ name: 'Value', type: FieldType.number, config: valueFieldConfig });
-
     Object.entries(aggregated[level])
       .sort((a, b) => Number(a[0]) - Number(b[0]))
       .forEach(([time, value]) => {
@@ -291,29 +261,26 @@ export const mergeLogsVolumeDataFrames = (dataFrames: DataFrame[]): { dataFrames
           Value: value,
         });
       });
-
     results.push(levelDataFrame);
   });
-
   return { dataFrames: results, maximum: maximumValue };
 };
-
-export const getLogsVolumeDataSourceInfo = (dataFrames: DataFrame[]): { name: string } | null => {
+export const getLogsVolumeDataSourceInfo = (
+  dataFrames: DataFrame[]
+): {
+  name: string;
+} | null => {
   const customMeta = dataFrames[0]?.meta?.custom;
-
   if (customMeta && customMeta.datasourceName) {
     return {
       name: customMeta.datasourceName,
     };
   }
-
   return null;
 };
-
 export const isLogsVolumeLimited = (dataFrames: DataFrame[]) => {
   return dataFrames[0]?.meta?.custom?.logsVolumeType === LogsVolumeType.Limited;
 };
-
 export const copyText = async (text: string, buttonRef: React.MutableRefObject<Element | null>) => {
   if (navigator.clipboard && window.isSecureContext) {
     return navigator.clipboard.writeText(text);
@@ -333,7 +300,6 @@ export const copyText = async (text: string, buttonRef: React.MutableRefObject<E
     textarea.remove();
   }
 };
-
 export async function handleOpenLogsContextClick(
   event: MouseEvent<HTMLElement>,
   row: LogRowModel,
@@ -354,34 +320,28 @@ export async function handleOpenLogsContextClick(
         }),
       });
       win.location = url;
-
       return;
     }
     win?.close();
   }
   onOpenContext(row);
 }
-
 export function getLogLevelInfo(dataFrame: DataFrame, allDataFrames: DataFrame[]) {
   const fieldCache = new FieldCache(dataFrame);
   const timeField = fieldCache.getFirstFieldOfType(FieldType.time);
   const valueField = fieldCache.getFirstFieldOfType(FieldType.number);
-
   if (!timeField) {
-    console.error('Time field missing in data frame');
+    structLog('error', 'Time field missing in data frame');
   }
   if (!valueField) {
-    console.error('Value field missing in data frame');
+    structLog('error', 'Value field missing in data frame');
   }
-
   const level = valueField ? getFieldDisplayName(valueField, dataFrame, allDataFrames) : 'logs';
   return { level, valueField, timeField };
 }
-
 export function targetIsElement(target: EventTarget | null): target is Element {
   return target instanceof Element;
 }
-
 export function createLogRowsMap() {
   const logRowsSet = new Set();
   return function (target: LogRowModel): boolean {
@@ -393,7 +353,6 @@ export function createLogRowsMap() {
     return false;
   };
 }
-
 function getLabelDisplayTypeFromFrame(labelKey: string, frame: DataFrame, index: number): null | string {
   const typeField = frame.fields.find((field) => field.name === 'labelTypes')?.values[index];
   if (!typeField) {
@@ -401,7 +360,6 @@ function getLabelDisplayTypeFromFrame(labelKey: string, frame: DataFrame, index:
   }
   return typeField[labelKey] ?? null;
 }
-
 /**
  * @deprecated Implement DataSourceWithLogsLabelTypesSupport and use ds.getLabelDisplayTypeFromFrame
  * to support label types.
@@ -420,7 +378,6 @@ export function getLabelTypeFromRow(label: string, row: LogRowModel, plural = fa
   }
   return getDataSourceLabelType(labelType, row.datasourceType, plural);
 }
-
 /**
  * @deprecated
  * @param labelType
@@ -444,26 +401,21 @@ function getDataSourceLabelType(labelType: string, datasourceType: string | unde
       return null;
   }
 }
-
 const POPOVER_STORAGE_KEY = 'logs.popover.disabled';
 export function disablePopoverMenu() {
   store.set(POPOVER_STORAGE_KEY, 'true');
 }
-
 export function enablePopoverMenu() {
   store.delete(POPOVER_STORAGE_KEY);
 }
-
 export function isPopoverMenuDisabled() {
   return Boolean(store.get(POPOVER_STORAGE_KEY));
 }
-
 export enum DownloadFormat {
   Text = 'text',
   Json = 'json',
   CSV = 'csv',
 }
-
 export const downloadLogs = async (
   format: DownloadFormat,
   logRows: LogRowModel[],
@@ -536,7 +488,6 @@ export const downloadLogs = async (
     }
   }
 };
-
 const addISODateTransformation: CustomTransformOperator = () => (source: Observable<DataFrame[]>) => {
   return source.pipe(
     map((data: DataFrame[]) => {
@@ -556,7 +507,6 @@ const addISODateTransformation: CustomTransformOperator = () => (source: Observa
     })
   );
 };
-
 /**
  * Get the start and end timestamps from series.
  */

--- a/public/app/features/panel/panellinks/linkSuppliers.ts
+++ b/public/app/features/panel/panellinks/linkSuppliers.ts
@@ -1,3 +1,4 @@
+import { structLog } from '@grafana/data';
 import {
   type DataLink,
   type DisplayValue,
@@ -15,19 +16,15 @@ import { t } from '@grafana/i18n';
 import { type VizPanel } from '@grafana/scenes';
 import { type PanelModel } from 'app/features/dashboard/state/PanelModel';
 import { dashboardSceneGraph } from 'app/features/dashboard-scene/utils/dashboardSceneGraph';
-
 import { getLinkSrv } from './link_srv';
-
 interface SeriesVars {
   name?: string;
   refId?: string;
 }
-
 interface FieldVars {
   name: string;
   labels?: Labels;
 }
-
 interface ValueVars {
   raw: any;
   numeric: number;
@@ -35,20 +32,17 @@ interface ValueVars {
   time?: number;
   calc?: string;
 }
-
 interface DataViewVars {
   name?: string;
   refId?: string;
   fields?: Record<string, DisplayValue>;
 }
-
 interface DataLinkScopedVars extends ScopedVars {
   __series: ScopedVar<SeriesVars>;
   __field: ScopedVar<FieldVars>;
   __value: ScopedVar<ValueVars>;
   __data: ScopedVar<DataViewVars>;
 }
-
 /**
  * Link suppliers creates link models based on a link origin
  */
@@ -57,14 +51,11 @@ export const getFieldLinksSupplier = (value: FieldDisplay): LinkModelSupplier<Fi
   if (!links || links.length === 0) {
     return undefined;
   }
-
   return {
     getLinks: (replaceVariables: InterpolateFunction) => {
       const scopedVars: Partial<DataLinkScopedVars> = {};
-
       if (value.view) {
         const { dataFrame } = value.view;
-
         scopedVars['__series'] = {
           value: {
             name: dataFrame.name,
@@ -72,9 +63,7 @@ export const getFieldLinksSupplier = (value: FieldDisplay): LinkModelSupplier<Fi
           },
           text: t('panel.get-field-links-supplier.text.series', 'Series'),
         };
-
         const field = value.colIndex !== undefined ? dataFrame.fields[value.colIndex] : undefined;
-
         if (field) {
           scopedVars['__field'] = {
             value: {
@@ -83,7 +72,6 @@ export const getFieldLinksSupplier = (value: FieldDisplay): LinkModelSupplier<Fi
             },
             text: t('panel.get-field-links-supplier.text.field', 'Field'),
           };
-
           if (value.rowIndex !== undefined && value.rowIndex >= 0) {
             const { timeField } = getTimeField(dataFrame);
             scopedVars['__value'] = {
@@ -96,7 +84,6 @@ export const getFieldLinksSupplier = (value: FieldDisplay): LinkModelSupplier<Fi
               text: t('panel.get-field-links-supplier.text.value', 'Value'),
             };
           }
-
           // Expose other values on the row
           if (value.view) {
             scopedVars['__data'] = {
@@ -124,9 +111,8 @@ export const getFieldLinksSupplier = (value: FieldDisplay): LinkModelSupplier<Fi
           };
         }
       } else {
-        console.log('VALUE', value);
+        structLog('log', 'VALUE', value);
       }
-
       const replace: InterpolateFunction = (value: string, vars: ScopedVars | undefined, fmt?: string | Function) => {
         const finalVars: ScopedVars = {
           ...scopedVars,
@@ -134,24 +120,20 @@ export const getFieldLinksSupplier = (value: FieldDisplay): LinkModelSupplier<Fi
         };
         return replaceVariables(value, finalVars, fmt);
       };
-
       return links.map((link: DataLink) => {
         return getLinkSrv().getDataLinkUIModel(link, replace, value);
       });
     },
   };
 };
-
 export const getPanelLinksSupplier = (
   panel: PanelModel,
   replaceVariables?: InterpolateFunction
 ): LinkModelSupplier<PanelModel> | undefined => {
   const links = panel.links;
-
   if (!links || links.length === 0) {
     return undefined;
   }
-
   return {
     getLinks: () => {
       return links.map((link) => {
@@ -160,17 +142,14 @@ export const getPanelLinksSupplier = (
     },
   };
 };
-
 export const getScenePanelLinksSupplier = (
   panel: VizPanel,
   replaceVariables: InterpolateFunction
 ): LinkModelSupplier<VizPanel> | undefined => {
   const links = dashboardSceneGraph.getPanelLinks(panel)?.state.rawLinks;
-
   if (!links || links.length === 0) {
     return undefined;
   }
-
   return {
     getLinks: () => {
       return links.map((link) => {

--- a/public/app/features/panel/state/actions.ts
+++ b/public/app/features/panel/state/actions.ts
@@ -1,3 +1,4 @@
+import { structLog } from '@grafana/data';
 import { type DataTransformerConfig, type FieldConfigSource, getPanelOptionsWithDefaults } from '@grafana/data';
 import { type PanelModel } from 'app/features/dashboard/state/PanelModel';
 import { getLibraryPanel } from 'app/features/library-panels/state/api';
@@ -6,9 +7,7 @@ import { getPanelPluginNotFound } from 'app/features/panel/components/PanelPlugi
 import { loadPanelPlugin } from 'app/features/plugins/admin/state/actions';
 import { DashboardPanelsChangedEvent, PanelOptionsChangedEvent, PanelQueriesChangedEvent } from 'app/types/events';
 import { type ThunkResult } from 'app/types/store';
-
 import { changePanelKey, panelModelAndPluginReady, removePanel } from './reducers';
-
 export function initPanelState(panel: PanelModel): ThunkResult<Promise<void>> {
   return async (dispatch, getStore) => {
     if (panel.libraryPanel?.uid && !('model' in panel.libraryPanel)) {
@@ -16,17 +15,14 @@ export function initPanelState(panel: PanelModel): ThunkResult<Promise<void>> {
       dispatch(loadLibraryPanelAndUpdate(panel));
       return;
     }
-
     // Some old panels, somehow have maxDataPoints value as string.
     // This is causing problems on the backend-side.
     // Here we make sure maxDataPoints is always as number.
     if (panel.maxDataPoints) {
       panel.maxDataPoints = Number(panel.maxDataPoints);
     }
-
     let pluginToLoad = panel.type;
     let plugin = getStore().plugins.panels[pluginToLoad];
-
     if (!plugin) {
       try {
         plugin = await dispatch(loadPanelPlugin(pluginToLoad));
@@ -35,21 +31,17 @@ export function initPanelState(panel: PanelModel): ThunkResult<Promise<void>> {
         plugin = getPanelPluginNotFound(pluginToLoad, pluginToLoad === 'row');
       }
     }
-
     if (!panel.plugin) {
       await panel.pluginLoaded(plugin);
     }
-
     dispatch(panelModelAndPluginReady({ key: panel.key, plugin }));
   };
 }
-
 export function cleanUpPanelState(panelKey: string): ThunkResult<void> {
   return (dispatch) => {
     dispatch(removePanel({ key: panelKey }));
   };
 }
-
 export interface ChangePanelPluginAndOptionsArgs {
   panel: PanelModel;
   pluginId: string;
@@ -57,7 +49,6 @@ export interface ChangePanelPluginAndOptionsArgs {
   fieldConfig?: FieldConfigSource;
   transformations?: DataTransformerConfig[];
 }
-
 export function changePanelPlugin({
   panel,
   pluginId,
@@ -70,18 +61,14 @@ export function changePanelPlugin({
     if (panel.type === pluginId && !options && !fieldConfig && !transformations) {
       return;
     }
-
     const store = getStore();
     let plugin = store.plugins.panels[pluginId];
-
     if (!plugin) {
       plugin = await dispatch(loadPanelPlugin(pluginId));
     }
-
     if (panel.type !== pluginId) {
       panel.changePlugin(plugin);
     }
-
     if (options || fieldConfig || transformations) {
       const newOptions = getPanelOptionsWithDefaults({
         plugin,
@@ -89,24 +76,19 @@ export function changePanelPlugin({
         currentFieldConfig: fieldConfig || panel.fieldConfig,
         isAfterPluginChange: false,
       });
-
       panel.options = newOptions.options;
       panel.fieldConfig = newOptions.fieldConfig;
       panel.transformations = transformations || panel.transformations;
       panel.configRev++;
     }
-
     panel.generateNewKey();
-
     dispatch(panelModelAndPluginReady({ key: panel.key, plugin }));
   };
 }
-
 export function changeToLibraryPanel(panel: PanelModel, libraryPanel: LibraryElementDTO): ThunkResult<void> {
   return async (dispatch, getStore) => {
     const newPluginId = libraryPanel.model.type;
     const oldType = panel.type;
-
     // Update model but preserve gridPos & id
     panel.restoreModel({
       ...libraryPanel.model,
@@ -114,22 +96,17 @@ export function changeToLibraryPanel(panel: PanelModel, libraryPanel: LibraryEle
       id: panel.id,
       libraryPanel: libraryPanel,
     });
-
     // a new library panel usually means new queries, clear any current result
     panel.getQueryRunner().clearLastResult();
-
     // Handle plugin change
     if (oldType !== newPluginId) {
       const store = getStore();
       let plugin = store.plugins.panels[newPluginId];
-
       if (!plugin) {
         plugin = await dispatch(loadPanelPlugin(newPluginId));
       }
-
       await panel.pluginLoaded(plugin);
       panel.generateNewKey();
-
       await dispatch(panelModelAndPluginReady({ key: panel.key, plugin }));
     } else {
       // Even if the plugin is the same, we want to change the key
@@ -138,23 +115,19 @@ export function changeToLibraryPanel(panel: PanelModel, libraryPanel: LibraryEle
       panel.generateNewKey();
       dispatch(changePanelKey({ oldKey, newKey: panel.key }));
     }
-
     panel.configRev = 0;
     panel.hasSavedPanelEditChange = true;
     panel.refresh();
-
     panel.events.publish(PanelQueriesChangedEvent);
     panel.events.publish(PanelOptionsChangedEvent);
   };
 }
-
 export function loadLibraryPanelAndUpdate(panel: PanelModel): ThunkResult<void> {
   return async (dispatch, getStore) => {
     const uid = panel.libraryPanel!.uid!;
     try {
       const libPanel = await getLibraryPanel(uid, true);
       panel.initLibraryPanel(libPanel);
-
       const dashboard = getStore().dashboard.getModel();
       if (panel.repeat && dashboard) {
         const panelIndex = dashboard.panels.findIndex((p) => p.id === panel.id);
@@ -162,10 +135,9 @@ export function loadLibraryPanelAndUpdate(panel: PanelModel): ThunkResult<void> 
         dashboard.sortPanelsByGridPos();
         dashboard.events.publish(new DashboardPanelsChangedEvent());
       }
-
       await dispatch(initPanelState(panel));
     } catch (ex) {
-      console.log('ERROR: ', ex);
+      structLog('log', 'ERROR: ', ex);
       dispatch(
         panelModelAndPluginReady({
           key: panel.key,

--- a/public/app/features/panel/suggestions/getAllSuggestions.ts
+++ b/public/app/features/panel/suggestions/getAllSuggestions.ts
@@ -1,3 +1,4 @@
+import { structLog } from '@grafana/data';
 import {
   AppEvents,
   type DataFrame,
@@ -14,23 +15,18 @@ import { getListedPanelPluginMetas, getPanelPluginMeta } from '@grafana/runtime/
 import { appEvents } from 'app/core/app_events';
 import { isBuiltinPluginPath } from 'app/features/plugins/built_in_plugins';
 import { importPanelPlugin } from 'app/features/plugins/importPanelPlugin';
-
 import { panelsToCheckFirst } from './consts';
-
 interface PluginLoadResult {
   plugins: PanelPlugin[];
   hasErrors: boolean;
 }
-
 async function getPanelPluginIds(): Promise<string[]> {
   if (config.featureToggles.externalVizSuggestions) {
     const plugins = await getListedPanelPluginMetas();
     return plugins.filter((panel) => panel.suggestions).map((m) => m.id);
   }
-
   return panelsToCheckFirst;
 }
-
 async function isBuiltInPlugin(id?: string): Promise<boolean> {
   if (!id) {
     return false;
@@ -38,7 +34,6 @@ async function isBuiltInPlugin(id?: string): Promise<boolean> {
   const meta = await getPanelPluginMeta(id);
   return Boolean(meta != null && isBuiltinPluginPath(meta.module));
 }
-
 /**
  * gather and cache the plugins which provide visualization suggestions so they can be invoked to build suggestions
  */
@@ -51,15 +46,13 @@ export async function loadPlugins(pluginIds: string[]): Promise<PluginLoadResult
       return await importPanelPlugin(pluginId);
     })
   );
-
   for (let i = 0; i < settledPromises.length; i++) {
     const settled = settledPromises[i];
     if (settled.status === 'fulfilled') {
       plugins.push(settled.value);
     } else {
       const pluginId = pluginIds[i];
-      console.error(`Failed to load ${pluginId} for visualization suggestions:`, settled.reason);
-
+      structLog('error', `Failed to load ${pluginId} for visualization suggestions:`, settled.reason);
       if (await isBuiltInPlugin(pluginId)) {
         hasErrors = true;
       } else {
@@ -76,10 +69,8 @@ export async function loadPlugins(pluginIds: string[]): Promise<PluginLoadResult
       }
     }
   }
-
   return { plugins, hasErrors };
 }
-
 /**
  * some of the PreferredVisualisationTypes do not match the panel plugin ids, so we have to map them. d'oh.
  */
@@ -94,7 +85,6 @@ const PLUGIN_ID_TO_PREFERRED_VIZ_TYPE: Record<string, PreferredVisualisationType
 const mapPreferredVisualisationTypeToPlugin = (type: string): PreferredVisualisationType | undefined => {
   return PLUGIN_ID_TO_PREFERRED_VIZ_TYPE[type];
 };
-
 /**
  * given a list of suggestions, sort them in place based on score and preferred visualisation type
  */
@@ -109,7 +99,6 @@ export async function sortSuggestions(
       builtInMap[s.pluginId] = isBuiltIn;
     })
   );
-
   suggestions.sort((a, b) => {
     // if one of these suggestions is from a built-in panel and the other isn't, prioritize the core panel.
     const isPluginABuiltIn = builtInMap[a.pluginId];
@@ -120,7 +109,6 @@ export async function sortSuggestions(
     if (isPluginBBuiltIn && !isPluginABuiltIn) {
       return 1;
     }
-
     // if a preferred visualisation type matches the data, prioritize it
     const mappedA = mapPreferredVisualisationTypeToPlugin(a.pluginId);
     const mappedB = mapPreferredVisualisationTypeToPlugin(b.pluginId);
@@ -132,17 +120,14 @@ export async function sortSuggestions(
         return 1;
       }
     }
-
     // compare scores directly if there are no other factors
     return (b.score ?? VisualizationSuggestionScore.OK) - (a.score ?? VisualizationSuggestionScore.OK);
   });
 }
-
 export interface SuggestionsResult {
   suggestions: PanelPluginVisualizationSuggestion[];
   hasErrors: boolean;
 }
-
 /**
  * given PanelData, return a sorted list of Suggestions from all plugins which support it.
  * @param {DataFrame[]} series data frames
@@ -151,10 +136,8 @@ export interface SuggestionsResult {
 export async function getAllSuggestions(series?: DataFrame[]): Promise<SuggestionsResult> {
   const dataSummary = getPanelDataSummary(series);
   const list: PanelPluginVisualizationSuggestion[] = [];
-
   const pluginIds: string[] = await getPanelPluginIds();
   const { plugins, hasErrors: pluginLoadErrors } = await loadPlugins(pluginIds);
-
   let pluginSuggestionsError = false;
   for (const plugin of plugins) {
     try {
@@ -163,12 +146,10 @@ export async function getAllSuggestions(series?: DataFrame[]): Promise<Suggestio
         list.push(...suggestions);
       }
     } catch (e) {
-      console.warn(`error when loading suggestions from plugin "${plugin.meta.id}"`, e);
+      structLog('warn', `error when loading suggestions from plugin "${plugin.meta.id}"`, e);
       pluginSuggestionsError = true;
     }
   }
-
   await sortSuggestions(list, dataSummary);
-
   return { suggestions: list, hasErrors: pluginLoadErrors || pluginSuggestionsError };
 }

--- a/public/app/features/plugins/admin/api.ts
+++ b/public/app/features/plugins/admin/api.ts
@@ -1,9 +1,9 @@
+import { structLog } from '@grafana/data';
 import { type PluginError, type PluginMeta, renderMarkdown } from '@grafana/data';
 import { getBackendSrv, isFetchError } from '@grafana/runtime';
 import { installPluginMeta, logPluginMetaError, uninstallPluginMeta } from '@grafana/runtime/internal';
 import { accessControlQueryParam } from 'app/core/utils/accessControl';
 import { isVersionGtOrEq } from 'app/core/utils/version';
-
 import { API_ROOT, GCOM_API_ROOT, INSTANCE_API_ROOT } from './constants';
 import { isLocalPluginVisibleByConfig, isRemotePluginVisibleByConfig } from './helpers';
 import {
@@ -16,7 +16,6 @@ import {
   type InstancePlugin,
   type ProvisionedPlugin,
 } from './types';
-
 export async function getPluginDetails(id: string): Promise<CatalogPluginDetails> {
   const remote = await getRemotePlugin(id);
   const isPublished = Boolean(remote);
@@ -26,10 +25,8 @@ export async function getPluginDetails(id: string): Promise<CatalogPluginDetails
     getLocalPluginReadme(id),
     getLocalPluginChangelog(id),
   ]);
-
   const local = localPlugins.find((p) => p.id === id);
   const dependencies = local?.dependencies || remote?.json?.dependencies;
-
   // Add installed version to the list if it's missing (could be deprecated/deleted)
   const installedVersion = local?.info.version;
   const installedVersionMissing = !versions.some((v) => v.version === installedVersion);
@@ -43,7 +40,6 @@ export async function getPluginDetails(id: string): Promise<CatalogPluginDetails
       });
     }
   }
-
   return {
     grafanaDependency: dependencies?.grafanaDependency ?? dependencies?.grafanaVersion ?? '',
     pluginDependencies: dependencies?.plugins || [],
@@ -63,7 +59,6 @@ export async function getPluginDetails(id: string): Promise<CatalogPluginDetails
     screenshots: remote?.json?.info.screenshots || local?.info.screenshots,
   };
 }
-
 export async function getPluginInsights(id: string, version: string | undefined): Promise<CatalogPluginInsights> {
   if (!version) {
     throw new Error('Version is required');
@@ -78,28 +73,28 @@ export async function getPluginInsights(id: string, version: string | undefined)
     throw error;
   }
 }
-
 export async function getRemotePlugins(): Promise<RemotePlugin[]> {
   try {
-    const { items: remotePlugins }: { items: RemotePlugin[] } = await getBackendSrv().get(`${GCOM_API_ROOT}/plugins`, {
+    const {
+      items: remotePlugins,
+    }: {
+      items: RemotePlugin[];
+    } = await getBackendSrv().get(`${GCOM_API_ROOT}/plugins`, {
       // We are also fetching deprecated plugins, because we would like to be able to label plugins in the list that are both installed and deprecated.
       // (We won't show not installed deprecated plugins in the list)
       includeDeprecated: true,
     });
-
     return remotePlugins.filter(isRemotePluginVisibleByConfig);
   } catch (error) {
     if (isFetchError(error)) {
       // It can happen that GCOM is not available, in that case we show a limited set of information to the user.
       error.isHandled = true;
-      console.error('Failed to fetch plugins from catalog (default https://grafana.com/api/plugins)');
+      structLog('error', 'Failed to fetch plugins from catalog (default https://grafana.com/api/plugins)');
       return [];
     }
-
     throw error;
   }
 }
-
 export async function getPluginErrors(): Promise<PluginError[]> {
   try {
     return await getBackendSrv().get(`${API_ROOT}/errors`);
@@ -107,7 +102,6 @@ export async function getPluginErrors(): Promise<PluginError[]> {
     return [];
   }
 }
-
 async function getRemotePlugin(id: string): Promise<RemotePlugin | undefined> {
   try {
     return await getBackendSrv().get(`${GCOM_API_ROOT}/plugins/${id}`, {});
@@ -119,11 +113,9 @@ async function getRemotePlugin(id: string): Promise<RemotePlugin | undefined> {
     return;
   }
 }
-
 async function getPluginVersion(id: string, version: string): Promise<Version | null> {
   try {
     const v: PluginVersion = await getBackendSrv().get(`${GCOM_API_ROOT}/plugins/${id}/versions/${version}`);
-
     return {
       version: v.version,
       createdAt: v.createdAt,
@@ -141,15 +133,14 @@ async function getPluginVersion(id: string, version: string): Promise<Version | 
     return null;
   }
 }
-
 async function getPluginVersions(id: string, isPublished: boolean): Promise<Version[]> {
   try {
     if (!isPublished) {
       return [];
     }
-
-    const versions: { items: PluginVersion[] } = await getBackendSrv().get(`${GCOM_API_ROOT}/plugins/${id}/versions`);
-
+    const versions: {
+      items: PluginVersion[];
+    } = await getBackendSrv().get(`${GCOM_API_ROOT}/plugins/${id}/versions`);
     return (versions.items || []).map((v) => ({
       version: v.version,
       createdAt: v.createdAt,
@@ -167,12 +158,10 @@ async function getPluginVersions(id: string, isPublished: boolean): Promise<Vers
     return [];
   }
 }
-
 async function getLocalPluginReadme(id: string): Promise<string> {
   try {
     const markdown: string = await getBackendSrv().get(`${API_ROOT}/${id}/markdown/README`);
     const markdownAsHtml = markdown ? renderMarkdown(markdown) : '';
-
     return markdownAsHtml;
   } catch (error) {
     if (isFetchError(error)) {
@@ -181,7 +170,6 @@ async function getLocalPluginReadme(id: string): Promise<string> {
     return '';
   }
 }
-
 async function getLocalPluginChangelog(id: string): Promise<string> {
   try {
     const markdown: string = await getBackendSrv().get(`${API_ROOT}/${id}/markdown/CHANGELOG`);
@@ -194,32 +182,31 @@ async function getLocalPluginChangelog(id: string): Promise<string> {
     return '';
   }
 }
-
 export async function getLocalPlugins(): Promise<LocalPlugin[]> {
   const localPlugins: LocalPlugin[] = await getBackendSrv().get(
     `${API_ROOT}`,
     accessControlQueryParam({ embedded: 0 })
   );
-
   return localPlugins.filter(isLocalPluginVisibleByConfig);
 }
-
 export async function getInstancePlugins(): Promise<InstancePlugin[]> {
-  const { items: instancePlugins }: { items: InstancePlugin[] } = await getBackendSrv().get(
-    `${INSTANCE_API_ROOT}/plugins`
-  );
-
+  const {
+    items: instancePlugins,
+  }: {
+    items: InstancePlugin[];
+  } = await getBackendSrv().get(`${INSTANCE_API_ROOT}/plugins`);
   return instancePlugins;
 }
-
 export async function getProvisionedPlugins(): Promise<ProvisionedPlugin[]> {
-  const { items: provisionedPlugins }: { items: Array<{ type: string }> } = await getBackendSrv().get(
-    `${INSTANCE_API_ROOT}/provisioned-plugins`
-  );
-
+  const {
+    items: provisionedPlugins,
+  }: {
+    items: Array<{
+      type: string;
+    }>;
+  } = await getBackendSrv().get(`${INSTANCE_API_ROOT}/provisioned-plugins`);
   return provisionedPlugins.map((plugin) => ({ slug: plugin.type }));
 }
-
 export async function installPlugin(id: string, version?: string) {
   // Install via K8s PluginMeta API (no-op when useMTPlugins is off).
   // We call both this and the legacy path because the K8s settings API doesn't cover all
@@ -230,7 +217,6 @@ export async function installPlugin(id: string, version?: string) {
   } catch (error: unknown) {
     logPluginMetaError(`PluginMeta: Failed to install plugin with id ${id} and version ${version}`, error);
   }
-
   // Legacy install path — kept until K8s settings API covers all plugin types.
   return await getBackendSrv().post(
     `${API_ROOT}/${id}/install`,
@@ -241,7 +227,6 @@ export async function installPlugin(id: string, version?: string) {
     }
   );
 }
-
 export async function uninstallPlugin(id: string) {
   // Uninstall via K8s PluginMeta API (no-op when useMTPlugins is off).
   // We call both this and the legacy path because the K8s settings API doesn't cover all
@@ -252,19 +237,15 @@ export async function uninstallPlugin(id: string) {
   } catch (error: unknown) {
     logPluginMetaError(`PluginMeta: Failed to uninstall plugin with id ${id}`, error);
   }
-
   // Legacy uninstall path — kept until K8s settings API covers all plugin types.
   return await getBackendSrv().post(`${API_ROOT}/${id}/uninstall`);
 }
-
 export async function updatePluginSettings(id: string, data: Partial<PluginMeta>) {
   const response = await getBackendSrv().datasourceRequest({
     url: `/api/plugins/${id}/settings`,
     method: 'POST',
     data,
   });
-
   return response?.data;
 }
-
 export const api = { getRemotePlugins, getInstalledPlugins: getLocalPlugins, installPlugin, uninstallPlugin };

--- a/public/app/features/plugins/admin/components/GetStartedWithPlugin/GetStartedWithApp.tsx
+++ b/public/app/features/plugins/admin/components/GetStartedWithPlugin/GetStartedWithApp.tsx
@@ -1,23 +1,19 @@
+import { structLog } from '@grafana/data';
 import * as React from 'react';
-
 import { type PluginMeta } from '@grafana/data';
 import { Trans } from '@grafana/i18n';
 import { reportInteraction } from '@grafana/runtime';
 import { Button } from '@grafana/ui';
 import { contextSrv } from 'app/core/services/context_srv';
 import { AccessControlAction } from 'app/types/accessControl';
-
 import { updatePluginSettings } from '../../api';
 import { usePluginConfig } from '../../hooks/usePluginConfig';
 import { type CatalogPlugin } from '../../types';
-
 type Props = {
   plugin: CatalogPlugin;
 };
-
 export function GetStartedWithApp({ plugin }: Props): React.ReactElement | null {
   const { value: pluginConfig } = usePluginConfig(plugin);
-
   if (!pluginConfig) {
     return null;
   }
@@ -25,9 +21,7 @@ export function GetStartedWithApp({ plugin }: Props): React.ReactElement | null 
   if (!contextSrv.hasPermission(AccessControlAction.PluginsWrite)) {
     return null;
   }
-
   const { enabled, autoEnabled, jsonData } = pluginConfig?.meta;
-
   const enable = () => {
     reportInteraction('plugins_detail_enable_clicked', {
       path: window.location.pathname,
@@ -41,7 +35,6 @@ export function GetStartedWithApp({ plugin }: Props): React.ReactElement | null 
       jsonData,
     });
   };
-
   const disable = () => {
     reportInteraction('plugins_detail_disable_clicked', {
       path: window.location.pathname,
@@ -55,7 +48,6 @@ export function GetStartedWithApp({ plugin }: Props): React.ReactElement | null 
       jsonData,
     });
   };
-
   return (
     <>
       {!enabled && (
@@ -72,14 +64,12 @@ export function GetStartedWithApp({ plugin }: Props): React.ReactElement | null 
     </>
   );
 }
-
 const updatePluginSettingsAndReload = async (id: string, data: Partial<PluginMeta>) => {
   try {
     await updatePluginSettings(id, data);
-
     // Reloading the page as the plugin meta changes made here wouldn't be propagated throughout the app.
     window.location.reload();
   } catch (e) {
-    console.error('Error while updating the plugin', e);
+    structLog('error', 'Error while updating the plugin', e);
   }
 };

--- a/public/app/features/plugins/admin/pages/Browse.tsx
+++ b/public/app/features/plugins/admin/pages/Browse.tsx
@@ -1,7 +1,7 @@
+import { structLog } from '@grafana/data';
 import { css } from '@emotion/css';
 import { useState } from 'react';
 import { useLocation } from 'react-router-dom-v5-compat';
-
 import { type SelectableValue, type GrafanaTheme2, type PluginType } from '@grafana/data';
 import { Trans, t } from '@grafana/i18n';
 import { locationSearchToObject } from '@grafana/runtime';
@@ -11,7 +11,6 @@ import { getNavModel } from 'app/core/selectors/navModel';
 import { AdvisorRedirectNotice } from 'app/features/connections/components/AdvisorRedirectNotice/AdvisorRedirectNotice';
 import { ROUTES as CONNECTIONS_ROUTES } from 'app/features/connections/constants';
 import { useSelector } from 'app/types/store';
-
 import { HorizontalGroup } from '../components/HorizontalGroup';
 import { PluginList } from '../components/PluginList';
 import { RoadmapLinks } from '../components/RoadmapLinks';
@@ -21,7 +20,6 @@ import { UpdateAllModal } from '../components/UpdateAllModal';
 import { Sorters } from '../helpers';
 import { useHistory } from '../hooks/useHistory';
 import { useGetAll, useGetUpdatable, useIsRemotePluginsAvailable } from '../state/hooks';
-
 export default function Browse() {
   const location = useLocation();
   const locationSearch = locationSearchToObject(location.search);
@@ -29,7 +27,6 @@ export default function Browse() {
   const styles = useStyles2(getStyles);
   const history = useHistory();
   const remotePluginsAvailable = useIsRemotePluginsAvailable();
-
   const keyword = locationSearch.q?.toString() || '';
   const filterBy = locationSearch.filterBy?.toString() || 'all';
   const filterByType = (locationSearch.filterByType as PluginType | 'all') || 'all';
@@ -43,39 +40,31 @@ export default function Browse() {
     },
     sortBy
   );
-
   const filterByOptions = [
     { value: 'all', label: t('plugins.browse.filter-by-options.label.all', 'All') },
     { value: 'installed', label: t('plugins.browse.filter-by-options.label.installed', 'Installed') },
     { value: 'has-update', label: t('plugins.browse.filter-by-options.label.new-updates', 'New Updates') },
   ];
-
   const { isLoading: areUpdatesLoading, updatablePlugins } = useGetUpdatable();
   const [showUpdateModal, setShowUpdateModal] = useState(false);
   const disableUpdateAllButton = updatablePlugins.length <= 0 || areUpdatesLoading;
-
   const onFilterByChange = (value: string) => {
     history.push({ query: { filterBy: value } });
   };
-
   const onFilterByTypeChange = (value: SelectableValue<string>) => {
     history.push({ query: { filterByType: value.value } });
   };
-
   const onSearch = (q: string) => {
     history.push({ query: { filterBy, filterByType, q } });
   };
-
   const onUpdateAll = () => {
     setShowUpdateModal(true);
   };
-
   // How should we handle errors?
   if (error) {
-    console.error(error.message);
+    structLog('error', error.message);
     return null;
   }
-
   const subTitle = (
     <div>
       <Trans i18nKey="plugins.browse.subtitle">
@@ -84,7 +73,6 @@ export default function Browse() {
       </Trans>
     </div>
   );
-
   const updateAllButton = (
     <UpdateAllButton
       disabled={disableUpdateAllButton}
@@ -92,7 +80,6 @@ export default function Browse() {
       updatablePluginsLength={updatablePlugins.length}
     />
   );
-
   return (
     <Page navModel={navModel} actions={updateAllButton} subTitle={subTitle} className={styles.pageContainer}>
       <Page.Contents>
@@ -161,7 +148,6 @@ export default function Browse() {
     </Page>
   );
 }
-
 const getStyles = (theme: GrafanaTheme2) => ({
   pageContainer: css({
     height: '100vh',

--- a/public/app/features/plugins/admin/state/actions.ts
+++ b/public/app/features/plugins/admin/state/actions.ts
@@ -1,12 +1,11 @@
+import { structLog } from '@grafana/data';
 import { createAction, createAsyncThunk, type Update } from '@reduxjs/toolkit';
 import { from, forkJoin, timeout, lastValueFrom, catchError, of } from 'rxjs';
-
 import { type PanelPlugin, type PluginError } from '@grafana/data';
 import { config, getBackendSrv, isFetchError } from '@grafana/runtime';
 import { refetchPanelPluginMetas } from '@grafana/runtime/internal';
 import { importPanelPlugin } from 'app/features/plugins/importPanelPlugin';
 import { type StoreState, type ThunkResult } from 'app/types/store';
-
 import { clearPluginInfoInCache } from '../../loader/pluginInfoCache';
 import {
   getRemotePlugins,
@@ -29,13 +28,11 @@ import {
   type ProvisionedPlugin,
   PluginStatus,
 } from '../types';
-
 // Fetches
 export const fetchAll = createAsyncThunk(`${STATE_PREFIX}/fetchAll`, async (_, thunkApi) => {
   try {
     thunkApi.dispatch({ type: `${STATE_PREFIX}/fetchLocal/pending` });
     thunkApi.dispatch({ type: `${STATE_PREFIX}/fetchRemote/pending` });
-
     const instance$ = config.pluginAdminExternalManageEnabled ? from(getInstancePlugins()) : of(undefined);
     const provisioned$ = config.pluginAdminExternalManageEnabled ? from(getProvisionedPlugins()) : of(undefined);
     const TIMEOUT = 500;
@@ -46,11 +43,10 @@ export const fetchAll = createAsyncThunk(`${STATE_PREFIX}/fetchAll`, async (_, t
     const remote$ = from(getRemotePlugins()).pipe(
       catchError((err) => {
         thunkApi.dispatch({ type: `${STATE_PREFIX}/fetchRemote/rejected` });
-        console.error(err);
+        structLog('error', err);
         return of([]);
       })
     );
-
     forkJoin({
       local: local$,
       remote: remote$,
@@ -70,19 +66,16 @@ export const fetchAll = createAsyncThunk(`${STATE_PREFIX}/fetchAll`, async (_, t
               // Remote plugins loaded after a timeout, updating the store
               .subscribe(async (remote: RemotePlugin[]) => {
                 thunkApi.dispatch({ type: `${STATE_PREFIX}/fetchRemote/fulfilled` });
-
                 if (remote.length > 0) {
                   const local = await lastValueFrom(local$);
                   const instance = await lastValueFrom(instance$);
                   const provisioned = await lastValueFrom(provisioned$);
                   const pluginErrors = await lastValueFrom(pluginErrors$);
-
                   thunkApi.dispatch(
                     addPlugins(mergeLocalsAndRemotes({ local, remote, instance, provisioned, pluginErrors }))
                   );
                 }
               });
-
             return forkJoin({
               local: local$,
               instance: instance$,
@@ -113,7 +106,6 @@ export const fetchAll = createAsyncThunk(`${STATE_PREFIX}/fetchAll`, async (_, t
             thunkApi.dispatch(
               addPlugins(mergeLocalsAndRemotes({ local, remote, instance, provisioned, pluginErrors }))
             );
-
             // Only remote plugins are loaded (remote timed out)
           } else if (local) {
             thunkApi.dispatch({ type: `${STATE_PREFIX}/fetchLocal/fulfilled` });
@@ -121,19 +113,17 @@ export const fetchAll = createAsyncThunk(`${STATE_PREFIX}/fetchAll`, async (_, t
           }
         },
         (error) => {
-          console.log(error);
+          structLog('log', error);
           thunkApi.dispatch({ type: `${STATE_PREFIX}/fetchLocal/rejected` });
           thunkApi.dispatch({ type: `${STATE_PREFIX}/fetchRemote/rejected` });
           return thunkApi.rejectWithValue('Unknown error.');
         }
       );
-
     return null;
   } catch (e) {
     return thunkApi.rejectWithValue('Unknown error.');
   }
 });
-
 export const fetchAllLocal = createAsyncThunk(`${STATE_PREFIX}/fetchAllLocal`, async (_, thunkApi) => {
   try {
     const localPlugins = await getLocalPlugins();
@@ -142,27 +132,27 @@ export const fetchAllLocal = createAsyncThunk(`${STATE_PREFIX}/fetchAllLocal`, a
     return thunkApi.rejectWithValue('Unknown error.');
   }
 });
-
-export const fetchRemotePlugins = createAsyncThunk<RemotePlugin[], void, { rejectValue: RemotePlugin[] }>(
-  `${STATE_PREFIX}/fetchRemotePlugins`,
-  async (_, thunkApi) => {
-    try {
-      return await getRemotePlugins();
-    } catch (error) {
-      if (isFetchError(error)) {
-        error.isHandled = true;
-      }
-      return thunkApi.rejectWithValue([]);
-    }
+export const fetchRemotePlugins = createAsyncThunk<
+  RemotePlugin[],
+  void,
+  {
+    rejectValue: RemotePlugin[];
   }
-);
-
+>(`${STATE_PREFIX}/fetchRemotePlugins`, async (_, thunkApi) => {
+  try {
+    return await getRemotePlugins();
+  } catch (error) {
+    if (isFetchError(error)) {
+      error.isHandled = true;
+    }
+    return thunkApi.rejectWithValue([]);
+  }
+});
 export const fetchDetails = createAsyncThunk<Update<CatalogPlugin, string>, string>(
   `${STATE_PREFIX}/fetchDetails`,
   async (id, thunkApi) => {
     try {
       const details = await getPluginDetails(id);
-
       return {
         id,
         changes: { details },
@@ -172,41 +162,38 @@ export const fetchDetails = createAsyncThunk<Update<CatalogPlugin, string>, stri
     }
   }
 );
-
-export const fetchPluginInsights = createAsyncThunk<Update<CatalogPlugin, string>, { id: string; version?: string }>(
-  `${STATE_PREFIX}/fetchPluginInsights`,
-  async ({ id, version }, thunkApi) => {
-    try {
-      const insights = await getPluginInsights(id, version);
-
-      return {
-        id,
-        changes: { insights },
-      };
-    } catch (e) {
-      return thunkApi.rejectWithValue('Unknown error.');
-    }
+export const fetchPluginInsights = createAsyncThunk<
+  Update<CatalogPlugin, string>,
+  {
+    id: string;
+    version?: string;
   }
-);
-
+>(`${STATE_PREFIX}/fetchPluginInsights`, async ({ id, version }, thunkApi) => {
+  try {
+    const insights = await getPluginInsights(id, version);
+    return {
+      id,
+      changes: { insights },
+    };
+  } catch (e) {
+    return thunkApi.rejectWithValue('Unknown error.');
+  }
+});
 export const addPlugins = createAction<CatalogPlugin[]>(`${STATE_PREFIX}/addPlugins`);
-
 // 1. gets remote equivalents from the store (if there are any)
 // 2. merges the remote equivalents with the local plugins
 // 3. updates the store with the updated CatalogPlugin objects
 export const addLocalPlugins = createAction<LocalPlugin[]>(`${STATE_PREFIX}/addLocalPlugins`);
-
 // 1. gets local equivalents from the store (if there are any)
 // 2. merges the local equivalents with the remote plugins
 // 3. updates the store with the updated CatalogPlugin objects
 export const addRemotePlugins = createAction<RemotePlugin[]>(`${STATE_PREFIX}/addLocalPlugins`);
-
 // 1. merges the local and remote plugins
 // 2. updates the store with the CatalogPlugin objects
-export const addLocalAndRemotePlugins = createAction<{ local: LocalPlugin[]; remote: RemotePlugin[] }>(
-  `${STATE_PREFIX}/addLocalPlugins`
-);
-
+export const addLocalAndRemotePlugins = createAction<{
+  local: LocalPlugin[];
+  remote: RemotePlugin[];
+}>(`${STATE_PREFIX}/addLocalPlugins`);
 // We are also using the install API endpoint to update the plugin
 export const install = createAsyncThunk<
   Update<CatalogPlugin, string>,
@@ -217,58 +204,47 @@ export const install = createAsyncThunk<
   }
 >(`${STATE_PREFIX}/install`, async ({ id, version, installType = PluginStatus.INSTALL }, thunkApi) => {
   const changes: Partial<CatalogPlugin> = { isInstalled: true, installedVersion: version };
-
   if (installType === PluginStatus.UPDATE) {
     changes.hasUpdate = false;
   }
   if (installType === PluginStatus.DOWNGRADE) {
     changes.hasUpdate = true;
   }
-
   try {
     await installPlugin(id, version);
     await refetchPanelPluginMetas();
-
     if (installType !== PluginStatus.INSTALL) {
       clearPluginInfoInCache(id);
     }
-
     return { id, changes };
   } catch (e) {
-    console.error(e);
+    structLog('error', e);
     if (isFetchError(e)) {
       // add id to identify errors in multiple requests
       e.data.id = id;
       return thunkApi.rejectWithValue(e.data);
     }
-
     return thunkApi.rejectWithValue('Unknown error.');
   }
 });
-
 export const unsetInstall = createAsyncThunk(`${STATE_PREFIX}/install`, async () => ({}));
-
 export const uninstall = createAsyncThunk<Update<CatalogPlugin, string>, string>(
   `${STATE_PREFIX}/uninstall`,
   async (id, thunkApi) => {
     try {
       await uninstallPlugin(id);
       await refetchPanelPluginMetas();
-
       clearPluginInfoInCache(id);
-
       return {
         id,
         changes: { isInstalled: false, installedVersion: undefined, isFullyInstalled: false },
       };
     } catch (e) {
-      console.error(e);
-
+      structLog('error', e);
       return thunkApi.rejectWithValue('Unknown error.');
     }
   }
 );
-
 // We need this to be backwards-compatible with other parts of Grafana.
 // (Originally in "public/app/features/plugins/state/actions.ts")
 // TODO<remove once the "plugin_admin_enabled" feature flag is removed>
@@ -276,12 +252,9 @@ export const loadPluginDashboards = createAsyncThunk(`${STATE_PREFIX}/loadPlugin
   const state = thunkApi.getState() as StoreState;
   const dataSourceType = state.dataSources.dataSource.type;
   const url = `api/plugins/${dataSourceType}/dashboards`;
-
   return getBackendSrv().get(url);
 });
-
 export const panelPluginLoaded = createAction<PanelPlugin>(`${STATE_PREFIX}/panelPluginLoaded`);
-
 // We need this to be backwards-compatible with other parts of Grafana.
 // (Originally in "public/app/features/plugins/state/actions.ts")
 // It cannot be constructed with `createAsyncThunk()` as we need the return value on the call-site,
@@ -291,16 +264,13 @@ export const loadPanelPlugin = (id: string): ThunkResult<Promise<PanelPlugin>> =
   return async (dispatch, getStore) => {
     const state = getStore();
     let plugin = state.plugins.panels[id];
-
     if (!plugin) {
       plugin = await importPanelPlugin(id);
-
       // second check to protect against raise condition
       if (!getStore().plugins.panels[id]) {
         dispatch(panelPluginLoaded(plugin));
       }
     }
-
     return plugin;
   };
 };

--- a/public/app/features/plugins/components/AppRootPage.tsx
+++ b/public/app/features/plugins/components/AppRootPage.tsx
@@ -1,9 +1,9 @@
+import { structLog } from '@grafana/data';
 // Libraries
 import { type AnyAction, createSlice, type PayloadAction } from '@reduxjs/toolkit';
 import { useCallback, useEffect, useMemo, useReducer } from 'react';
 import * as React from 'react';
 import { useLocation, useParams } from 'react-router-dom-v5-compat';
-
 import {
   AppEvents,
   type AppPlugin,
@@ -25,7 +25,6 @@ import { useGrafana } from 'app/core/context/GrafanaContext';
 import { getNotFoundNav, getWarningNav, getExceptionNav } from 'app/core/navigation/errorModels';
 import { contextSrv } from 'app/core/services/context_srv';
 import { getMessageFromError } from 'app/core/utils/errors';
-
 import {
   ExtensionRegistriesProvider,
   useAddedLinksRegistry,
@@ -36,11 +35,9 @@ import {
 import { pluginImporter } from '../importer/pluginImporter';
 import { getPluginSettings } from '../pluginSettings';
 import { buildPluginSectionNav, pluginsLogger } from '../utils';
-
 import { PluginErrorBoundary } from './PluginErrorBoundary';
 import { buildPluginPageContext, PluginPageContext } from './PluginPageContext';
 import { RestrictedGrafanaApisProvider } from './restrictedGrafanaApis/RestrictedGrafanaApisProvider';
-
 interface Props {
   // The ID of the plugin we would like to load and display
   pluginId?: string;
@@ -48,7 +45,6 @@ interface Props {
   // for example it's in some way embedded or shown in a sideview this can be undefined.
   pluginNavSection?: NavModelItem;
 }
-
 interface State {
   loading: boolean;
   loadingError: boolean;
@@ -56,9 +52,7 @@ interface State {
   // Used to display a tab navigation (used before the new Top Nav)
   pluginNav: NavModel | null;
 }
-
 const initialState: State = { loading: true, loadingError: false, pluginNav: null, plugin: null };
-
 export function AppRootPage({ pluginId, pluginNavSection }: Props) {
   const { pluginId: pluginIdParam = '' } = useParams();
   pluginId = pluginId || pluginIdParam;
@@ -74,16 +68,13 @@ export function AppRootPage({ pluginId, pluginNavSection }: Props) {
   const queryParams = useMemo(() => locationSearchToObject(location.search), [location.search]);
   const context = useMemo(() => buildPluginPageContext(navModel), [navModel]);
   const grafanaContext = useGrafana();
-
   useEffect(() => {
     loadAppPlugin(pluginId, dispatch);
   }, [pluginId]);
-
   const onNavChanged = useCallback(
     (newPluginNav: NavModel) => dispatch(stateSlice.actions.changeNav(newPluginNav)),
     []
   );
-
   if (!plugin || pluginId !== plugin.meta.id) {
     // Use current layout while loading to reduce flickering
     const currentLayout = grafanaContext.chrome.state.getValue().layout;
@@ -94,7 +85,6 @@ export function AppRootPage({ pluginId, pluginNavSection }: Props) {
       </Page>
     );
   }
-
   if (!plugin.root) {
     return (
       <Page navModel={navModel ?? getWarningNav('Plugin load error')}>
@@ -106,7 +96,6 @@ export function AppRootPage({ pluginId, pluginNavSection }: Props) {
       </Page>
     );
   }
-
   const pluginRoot = plugin.root && (
     <PluginContextProvider meta={plugin.meta}>
       <PluginErrorBoundary
@@ -139,7 +128,6 @@ export function AppRootPage({ pluginId, pluginNavSection }: Props) {
       </PluginErrorBoundary>
     </PluginContextProvider>
   );
-
   // Because of the fallback at plugin routes, we need to check
   // if the user has permissions to see the plugin page.
   const userHasPermissionsToPluginPage = () => {
@@ -147,22 +135,18 @@ export function AppRootPage({ pluginId, pluginNavSection }: Props) {
     if (!plugin.meta?.includes) {
       return true;
     }
-
     const pluginInclude = plugin.meta?.includes.find((include) => include.path === location.pathname);
     // Check if include configuration contains current path
     if (!pluginInclude) {
       return true;
     }
-
     // Check if action exists and give access if user has the required permission.
     if (pluginInclude?.action) {
       return contextSrv.hasPermission(pluginInclude.action);
     }
-
     if (contextSrv.isGrafanaAdmin || contextSrv.user.orgRole === OrgRole.Admin) {
       return true;
     }
-
     const pathRole: string = pluginInclude?.role || '';
     // Check if role exists  and give access to Editor to be able to see Viewer pages
     if (!pathRole || (contextSrv.isEditor && pathRole === OrgRole.Viewer)) {
@@ -170,7 +154,6 @@ export function AppRootPage({ pluginId, pluginNavSection }: Props) {
     }
     return contextSrv.hasRole(pathRole);
   };
-
   const AccessDenied = () => {
     return (
       <Alert severity="warning" title={t('plugins.app-root-page.access-denied.title-access-denied', 'Access denied')}>
@@ -180,15 +163,12 @@ export function AppRootPage({ pluginId, pluginNavSection }: Props) {
       </Alert>
     );
   };
-
   if (!userHasPermissionsToPluginPage()) {
     return <AccessDenied />;
   }
-
   if (!pluginNav) {
     return <PluginPageContext.Provider value={context}>{pluginRoot}</PluginPageContext.Provider>;
   }
-
   return (
     <>
       {navModel ? (
@@ -201,7 +181,6 @@ export function AppRootPage({ pluginId, pluginNavSection }: Props) {
     </>
   );
 }
-
 const stateSlice = createSlice({
   name: 'prom-builder-container',
   initialState: initialState,
@@ -225,7 +204,6 @@ const stateSlice = createSlice({
     },
   },
 });
-
 async function loadAppPlugin(pluginId: string, dispatch: React.Dispatch<AnyAction>) {
   try {
     const app = await getPluginSettings(pluginId).then((info) => {
@@ -249,10 +227,9 @@ async function loadAppPlugin(pluginId: string, dispatch: React.Dispatch<AnyActio
     );
     const error = err instanceof Error ? err : new Error(getMessageFromError(err));
     pluginsLogger.logError(error);
-    console.error(error);
+    structLog('error', error);
   }
 }
-
 export function getAppPluginPageError(meta: AppPluginMeta) {
   if (!meta) {
     return 'Unknown Plugin';
@@ -265,5 +242,4 @@ export function getAppPluginPageError(meta: AppPluginMeta) {
   }
   return null;
 }
-
 export default AppRootPage;

--- a/public/app/features/plugins/components/PluginErrorBoundary.tsx
+++ b/public/app/features/plugins/components/PluginErrorBoundary.tsx
@@ -1,49 +1,42 @@
+import { structLog } from '@grafana/data';
 import * as React from 'react';
-
 import { PluginContext } from '@grafana/data';
-
 interface PluginErrorBoundaryProps {
   children: React.ReactNode;
-  fallback?: React.ComponentType<{ error: Error | null; errorInfo: React.ErrorInfo | null }>;
+  fallback?: React.ComponentType<{
+    error: Error | null;
+    errorInfo: React.ErrorInfo | null;
+  }>;
   onError?: (error: Error, info: React.ErrorInfo) => void;
 }
-
 interface PluginErrorBoundaryState {
   hasError: boolean;
   error: Error | null;
   errorInfo: React.ErrorInfo | null;
 }
-
 export class PluginErrorBoundary extends React.Component<PluginErrorBoundaryProps, PluginErrorBoundaryState> {
   static contextType = PluginContext;
-
   declare context: React.ContextType<typeof PluginContext>;
-
   constructor(props: PluginErrorBoundaryProps) {
     super(props);
     this.state = { hasError: false, error: null, errorInfo: null };
   }
-
   static getDerivedStateFromError(error: Error): PluginErrorBoundaryState {
     return { hasError: true, error: error, errorInfo: null };
   }
-
   componentDidCatch(error: Error, info: React.ErrorInfo) {
     if (this.props.onError) {
       this.props.onError(error, info);
     } else {
-      console.error(`Plugin "${this.context?.meta.id}" failed to load:`, error, info);
+      structLog('error', `Plugin "${this.context?.meta.id}" failed to load:`, error, info);
     }
-
     this.setState({ error, errorInfo: info });
   }
-
   render() {
     const Fallback = this.props.fallback;
     if (this.state.hasError) {
       return Fallback ? <Fallback error={this.state.error} errorInfo={this.state.errorInfo} /> : null;
     }
-
     return this.props.children;
   }
 }

--- a/public/app/features/plugins/components/restrictedGrafanaApis/dashboardMutation/dashboardMutationApi.ts
+++ b/public/app/features/plugins/components/restrictedGrafanaApis/dashboardMutation/dashboardMutationApi.ts
@@ -1,3 +1,4 @@
+import { structLog } from '@grafana/data';
 /**
  * Dashboard Mutation API -- Restricted API wrapper with built-in store.
  *
@@ -9,36 +10,29 @@
  * Plugins access it through RestrictedGrafanaApis context -- they cannot
  * import this module directly because it lives inside the core bundle.
  */
-
 import type { DashboardMutationAPI } from '@grafana/data';
 import { ALL_COMMANDS } from 'app/features/dashboard-scene/mutation-api';
 import { DashboardMutationClient } from 'app/features/dashboard-scene/mutation-api/DashboardMutationClient';
 import type { MutationClient, MutationRequest } from 'app/features/dashboard-scene/mutation-api/types';
 import { provideMutationClientFactory } from 'app/features/dashboard-scene/scene/DashboardMutationClientSetter';
 import type { DashboardScene } from 'app/features/dashboard-scene/scene/DashboardScene';
-
 let _client: MutationClient | null = null;
-
 provideMutationClientFactory((sceneObject) => {
   // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
   const scene = sceneObject as unknown as DashboardScene;
-
   try {
     _client = new DashboardMutationClient(scene);
   } catch (error) {
-    console.error('Failed to register Dashboard Mutation API:', error);
+    structLog('error', 'Failed to register Dashboard Mutation API:', error);
   }
-
   return () => {
     _client = null;
   };
 });
-
 /** @internal — exposed only for unit tests that need to inject a mock client. */
 export function setDashboardMutationClientForTests(client: MutationClient | null): void {
   _client = client;
 }
-
 export const dashboardMutationApi: DashboardMutationAPI = {
   execute: (mutation: MutationRequest) => {
     if (!_client) {

--- a/public/app/features/plugins/extensions/logs/LogViewFilters.tsx
+++ b/public/app/features/plugins/extensions/logs/LogViewFilters.tsx
@@ -1,67 +1,54 @@
+import { structLog } from '@grafana/data';
 import { isEmpty } from 'lodash';
 import { type ReactElement, useMemo } from 'react';
-
 import { type DataFrame, type MatcherConfig, type SelectableValue } from '@grafana/data';
 import { t } from '@grafana/i18n';
 import { type SceneDataProvider } from '@grafana/scenes';
 import { InlineField, InlineFieldRow, MultiSelect } from '@grafana/ui';
-
 export type LogFilter = {
   pluginIds?: Set<string>;
   extensionPointIds?: Set<string>;
   severity?: Set<string>;
   initial?: string;
 };
-
 type LogViewFiltersProps = {
   provider: SceneDataProvider;
   filteredProvider: SceneDataProvider;
   filter: LogFilter;
   onChange: (filter: LogFilter) => void;
 };
-
 export function LogViewFilters({ provider, filteredProvider, filter, onChange }: LogViewFiltersProps): ReactElement {
   const { pluginIds, extensionPointIds, severity } = useLogFilters(provider, filteredProvider, filter);
-
   const onChangePluginIds = (values: Array<SelectableValue<string>>) => {
     const update = {
       ...filter,
       pluginIds: mapToSet(values),
     };
-
     if (isEmpty(filter.extensionPointIds) && isEmpty(filter.severity)) {
       update.initial = isEmpty(values) ? undefined : 'pluginId';
     }
-
     onChange(update);
   };
-
   const onChangeExtensionPointIds = (values: Array<SelectableValue<string>>) => {
     const update = {
       ...filter,
       extensionPointIds: mapToSet(values),
     };
-
     if (isEmpty(filter.pluginIds) && isEmpty(filter.severity)) {
       update.initial = isEmpty(values) ? undefined : 'extensionPointId';
     }
-
     onChange(update);
   };
-
   const onChangeSeverity = (values: Array<SelectableValue<string>>) => {
     const update = {
       ...filter,
       severity: mapToSet(values),
     };
-
     if (isEmpty(filter.pluginIds) && isEmpty(filter.extensionPointIds)) {
       update.initial = isEmpty(values) ? undefined : 'severity';
     }
-
     onChange(update);
   };
-
   return (
     <InlineFieldRow>
       <InlineField label={t('plugins.log-view-filters.label-plugin-id', 'Plugin Id')}>
@@ -76,18 +63,15 @@ export function LogViewFilters({ provider, filteredProvider, filter, onChange }:
     </InlineFieldRow>
   );
 }
-
 export type FilterConfig = {
   fieldName: string;
   config: MatcherConfig;
 };
-
 type LogFilterOptions = {
   pluginIds: Array<SelectableValue<string>>;
   extensionPointIds: Array<SelectableValue<string>>;
   severity: Array<SelectableValue<string>>;
 };
-
 function useLogFilters(
   provider: SceneDataProvider,
   filteredProvider: SceneDataProvider,
@@ -95,15 +79,12 @@ function useLogFilters(
 ): LogFilterOptions {
   const { data } = provider.useState();
   const { data: filteredData } = filteredProvider.useState();
-
   return useMemo(() => {
     if (data && data?.series.length > 1) {
-      console.warn('LogViewFilter does not support multiple series in query result.');
+      structLog('warn', 'LogViewFilter does not support multiple series in query result.');
     }
-
     const frame = data?.series[0];
     const filteredFrame = filteredData?.series[0];
-
     if (!frame) {
       return {
         pluginIds: [],
@@ -111,7 +92,6 @@ function useLogFilters(
         severity: [],
       };
     }
-
     if (!filteredFrame) {
       return toFilterOptions({
         severity: frame,
@@ -119,7 +99,6 @@ function useLogFilters(
         extensionPointId: frame,
       });
     }
-
     switch (filter.initial) {
       case 'extensionPointId':
         return toFilterOptions({
@@ -127,21 +106,18 @@ function useLogFilters(
           pluginId: filteredFrame,
           extensionPointId: frame,
         });
-
       case 'severity':
         return toFilterOptions({
           severity: frame,
           pluginId: filteredFrame,
           extensionPointId: filteredFrame,
         });
-
       case 'pluginId':
         return toFilterOptions({
           severity: filteredFrame,
           pluginId: frame,
           extensionPointId: filteredFrame,
         });
-
       default:
         return toFilterOptions({
           severity: frame,
@@ -151,12 +127,10 @@ function useLogFilters(
     }
   }, [data, filteredData, filter]);
 }
-
 function mapToSet(selected: Array<SelectableValue<string>>): Set<string> | undefined {
   if (selected.length <= 0) {
     return undefined;
   }
-
   return selected.reduce((set, selectable) => {
     if (selectable.value) {
       set.add(selectable.value);
@@ -164,7 +138,6 @@ function mapToSet(selected: Array<SelectableValue<string>>): Set<string> | undef
     return set;
   }, new Set<string>());
 }
-
 function toSelectableArray(source: Set<string>): Array<SelectableValue<string>> {
   return Array.from(source).reduce((all: Array<SelectableValue<string>>, current) => {
     if (!current) {
@@ -177,7 +150,6 @@ function toSelectableArray(source: Set<string>): Array<SelectableValue<string>> 
     return all;
   }, []);
 }
-
 function toFilterOptions(sources: {
   severity: DataFrame;
   pluginId: DataFrame;
@@ -187,11 +159,9 @@ function toFilterOptions(sources: {
   const severityIndex = severity.fields.findIndex((f) => f.name === 'severity');
   const pluginIdIndex = pluginId.fields.findIndex((f) => f.name === 'pluginId');
   const extensionPointIdIndex = extensionPointId.fields.findIndex((f) => f.name === 'extensionPointId');
-
   const severities = new Set<string>(severity.fields[severityIndex].values);
   const pluginIds = new Set<string>(pluginId.fields[pluginIdIndex].values);
   const extensionPointIds = new Set<string>(extensionPointId.fields[extensionPointIdIndex].values);
-
   return {
     severity: toSelectableArray(severities),
     pluginIds: toSelectableArray(pluginIds),

--- a/public/app/features/plugins/extensions/logs/log.ts
+++ b/public/app/features/plugins/extensions/logs/log.ts
@@ -1,10 +1,9 @@
+import { structLog } from '@grafana/data';
 import { isString } from 'lodash';
 import { nanoid } from 'nanoid';
 import { type Observable, ReplaySubject } from 'rxjs';
-
 import { type Labels, LogLevel } from '@grafana/data';
 import { config, createMonitoringLogger } from '@grafana/runtime';
-
 export type ExtensionsLogItem = {
   level: LogLevel;
   timestamp: number;
@@ -14,61 +13,49 @@ export type ExtensionsLogItem = {
   pluginId?: string;
   extensionPointId?: string;
 };
-
 const channelName = 'ui-extension-logs';
 const logsNumberLimit = 1000;
 const logsRetentionTime = 1000 * 60 * 10;
 const monitoringLogger = createMonitoringLogger(channelName);
-
 export class ExtensionsLog {
   private baseLabels: Labels | undefined;
   private subject: ReplaySubject<ExtensionsLogItem>;
   private channel: BroadcastChannel;
-
   constructor(baseLabels?: Labels, subject?: ReplaySubject<ExtensionsLogItem>, channel?: BroadcastChannel) {
     this.baseLabels = baseLabels;
     this.channel = channel ?? new BroadcastChannel(channelName);
     this.subject = subject ?? new ReplaySubject<ExtensionsLogItem>(logsNumberLimit, logsRetentionTime);
-
     if (!channel) {
       this.channel.onmessage = (msg: MessageEvent<ExtensionsLogItem>) => this.subject.next(msg.data);
     }
   }
-
   info(message: string, labels?: Labels): void {
     this.log(LogLevel.info, message, labels);
   }
-
   warning(message: string, labels?: Labels): void {
     monitoringLogger.logWarning(message, { ...this.baseLabels, ...labels });
-    config.buildInfo.env === 'development' && console.warn(message, { ...this.baseLabels, ...labels });
+    config.buildInfo.env === 'development' && structLog('warn', message, { ...this.baseLabels, ...labels });
     this.log(LogLevel.warning, message, labels);
   }
-
   error(message: string, labels?: Labels): void {
     // TODO: If Faro has console instrumentation, then the following will track the same error message twice
     // (first: `monitoringLogger.logError()`, second: `console.error()` which gets picked up by Faro)
     monitoringLogger.logError(new Error(message), { ...this.baseLabels, ...labels });
-    console.error(message, { ...this.baseLabels, ...labels });
+    structLog('error', message, { ...this.baseLabels, ...labels });
     this.log(LogLevel.error, message, labels);
   }
-
   debug(message: string, labels?: Labels): void {
     this.log(LogLevel.debug, message, labels);
   }
-
   trace(message: string, labels?: Labels): void {
     this.log(LogLevel.trace, message, labels);
   }
-
   fatal(message: string, labels?: Labels): void {
     this.log(LogLevel.fatal, message, labels);
   }
-
   private log(level: LogLevel, message: string, labels?: Labels): void {
     const combinedLabels = { ...labels, ...this.baseLabels };
     const { pluginId, extensionPointId } = combinedLabels;
-
     const item: ExtensionsLogItem = {
       level: level,
       labels: combinedLabels,
@@ -78,17 +65,14 @@ export class ExtensionsLog {
       pluginId: isString(pluginId) ? pluginId : undefined,
       extensionPointId: isString(extensionPointId) ? extensionPointId : undefined,
     };
-
     // We only receive messages from different contexts so adding the ones
     // pushed by this log to the local subject.
     this.subject.next(item);
     this.channel.postMessage(item);
   }
-
   asObservable(): Observable<ExtensionsLogItem> {
     return this.subject.asObservable();
   }
-
   child(labels: Labels): ExtensionsLog {
     return new ExtensionsLog(
       {
@@ -100,5 +84,4 @@ export class ExtensionsLog {
     );
   }
 }
-
 export const log = new ExtensionsLog();

--- a/public/app/features/plugins/extensions/utils.tsx
+++ b/public/app/features/plugins/extensions/utils.tsx
@@ -1,8 +1,8 @@
+import { structLog } from '@grafana/data';
 import { css } from '@emotion/css';
 import { cloneDeep, isArray, isObject, isString } from 'lodash';
 import * as React from 'react';
 import { useAsync } from 'react-use';
-
 import {
   type AppPluginConfig,
   type PluginExtensionEventHelpers,
@@ -27,9 +27,7 @@ import {
   ShowModalReactEvent,
   ToggleExtensionSidebarEvent,
 } from 'app/types/events';
-
 import { RestrictedGrafanaApisProvider } from '../components/restrictedGrafanaApis/RestrictedGrafanaApisProvider';
-
 import { ExtensionErrorBoundary } from './ExtensionErrorBoundary';
 import {
   getAppPluginConfigsSync,
@@ -42,23 +40,20 @@ import {
 import { type ExtensionsLog, log as baseLog } from './logs/log';
 import { type AddedLinkRegistryItem } from './registry/AddedLinksRegistry';
 import { assertIsNotPromise, assertStringProps, isPromise } from './validators';
-
 export function handleErrorsInFn(fn: Function, errorMessagePrefix = '') {
   return (...args: unknown[]) => {
     try {
       return fn(...args);
     } catch (e) {
       if (e instanceof Error) {
-        console.warn(`${errorMessagePrefix}${e.message}`);
+        structLog('warn', `${errorMessagePrefix}${e.message}`);
       }
     }
   };
 }
-
 export function createOpenModalFunction(config: AddedLinkRegistryItem): PluginExtensionEventHelpers['openModal'] {
   return async (options) => {
     const { title, body, width, height } = options;
-
     appEvents.publish(
       new ShowModalReactEvent({
         component: wrapWithPluginContext<ModalWrapperProps>({
@@ -71,11 +66,9 @@ export function createOpenModalFunction(config: AddedLinkRegistryItem): PluginEx
     );
   };
 }
-
 type ModalWrapperProps = {
   onDismiss: () => void;
 };
-
 export const wrapWithPluginContext = <T,>({
   pluginId,
   extensionTitle,
@@ -93,11 +86,9 @@ export const wrapWithPluginContext = <T,>({
       loading,
       value: pluginMeta,
     } = useAsync(() => getPluginSettings(pluginId, { showErrorAlert: false }));
-
     if (loading) {
       return null;
     }
-
     if (error) {
       log.error(`Could not fetch plugin meta information for "${pluginId}", aborting. (${error.message})`, {
         stack: error.stack ?? '',
@@ -105,12 +96,10 @@ export const wrapWithPluginContext = <T,>({
       });
       return null;
     }
-
     if (!pluginMeta) {
       log.error(`Fetched plugin meta information is empty for "${pluginId}", aborting.`);
       return null;
     }
-
     return (
       <PluginContextProvider meta={pluginMeta}>
         <ExtensionErrorBoundary pluginId={pluginId} extensionTitle={extensionTitle} log={log}>
@@ -123,10 +112,8 @@ export const wrapWithPluginContext = <T,>({
       </PluginContextProvider>
     );
   };
-
   return WrappedExtensionComponent;
 };
-
 // Wraps a component with a modal.
 // This way we can make sure that the modal is closable, and we also make the usage simpler.
 const getModalWrapper = ({
@@ -137,16 +124,17 @@ const getModalWrapper = ({
   width,
   height,
   config,
-}: PluginExtensionOpenModalOptions & { config: AddedLinkRegistryItem }) => {
+}: PluginExtensionOpenModalOptions & {
+  config: AddedLinkRegistryItem;
+}) => {
   const className = css({ width, height });
-
   const ModalWrapper = ({ onDismiss }: ModalWrapperProps) => {
     return (
       <Modal title={title} className={className} isOpen onDismiss={onDismiss} onClickBackdrop={onDismiss}>
         {/*
-          We also add an error boundary here (apart from the one in the `wrapWithPluginContext`)
-          so the error appears inside the modal (and not at the bottom of the page.)
-        */}
+              We also add an error boundary here (apart from the one in the `wrapWithPluginContext`)
+              so the error appears inside the modal (and not at the bottom of the page.)
+            */}
         <ExtensionErrorBoundary
           pluginId={config.pluginId}
           extensionTitle={config.title}
@@ -160,10 +148,8 @@ const getModalWrapper = ({
       </Modal>
     );
   };
-
   return ModalWrapper;
 };
-
 // Deep-clones and deep-freezes an object.
 // (Returns with a new object, does not modify the original object)
 //
@@ -173,21 +159,16 @@ export function deepFreeze(value?: object | Record<string | symbol, unknown> | u
   if (!value || typeof value !== 'object' || Object.isFrozen(value)) {
     return value;
   }
-
   // Deep cloning the object to prevent freezing the original object
   const clonedValue = Array.isArray(value) ? [...value] : { ...value };
-
   // Prevent infinite recursion by looking for cycles inside an object
   if (frozenProps.has(value)) {
     return frozenProps.get(value);
   }
   frozenProps.set(value, clonedValue);
-
   const propNames = Reflect.ownKeys(clonedValue);
-
   for (const name of propNames) {
     const prop = Array.isArray(clonedValue) ? clonedValue[Number(name)] : clonedValue[name];
-
     // If the property is an object:
     //   1. clone it
     //   2. freeze it
@@ -199,28 +180,22 @@ export function deepFreeze(value?: object | Record<string | symbol, unknown> | u
       }
     }
   }
-
   return Object.freeze(clonedValue);
 }
-
 export function generateExtensionId(pluginId: string, extensionPointId: string, title: string): string {
   const str = `${pluginId}${extensionPointId}${title}`;
-
   return Array.from(str)
     .reduce((s, c) => (Math.imul(31, s) + c.charCodeAt(0)) | 0, 0)
     .toString();
 }
-
 const _isReadOnlyProxy = Symbol('isReadOnlyProxy');
 const _isMutationObserverProxy = Symbol('isMutationObserverProxy');
-
 export class ReadOnlyProxyError extends Error {
   constructor(message?: string) {
     super(message ?? 'Mutating a read-only proxy object');
     this.name = 'ReadOnlyProxyError';
   }
 }
-
 /**
  * Returns a proxy that wraps the given object in a way that makes it read only.
  * If you try to modify the object a TypeError exception will be thrown.
@@ -232,9 +207,7 @@ export function getReadOnlyProxy<T extends object>(obj: T): T {
   if (!obj || typeof obj !== 'object' || isReadOnlyProxy(obj)) {
     return obj;
   }
-
   const cache = new WeakMap();
-
   return new Proxy(obj, {
     defineProperty: () => false,
     deleteProperty: () => false,
@@ -244,28 +217,23 @@ export function getReadOnlyProxy<T extends object>(obj: T): T {
       if (prop === _isReadOnlyProxy) {
         return true;
       }
-
       const value = Reflect.get(target, prop, receiver);
-
       // This will create a clone of the date time object
       // instead of creating a proxy because the underlying
       // momentjs object needs to be able to mutate itself.
       if (isDateTime(value)) {
         return dateTime(value);
       }
-
       if (isObject(value) || isArray(value)) {
         if (!cache.has(value)) {
           cache.set(value, getReadOnlyProxy(value));
         }
         return cache.get(value);
       }
-
       return value;
     },
   });
 }
-
 type MutationSource = 'extension' | 'datasource';
 interface ProxyOptions {
   log?: ExtensionsLog;
@@ -273,7 +241,6 @@ interface ProxyOptions {
   pluginId?: string;
   pluginVersion?: string;
 }
-
 /**
  * Returns a proxy that logs any attempted mutation to the original object.
  *
@@ -289,11 +256,9 @@ export function getMutationObserverProxy<T extends object>(obj: T, options?: Pro
   if (!obj || typeof obj !== 'object' || isMutationObserverProxy(obj)) {
     return obj;
   }
-
   const { log = baseLog, source = 'extension', pluginId = 'unknown', pluginVersion = 'unknown' } = options ?? {};
   const cache = new WeakMap();
   const logFunction = isGrafanaDevMode() ? log.error.bind(log) : log.warning.bind(log); // should show error during local development
-
   return new Proxy(obj, {
     deleteProperty(target, prop) {
       logFunction(
@@ -331,34 +296,28 @@ export function getMutationObserverProxy<T extends object>(obj: T, options?: Pro
       if (prop === _isMutationObserverProxy) {
         return true;
       }
-
       const value = Reflect.get(target, prop, receiver);
-
       // Return read-only properties as-is to avoid proxy invariant violations
       const descriptor = Reflect.getOwnPropertyDescriptor(target, prop);
       if (descriptor && !descriptor.configurable && !descriptor.writable) {
         return value;
       }
-
       // This will create a clone of the date time object
       // instead of creating a proxy because the underlying
       // momentjs object needs to be able to mutate itself.
       if (isDateTime(value)) {
         return dateTime(value);
       }
-
       if (isObject(value) || isArray(value)) {
         if (!cache.has(value)) {
           cache.set(value, getMutationObserverProxy(value, { log, source, pluginId, pluginVersion }));
         }
         return cache.get(value);
       }
-
       return value;
     },
   });
 }
-
 /**
  * Returns a proxy that logs any attempted mutation to the original object.
  *
@@ -375,21 +334,16 @@ export function writableProxy<T>(value: T, options?: ProxyOptions): T {
   if (!value || typeof value !== 'object') {
     return value;
   }
-
   const { log = baseLog, source = 'extension', pluginId = 'unknown', pluginVersion = 'unknown' } = options ?? {};
-
   // Default: we return a proxy of a deep-cloned version of the original object, which logs warnings when mutation is attempted
   return getMutationObserverProxy(cloneDeep(value), { log, pluginId, pluginVersion, source });
 }
-
 export function isReadOnlyProxy(value: unknown): boolean {
   return isRecord(value) && value[_isReadOnlyProxy] === true;
 }
-
 export function isMutationObserverProxy(value: unknown): boolean {
   return isRecord(value) && value[_isMutationObserverProxy] === true;
 }
-
 export function createAddedLinkConfig<T extends object>(
   config: PluginExtensionAddedLinkConfig<T>
 ): PluginExtensionAddedLinkConfig {
@@ -399,11 +353,9 @@ export function createAddedLinkConfig<T extends object>(
   assertLinkConfig(linkConfig);
   return linkConfig;
 }
-
 function assertLinkConfig<T extends object>(
   config: PluginExtensionAddedLinkConfig<T>
 ): asserts config is PluginExtensionAddedLinkConfig {}
-
 export function truncateTitle(title: string, length: number): string {
   if (title.length < length) {
     return title;
@@ -411,7 +363,6 @@ export function truncateTitle(title: string, length: number): string {
   const part = title.slice(0, length - 3);
   return `${part.trimEnd()}...`;
 }
-
 export function getLinkExtensionOverrides(
   pluginId: string,
   config: AddedLinkRegistryItem,
@@ -420,12 +371,10 @@ export function getLinkExtensionOverrides(
 ) {
   try {
     const overrides = config.configure?.(context);
-
     // Hiding the extension
     if (overrides === undefined) {
       return undefined;
     }
-
     // Only allowing to override the following properties
     let {
       title = config.title,
@@ -437,22 +386,16 @@ export function getLinkExtensionOverrides(
       openInNewTab = config.openInNewTab,
       ...rest
     } = overrides;
-
     assertIsNotPromise(
       overrides,
       `The configure() function for "${config.title}" returned a promise, skipping updates.`
     );
-
     assertStringProps({ title, description }, ['title', 'description']);
-
     if (Object.keys(rest).length > 0) {
       log.warning(
-        `Extension "${config.title}", is trying to override restricted properties: ${Object.keys(rest).join(
-          ', '
-        )} which will be ignored.`
+        `Extension "${config.title}", is trying to override restricted properties: ${Object.keys(rest).join(', ')} which will be ignored.`
       );
     }
-
     return {
       title,
       description,
@@ -469,13 +412,11 @@ export function getLinkExtensionOverrides(
         message: error.message,
       });
     }
-
     // If there is an error, we hide the extension
     // (This seems to be safest option in case the extension is doing something wrong.)
     return undefined;
   }
 }
-
 export function getLinkExtensionOnClick(
   pluginId: string,
   extensionPointId: string,
@@ -484,11 +425,9 @@ export function getLinkExtensionOnClick(
   context?: object
 ): ((event?: React.MouseEvent) => void) | undefined {
   const { onClick } = config;
-
   if (!onClick) {
     return;
   }
-
   return function onClickExtensionLink(event?: React.MouseEvent) {
     try {
       reportInteraction('ui_extension_link_clicked', {
@@ -497,7 +436,6 @@ export function getLinkExtensionOnClick(
         title: config.title,
         category: config.category,
       });
-
       const helpers: PluginExtensionEventHelpers = {
         context,
         extensionPointId,
@@ -524,10 +462,8 @@ export function getLinkExtensionOnClick(
           );
         },
       };
-
       log.debug(`onClick '${config.title}' at '${extensionPointId}'`);
       const result = onClick(event, helpers);
-
       if (isPromise(result)) {
         result.catch((error) => {
           if (error instanceof Error) {
@@ -548,7 +484,6 @@ export function getLinkExtensionOnClick(
     }
   };
 }
-
 export function getLinkExtensionPathWithTracking(pluginId: string, path: string, extensionPointId: string): string {
   return urlUtil.appendQueryToUrl(
     path,
@@ -558,9 +493,7 @@ export function getLinkExtensionPathWithTracking(pluginId: string, path: string,
     })
   );
 }
-
 export type LinkExtensionOverrides = ReturnType<typeof getLinkExtensionOverrides>;
-
 /**
  * Builds a PluginExtensionLink from an added link config and optional configure() overrides.
  * Shared by getPluginExtensions and usePluginLinks.
@@ -590,11 +523,9 @@ export function addedLinkToExtensionLink(
     openInNewTab: overrides?.openInNewTab ?? addedLink.openInNewTab,
   };
 }
-
 // Comes from the `app_mode` setting in the Grafana config (defaults to "development")
 // Can be set with the `GF_DEFAULT_APP_MODE` environment variable
 export const isGrafanaDevMode = () => config.buildInfo.env === 'development';
-
 /**
  * Returns a list of app plugin configs that match the given plugin ids.
  * @param pluginIds - The list of plugin ids to filter by.
@@ -604,7 +535,6 @@ export async function getAppPluginConfigs(pluginIds: string[] = []): Promise<App
   const apps = await getAppPluginMetas();
   return getAppPluginConfigsSync(pluginIds, apps);
 }
-
 /**
  * Returns a list of app plugin ids that are registering extensions to this extension point.
  * (These plugins are necessary to be loaded to use the extension point.)
@@ -616,7 +546,6 @@ export async function getExtensionPointPluginDependencies(extensionPointId: stri
   const apps = await getAppPluginMetas();
   return getExtensionPointPluginDependenciesSync(extensionPointId, apps);
 }
-
 /**
  * Returns a map of plugin ids and their addedComponents and addedLinks to the extension point.
  * @param extensionPointId - The id of the extension point.
@@ -626,7 +555,6 @@ export async function getExtensionPointPluginMeta(extensionPointId: string): Pro
   const apps = await getAppPluginMetas();
   return getExtensionPointPluginMetaSync(extensionPointId, apps);
 }
-
 /**
  * Returns a list of app plugin ids that are necessary to be loaded to use the exposed component.
  * (It is first the plugin that exposes the component, and then the ones that it depends on.)
@@ -637,7 +565,6 @@ export async function getExposedComponentPluginDependencies(exposedComponentId: 
   const apps = await getAppPluginMetas();
   return getExposedComponentPluginDependenciesSync(exposedComponentId, apps);
 }
-
 /**
  * Returns a list of app plugins that has to be preloaded in parallel with the core Grafana initialization.
  * @returns An array of app plugin configs that has to be preloaded in parallel with the core Grafana initialization.

--- a/public/app/features/plugins/importer/addTranslationsToI18n.ts
+++ b/public/app/features/plugins/importer/addTranslationsToI18n.ts
@@ -1,15 +1,13 @@
+import { structLog } from '@grafana/data';
 import { addResourceBundle } from '@grafana/i18n/internal';
-
 import { SystemJS } from '../loader/systemjs';
 import { resolveModulePath } from '../loader/utils';
-
 interface AddTranslationsToI18nOptions {
   resolvedLanguage: string;
   fallbackLanguage: string;
   pluginId: string;
   translations: Record<string, string>;
 }
-
 export async function addTranslationsToI18n({
   resolvedLanguage,
   fallbackLanguage,
@@ -19,27 +17,24 @@ export async function addTranslationsToI18n({
   const resolvedPath = translations[resolvedLanguage];
   const fallbackPath = translations[fallbackLanguage];
   const path = resolvedPath ?? fallbackPath;
-
   if (!path) {
-    console.warn(`Could not find any translation for plugin ${pluginId}`, { resolvedLanguage, fallbackLanguage });
+    structLog('warn', `Could not find any translation for plugin ${pluginId}`, { resolvedLanguage, fallbackLanguage });
     return;
   }
-
   try {
     const module = await SystemJS.import(resolveModulePath(path));
     if (!module.default) {
-      console.warn(`Could not find default export for plugin ${pluginId}`, {
+      structLog('warn', `Could not find default export for plugin ${pluginId}`, {
         resolvedLanguage,
         fallbackLanguage,
         path,
       });
       return;
     }
-
     const language = resolvedPath ? resolvedLanguage : fallbackLanguage;
     addResourceBundle(language, pluginId, module.default);
   } catch (error) {
-    console.warn(`Could not load translation for plugin ${pluginId}`, {
+    structLog('warn', `Could not load translation for plugin ${pluginId}`, {
       resolvedLanguage,
       fallbackLanguage,
       error,

--- a/public/app/features/plugins/importer/importPluginModule.ts
+++ b/public/app/features/plugins/importer/importPluginModule.ts
@@ -1,7 +1,7 @@
+import { structLog } from '@grafana/data';
 import { DEFAULT_LANGUAGE } from '@grafana/i18n';
 import { getResolvedLanguage } from '@grafana/i18n/internal';
 import { config } from '@grafana/runtime';
-
 import builtInPlugins, { isBuiltinPluginPath } from '../built_in_plugins';
 import { registerPluginInfoInCache } from '../loader/pluginInfoCache';
 import { SystemJS } from '../loader/systemjs';
@@ -9,10 +9,8 @@ import { resolveModulePath } from '../loader/utils';
 import { importPluginModuleInSandbox } from '../sandbox/sandboxPluginLoader';
 import { shouldLoadPluginInFrontendSandbox } from '../sandbox/sandboxPluginLoaderRegistry';
 import { pluginsLogger } from '../utils';
-
 import { addTranslationsToI18n } from './addTranslationsToI18n';
 import { type PluginImportInfo } from './types';
-
 export async function importPluginModule({
   path,
   pluginId,
@@ -24,7 +22,6 @@ export async function importPluginModule({
   if (version) {
     registerPluginInfoInCache({ path, version, loadingStrategy });
   }
-
   // Add locales to i18n for a plugin if the feature toggle is enabled and the plugin has locales
   if (translations) {
     await addTranslationsToI18n({
@@ -34,7 +31,6 @@ export async function importPluginModule({
       translations,
     });
   }
-
   if (isBuiltinPluginPath(path)) {
     const builtIn = builtInPlugins[path];
     // for handling dynamic imports
@@ -44,14 +40,11 @@ export async function importPluginModule({
       return builtIn;
     }
   }
-
   const modulePath = resolveModulePath(path);
-
   // inject integrity hash into SystemJS import map
   if (config.featureToggles.pluginsSriChecks) {
     const resolvedModule = System.resolve(modulePath);
     const integrityMap = System.getImportMap().integrity;
-
     if (moduleHash && integrityMap && !integrityMap[resolvedModule]) {
       SystemJS.addImportMap({
         integrity: {
@@ -60,15 +53,13 @@ export async function importPluginModule({
       });
     }
   }
-
   // the sandboxing environment code cannot work in nodejs and requires a real browser
   if (await shouldLoadPluginInFrontendSandbox({ pluginId })) {
     return importPluginModuleInSandbox({ pluginId });
   }
-
   return SystemJS.import(modulePath).catch((e) => {
     let error = new Error('Could not load plugin', { cause: e });
-    console.error(error);
+    structLog('error', error);
     pluginsLogger.logError(error, {
       path,
       pluginId,

--- a/public/app/features/plugins/importer/pluginImporter.ts
+++ b/public/app/features/plugins/importer/pluginImporter.ts
@@ -1,3 +1,4 @@
+import { structLog } from '@grafana/data';
 import {
   AppPlugin,
   type AppPluginMeta,
@@ -15,17 +16,13 @@ import {
 import { config } from '@grafana/runtime';
 import { type GenericDataSourcePlugin } from 'app/features/datasources/types';
 import { getPanelPluginLoadError } from 'app/features/panel/components/PanelPluginError';
-
 import { getPluginExtensionRegistries } from '../extensions/registry/setup';
 import { pluginsLogger } from '../utils';
-
 import { importPluginModule } from './importPluginModule';
 import { type PluginImporter, type PostImportStrategy, type PreImportStrategy } from './types';
-
 const defaultPreImport: PreImportStrategy = (plugin) => {
   throwIfAngular(plugin);
   const fallbackLoadingStrategy = plugin.loadingStrategy ?? PluginLoadingStrategy.fetch;
-
   const args = {
     path: plugin.module,
     version: plugin.info?.version,
@@ -34,14 +31,11 @@ const defaultPreImport: PreImportStrategy = (plugin) => {
     moduleHash: plugin.moduleHash,
     translations: plugin.translations,
   };
-
   return args;
 };
-
 const panelPluginPostImport: PostImportStrategy<PanelPlugin, PanelPluginMeta> = async (meta, module) => {
   try {
     const pluginExports = await module;
-
     if (pluginExports.plugin) {
       // pluginExports.plugin can either be a Promise<PanelPlugin> or a PanelPlugin
       const plugin: PanelPlugin = await pluginExports.plugin;
@@ -49,29 +43,25 @@ const panelPluginPostImport: PostImportStrategy<PanelPlugin, PanelPluginMeta> = 
       pluginsCache.set(meta.id, plugin);
       return plugin;
     }
-
     throwIfAngular(pluginExports);
     throw new Error('missing export: plugin');
   } catch (error) {
     // TODO, maybe a different error plugin
-    console.warn('Error loading panel plugin: ' + meta.id, error);
+    structLog('warn', 'Error loading panel plugin: ' + meta.id, error);
     return getPanelPluginLoadError(meta, error);
   }
 };
-
 const datasourcePluginPostImport: PostImportStrategy<GenericDataSourcePlugin, DataSourcePluginMeta> = async (
   meta,
   module
 ) => {
   const pluginExports = await module;
-
   if (pluginExports.plugin) {
     const dsPlugin: GenericDataSourcePlugin = pluginExports.plugin;
     dsPlugin.meta = meta;
     pluginsCache.set(meta.id, dsPlugin);
     return dsPlugin;
   }
-
   if (pluginExports.Datasource) {
     const dsPlugin = new DataSourcePlugin<DataSourceApi<DataQuery, DataSourceJsonData>, DataQuery, DataSourceJsonData>(
       pluginExports.Datasource
@@ -81,31 +71,24 @@ const datasourcePluginPostImport: PostImportStrategy<GenericDataSourcePlugin, Da
     pluginsCache.set(meta.id, dsPlugin);
     return dsPlugin;
   }
-
   throw new Error('Plugin module is missing DataSourcePlugin or Datasource constructor export');
 };
-
 const appPluginPostImport: PostImportStrategy<AppPlugin, AppPluginMeta> = async (meta, module) => {
   const pluginExports = await module;
-
   const { plugin = new AppPlugin() } = pluginExports;
   plugin.init(meta);
   plugin.meta = meta;
   plugin.setComponentsFromLegacyExports(pluginExports);
-
   const { exposedComponentsRegistry, addedComponentsRegistry, addedFunctionsRegistry, addedLinksRegistry } =
     await getPluginExtensionRegistries();
   exposedComponentsRegistry.register({ pluginId: meta.id, configs: plugin.exposedComponentConfigs || [] });
   addedComponentsRegistry.register({ pluginId: meta.id, configs: plugin.addedComponentConfigs || [] });
   addedLinksRegistry.register({ pluginId: meta.id, configs: plugin.addedLinkConfigs || [] });
   addedFunctionsRegistry.register({ pluginId: meta.id, configs: plugin.addedFunctionConfigs || [] });
-
   pluginsCache.set(meta.id, plugin);
   return plugin;
 };
-
 const promisesCache: Map<string, Promise<PanelPlugin | GenericDataSourcePlugin | AppPlugin>> = new Map();
-
 const getPromiseFromCache = <M extends PluginMeta, P extends PanelPlugin | GenericDataSourcePlugin | AppPlugin>(
   meta: M
 ): Promise<P> => {
@@ -114,22 +97,17 @@ const getPromiseFromCache = <M extends PluginMeta, P extends PanelPlugin | Gener
     // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
     return cached as Promise<P>;
   }
-
   throw new Error(`Trying to get unknown plugin type ${meta.type} from cache for plugin ${meta.id}`);
 };
-
 const pluginsCache: Map<string, PanelPlugin | GenericDataSourcePlugin | AppPlugin> = new Map();
-
 const getPluginFromCache = <P extends PanelPlugin | GenericDataSourcePlugin | AppPlugin>(id: string): P | undefined => {
   const cached = pluginsCache.get(id);
   if (cached) {
     // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
     return cached as P;
   }
-
   return undefined;
 };
-
 const importPlugin = <M extends PluginMeta, P extends PanelPlugin | GenericDataSourcePlugin | AppPlugin>(
   meta: M,
   postImportStrategy: PostImportStrategy<P, M>,
@@ -147,7 +125,6 @@ const importPlugin = <M extends PluginMeta, P extends PanelPlugin | GenericDataS
     });
     return Promise.resolve(cached);
   }
-
   if (promisesCache.has(meta.id)) {
     pluginsLogger.logDebug(`Retrieving plugin from inflight plugin load request`, {
       path: meta.module,
@@ -159,22 +136,18 @@ const importPlugin = <M extends PluginMeta, P extends PanelPlugin | GenericDataS
     });
     return getPromiseFromCache(meta);
   }
-
   const args = preImportStrategy(meta);
   const module = importPluginModule(args);
   const plugin = postImportStrategy(meta, module);
   promisesCache.set(meta.id, plugin);
-
   return getPromiseFromCache(meta);
 };
-
 export const pluginImporter: PluginImporter = {
   importPanel: (meta: PanelPluginMeta) => importPlugin(meta, panelPluginPostImport),
   importDataSource: (meta: DataSourcePluginMeta) => importPlugin(meta, datasourcePluginPostImport),
   importApp: (meta: AppPluginMeta) => importPlugin(meta, appPluginPostImport),
   getPanel: (id: string) => getPluginFromCache<PanelPlugin>(id), // we need this sync because how the panel plugins are loaded in PanelRenderer
 };
-
 export const clearCaches = () => {
   promisesCache.clear();
   pluginsCache.clear();

--- a/public/app/features/plugins/loader/systemjsHooks.ts
+++ b/public/app/features/plugins/loader/systemjsHooks.ts
@@ -1,8 +1,7 @@
+import { structLog } from '@grafana/data';
 import { PluginLoadingStrategy } from '@grafana/data';
 import { config } from '@grafana/runtime';
-
 import { transformPluginSourceForCDN } from '../cdn/utils';
-
 import { LOAD_PLUGIN_CSS_REGEX, JS_CONTENT_TYPE_REGEX, SHARED_DEPENDENCY_PREFIX } from './constants';
 import { getPluginInfoFromCache, resolvePluginUrlWithCache } from './pluginInfoCache';
 // SystemJS has to be imported before the sharedDependenciesMap
@@ -11,28 +10,21 @@ import { SystemJS } from './systemjs';
 import { sharedDependenciesMap } from './sharedDependencies';
 import { type SystemJSWithLoaderHooks } from './types';
 import { buildImportMap, isHostedOnCDN } from './utils';
-
 export function initSystemJSHooks() {
   const imports = buildImportMap(sharedDependenciesMap);
-
   SystemJS.addImportMap({ imports });
-
   const systemJSPrototype: SystemJSWithLoaderHooks = SystemJS.constructor.prototype;
-
   // This instructs SystemJS to load plugin assets using fetch and eval if it returns a truthy value, otherwise
   // it will load the plugin using a script tag. The logic that sets loadingStrategy comes from the backend.
   // Loading strategy is calculated during bootstrap in pkg/plugins/pluginassets/loadingstrategy.go
   systemJSPrototype.shouldFetch = function (url) {
     const pluginInfo = getPluginInfoFromCache(url);
     const jsTypeRegEx = /^[^#?]+\.(js)([?#].*)?$/;
-
     if (!jsTypeRegEx.test(url)) {
       return true;
     }
-
     return Boolean(pluginInfo?.loadingStrategy !== PluginLoadingStrategy.script);
   };
-
   const originalImport = systemJSPrototype.import;
   // Hook Systemjs import to support plugins that only have a default export.
   systemJSPrototype.import = function (...args: Parameters<typeof originalImport>) {
@@ -43,21 +35,17 @@ export function initSystemJSHooks() {
       return module;
     });
   };
-
   const systemJSFetch = systemJSPrototype.fetch;
   systemJSPrototype.fetch = function (url: string, options?: Record<string, unknown>) {
     return decorateSystemJSFetch(systemJSFetch, url, options);
   };
-
   const systemJSResolve = systemJSPrototype.resolve;
   systemJSPrototype.resolve = decorateSystemJSResolve.bind(systemJSPrototype, systemJSResolve);
-
   // Older plugins load .css files which resolves to a CSS Module.
   // https://github.com/WICG/webcomponents/blob/gh-pages/proposals/css-modules-v1-explainer.md#importing-a-css-module
   // Any css files loaded via SystemJS have their styles applied onload.
   systemJSPrototype.onload = decorateSystemJsOnload;
 }
-
 export async function decorateSystemJSFetch(
   systemJSFetch: SystemJSWithLoaderHooks['fetch'],
   url: string,
@@ -65,22 +53,18 @@ export async function decorateSystemJSFetch(
 ) {
   const res = await systemJSFetch(url, options);
   const contentType = res.headers.get('content-type') || '';
-
   if (JS_CONTENT_TYPE_REGEX.test(contentType)) {
     const source = await res.text();
     let transformedSrc = source;
-
     // JS files on the CDN need their asset paths transformed in the source
     if (isHostedOnCDN(res.url)) {
       const cdnTransformedSrc = transformPluginSourceForCDN({ url: res.url, source: transformedSrc });
       return new Response(new Blob([cdnTransformedSrc], { type: 'text/javascript' }));
     }
-
     return new Response(new Blob([transformedSrc], { type: 'text/javascript' }));
   }
   return res;
 }
-
 export function decorateSystemJSResolve(
   this: SystemJSWithLoaderHooks,
   originalResolve: SystemJSWithLoaderHooks['resolve'],
@@ -102,11 +86,10 @@ export function decorateSystemJSResolve(
       const url = originalResolve.apply(this, [resolvedUrl, parentUrl]);
       return resolvePluginUrlWithCache(url);
     }
-    console.warn(`SystemJS: failed to resolve '${id}'`);
+    structLog('warn', `SystemJS: failed to resolve '${id}'`);
     return id;
   }
 }
-
 export function decorateSystemJsOnload(err: unknown, id: string) {
   // IF the url is relative resolve to current origin, absolute urls passed in will ignore base.
   const url = new URL(id, window.location.origin);
@@ -118,7 +101,6 @@ export function decorateSystemJsOnload(err: unknown, id: string) {
     }
   }
 }
-
 // This function handles the following legacy SystemJS functionality:
 // - strips legacy loader wildcard from urls
 // - support config.defaultExtension for System.register deps that lack an extension (e.g. './my_ctrl')
@@ -131,10 +113,8 @@ function getBackWardsCompatibleUrl(url: string) {
   }
   const systemJSFileExtensions = ['css', 'js', 'json', 'wasm'];
   const hasValidFileExtension = systemJSFileExtensions.some((extensionName) => url.endsWith(extensionName));
-
   return hasValidFileExtension ? url : url + '.js';
 }
-
 // This function takes the path used in loadPluginCss and attempts to resolve it
 // by checking the SystemJS entries for a matching pluginId then using that entry to find the baseUrl.
 // If no match is found then it returns a fallback attempt at a relative path.
@@ -147,7 +127,6 @@ export function getLoadPluginCssUrl(id: string) {
       break;
     }
   }
-
   const index = url.lastIndexOf('/plugins');
   if (index === -1) {
     return `${config.appSubUrl ?? ''}/public/${id}`;

--- a/public/app/features/plugins/loader/utils.ts
+++ b/public/app/features/plugins/loader/utils.ts
@@ -1,41 +1,32 @@
+import { structLog } from '@grafana/data';
 import { config } from '@grafana/runtime';
-
 import { sandboxPluginDependencies } from '../sandbox/pluginDependencies';
-
 import { SHARED_DEPENDENCY_PREFIX } from './constants';
 import { SystemJS } from './systemjs';
-
 export function buildImportMap(importMap: Record<string, System.Module>) {
   return Object.keys(importMap).reduce<Record<string, string>>((acc, key) => {
     // Use the 'package:' prefix to act as a URL instead of a bare specifier
     const module_name = `${SHARED_DEPENDENCY_PREFIX}:${key}`;
-
     // expose dependency to loaders
     addPreload(module_name, importMap[key]);
-
     sandboxPluginDependencies.set(key, importMap[key]);
-
     acc[key] = module_name;
     return acc;
   }, {});
 }
-
 function addPreload(id: string, preload: (() => Promise<System.Module>) | System.Module) {
   if (SystemJS.has(id)) {
     return;
   }
-
   let resolvedId;
   try {
     resolvedId = SystemJS.resolve(id);
   } catch (e) {
-    console.log(e);
+    structLog('log', e);
   }
-
   if (resolvedId && SystemJS.has(resolvedId)) {
     return;
   }
-
   const moduleId = resolvedId || id;
   if (typeof preload === 'function') {
     SystemJS.register(id, [], (_export) => {
@@ -50,11 +41,9 @@ function addPreload(id: string, preload: (() => Promise<System.Module>) | System
     SystemJS.set(moduleId, preload);
   }
 }
-
 export function isHostedOnCDN(path: string) {
   return Boolean(config.pluginsCDNBaseURL) && path.startsWith(config.pluginsCDNBaseURL);
 }
-
 // This function is used to dynamically prepend the appSubUrl in the frontend.
 // This is required because if serve_from_sub_path is false the Image Renderer sets the subpath
 // to an empty string and sets appurl to localhost which causes plugins to fail to load.
@@ -63,6 +52,5 @@ export function resolveModulePath(path: string) {
   if (path.startsWith('http') || path.startsWith('/')) {
     return path;
   }
-
   return `${config.appSubUrl ?? ''}/${path}`;
 }

--- a/public/app/features/plugins/pluginPreloader.ts
+++ b/public/app/features/plugins/pluginPreloader.ts
@@ -1,3 +1,4 @@
+import { structLog } from '@grafana/data';
 import type {
   AppPluginConfig,
   PluginExtensionAddedLinkConfig,
@@ -6,9 +7,7 @@ import type {
 } from '@grafana/data';
 import { contextSrv } from 'app/core/services/context_srv';
 import { getPluginSettings } from 'app/features/plugins/pluginSettings';
-
 import { pluginImporter } from './importer/pluginImporter';
-
 export type PluginPreloadResult = {
   pluginId: string;
   error?: unknown;
@@ -16,13 +15,10 @@ export type PluginPreloadResult = {
   addedComponentConfigs?: PluginExtensionAddedComponentConfig[];
   addedLinkConfigs?: PluginExtensionAddedLinkConfig[];
 };
-
 const preloadPromises = new Map<string, Promise<void>>();
-
 export const clearPreloadedPluginsCache = () => {
   preloadPromises.clear();
 };
-
 export async function preloadPlugins(apps: AppPluginConfig[] = []) {
   // Create preload promises for each app, reusing existing promises if already loading
   const promises = apps.map((app) => {
@@ -31,13 +27,10 @@ export async function preloadPlugins(apps: AppPluginConfig[] = []) {
     }
     return preloadPromises.get(app.id)!;
   });
-
   await Promise.all(promises);
 }
-
 async function preload(config: AppPluginConfig): Promise<void> {
   const showErrorAlert = contextSrv.user.orgRole !== '';
-
   try {
     const meta = await getPluginSettings(config.id, { showErrorAlert });
     await pluginImporter.importApp(meta);
@@ -45,7 +38,6 @@ async function preload(config: AppPluginConfig): Promise<void> {
     if (!showErrorAlert) {
       return;
     }
-
-    console.error(`[Plugins] Failed to preload plugin: ${config.path} (version: ${config.version})`, error);
+    structLog('error', `[Plugins] Failed to preload plugin: ${config.path} (version: ${config.version})`, error);
   }
 }

--- a/public/app/features/plugins/sandbox/distortions.ts
+++ b/public/app/features/plugins/sandbox/distortions.ts
@@ -1,15 +1,13 @@
+import { structLog } from '@grafana/data';
 import { type ProxyTarget } from '@locker/near-membrane-shared';
 import DOMPurify from 'dompurify';
 import { cloneDeep, isFunction } from 'lodash';
-
 import { type Monaco } from '@grafana/ui';
-
 import { loadScriptIntoSandbox } from './codeLoader';
 import { forbiddenElements } from './constants';
 import { recursivePatchObjectAsLiveTarget } from './documentSandbox';
 import { type SandboxEnvironment, type SandboxPluginMeta } from './types';
 import { logWarning, unboxRegexesFromMembraneProxy } from './utils';
-
 /**
  * Distortions are near-membrane mechanisms to altert JS instrics and DOM APIs.
  *
@@ -60,15 +58,12 @@ import { logWarning, unboxRegexesFromMembraneProxy } from './utils';
  *
  * The code in this file defines that generalDistortionMap.
  */
-
 type DistortionMap = Map<
   unknown,
   (originalAttrOrMethod: unknown, pluginMeta: SandboxPluginMeta, sandboxEnv?: SandboxEnvironment) => unknown
 >;
 const generalDistortionMap: DistortionMap = new Map();
-
 const SANDBOX_LIVE_API_PATCHED = Symbol.for('@SANDBOX_LIVE_API_PATCHED');
-
 export function getGeneralSandboxDistortionMap() {
   if (generalDistortionMap.size === 0) {
     // initialize the distortion map
@@ -87,7 +82,6 @@ export function getGeneralSandboxDistortionMap() {
   }
   return generalDistortionMap;
 }
-
 function failToSet(originalAttrOrMethod: unknown, meta: SandboxPluginMeta) {
   logWarning(`Plugin ${meta.id} tried to set a sandboxed property`, {
     pluginId: meta.id,
@@ -98,11 +92,9 @@ function failToSet(originalAttrOrMethod: unknown, meta: SandboxPluginMeta) {
     throw new Error('Plugins are not allowed to set sandboxed properties');
   };
 }
-
 // sets distortion to protect iframe elements
 function distortIframeAttributes(distortions: DistortionMap) {
   const iframeHtmlForbiddenProperties = ['contentDocument', 'contentWindow', 'src', 'srcdoc', 'srcObject', 'srcset'];
-
   for (const property of iframeHtmlForbiddenProperties) {
     const descriptor = Object.getOwnPropertyDescriptor(HTMLIFrameElement.prototype, property);
     if (descriptor) {
@@ -113,12 +105,10 @@ function distortIframeAttributes(distortions: DistortionMap) {
           attrOrMethod: property,
           entity: 'iframe',
         });
-
         return () => {
           throw new Error('iframe.' + property + ' is not allowed in sandboxed plugins');
         };
       }
-
       if (descriptor.value) {
         distortions.set(descriptor.value, fail);
       }
@@ -131,16 +121,14 @@ function distortIframeAttributes(distortions: DistortionMap) {
     }
   }
 }
-
 // set distortions to always prefix any usage of console
 function distortConsole(distortions: DistortionMap) {
   const descriptor = Object.getOwnPropertyDescriptor(window, 'console');
   if (descriptor?.value) {
     function getSandboxConsole(originalAttrOrMethod: unknown, meta: SandboxPluginMeta) {
       const pluginId = meta.id;
-
       function sandboxLog(...args: unknown[]) {
-        console.log(`[plugin ${pluginId}]`, ...args);
+        structLog('log', `[plugin ${pluginId}]`, ...args);
       }
       return {
         log: sandboxLog,
@@ -151,14 +139,12 @@ function distortConsole(distortions: DistortionMap) {
         table: sandboxLog,
       };
     }
-
     distortions.set(descriptor.value, getSandboxConsole);
   }
   if (descriptor?.set) {
     distortions.set(descriptor.set, failToSet);
   }
 }
-
 // set distortions to alert to always output to the console
 function distortAlert(distortions: DistortionMap) {
   function getAlertDistortion(originalAttrOrMethod: unknown, meta: SandboxPluginMeta) {
@@ -168,9 +154,8 @@ function distortAlert(distortions: DistortionMap) {
       attrOrMethod: 'alert',
       entity: 'window',
     });
-
     return function (...args: unknown[]) {
-      console.log(`[plugin ${pluginId}]`, ...args);
+      structLog('log', `[plugin ${pluginId}]`, ...args);
     };
   }
   const descriptor = Object.getOwnPropertyDescriptor(window, 'alert');
@@ -181,7 +166,6 @@ function distortAlert(distortions: DistortionMap) {
     distortions.set(descriptor.set, failToSet);
   }
 }
-
 function distortInnerHTML(distortions: DistortionMap) {
   function getInnerHTMLDistortion(originalMethod: unknown, meta: SandboxPluginMeta) {
     const pluginId = meta.id;
@@ -200,7 +184,6 @@ function distortInnerHTML(distortions: DistortionMap) {
               param: forbiddenElement,
               entity: 'HTMLElement',
             });
-
             throw new Error('<' + forbiddenElement + '> is not allowed in sandboxed plugins');
           }
         }
@@ -215,7 +198,6 @@ function distortInnerHTML(distortions: DistortionMap) {
           args[i] = DOMPurify.sanitize(args[i]);
         }
       }
-
       if (isFunction(originalMethod)) {
         return originalMethod.apply(this, args);
       }
@@ -227,7 +209,6 @@ function distortInnerHTML(distortions: DistortionMap) {
     Object.getOwnPropertyDescriptor(Element.prototype, 'insertAdjacentHTML'),
     Object.getOwnPropertyDescriptor(DOMParser.prototype, 'parseFromString'),
   ];
-
   for (const descriptor of descriptors) {
     if (descriptor?.set) {
       distortions.set(descriptor.set, getInnerHTMLDistortion);
@@ -237,7 +218,6 @@ function distortInnerHTML(distortions: DistortionMap) {
     }
   }
 }
-
 function distortCreateElement(distortions: DistortionMap) {
   function getCreateElementDistortion(originalMethod: unknown, meta: SandboxPluginMeta) {
     const pluginId = meta.id;
@@ -261,13 +241,11 @@ function distortCreateElement(distortions: DistortionMap) {
     distortions.set(descriptor.value, getCreateElementDistortion);
   }
 }
-
 function distortInsert(distortions: DistortionMap) {
   function getInsertDistortion(originalMethod: unknown, meta: SandboxPluginMeta) {
     const pluginId = meta.id;
     return function insertChildDistortion(this: HTMLElement, node?: Node, ref?: Node) {
       const nodeType = node?.nodeName?.toLowerCase() || '';
-
       if (node && forbiddenElements.includes(nodeType)) {
         logWarning(`Plugin ${pluginId} tried to insert ${nodeType}`, {
           pluginId,
@@ -282,7 +260,6 @@ function distortInsert(distortions: DistortionMap) {
       }
     };
   }
-
   function getinsertAdjacentElementDistortion(originalMethod: unknown, meta: SandboxPluginMeta) {
     const pluginId = meta.id;
     return function insertAdjacentElementDistortion(this: HTMLElement, position?: string, node?: Node) {
@@ -294,7 +271,6 @@ function distortInsert(distortions: DistortionMap) {
           param: nodeType,
           entity: 'HTMLElement',
         });
-
         return document.createDocumentFragment();
       }
       if (isFunction(originalMethod)) {
@@ -302,24 +278,20 @@ function distortInsert(distortions: DistortionMap) {
       }
     };
   }
-
   const descriptors = [
     Object.getOwnPropertyDescriptor(Node.prototype, 'insertBefore'),
     Object.getOwnPropertyDescriptor(Node.prototype, 'replaceChild'),
   ];
-
   for (const descriptor of descriptors) {
     if (descriptor?.value) {
       distortions.set(descriptor.set, getInsertDistortion);
     }
   }
-
   const descriptorAdjacent = Object.getOwnPropertyDescriptor(Element.prototype, 'insertAdjacentElement');
   if (descriptorAdjacent?.value) {
     distortions.set(descriptorAdjacent.set, getinsertAdjacentElementDistortion);
   }
 }
-
 // set distortions to append elements to the document
 function distortAppend(distortions: DistortionMap) {
   // append accepts an array of nodes to append https://developer.mozilla.org/en-US/docs/Web/API/Node/append
@@ -329,7 +301,6 @@ function distortAppend(distortions: DistortionMap) {
       let acceptedNodes = args;
       const filteredAcceptedNodes = args?.filter((node) => !forbiddenElements.includes(node.nodeName.toLowerCase()));
       acceptedNodes = filteredAcceptedNodes;
-
       if (acceptedNodes.length !== filteredAcceptedNodes.length) {
         logWarning(`Plugin ${pluginId} tried to append fobiddenElements`, {
           pluginId,
@@ -338,7 +309,6 @@ function distortAppend(distortions: DistortionMap) {
           entity: 'HTMLElement',
         });
       }
-
       if (isFunction(originalMethod)) {
         originalMethod.apply(this, acceptedNodes);
       }
@@ -346,7 +316,6 @@ function distortAppend(distortions: DistortionMap) {
       return undefined;
     };
   }
-
   // appendChild accepts a single node to add https://developer.mozilla.org/en-US/docs/Web/API/Node/appendChild
   function getAppendChildDistortion(originalMethod: unknown, meta: SandboxPluginMeta, sandboxEnv?: SandboxEnvironment) {
     const pluginId = meta.id;
@@ -359,7 +328,6 @@ function distortAppend(distortions: DistortionMap) {
           param: nodeType,
           entity: 'HTMLElement',
         });
-
         return document.createDocumentFragment();
       }
       // if the node is a script, load it into the sandbox
@@ -380,7 +348,6 @@ function distortAppend(distortions: DistortionMap) {
       }
     };
   }
-
   const descriptors = [
     Object.getOwnPropertyDescriptor(Element.prototype, 'append'),
     Object.getOwnPropertyDescriptor(Element.prototype, 'prepend'),
@@ -389,19 +356,16 @@ function distortAppend(distortions: DistortionMap) {
     Object.getOwnPropertyDescriptor(Document.prototype, 'append'),
     Object.getOwnPropertyDescriptor(Document.prototype, 'prepend'),
   ];
-
   for (const descriptor of descriptors) {
     if (descriptor?.value) {
       distortions.set(descriptor.value, getAppendDistortion);
     }
   }
-
   const appendChildDescriptor = Object.getOwnPropertyDescriptor(Node.prototype, 'appendChild');
   if (appendChildDescriptor?.value) {
     distortions.set(appendChildDescriptor.value, getAppendChildDistortion);
   }
 }
-
 // this is not a distortion for security reasons but to make plugins using web workers work correctly.
 function distortWorkers(distortions: DistortionMap) {
   const descriptor = Object.getOwnPropertyDescriptor(Worker.prototype, 'postMessage');
@@ -424,7 +388,6 @@ function distortWorkers(distortions: DistortionMap) {
     distortions.set(descriptor.value, getPostMessageDistortion);
   }
 }
-
 // this is not a distortion for security reasons but to make plugins using document.defaultView work correctly.
 function distortDocument(distortions: DistortionMap) {
   const descriptor = Object.getOwnPropertyDescriptor(Document.prototype, 'defaultView');
@@ -435,7 +398,6 @@ function distortDocument(distortions: DistortionMap) {
       };
     });
   }
-
   const documentForbiddenMethods = ['write'];
   for (const method of documentForbiddenMethods) {
     const descriptor = Object.getOwnPropertyDescriptor(Document.prototype, method);
@@ -447,7 +409,6 @@ function distortDocument(distortions: DistortionMap) {
     }
   }
 }
-
 async function distortMonacoEditor(distortions: DistortionMap) {
   // We rely on `monaco` being instanciated inside `window.monaco`.
   // this is the same object passed down to plugins using monaco editor for their editors
@@ -456,13 +417,11 @@ async function distortMonacoEditor(distortions: DistortionMap) {
   // Short of abusing the `window.monaco` object we would have to modify grafana-ui to export
   // the monaco instance directly in the ReactMonacoEditor component
   const monacoEditor: Monaco = Reflect.get(window, 'monaco');
-
   // do not double patch
   if (!monacoEditor || Object.hasOwn(monacoEditor, SANDBOX_LIVE_API_PATCHED)) {
     return;
   }
   const originalSetMonarchTokensProvider = monacoEditor.languages.setMonarchTokensProvider;
-
   // NOTE: this function in particular is called only once per intialized custom language inside a plugin which is a
   // rare ocurrance but if not patched it'll break the syntax highlighting for the custom language.
   function getSetMonarchTokensProvider() {
@@ -480,10 +439,8 @@ async function distortMonacoEditor(distortions: DistortionMap) {
   distortions.set(monacoEditor.languages.setMonarchTokensProvider, getSetMonarchTokensProvider);
   Reflect.set(monacoEditor, SANDBOX_LIVE_API_PATCHED, {});
 }
-
 async function distortPostMessage(distortions: DistortionMap) {
   const descriptor = Object.getOwnPropertyDescriptor(window, 'postMessage');
-
   function getPostMessageDistortion(originalMethod: unknown) {
     return function postMessageDistortion(this: Window, ...args: unknown[]) {
       // proxies can't be serialized by postMessage algorithm
@@ -499,12 +456,10 @@ async function distortPostMessage(distortions: DistortionMap) {
       }
     };
   }
-
   if (descriptor?.value) {
     distortions.set(descriptor.value, getPostMessageDistortion);
   }
 }
-
 /**
  * "Live" APIs are APIs that can only be distorted at runtime.
  * This could be because the objects we want to patch only become available after specific states are reached,
@@ -515,7 +470,6 @@ export function distortLiveApis(_originalValue: ProxyTarget): ProxyTarget | unde
   distortMonacoEditor(generalDistortionMap);
   return;
 }
-
 export function distortLodash(distortions: DistortionMap) {
   /**
    * This is a distortion for lodash clone Deep function

--- a/public/app/features/plugins/sandbox/sandboxPluginLoader.ts
+++ b/public/app/features/plugins/sandbox/sandboxPluginLoader.ts
@@ -1,10 +1,9 @@
+import { structLog } from '@grafana/data';
 import createVirtualEnvironment from '@locker/near-membrane-dom';
 import { type ProxyTarget } from '@locker/near-membrane-shared';
-
 import { type BootData } from '@grafana/data';
 import { config } from '@grafana/runtime';
 import { defaultTrustedTypesPolicy } from 'app/core/trustedTypePolicies';
-
 import { getPluginCode, getPluginLoadData, patchSandboxEnvironmentPrototype } from './codeLoader';
 import { getGeneralSandboxDistortionMap, distortLiveApis } from './distortions';
 import {
@@ -24,15 +23,12 @@ import {
   type SandboxPluginMeta,
 } from './types';
 import { logError, logInfo } from './utils';
-
 // Loads near membrane custom formatter for near membrane proxy objects.
 if (process.env.NODE_ENV !== 'production') {
   require('@locker/near-membrane-dom/custom-devtools-formatter');
 }
-
 const pluginImportCache = new Map<string, Promise<System.Module>>();
 const pluginLogCache: Record<string, boolean> = {};
-
 export async function importPluginModuleInSandbox({ pluginId }: { pluginId: string }): Promise<System.Module> {
   patchWebAPIs();
   try {
@@ -50,7 +46,6 @@ export async function importPluginModuleInSandbox({ pluginId }: { pluginId: stri
     throw error;
   }
 }
-
 async function doImportPluginModuleInSandbox(meta: SandboxPluginMeta): Promise<System.Module> {
   logInfo('Loading with sandbox', {
     pluginId: meta.id,
@@ -71,13 +66,11 @@ async function doImportPluginModuleInSandbox(meta: SandboxPluginMeta): Promise<S
       } else {
         patchObjectAsLiveTarget(originalValue);
       }
-
       // static distortions are faster distortions with direct object descriptors checks
       const staticDistortion = generalDistortionMap.get(originalValue);
       if (staticDistortion) {
         return staticDistortion(originalValue, meta, sandboxEnvironment) as ProxyTarget;
       }
-
       // live distortions are slower and have to do runtime checks
       const liveDistortion = distortLiveApis(originalValue);
       if (liveDistortion) {
@@ -85,7 +78,6 @@ async function doImportPluginModuleInSandbox(meta: SandboxPluginMeta): Promise<S
       }
       return originalValue;
     }
-
     // each plugin has its own sandbox
     sandboxEnvironment = createVirtualEnvironment(window, {
       // distortions are interceptors to modify the behavior of objects when
@@ -130,7 +122,6 @@ async function doImportPluginModuleInSandbox(meta: SandboxPluginMeta): Promise<S
               key: 'grafanaBootData',
             });
           }
-
           // We don't want to encourage plugins to use `window.grafanaBootData`. They should
           // use `@grafana/runtime.config` instead.
           // if we are in dev mode we fail this access
@@ -139,13 +130,13 @@ async function doImportPluginModuleInSandbox(meta: SandboxPluginMeta): Promise<S
               `Error in ${meta.id}: Plugins should not use window.grafanaBootData. Use "config" from "@grafana/runtime" instead.`
             );
           } else {
-            console.error(
+            structLog(
+              'error',
               `${meta.id.toUpperCase()}: Plugins should not use window.grafanaBootData. Use "config" from "@grafana/runtime" instead.`
             );
           }
           return config.bootData;
         },
-
         // Plugins builds use the AMD module system. Their code consists
         // of a single function call to `define()` that internally contains all the plugin code.
         // This is that `define` function the plugin will call.
@@ -165,7 +156,6 @@ async function doImportPluginModuleInSandbox(meta: SandboxPluginMeta): Promise<S
             dependencies = maybeDependencies as string[];
             factory = maybeFactory!;
           }
-
           try {
             const resolvedDeps = await resolvePluginDependencies(dependencies, meta);
             // execute the plugin's code
@@ -186,9 +176,7 @@ async function doImportPluginModuleInSandbox(meta: SandboxPluginMeta): Promise<S
         },
       }),
     });
-
     patchSandboxEnvironmentPrototype(sandboxEnvironment);
-
     // fetch plugin's code
     let pluginCode = '';
     try {
@@ -201,7 +189,6 @@ async function doImportPluginModuleInSandbox(meta: SandboxPluginMeta): Promise<S
       });
       reject(error);
     }
-
     try {
       // runs the code inside the sandbox environment
       // this evaluate will eventually run the `define` function inside
@@ -217,7 +204,6 @@ async function doImportPluginModuleInSandbox(meta: SandboxPluginMeta): Promise<S
     }
   });
 }
-
 /**
  *
  * This function resolves the dependencies using the array of AMD deps.
@@ -232,27 +218,22 @@ async function resolvePluginDependencies(deps: string[], pluginMeta: SandboxPlug
     uri: pluginMeta.module,
     exports: pluginExports,
   };
-
   // resolve dependencies
   const resolvedDeps: CompartmentDependencyModule[] = [];
   for (const dep of deps) {
     let resolvedDep = sandboxPluginDependencies.get(dep);
-
     if (typeof resolvedDep === 'function') {
       resolvedDep = await resolvedDep();
     }
     if (resolvedDep?.__useDefault) {
       resolvedDep = resolvedDep.default;
     }
-
     if (dep === 'module') {
       resolvedDep = pluginModuleDep;
     }
-
     if (dep === 'exports') {
       resolvedDep = pluginExports;
     }
-
     if (!resolvedDep) {
       const error = new Error(`[sandbox] Could not resolve dependency ${dep}`);
       logError(error, {
@@ -266,7 +247,6 @@ async function resolvePluginDependencies(deps: string[], pluginMeta: SandboxPlug
   }
   return resolvedDeps;
 }
-
 interface ModuleMeta {
   id: string;
   uri: string;

--- a/public/app/features/profile/api.ts
+++ b/public/app/features/profile/api.ts
@@ -1,51 +1,42 @@
+import { structLog } from '@grafana/data';
 import { getBackendSrv } from '@grafana/runtime';
 import { type Team } from 'app/types/teams';
 import { type UserDTO, type UserOrg, type UserSession } from 'app/types/user';
-
 import { type ChangePasswordFields, type ProfileUpdateFields } from './types';
-
 async function changePassword(payload: ChangePasswordFields): Promise<void> {
   try {
     await getBackendSrv().put('/api/user/password', payload);
   } catch (err) {
-    console.error(err);
+    structLog('error', err);
   }
 }
-
 function loadUser(): Promise<UserDTO> {
   return getBackendSrv().get('/api/user');
 }
-
 function loadTeams(): Promise<Team[]> {
   return getBackendSrv().get('/api/user/teams');
 }
-
 function loadOrgs(): Promise<UserOrg[]> {
   return getBackendSrv().get('/api/user/orgs');
 }
-
 function loadSessions(): Promise<UserSession[]> {
   return getBackendSrv().get('/api/user/auth-tokens');
 }
-
 async function revokeUserSession(tokenId: number): Promise<void> {
   await getBackendSrv().post('/api/user/revoke-auth-token', {
     authTokenId: tokenId,
   });
 }
-
 async function setUserOrg(org: UserOrg): Promise<void> {
   await getBackendSrv().post('/api/user/using/' + org.orgId, {});
 }
-
 async function updateUserProfile(payload: ProfileUpdateFields): Promise<void> {
   try {
     await getBackendSrv().put('/api/user', payload);
   } catch (err) {
-    console.error(err);
+    structLog('error', err);
   }
 }
-
 export const api = {
   changePassword,
   revokeUserSession,

--- a/public/app/features/provisioning/utils/sourceLink.ts
+++ b/public/app/features/provisioning/utils/sourceLink.ts
@@ -1,3 +1,4 @@
+import { structLog } from '@grafana/data';
 import { t } from '@grafana/i18n';
 import { config } from '@grafana/runtime';
 import { type DashboardLink } from '@grafana/schema';
@@ -10,12 +11,9 @@ import {
   type ObjectMeta,
 } from 'app/features/apiserver/types';
 import { dispatch } from 'app/store/store';
-
 import { RepoTypeDisplay } from '../Wizard/types';
 import { isValidRepoType } from '../guards';
-
 import { getHasTokenInstructions, getRepoFileUrl } from './git';
-
 /**
  * Find and remove existing source links from the links array.
  * A source link is identified by its tooltip matching the source link tooltip translation.
@@ -29,7 +27,6 @@ export function removeExistingSourceLinks(links: DashboardLink[] | undefined): D
   const sourceLinkTooltip = t('dashboard.source-link.tooltip', 'View source file in repository');
   return links.filter((link) => link.tooltip !== sourceLinkTooltip);
 }
-
 /**
  * Build a source link for a repo-managed dashboard.
  * Returns undefined if the dashboard is not repo-managed or if the repository is not a git provider.
@@ -38,26 +35,21 @@ export async function buildSourceLink(annotations: ObjectMeta['annotations']): P
   if (!annotations || !config.featureToggles.provisioning || annotations[AnnoKeyManagerKind] !== ManagerKind.Repo) {
     return undefined;
   }
-
   const managerIdentity = annotations[AnnoKeyManagerIdentity];
   const sourcePath = annotations[AnnoKeySourcePath];
   if (!managerIdentity || !sourcePath) {
     return undefined;
   }
-
   try {
     const settingsResult = await dispatch(provisioningAPIv0alpha1.endpoints.getFrontendSettings.initiate());
     const repository = settingsResult.data?.items.find((repo: RepositoryView) => repo.name === managerIdentity);
-
     if (!repository) {
       return undefined;
     }
-
     const repoType = repository.type;
     if (!getHasTokenInstructions(repoType) || !isValidRepoType(repoType)) {
       return undefined;
     }
-
     const sourceUrl = getRepoFileUrl({
       repoType,
       url: repository.url,
@@ -68,7 +60,6 @@ export async function buildSourceLink(annotations: ObjectMeta['annotations']): P
     if (!sourceUrl) {
       return undefined;
     }
-
     const providerName = RepoTypeDisplay[repoType];
     return {
       title: t('dashboard.source-link.title', 'Source ({{provider}})', { provider: providerName }),
@@ -83,7 +74,7 @@ export async function buildSourceLink(annotations: ObjectMeta['annotations']): P
       keepTime: false,
     };
   } catch (e) {
-    console.warn('Failed to fetch repository info for source link:', e);
+    structLog('warn', 'Failed to fetch repository info for source link:', e);
     return undefined;
   }
 }

--- a/public/app/features/query/components/QueryGroup.tsx
+++ b/public/app/features/query/components/QueryGroup.tsx
@@ -1,8 +1,8 @@
+import { structLog } from '@grafana/data';
 import { css } from '@emotion/css';
 import { PureComponent, useEffect, useState } from 'react';
 import * as React from 'react';
 import { type Unsubscribable } from 'rxjs';
-
 import {
   CoreApp,
   type DataSourceApi,
@@ -28,14 +28,11 @@ import { dataSource as expressionDatasource } from 'app/features/expressions/Exp
 import { isSharedDashboardQuery } from 'app/plugins/datasource/dashboard/runSharedRequest';
 import { type GrafanaQuery } from 'app/plugins/datasource/grafana/types';
 import { type QueryGroupOptions } from 'app/types/query';
-
 import { type PanelQueryRunner } from '../state/PanelQueryRunner';
 import { updateQueries } from '../state/updateQueries';
-
 import { GroupActionComponents } from './QueryActionComponent';
 import { QueryEditorRows } from './QueryEditorRows';
 import { QueryGroupOptionsEditor } from './QueryGroupOptions';
-
 export interface Props {
   queryRunner: PanelQueryRunner;
   options: QueryGroupOptions;
@@ -43,7 +40,6 @@ export interface Props {
   onRunQueries: () => void;
   onOptionsChange: (options: QueryGroupOptions) => void;
 }
-
 interface State {
   dataSource?: DataSourceApi;
   dsSettings?: DataSourceInstanceSettings;
@@ -57,12 +53,10 @@ interface State {
   defaultDataSource?: DataSourceApi;
   scrollElement?: HTMLDivElement;
 }
-
 export class QueryGroup extends PureComponent<Props, State> {
   backendSrv = backendSrv;
   dataSourceSrv = getDataSourceSrv();
   querySubscription: Unsubscribable | null = null;
-
   state: State = {
     isDataSourceModalOpen: !!locationService.getSearchObject().firstPanel,
     isLoadingHelp: false,
@@ -76,38 +70,30 @@ export class QueryGroup extends PureComponent<Props, State> {
       timeRange: getDefaultTimeRange(),
     },
   };
-
   async componentDidMount() {
     const { options, queryRunner } = this.props;
-
     this.querySubscription = queryRunner.getData({ withTransforms: false, withFieldConfig: false }).subscribe({
       next: (data: PanelData) => this.onPanelDataUpdate(data),
     });
-
     this.setNewQueriesAndDatasource(options);
   }
-
   componentWillUnmount() {
     if (this.querySubscription) {
       this.querySubscription.unsubscribe();
       this.querySubscription = null;
     }
   }
-
   async componentDidUpdate() {
     const { options } = this.props;
-
     const currentDS = await getDataSourceSrv().get(options.dataSource);
     if (this.state.dataSource && currentDS.uid !== this.state.dataSource?.uid) {
       this.setNewQueriesAndDatasource(options);
     }
   }
-
   async setNewQueriesAndDatasource(options: QueryGroupOptions) {
     try {
       const ds = await this.dataSourceSrv.get(options.dataSource);
       const dsSettings = this.dataSourceSrv.getInstanceSettings(options.dataSource);
-
       const defaultDataSource = await this.dataSourceSrv.get();
       const datasource = ds.getRef();
       const queries = options.queries.map((q) => ({
@@ -115,7 +101,6 @@ export class QueryGroup extends PureComponent<Props, State> {
         datasource,
         ...q,
       }));
-
       this.setState({
         queries,
         dataSource: ds,
@@ -123,14 +108,12 @@ export class QueryGroup extends PureComponent<Props, State> {
         defaultDataSource,
       });
     } catch (error) {
-      console.error('failed to load data source', error);
+      structLog('error', 'failed to load data source', error);
     }
   }
-
   onPanelDataUpdate(data: PanelData) {
     this.setState({ data });
   }
-
   onChangeDataSource = async (
     newSettings: DataSourceInstanceSettings,
     defaultQueries?: DataQuery[] | GrafanaQuery[]
@@ -138,12 +121,9 @@ export class QueryGroup extends PureComponent<Props, State> {
     const { dsSettings } = this.state;
     const currentDS = dsSettings ? await getDataSourceSrv().get(dsSettings.uid) : undefined;
     const nextDS = await getDataSourceSrv().get(newSettings.uid);
-
     // We need to pass in newSettings.uid as well here as that can be a variable expression and we want to store that in the query model not the current ds variable value
     const queries = defaultQueries || (await updateQueries(nextDS, newSettings.uid, this.state.queries, currentDS));
-
     const dataSource = await this.dataSourceSrv.get(newSettings.name);
-
     this.onChange({
       queries,
       dataSource: {
@@ -152,52 +132,43 @@ export class QueryGroup extends PureComponent<Props, State> {
         ...getDataSourceRef(newSettings),
       },
     });
-
     this.setState({
       queries,
       dataSource: dataSource,
       dsSettings: newSettings,
     });
-
     if (defaultQueries) {
       this.props.onRunQueries();
     }
   };
-
   onAddQueryClick = () => {
     const { queries } = this.state;
     this.onQueriesChange(addQuery(queries, this.newQuery()));
     this.onScrollBottom();
   };
-
   newQuery(): Partial<DataQuery> {
     const { dsSettings, defaultDataSource } = this.state;
-
     const ds =
       dsSettings && !dsSettings.meta.mixed
         ? getDataSourceRef(dsSettings)
         : defaultDataSource
           ? defaultDataSource.getRef()
           : { type: undefined, uid: undefined };
-
     return {
       ...this.state.dataSource?.getDefaultQuery?.(CoreApp.PanelEditor),
       datasource: ds,
     };
   }
-
   onChange(changedProps: Partial<QueryGroupOptions>) {
     this.props.onOptionsChange({
       ...this.props.options,
       ...changedProps,
     });
   }
-
   onAddExpressionClick = () => {
     this.onQueriesChange(addQuery(this.state.queries, expressionDatasource.newQuery()));
     this.onScrollBottom();
   };
-
   onScrollBottom = () => {
     setTimeout(() => {
       if (this.state.scrollElement) {
@@ -205,16 +176,13 @@ export class QueryGroup extends PureComponent<Props, State> {
       }
     }, 20);
   };
-
   onUpdateAndRun = (options: QueryGroupOptions) => {
     this.props.onOptionsChange(options);
     this.props.onRunQueries();
   };
-
   renderTopSection(styles: QueriesTabStyles) {
     const { onOpenQueryInspector, options } = this.props;
     const { dataSource, data, dsSettings } = this.state;
-
     if (!dsSettings || !dataSource) {
       return null;
     }
@@ -230,19 +198,15 @@ export class QueryGroup extends PureComponent<Props, State> {
       />
     );
   }
-
   onOpenHelp = () => {
     this.setState({ isHelpOpen: true });
   };
-
   onCloseHelp = () => {
     this.setState({ isHelpOpen: false });
   };
-
   onCloseDataSourceModal = () => {
     this.setState({ isDataSourceModalOpen: false });
   };
-
   onAddQuery = (query: Partial<DataQuery>) => {
     const { dsSettings, queries } = this.state;
     this.onQueriesChange(
@@ -250,16 +214,13 @@ export class QueryGroup extends PureComponent<Props, State> {
     );
     this.onScrollBottom();
   };
-
   onQueriesChange = (queries: DataQuery[] | GrafanaQuery[]) => {
     this.onChange({ queries });
     this.setState({ queries });
   };
-
   renderQueries(dsSettings: DataSourceInstanceSettings) {
     const { onRunQueries } = this.props;
     const { data, queries } = this.state;
-
     return (
       <div data-testid={selectors.components.QueryTab.content}>
         <QueryEditorRows
@@ -273,11 +234,9 @@ export class QueryGroup extends PureComponent<Props, State> {
       </div>
     );
   }
-
   isExpressionsSupported(dsSettings: DataSourceInstanceSettings): boolean {
     return (dsSettings.meta.backend || dsSettings.meta.alerting || dsSettings.meta.mixed) === true;
   }
-
   renderExtraActions() {
     return GroupActionComponents.getAllExtraRenderAction()
       .map((action, index) =>
@@ -289,10 +248,8 @@ export class QueryGroup extends PureComponent<Props, State> {
       )
       .filter(Boolean);
   }
-
   renderAddQueryRow(dsSettings: DataSourceInstanceSettings, styles: QueriesTabStyles) {
     const showAddButton = !isSharedDashboardQuery(dsSettings.name);
-
     return (
       <Stack gap={2} alignItems="flex-start">
         {showAddButton && (
@@ -322,15 +279,12 @@ export class QueryGroup extends PureComponent<Props, State> {
       </Stack>
     );
   }
-
   setScrollRef = (scrollElement: HTMLDivElement): void => {
     this.setState({ scrollElement });
   };
-
   render() {
     const { isHelpOpen, dsSettings } = this.state;
     const styles = getStyles();
-
     return (
       <ScrollContainer minHeight="100%" ref={this.setScrollRef}>
         <div className={styles.innerWrapper}>
@@ -355,10 +309,8 @@ export class QueryGroup extends PureComponent<Props, State> {
     );
   }
 }
-
 const getStyles = stylesFactory(() => {
   const { theme } = config;
-
   return {
     innerWrapper: css({
       display: 'flex',
@@ -385,9 +337,7 @@ const getStyles = stylesFactory(() => {
     }),
   };
 });
-
 type QueriesTabStyles = ReturnType<typeof getStyles>;
-
 interface QueryGroupTopSectionProps {
   data: PanelData;
   dataSource: DataSourceApi;
@@ -398,7 +348,6 @@ interface QueryGroupTopSectionProps {
   onOptionsChange?: (options: QueryGroupOptions) => void;
   onDataSourceChange?: (ds: DataSourceInstanceSettings, defaultQueries?: DataQuery[] | GrafanaQuery[]) => Promise<void>;
 }
-
 export function QueryGroupTopSection({
   dataSource,
   options,
@@ -411,7 +360,6 @@ export function QueryGroupTopSection({
 }: QueryGroupTopSectionProps) {
   const styles = getStyles();
   const [isHelpOpen, setIsHelpOpen] = useState(false);
-
   return (
     <>
       <div data-testid={selectors.components.QueryTab.queryGroupTopSection}>
@@ -480,24 +428,20 @@ export function QueryGroupTopSection({
     </>
   );
 }
-
 interface DataSourcePickerWithPromptProps {
   isDataSourceModalOpen?: boolean;
   options: QueryGroupOptions;
   scopedVars?: ScopedVars;
   onChange: (ds: DataSourceInstanceSettings, defaultQueries?: DataQuery[] | GrafanaQuery[]) => Promise<void>;
 }
-
 function DataSourcePickerWithPrompt({ options, scopedVars, onChange, ...otherProps }: DataSourcePickerWithPromptProps) {
   const [isDataSourceModalOpen, setIsDataSourceModalOpen] = useState(Boolean(otherProps.isDataSourceModalOpen));
-
   useEffect(() => {
     // Clean up the first panel flag since the modal is now open
     if (!!locationService.getSearchObject().firstPanel) {
       locationService.partial({ firstPanel: null }, true);
     }
   }, []);
-
   const commonProps = {
     metrics: true,
     mixed: true,
@@ -510,7 +454,6 @@ function DataSourcePickerWithPrompt({ options, scopedVars, onChange, ...otherPro
       setIsDataSourceModalOpen(false);
     },
   };
-
   return (
     <>
       {isDataSourceModalOpen && (

--- a/public/app/features/query/state/DashboardQueryRunner/LegacyAnnotationQueryRunner.ts
+++ b/public/app/features/query/state/DashboardQueryRunner/LegacyAnnotationQueryRunner.ts
@@ -1,41 +1,33 @@
+import { structLog } from '@grafana/data';
 import { from, type Observable, of } from 'rxjs';
 import { catchError } from 'rxjs/operators';
-
 import { type AnnotationEvent, type DataSourceApi } from '@grafana/data';
 import { shouldUseLegacyRunner } from 'app/features/annotations/standardAnnotationSupport';
-
 import { type AnnotationQueryRunner, type AnnotationQueryRunnerOptions } from './types';
 import { handleAnnotationQueryRunnerError } from './utils';
-
 export class LegacyAnnotationQueryRunner implements AnnotationQueryRunner {
   canRun(datasource?: DataSourceApi): boolean {
     if (!datasource) {
       return false;
     }
-
     if (shouldUseLegacyRunner(datasource)) {
       return true;
     }
-
     return Boolean(datasource.annotationQuery && !datasource.annotations);
   }
-
   run({ annotation, datasource, dashboard, range }: AnnotationQueryRunnerOptions): Observable<AnnotationEvent[]> {
     if (!this.canRun(datasource)) {
       return of([]);
     }
-
     if (datasource?.annotationQuery === undefined) {
-      console.warn('datasource does not have an annotation query');
+      structLog('warn', 'datasource does not have an annotation query');
       return of([]);
     }
-
     const annotationQuery = datasource.annotationQuery({ range, rangeRaw: range.raw, annotation, dashboard });
     if (annotationQuery === undefined) {
-      console.warn('datasource does not have an annotation query');
+      structLog('warn', 'datasource does not have an annotation query');
       return of([]);
     }
-
     return from(annotationQuery).pipe(catchError(handleAnnotationQueryRunnerError));
   }
 }

--- a/public/app/features/query/state/DashboardQueryRunner/utils.ts
+++ b/public/app/features/query/state/DashboardQueryRunner/utils.ts
@@ -1,6 +1,6 @@
+import { structLog } from '@grafana/data';
 import { cloneDeep } from 'lodash';
 import { type Observable, of } from 'rxjs';
-
 import {
   type AnnotationEvent,
   type AnnotationQuery,
@@ -10,57 +10,45 @@ import {
 } from '@grafana/data';
 import { config, toDataQueryError } from '@grafana/runtime';
 import { dispatch } from 'app/store/store';
-
 import { createErrorNotification } from '../../../../core/copy/appNotification';
 import { notifyApp } from '../../../../core/reducers/appNotification';
-
 import { type DashboardQueryRunnerWorkerResult } from './types';
-
 export function handleAnnotationQueryRunnerError(err: any): Observable<AnnotationEvent[]> {
   if (err.cancelled) {
     return of([]);
   }
-
   notifyWithError('AnnotationQueryRunner failed', err);
   return of([]);
 }
-
 export function handleDatasourceSrvError(err: any): Observable<DataSourceApi | undefined> {
   notifyWithError('Failed to retrieve datasource', err);
   return of(undefined);
 }
-
 export const emptyResult: () => Observable<DashboardQueryRunnerWorkerResult> = () =>
   of({ annotations: [], alertStates: [] });
-
 export function handleDashboardQueryRunnerWorkerError(err: any): Observable<DashboardQueryRunnerWorkerResult> {
   if (err.cancelled) {
     return emptyResult();
   }
-
   notifyWithError('DashboardQueryRunner failed', err);
   return emptyResult();
 }
-
 function notifyWithError(title: string, err: any) {
   const error = toDataQueryError(err);
-  console.error('handleAnnotationQueryRunnerError', error);
+  structLog('error', 'handleAnnotationQueryRunnerError', error);
   const notification = createErrorNotification(title, error.message);
   dispatch(notifyApp(notification));
 }
-
 export function getAnnotationsByPanelId(annotations: AnnotationEvent[], panelId?: number) {
   if (panelId == null) {
     return annotations;
   }
-
   return annotations.filter((item) => {
     let source: AnnotationQuery;
     source = item.source;
     if (!source) {
       return true; // should not happen
     }
-
     // generic panel filtering
     if (source.filter) {
       const includes = (source.filter.ids ?? []).includes(panelId);
@@ -72,7 +60,6 @@ export function getAnnotationsByPanelId(annotations: AnnotationEvent[], panelId?
         return false;
       }
     }
-
     // this is valid for the main 'grafana' datasource
     if (item.panelId && item.source.type === 'dashboard') {
       return item.panelId === panelId;
@@ -80,7 +67,6 @@ export function getAnnotationsByPanelId(annotations: AnnotationEvent[], panelId?
     return true;
   });
 }
-
 export function translateQueryResult(annotation: AnnotationQuery, results: AnnotationEvent[]): AnnotationEvent[] {
   // if annotation has snapshotData
   // make clone and remove it
@@ -88,13 +74,11 @@ export function translateQueryResult(annotation: AnnotationQuery, results: Annot
     annotation = cloneDeep(annotation);
     delete annotation.snapshotData;
   }
-
   for (const item of results) {
     item.source = annotation;
     item.color = config.theme2.visualization.getColorByName(annotation.iconColor);
     item.type = annotation.name;
     item.isRegion = Boolean(item.timeEnd && item.time !== item.timeEnd);
-
     switch (item.newState?.toLowerCase()) {
       case 'pending':
         item.color = 'yellow';
@@ -116,15 +100,12 @@ export function translateQueryResult(annotation: AnnotationQuery, results: Annot
         break;
     }
   }
-
   return results;
 }
-
 export function annotationsFromDataFrames(data?: DataFrame[]): AnnotationEvent[] {
   if (!data || !data.length) {
     return [];
   }
-
   const annotations: AnnotationEvent[] = [];
   for (const frame of data) {
     const view = new DataFrameView<AnnotationEvent>(frame);
@@ -133,6 +114,5 @@ export function annotationsFromDataFrames(data?: DataFrame[]): AnnotationEvent[]
       annotations.push(annotation);
     }
   }
-
   return annotations;
 }

--- a/public/app/features/query/state/PanelQueryRunner.ts
+++ b/public/app/features/query/state/PanelQueryRunner.ts
@@ -1,7 +1,7 @@
+import { structLog } from '@grafana/data';
 import { cloneDeep, isEqual } from 'lodash';
 import { forkJoin, type Observable, of, ReplaySubject, type Unsubscribable } from 'rxjs';
 import { map, mergeMap, catchError } from 'rxjs/operators';
-
 import {
   applyFieldOverrides,
   compareArrayValues,
@@ -35,14 +35,11 @@ import { ExpressionDatasourceRef } from '@grafana/runtime/internal';
 import { isStreamingDataFrame } from 'app/features/live/data/utils';
 import { getDatasourceSrv } from 'app/features/plugins/datasource_srv';
 import { getTemplateSrv } from 'app/features/templating/template_srv';
-
 import { isSharedDashboardQuery, runSharedRequest } from '../../../plugins/datasource/dashboard/runSharedRequest';
 import { type PanelModel } from '../../dashboard/state/PanelModel';
-
 import { getDashboardQueryRunner } from './DashboardQueryRunner/DashboardQueryRunner';
 import { mergePanelAndDashData } from './mergePanelAndDashData';
 import { runRequest } from './runRequest';
-
 export interface QueryRunnerOptions<
   TQuery extends DataQuery = DataQuery,
   TOptions extends DataSourceJsonData = DataSourceJsonData,
@@ -65,18 +62,14 @@ export interface QueryRunnerOptions<
   transformations?: DataTransformerConfig[];
   app?: CoreApp;
 }
-
 let counter = 100;
-
 export function getNextRequestId() {
   return 'Q' + counter++;
 }
-
 export interface GetDataOptions {
   withTransforms: boolean;
   withFieldConfig: boolean;
 }
-
 export class PanelQueryRunner {
   private subject: ReplaySubject<PanelData>;
   private subscription?: Unsubscribable;
@@ -84,12 +77,10 @@ export class PanelQueryRunner {
   private dataConfigSource: DataConfigSource;
   private lastRequest?: DataQueryRequest;
   private templateSrv = getTemplateSrv();
-
   constructor(dataConfigSource: DataConfigSource) {
     this.subject = new ReplaySubject(1);
     this.dataConfigSource = dataConfigSource;
   }
-
   /**
    * Returns an observable that subscribes to the shared multi-cast subject (that reply last result).
    */
@@ -102,7 +93,6 @@ export class PanelQueryRunner {
     let lastTransformations: DataTransformerConfig[] | undefined;
     let isFirstPacket = true;
     let lastConfigRev = -1;
-
     if (this.dataConfigSource.snapshotData) {
       const snapshotPanelData: PanelData = {
         state: LoadingState.Done,
@@ -112,12 +102,10 @@ export class PanelQueryRunner {
       };
       return of(snapshotPanelData);
     }
-
     return this.subject.pipe(
       mergeMap((data: PanelData) => {
         let fieldConfig = this.dataConfigSource.getFieldOverrideOptions();
         let transformations = this.dataConfigSource.getTransformations();
-
         if (
           data.series === lastRawFrames &&
           lastFieldConfig?.fieldConfig === fieldConfig?.fieldConfig &&
@@ -125,32 +113,26 @@ export class PanelQueryRunner {
         ) {
           return of({ ...data, structureRev, series: lastProcessedFrames });
         }
-
         lastFieldConfig = fieldConfig;
         lastTransformations = transformations;
         lastRawFrames = data.series;
         let dataWithTransforms = of(data);
-
         if (withTransforms) {
           dataWithTransforms = this.applyTransformations(data);
         }
-
         return dataWithTransforms.pipe(
           map((data: PanelData) => {
             let processedData = data;
             let streamingPacketWithSameSchema = false;
-
             if (withFieldConfig && data.series?.length) {
               if (lastConfigRev === this.dataConfigSource.configRev) {
                 let streamingDataFrame: StreamingDataFrame | undefined;
-
                 for (const frame of data.series) {
                   if (isStreamingDataFrame(frame)) {
                     streamingDataFrame = frame;
                     break;
                   }
                 }
-
                 if (
                   streamingDataFrame &&
                   !streamingDataFrame.packetInfo.schemaChanged &&
@@ -174,11 +156,9 @@ export class PanelQueryRunner {
                       })),
                     })),
                   };
-
                   streamingPacketWithSameSchema = true;
                 }
               }
-
               if (fieldConfig != null && (isFirstPacket || !streamingPacketWithSameSchema)) {
                 lastConfigRev = this.dataConfigSource.configRev!;
                 processedData = {
@@ -202,44 +182,34 @@ export class PanelQueryRunner {
                 isFirstPacket = false;
               }
             }
-
             if (
               !streamingPacketWithSameSchema &&
               !compareArrayValues(lastProcessedFrames, processedData.series, compareDataFrameStructures)
             ) {
               structureRev++;
             }
-
             lastProcessedFrames = processedData.series;
-
             return { ...processedData, structureRev };
           })
         );
       })
     );
   }
-
   private applyTransformations(data: PanelData): Observable<PanelData> {
     const transformations = this.dataConfigSource.getTransformations();
-
     const allTransformationsDisabled = transformations && transformations.every((t) => t.disabled);
     if (allTransformationsDisabled || !transformations || transformations.length === 0) {
       return of(data);
     }
-
     const ctx: DataTransformContext = {
       interpolate: (v: string) => this.templateSrv.replace(v, data?.request?.scopedVars),
     };
-
     let seriesTransformations = transformations.filter((t) => t.topic == null || t.topic === DataTopic.Series);
     let annotationsTransformations = transformations.filter((t) => t.topic === DataTopic.Annotations);
-
     let seriesStream = transformDataFrame(seriesTransformations, data.series, ctx);
     let annotationsStream = transformDataFrame(annotationsTransformations, data.annotations ?? [], ctx);
-
     let series: DataFrame[] = [];
     let annotations: DataFrame[] = [];
-
     return forkJoin([seriesStream, annotationsStream]).pipe(
       map((results) => {
         // this strategy allows transformations to take in series frames and produce anno frames
@@ -253,11 +223,10 @@ export class PanelQueryRunner {
             }
           }
         });
-
         return { ...data, series, annotations };
       }),
       catchError((err) => {
-        console.warn('Error running transformation:', err);
+        structLog('warn', 'Error running transformation:', err);
         return of({
           ...data,
           state: LoadingState.Error,
@@ -266,7 +235,6 @@ export class PanelQueryRunner {
       })
     );
   }
-
   async run(options: QueryRunnerOptions) {
     const {
       queries,
@@ -286,15 +254,12 @@ export class PanelQueryRunner {
       minInterval,
       app,
     } = options;
-
     if (isSharedDashboardQuery(datasource)) {
       this.pipeToSubject(runSharedRequest(options, queries[0]), panelId, true);
       return;
     }
-
     //check if datasource is a variable datasource and if that variable has multiple values
     const addErroDSVariable = this.shouldAddErrorWhenDatasourceVariableIsMultiple(datasource, scopedVars);
-
     const request: DataQueryRequest = {
       app: app ?? CoreApp.Dashboard,
       requestId: getNextRequestId(),
@@ -316,12 +281,9 @@ export class PanelQueryRunner {
       startTime: Date.now(),
       rangeRaw: timeRange.raw,
     };
-
     try {
       const ds = await getDataSource(datasource, request.scopedVars);
-
       const isMixedDS = ds.meta?.mixed;
-
       // Attach the data source to each query
       request.targets = request.targets.map((query) => {
         const isExpressionQuery = query.datasource?.type === ExpressionDatasourceRef.type;
@@ -332,26 +294,20 @@ export class PanelQueryRunner {
         }
         return query;
       });
-
       const lowerIntervalLimit = minInterval ? this.templateSrv.replace(minInterval, request.scopedVars) : ds.interval;
       const norm = rangeUtil.calculateInterval(timeRange, maxDataPoints, lowerIntervalLimit);
-
       // make shallow copy of scoped vars,
       // and add built in variables interval and interval_ms
       request.scopedVars = Object.assign({}, request.scopedVars, {
         __interval: { text: norm.interval, value: norm.interval },
         __interval_ms: { text: norm.intervalMs.toString(), value: norm.intervalMs },
       });
-
       request.interval = norm.interval;
       request.intervalMs = norm.intervalMs;
       request.filters = this.templateSrv.getAdhocFilters(ds.name, true);
-
       request.panelId = panelId;
       request.panelName = panelName;
-
       this.lastRequest = request;
-
       this.pipeToSubject(runRequest(ds, request), panelId, false, addErroDSVariable);
     } catch (err) {
       this.pipeToSubject(
@@ -365,7 +321,6 @@ export class PanelQueryRunner {
       );
     }
   }
-
   private pipeToSubject(
     observable: Observable<PanelData>,
     panelId?: number,
@@ -375,41 +330,32 @@ export class PanelQueryRunner {
     if (this.subscription) {
       this.subscription.unsubscribe();
     }
-
     let panelData = observable;
     const dataSupport = this.dataConfigSource.getDataSupport();
-
     if (dataSupport.alertStates || dataSupport.annotations) {
       const panel = this.dataConfigSource as unknown as PanelModel;
       panelData = mergePanelAndDashData(observable, getDashboardQueryRunner().getResult(panel.id));
     }
-
     this.subscription = panelData.subscribe({
       next: (data) => {
         const last = this.lastResult;
         const next = skipPreProcess ? data : preProcessPanelData(data, last);
-
         if (last != null && next.state !== LoadingState.Streaming) {
           let sameSeries = compareArrayValues(last.series ?? [], next.series ?? [], (a, b) => a === b);
           let sameAnnotations = compareArrayValues(last.annotations ?? [], next.annotations ?? [], (a, b) => a === b);
           let sameState = last.state === next.state;
           let sameErrors = compareArrayValues(last.errors ?? [], next.errors ?? [], (a, b) => isEqual(a, b));
-
           if (sameSeries) {
             next.series = last.series;
           }
-
           if (sameAnnotations) {
             next.annotations = last.annotations;
           }
-
           if (sameSeries && sameAnnotations && sameState && sameErrors) {
             return;
           }
         }
-
         this.lastResult = next;
-
         //add error message if datasource is a variable and has multiple values
         if (addErroDSVariable) {
           next.errors = [
@@ -420,20 +366,16 @@ export class PanelQueryRunner {
           ];
           next.state = LoadingState.Error;
         }
-
         // Store preprocessed query results for applying overrides later on in the pipeline
         this.subject.next(next);
       },
     });
   }
-
   cancelQuery() {
     if (!this.subscription) {
       return;
     }
-
     this.subscription.unsubscribe();
-
     // If we have an old result with loading or streaming state, send it with done state
     if (
       this.lastResult &&
@@ -445,19 +387,16 @@ export class PanelQueryRunner {
       });
     }
   }
-
   resendLastResult = () => {
     if (this.lastResult) {
       this.subject.next(this.lastResult);
     }
   };
-
   clearLastResult() {
     this.lastResult = undefined;
     // A new subject is also needed since it's a replay subject that remembers/sends last value
     this.subject = new ReplaySubject(1);
   }
-
   /**
    * Called when the panel is closed
    */
@@ -466,40 +405,32 @@ export class PanelQueryRunner {
     if (this.subject) {
       this.subject.complete();
     }
-
     if (this.subscription) {
       this.subscription.unsubscribe();
     }
   }
-
   useLastResultFrom(runner: PanelQueryRunner) {
     this.lastResult = runner.getLastResult();
-
     if (this.lastResult) {
       // The subject is a replay subject so anyone subscribing will get this last result
       this.subject.next(this.lastResult);
     }
   }
-
   /** Useful from tests */
   setLastResult(data: PanelData) {
     this.lastResult = data;
   }
-
   getLastResult(): PanelData | undefined {
     return this.lastResult;
   }
-
   getLastRequest(): DataQueryRequest | undefined {
     return this.lastRequest;
   }
-
   shouldAddErrorWhenDatasourceVariableIsMultiple(
     datasource: DataSourceRef | DataSourceApi | null,
     scopedVars: ScopedVars | undefined
   ): boolean {
     let addWarningMessageMultipleDatasourceVariable = false;
-
     //If datasource is a variable
     if (datasource?.uid?.startsWith('${')) {
       // we can access the raw datasource variable values inside the replace function if we pass a custom format function
@@ -512,11 +443,9 @@ export class PanelQueryRunner {
         return '';
       });
     }
-
     return addWarningMessageMultipleDatasourceVariable;
   }
 }
-
 async function getDataSource(
   datasource: DataSourceRef | string | DataSourceApi | null,
   scopedVars: ScopedVars
@@ -524,6 +453,5 @@ async function getDataSource(
   if (datasource && typeof datasource === 'object' && 'query' in datasource) {
     return datasource;
   }
-
   return await getDatasourceSrv().get(datasource, scopedVars);
 }

--- a/public/app/features/query/state/QueryRunner.ts
+++ b/public/app/features/query/state/QueryRunner.ts
@@ -1,7 +1,7 @@
+import { structLog } from '@grafana/data';
 import { cloneDeep } from 'lodash';
 import { from, type Observable, ReplaySubject, type Unsubscribable } from 'rxjs';
 import { first } from 'rxjs/operators';
-
 import {
   CoreApp,
   type DataQueryRequest,
@@ -17,24 +17,19 @@ import {
 } from '@grafana/data';
 import { getTemplateSrv } from '@grafana/runtime';
 import { getDatasourceSrv } from 'app/features/plugins/datasource_srv';
-
 import { getNextRequestId } from './PanelQueryRunner';
 import { setStructureRevision } from './processing/revision';
 import { runRequest } from './runRequest';
-
 export class QueryRunner implements QueryRunnerSrv {
   private subject: ReplaySubject<PanelData>;
   private subscription?: Unsubscribable;
   private lastResult?: PanelData;
-
   constructor() {
     this.subject = new ReplaySubject(1);
   }
-
   get(): Observable<PanelData> {
     return this.subject.asObservable();
   }
-
   run(options: QueryRunnerOptions): void {
     const {
       queries,
@@ -51,11 +46,9 @@ export class QueryRunner implements QueryRunnerSrv {
       scopedVars,
       minInterval,
     } = options;
-
     if (this.subscription) {
       this.subscription.unsubscribe();
     }
-
     const request: DataQueryRequest = {
       app: app ?? CoreApp.Unknown,
       requestId: getNextRequestId(),
@@ -73,10 +66,8 @@ export class QueryRunner implements QueryRunnerSrv {
       queryCachingTTL,
       startTime: Date.now(),
     };
-
     // Add deprecated property
     request.rangeRaw = timeRange.raw;
-
     from(getDataSource(datasource, request.scopedVars))
       .pipe(first())
       .subscribe({
@@ -88,22 +79,18 @@ export class QueryRunner implements QueryRunnerSrv {
             }
             return query;
           });
-
           const lowerIntervalLimit = minInterval
             ? getTemplateSrv().replace(minInterval, request.scopedVars)
             : ds.interval;
           const norm = rangeUtil.calculateInterval(timeRange, maxDataPoints, lowerIntervalLimit);
-
           // make shallow copy of scoped vars,
           // and add built in variables interval and interval_ms
           request.scopedVars = Object.assign({}, request.scopedVars, {
             __interval: { text: norm.interval, value: norm.interval },
             __interval_ms: { text: norm.intervalMs.toString(), value: norm.intervalMs },
           });
-
           request.interval = norm.interval;
           request.intervalMs = norm.intervalMs;
-
           this.subscription = runRequest(ds, request).subscribe({
             next: (data) => {
               const results = preProcessPanelData(data, this.lastResult);
@@ -113,17 +100,14 @@ export class QueryRunner implements QueryRunnerSrv {
             },
           });
         },
-        error: (error) => console.error('PanelQueryRunner Error', error),
+        error: (error) => structLog('error', 'PanelQueryRunner Error', error),
       });
   }
-
   cancel(): void {
     if (!this.subscription) {
       return;
     }
-
     this.subscription.unsubscribe();
-
     // If we have an old result with loading state, send it with done state
     if (this.lastResult && this.lastResult.state === LoadingState.Loading) {
       this.subject.next({
@@ -132,19 +116,16 @@ export class QueryRunner implements QueryRunnerSrv {
       });
     }
   }
-
   destroy(): void {
     // Tell anyone listening that we are done
     if (this.subject) {
       this.subject.complete();
     }
-
     if (this.subscription) {
       this.subscription.unsubscribe();
     }
   }
 }
-
 async function getDataSource(
   datasource: DataSourceRef | DataSourceApi | null,
   scopedVars: ScopedVars
@@ -152,6 +133,5 @@ async function getDataSource(
   if (datasource && 'query' in datasource) {
     return datasource;
   }
-
   return getDatasourceSrv().get(datasource, scopedVars);
 }

--- a/public/app/features/query/state/runRequest.ts
+++ b/public/app/features/query/state/runRequest.ts
@@ -1,8 +1,8 @@
+import { structLog } from '@grafana/data';
 // Libraries
 import { isString, map as isArray } from 'lodash';
 import { from, merge, type Observable, of, timer } from 'rxjs';
 import { catchError, map, mapTo, mergeMap, share, takeUntil, tap } from 'rxjs/operators';
-
 // Utils & Services
 // Types
 import {
@@ -23,17 +23,17 @@ import { backendSrv } from 'app/core/services/backend_srv';
 import { queryIsEmpty } from 'app/core/utils/query';
 import { dataSource as expressionDatasource } from 'app/features/expressions/ExpressionDatasource';
 import { type ExpressionQuery } from 'app/features/expressions/types';
-
 import { cancelNetworkRequestsOnUnsubscribe } from './processing/canceler';
 import { emitDataRequestEvent } from './queryAnalytics';
-
-type MapOfResponsePackets = { [str: string]: DataQueryResponse };
-
+type MapOfResponsePackets = {
+  [str: string]: DataQueryResponse;
+};
 interface RunningQueryState {
-  packets: { [key: string]: DataQueryResponse };
+  packets: {
+    [key: string]: DataQueryResponse;
+  };
   panelData: PanelData;
 }
-
 /*
  * This function should handle composing a PanelData from multiple responses
  */
@@ -42,41 +42,32 @@ export function processResponsePacket(packet: DataQueryResponse, state: RunningQ
   const packets: MapOfResponsePackets = {
     ...state.packets,
   };
-
   // updates to the same key will replace previous values
   const key = packet.key ?? packet.data?.[0]?.refId ?? 'A';
   packets[key] = packet;
-
   let loadingState = packet.state || LoadingState.Done;
   let error: DataQueryError | undefined = undefined;
   let errors: DataQueryError[] | undefined = undefined;
-
   const series: DataQueryResponseData[] = [];
   const annotations: DataQueryResponseData[] = [];
-
   for (const key in packets) {
     const packet = packets[key];
-
     if (packet.error || packet.errors?.length) {
       loadingState = LoadingState.Error;
       error = packet.error;
       errors = packet.errors;
     }
-
     if (packet.data && packet.data.length) {
       for (const dataItem of packet.data) {
         if (dataItem.meta?.dataTopic === DataTopic.Annotations) {
           annotations.push(dataItem);
           continue;
         }
-
         series.push(dataItem);
       }
     }
   }
-
   const timeRange = getRequestTimeRange(request, loadingState);
-
   const panelData: PanelData = {
     state: loadingState,
     series,
@@ -86,31 +77,24 @@ export function processResponsePacket(packet: DataQueryResponse, state: RunningQ
     request,
     timeRange,
   };
-
   // we use a Set to deduplicate the traceIds
   const traceIdSet = new Set([...(state.panelData.traceIds ?? []), ...(packet.traceIds ?? [])]);
-
   if (traceIdSet.size > 0) {
     panelData.traceIds = Array.from(traceIdSet);
   }
-
   return { packets, panelData };
 }
-
 function getRequestTimeRange(request: DataQueryRequest, loadingState: LoadingState): TimeRange {
   const range = request.range;
-
   if (!isString(range.raw.from) || loadingState !== LoadingState.Streaming) {
     return range;
   }
-
   return {
     ...range,
     from: dateMath.parse(range.raw.from, false)!,
     to: dateMath.parse(range.raw.to, true)!,
   };
 }
-
 /**
  * This function handles the execution of requests & and processes the single or multiple response packets into
  * a combined PanelData response. It will
@@ -132,36 +116,30 @@ export function runRequest(
     },
     packets: {},
   };
-
   // Return early if there are no queries to run
   if (!request.targets.length) {
     request.endTime = Date.now();
     state.panelData.state = LoadingState.Done;
     return of(state.panelData);
   }
-
   const dataObservable = callQueryMethodWithMigration(datasource, request, queryFunction).pipe(
     // Transform response packets into PanelData with merged results
     map((packet: DataQueryResponse) => {
       if (!isArray(packet.data)) {
         throw new Error(`Expected response data to be array, got ${typeof packet.data}.`);
       }
-
       // filter out responses for hidden queries
       const hiddenQueries = request.targets.filter((q) => q.hide);
       for (const query of hiddenQueries) {
         packet.data = packet.data.filter((d) => d.refId !== query.refId);
       }
-
       request.endTime = Date.now();
-
       state = processResponsePacket(packet, state);
-
       return state.panelData;
     }),
     // handle errors
     catchError((err) => {
-      console.error('runRequest.catchError', err);
+      structLog('error', 'runRequest.catchError', err);
       return of({
         ...state.panelData,
         state: LoadingState.Error,
@@ -175,13 +153,11 @@ export function runRequest(
     // this makes it possible to share this observable in takeUntil
     share()
   );
-
   // If 50ms without a response emit a loading state
   // mapTo will translate the timer event into state.panelData (which has state set to loading)
   // takeUntil will cancel the timer emit when first response packet is received on the dataObservable
   return merge(timer(200).pipe(mapTo(state.panelData), takeUntil(dataObservable)), dataObservable);
 }
-
 export function callQueryMethodWithMigration(
   datasource: DataSourceApi,
   request: DataQueryRequest,
@@ -195,7 +171,6 @@ export function callQueryMethodWithMigration(
   }
   return callQueryMethod(datasource, request, queryFunction);
 }
-
 export function callQueryMethod(
   datasource: DataSourceApi,
   request: DataQueryRequest,
@@ -210,27 +185,22 @@ export function callQueryMethod(
         }
       : t
   );
-
   // If its a public datasource, just return the result. Expressions will be handled on the backend.
   if (config.publicDashboardAccessToken) {
     return from(datasource.query(request));
   }
-
   for (const target of request.targets) {
     if (isExpressionReference(target.datasource)) {
       return expressionDatasource.query(request as DataQueryRequest<ExpressionQuery>);
     }
   }
-
   // do not filter queries in case a custom query function is provided (for example in variable queries)
   if (!queryFunction) {
     request.targets = request.targets.filter((t) => datasource.filterQuery?.(t) ?? true);
   }
-
   if (request.targets.length === 0) {
     return of<DataQueryResponse>({ data: [] });
   }
-
   // Otherwise it is a standard datasource request
   const returnVal = queryFunction ? queryFunction(request) : datasource.query(request);
   return from(returnVal);

--- a/public/app/features/scopes/ScopesApiClient.ts
+++ b/public/app/features/scopes/ScopesApiClient.ts
@@ -1,18 +1,22 @@
+import { structLog } from '@grafana/data';
 import { type Scope, type ScopeDashboardBinding, type ScopeNode } from '@grafana/data';
 import { config } from '@grafana/runtime';
 import { scopeAPIv0alpha1 } from 'app/api/clients/scope/v0alpha1';
 import { getMessageFromError } from 'app/core/utils/errors';
 import { dispatch } from 'app/store/store';
-
 import { type ScopeNavigation } from './dashboards/types';
-
 export class ScopesApiClient {
   /**
    * Checks if the data is a Kubernetes Status error response.
    * @param data The data to check
    * @returns true if the data is a Status error, false otherwise
    */
-  private isStatusError(data: unknown): data is { kind: 'Status'; status: 'Failure'; message?: string; code?: number } {
+  private isStatusError(data: unknown): data is {
+    kind: 'Status';
+    status: 'Failure';
+    message?: string;
+    code?: number;
+  } {
     return (
       data !== null &&
       typeof data === 'object' &&
@@ -22,29 +26,32 @@ export class ScopesApiClient {
       data.status === 'Failure'
     );
   }
-
   /**
    * Extracts and validates data from an RTK Query result, checking for error responses.
    * @param result The RTK Query result
    * @param context Context for error logging (e.g., resource name)
    * @returns The data if valid, undefined if it's an error response
    */
-  private extractDataOrHandleError<T>(result: { data?: T; error?: unknown }, context: string): T | undefined {
+  private extractDataOrHandleError<T>(
+    result: {
+      data?: T;
+      error?: unknown;
+    },
+    context: string
+  ): T | undefined {
     if ('data' in result && result.data) {
       // Check if the data is actually an error response (Kubernetes Status object)
       if (this.isStatusError(result.data)) {
         const errorMessage = getMessageFromError(result.data);
-        console.error(`Failed to fetch %s:`, context, errorMessage);
+        structLog('error', `Failed to fetch %s:`, context, errorMessage);
         return undefined;
       }
       return result.data;
     }
-
     if ('error' in result) {
       const errorMessage = getMessageFromError(result.error);
-      console.error(`Failed to fetch %s:`, context, errorMessage);
+      structLog('error', `Failed to fetch %s:`, context, errorMessage);
     }
-
     return undefined;
   }
   async fetchScope(name: string): Promise<Scope | undefined> {
@@ -54,7 +61,7 @@ export class ScopesApiClient {
       return this.extractDataOrHandleError(result, `scope: ${name}`);
     } catch (err) {
       const errorMessage = getMessageFromError(err);
-      console.error('Failed to fetch scope:', name, errorMessage);
+      structLog('error', 'Failed to fetch scope:', name, errorMessage);
       return undefined;
     } finally {
       // Unsubscribe for extra safety, even though with subscribe: false and awaiting,
@@ -62,19 +69,17 @@ export class ScopesApiClient {
       subscription.unsubscribe();
     }
   }
-
   async fetchMultipleScopes(scopesIds: string[]): Promise<Scope[]> {
     if (scopesIds.length === 0) {
       return [];
     }
-
     try {
       const scopes = await Promise.all(scopesIds.map((id) => this.fetchScope(id)));
       const successfulScopes = scopes.filter((scope) => scope !== undefined);
-
       if (successfulScopes.length < scopesIds.length) {
         const failedCount = scopesIds.length - successfulScopes.length;
-        console.warn(
+        structLog(
+          'warn',
           'Failed to fetch',
           failedCount,
           'of',
@@ -83,40 +88,34 @@ export class ScopesApiClient {
           scopesIds.join(', ')
         );
       }
-
       return successfulScopes;
     } catch (err) {
       const errorMessage = getMessageFromError(err);
-      console.error('Failed to fetch multiple scopes:', scopesIds, errorMessage);
+      structLog('error', 'Failed to fetch multiple scopes:', scopesIds, errorMessage);
       return [];
     }
   }
-
   async fetchMultipleScopeNodes(names: string[]): Promise<ScopeNode[]> {
     if (!config.featureToggles.useMultipleScopeNodesEndpoint || names.length === 0) {
       return Promise.resolve([]);
     }
-
     const subscription = dispatch(
       scopeAPIv0alpha1.endpoints.getFindScopeNodeChildrenResults.initiate({ names }, { subscribe: false })
     );
     try {
       const result = await subscription;
-
       if ('data' in result && result.data) {
         // The generated API returns items compatible with @grafana/data ScopeNode
         return result.data.items ?? [];
       }
-
       if ('error' in result) {
         const errorMessage = getMessageFromError(result.error);
-        console.error('Failed to fetch multiple scope nodes:', names, errorMessage);
+        structLog('error', 'Failed to fetch multiple scope nodes:', names, errorMessage);
       }
-
       return [];
     } catch (err) {
       const errorMessage = getMessageFromError(err);
-      console.error('Failed to fetch multiple scope nodes:', names, errorMessage);
+      structLog('error', 'Failed to fetch multiple scope nodes:', names, errorMessage);
       return [];
     } finally {
       // Unsubscribe for extra safety, even though with subscribe: false and awaiting,
@@ -124,7 +123,6 @@ export class ScopesApiClient {
       subscription.unsubscribe();
     }
   }
-
   /**
    * Fetches a map of nodes based on the specified options.
    *
@@ -136,11 +134,9 @@ export class ScopesApiClient {
    */
   async fetchNodes(options: { parent?: string; query?: string; limit?: number }): Promise<ScopeNode[]> {
     const limit = options.limit ?? 1000;
-
     if (!(0 < limit && limit <= 10000)) {
       throw new Error('Limit must be between 1 and 10000');
     }
-
     const subscription = dispatch(
       scopeAPIv0alpha1.endpoints.getFindScopeNodeChildrenResults.initiate(
         {
@@ -153,12 +149,10 @@ export class ScopesApiClient {
     );
     try {
       const result = await subscription;
-
       if ('data' in result && result.data) {
         // The generated API returns items compatible with @grafana/data ScopeNode
         return result.data.items ?? [];
       }
-
       if ('error' in result) {
         const errorMessage = getMessageFromError(result.error);
         const contextParts: string[] = [];
@@ -170,9 +164,8 @@ export class ScopesApiClient {
         }
         contextParts.push('limit=' + limit);
         const context = contextParts.join(', ');
-        console.error('Failed to fetch scope nodes:', context, errorMessage);
+        structLog('error', 'Failed to fetch scope nodes:', context, errorMessage);
       }
-
       return [];
     } catch (err) {
       const errorMessage = getMessageFromError(err);
@@ -185,7 +178,7 @@ export class ScopesApiClient {
       }
       contextParts.push('limit=' + limit);
       const context = contextParts.join(', ');
-      console.error('Failed to fetch scope nodes:', context, errorMessage);
+      structLog('error', 'Failed to fetch scope nodes:', context, errorMessage);
       return [];
     } finally {
       // Unsubscribe for extra safety, even though with subscribe: false and awaiting,
@@ -193,7 +186,6 @@ export class ScopesApiClient {
       subscription.unsubscribe();
     }
   }
-
   public fetchDashboards = async (scopeNames: string[]): Promise<ScopeDashboardBinding[]> => {
     const subscription = dispatch(
       scopeAPIv0alpha1.endpoints.getFindScopeDashboardBindingsResults.initiate(
@@ -205,21 +197,18 @@ export class ScopesApiClient {
     );
     try {
       const result = await subscription;
-
       if ('data' in result && result.data) {
         // The generated API returns items compatible with @grafana/data ScopeDashboardBinding
         return result.data.items ?? [];
       }
-
       if ('error' in result) {
         const errorMessage = getMessageFromError(result.error);
-        console.error('Failed to fetch dashboards for scopes:', scopeNames, errorMessage);
+        structLog('error', 'Failed to fetch dashboards for scopes:', scopeNames, errorMessage);
       }
-
       return [];
     } catch (err) {
       const errorMessage = getMessageFromError(err);
-      console.error('Failed to fetch dashboards for scopes:', scopeNames, errorMessage);
+      structLog('error', 'Failed to fetch dashboards for scopes:', scopeNames, errorMessage);
       return [];
     } finally {
       // Unsubscribe for extra safety, even though with subscribe: false and awaiting,
@@ -227,10 +216,12 @@ export class ScopesApiClient {
       subscription.unsubscribe();
     }
   };
-
   public fetchScopeNavigations = async (
     scopeNames: string[],
-    options?: { depth?: number; rootScope?: string }
+    options?: {
+      depth?: number;
+      rootScope?: string;
+    }
   ): Promise<ScopeNavigation[]> => {
     const subscription = dispatch(
       scopeAPIv0alpha1.endpoints.getFindScopeNavigationsResults.initiate(
@@ -244,21 +235,18 @@ export class ScopesApiClient {
     );
     try {
       const result = await subscription;
-
       if ('data' in result && result.data) {
         // The generated API returns items compatible with ScopeNavigation
         return result.data.items ?? [];
       }
-
       if ('error' in result) {
         const errorMessage = getMessageFromError(result.error);
-        console.error('Failed to fetch scope navigations for scopes:', scopeNames, errorMessage);
+        structLog('error', 'Failed to fetch scope navigations for scopes:', scopeNames, errorMessage);
       }
-
       return [];
     } catch (err) {
       const errorMessage = getMessageFromError(err);
-      console.error('Failed to fetch scope navigations for scopes:', scopeNames, errorMessage);
+      structLog('error', 'Failed to fetch scope navigations for scopes:', scopeNames, errorMessage);
       return [];
     } finally {
       // Unsubscribe for extra safety, even though with subscribe: false and awaiting,
@@ -266,12 +254,10 @@ export class ScopesApiClient {
       subscription.unsubscribe();
     }
   };
-
   public fetchScopeNode = async (scopeNodeId: string): Promise<ScopeNode | undefined> => {
     if (!config.featureToggles.useScopeSingleNodeEndpoint) {
       return Promise.resolve(undefined);
     }
-
     const subscription = dispatch(
       scopeAPIv0alpha1.endpoints.getScopeNode.initiate({ name: scopeNodeId }, { subscribe: false })
     );
@@ -280,7 +266,7 @@ export class ScopesApiClient {
       return this.extractDataOrHandleError(result, `scope node: ${scopeNodeId}`);
     } catch (err) {
       const errorMessage = getMessageFromError(err);
-      console.error('Failed to fetch scope node:', scopeNodeId, errorMessage);
+      structLog('error', 'Failed to fetch scope node:', scopeNodeId, errorMessage);
       return undefined;
     } finally {
       // Unsubscribe for extra safety, even though with subscribe: false and awaiting,

--- a/public/app/features/scopes/ScopesService.ts
+++ b/public/app/features/scopes/ScopesService.ts
@@ -1,18 +1,15 @@
+import { structLog } from '@grafana/data';
 import { isEqual } from 'lodash';
 import { BehaviorSubject, type Observable, combineLatest, type Subscription } from 'rxjs';
 import { map, distinctUntilChanged } from 'rxjs/operators';
-
 import { type LocationService, type ScopesContextValue, type ScopesContextValueState } from '@grafana/runtime';
-
 import { type ScopesDashboardsService } from './dashboards/ScopesDashboardsService';
 import { deserializeFolderPath, serializeFolderPath } from './dashboards/scopeNavgiationUtils';
 import { type ScopesSelectorService } from './selector/ScopesSelectorService';
-
 export interface State {
   enabled: boolean;
   readOnly: boolean;
 }
-
 /**
  * The ScopesService is mainly an aggregation of the ScopesSelectorService and ScopesDashboardsService which handle
  * the scope selection mechanics and then loading and showing related dashboards. We aggregate the state of these
@@ -21,12 +18,9 @@ export interface State {
 export class ScopesService implements ScopesContextValue {
   // Only internal part of the state.
   private readonly _state: BehaviorSubject<State>;
-
   // This will contain the combined state that will be public.
   private readonly _stateObservable: BehaviorSubject<ScopesContextValueState>;
-
   private subscriptions: Subscription[] = [];
-
   constructor(
     private selectorService: ScopesSelectorService,
     private dashboardsService: ScopesDashboardsService,
@@ -36,7 +30,6 @@ export class ScopesService implements ScopesContextValue {
       enabled: false,
       readOnly: false,
     });
-
     this._stateObservable = new BehaviorSubject({
       ...this._state.getValue(),
       value: this.selectorService.state.appliedScopes
@@ -46,7 +39,6 @@ export class ScopesService implements ScopesContextValue {
       loading: this.selectorService.state.loading,
       drawerOpened: this.dashboardsService.state.drawerOpened,
     });
-
     // We combine the latest emissions from this state + selectorService + dashboardsService.
     this.subscriptions.push(
       combineLatest([
@@ -68,13 +60,11 @@ export class ScopesService implements ScopesContextValue {
         // We pass this into behaviourSubject so we get the 1 event buffer and we can access latest value.
         .subscribe(this._stateObservable)
     );
-
     // Init from the URL when we first load
     const queryParams = new URLSearchParams(locationService.getLocation().search);
     const scopeNodeId = queryParams.get('scope_node');
     const navigationScope = queryParams.get('navigation_scope');
     const navScopePath = queryParams.get('nav_scope_path');
-
     if (navigationScope) {
       this.dashboardsService.setNavigationScope(
         navigationScope,
@@ -82,21 +72,18 @@ export class ScopesService implements ScopesContextValue {
         navScopePath ? deserializeFolderPath(navScopePath) : undefined
       );
     }
-
     this.changeScopes(queryParams.getAll('scopes'), undefined, scopeNodeId ?? undefined).then(() => {
       if (navScopePath && !navigationScope) {
         this.dashboardsService.setNavScopePath(deserializeFolderPath(navScopePath));
       }
     });
-
     // Pre-load scope node (which loads parent too)
     const nodeToPreload = scopeNodeId;
     if (nodeToPreload) {
       this.selectorService.resolvePathToRoot(nodeToPreload, this.selectorService.state.tree!).catch((error) => {
-        console.error('Failed to pre-load node path', error);
+        structLog('error', 'Failed to pre-load node path', error);
       });
     }
-
     // Update scopes state based on URL.
     this.subscriptions.push(
       locationService.getLocationObservable().subscribe((location) => {
@@ -105,13 +92,10 @@ export class ScopesService implements ScopesContextValue {
           return;
         }
         const queryParams = new URLSearchParams(location.search);
-
         const scopes = queryParams.getAll('scopes');
         const scopeNodeId = queryParams.get('scope_node');
-
         const navigationScope = queryParams.get('navigation_scope');
         const navScopePath = queryParams.get('nav_scope_path');
-
         // Check if new scopes are different from the old scopes
         const currentScopes = this.selectorService.state.appliedScopes.map((scope) => scope.scopeId);
         if (scopes.length && !isEqual(scopes, currentScopes)) {
@@ -120,16 +104,13 @@ export class ScopesService implements ScopesContextValue {
           // changes the URL directly, it would trigger a reload so scopes would still be reset.
           this.changeScopes(scopes, undefined, scopeNodeId ?? undefined);
         }
-
         // Handle navigation_scope and nav_scope_path changes from back/forward navigation
         const currentNavigationScope = this.dashboardsService.state.navigationScope;
         const currentNavScopePath = this.dashboardsService.state.navScopePath;
         const newNavScopePath = navScopePath ? deserializeFolderPath(navScopePath) : undefined;
         const decodedNavigationScope = navigationScope ? decodeURIComponent(navigationScope) : undefined;
-
         const navigationScopeChanged = decodedNavigationScope !== currentNavigationScope;
         const navScopePathChanged = !isEqual(newNavScopePath, currentNavScopePath);
-
         if (navigationScopeChanged) {
           // Navigation scope changed - do full update
           if (decodedNavigationScope) {
@@ -147,13 +128,11 @@ export class ScopesService implements ScopesContextValue {
         }
       })
     );
-
     // Update the URL based on change in the scopes state
     this.subscriptions.push(
       selectorService.subscribeToState((state, prevState) => {
         const oldScopeNames = prevState.appliedScopes.map((scope) => scope.scopeId);
         const newScopeNames = state.appliedScopes.map((scope) => scope.scopeId);
-
         // Extract scopeNodeId from defaultPath when available
         const getScopeNodeId = (appliedScopes: typeof state.appliedScopes, scopes: typeof state.scopes) => {
           const firstScope = appliedScopes[0];
@@ -167,13 +146,10 @@ export class ScopesService implements ScopesContextValue {
           }
           return firstScope.scopeNodeId;
         };
-
         const oldScopeNodeId = getScopeNodeId(prevState.appliedScopes, prevState.scopes);
         const newScopeNodeId = getScopeNodeId(state.appliedScopes, state.scopes);
-
         const scopesChanged = !isEqual(oldScopeNames, newScopeNames);
         const scopeNodeChanged = oldScopeNodeId !== newScopeNodeId;
-
         if (scopesChanged || scopeNodeChanged) {
           this.locationService.partial(
             {
@@ -204,7 +180,6 @@ export class ScopesService implements ScopesContextValue {
       })
     );
   }
-
   /**
    * This updates only the internal state of this service.
    * @param newState
@@ -212,7 +187,6 @@ export class ScopesService implements ScopesContextValue {
   private updateState = (newState: Partial<State>) => {
     this._state.next({ ...this._state.getValue(), ...newState });
   };
-
   /**
    * The state of this service is a combination of the downstream services state plus the state of this service.
    */
@@ -221,25 +195,20 @@ export class ScopesService implements ScopesContextValue {
     // rerenders.
     return this._stateObservable.value;
   }
-
   public get stateObservable(): Observable<ScopesContextValueState> {
     return this._stateObservable;
   }
-
   public changeScopes = (scopeNames: string[], parentNodeId?: string, scopeNodeId?: string) =>
     // Don't redirect on apply for initial load from URL. We only want to redirect when selecting from the selector
     this.selectorService.changeScopes(scopeNames, parentNodeId, scopeNodeId, false);
-
   public setReadOnly = (readOnly: boolean) => {
     if (this.state.readOnly !== readOnly) {
       this.updateState({ readOnly });
     }
-
     if (readOnly && this.selectorService.state.opened) {
       this.selectorService.closeAndReset();
     }
   };
-
   public setEnabled = (enabled: boolean) => {
     if (this.state.enabled !== enabled) {
       this.updateState({ enabled });
@@ -256,7 +225,6 @@ export class ScopesService implements ScopesContextValue {
       }
     }
   };
-
   /**
    * Extracts the scopeNodeId for URL syncing, preferring defaultPath when available.
    * When a scope has defaultPath, that is the source of truth for the node ID.
@@ -267,19 +235,15 @@ export class ScopesService implements ScopesContextValue {
     if (!firstScope) {
       return undefined;
     }
-
     const scope = this.selectorService.state.scopes[firstScope.scopeId];
-
     // Prefer scopeNodeId from defaultPath if available (most reliable source)
     if (scope?.spec.defaultPath && scope.spec.defaultPath.length > 0) {
       // Extract scopeNodeId from the last element of defaultPath
       return scope.spec.defaultPath[scope.spec.defaultPath.length - 1];
     }
-
     // Fallback to next in priority order: scopeNodeId from appliedScopes
     return firstScope.scopeNodeId;
   }
-
   /**
    * Returns observable that emits when relevant parts of the selectorService state change.
    * @private
@@ -300,7 +264,6 @@ export class ScopesService implements ScopesContextValue {
       )
     );
   }
-
   /**
    * Returns observable that emits when relevant parts of the dashboardService state change.
    * @private
@@ -310,7 +273,6 @@ export class ScopesService implements ScopesContextValue {
       distinctUntilChanged((prev, curr) => prev.drawerOpened === curr.drawerOpened)
     );
   }
-
   /**
    * Cleanup subscriptions so this can be garbage collected.
    */

--- a/public/app/features/scopes/selector/ScopesSelectorService.ts
+++ b/public/app/features/scopes/selector/ScopesSelectorService.ts
@@ -1,13 +1,12 @@
+import { structLog } from '@grafana/data';
 import { type Scope, type ScopeNode, store as storeImpl } from '@grafana/data';
 import { config, locationService } from '@grafana/runtime';
 import { type performanceUtils } from '@grafana/scenes';
 import { getDashboardSceneProfiler } from 'app/features/dashboard/services/DashboardProfiler';
-
 import { type ScopesApiClient } from '../ScopesApiClient';
 import { ScopesServiceBase } from '../ScopesServiceBase';
 import { type ScopesDashboardsService } from '../dashboards/ScopesDashboardsService';
 import { isCurrentPath } from '../dashboards/scopeNavgiationUtils';
-
 import {
   closeNodes,
   expandNodes,
@@ -27,44 +26,33 @@ import {
   type SelectedScope,
   type TreeNode,
 } from './types';
-
 export const RECENT_SCOPES_KEY = 'grafana.scopes.recent';
-
 export interface ScopesSelectorServiceState {
   // Used to indicate loading of the scopes themselves for example when applying them.
   loading: boolean;
-
   // Indicates loading children of a specific scope node.
   loadingNodeName: string | undefined;
-
   // Whether the scopes selector drawer is opened
   opened: boolean;
-
   // A cache for a specific scope objects that come from the API. nodes being objects in the categories tree and scopes
   // the actual scope definitions. They are not guaranteed to be there! For example we may have a scope applied from
   // url for which we don't have a node, or scope is still loading after it is selected in the UI. This means any
   // access needs to be guarded and not automatically assumed it will return an object.
   nodes: NodesMap;
   scopes: ScopesMap;
-
   // Scopes that are selected and applied.
   appliedScopes: SelectedScope[];
-
   // Scopes that are selected but not applied yet.
   selectedScopes: SelectedScope[];
-
   // Simple tree structure for the scopes categories. Each node in a tree has a scopeNodeId which keys the nodes cache
   // map.
   tree: TreeNode;
 }
-
 export class ScopesSelectorService extends ScopesServiceBase<ScopesSelectorServiceState> {
   private redirectEnabled = true;
-
   public setRedirectEnabled(enabled: boolean) {
     this.redirectEnabled = enabled;
   }
-
   constructor(
     private apiClient: ScopesApiClient,
     private dashboardsService: ScopesDashboardsService,
@@ -78,13 +66,10 @@ export class ScopesSelectorService extends ScopesServiceBase<ScopesSelectorServi
       loading: false,
       opened: false,
       loadingNodeName: undefined,
-
       nodes: {},
       scopes: {},
-
       selectedScopes: [],
       appliedScopes: [],
-
       tree: {
         expanded: false,
         scopeNodeId: '', // root
@@ -92,18 +77,15 @@ export class ScopesSelectorService extends ScopesServiceBase<ScopesSelectorServi
         children: undefined,
       },
     });
-
     // Load nodes from recent scopes so they are readily available
     const parentNodes = this.getNodesFromRecentScopes();
     this.updateState({ nodes: { ...this.state.nodes, ...parentNodes } });
   }
-
   // Loads a node from the API and adds it to the nodes cache
   public getScopeNode = async (scopeNodeId: string) => {
     if (this.state.nodes[scopeNodeId]) {
       return this.state.nodes[scopeNodeId];
     }
-
     try {
       const node = await this.apiClient.fetchScopeNode(scopeNodeId);
       if (node) {
@@ -111,35 +93,29 @@ export class ScopesSelectorService extends ScopesServiceBase<ScopesSelectorServi
       }
       return node;
     } catch (error) {
-      console.error('Failed to load node', error);
+      structLog('error', 'Failed to load node', error);
       return undefined;
     }
   };
-
   private getNodePath = async (scopeNodeId: string, visited: Set<string> = new Set()): Promise<ScopeNode[]> => {
     // Protect against circular references
     if (visited.has(scopeNodeId)) {
-      console.error('Circular reference detected in node path', scopeNodeId);
+      structLog('error', 'Circular reference detected in node path', scopeNodeId);
       return [];
     }
-
     const node = await this.getScopeNode(scopeNodeId);
     if (!node) {
       return [];
     }
-
     // Add current node to visited set
     const newVisited = new Set(visited);
     newVisited.add(scopeNodeId);
-
     const parentPath =
       node.spec.parentName && node.spec.parentName !== ''
         ? await this.getNodePath(node.spec.parentName, newVisited)
         : [];
-
     return [...parentPath, node];
   };
-
   /**
    * Determines the path to a scope node, preferring defaultPath from scope metadata.
    * This is the single source of truth for path resolution.
@@ -158,22 +134,21 @@ export class ScopesSelectorService extends ScopesServiceBase<ScopesSelectorServi
       // Batch fetch all nodes in defaultPath
       return await this.getScopeNodes(scope.spec.defaultPath);
     }
-
     // 2. Fall back to calculating path from scopeNodeId
     if (scopeNodeId) {
       return await this.getNodePath(scopeNodeId);
     }
-
     return [];
   }
-
   public resolvePathToRoot = async (
     scopeNodeId: string,
     tree: TreeNode,
     scopeId?: string
-  ): Promise<{ path: ScopeNode[]; tree: TreeNode }> => {
+  ): Promise<{
+    path: ScopeNode[];
+    tree: TreeNode;
+  }> => {
     let nodePath: ScopeNode[];
-
     // Check if scope has defaultPath for optimized resolution
     const scope = scopeId ? this.state.scopes[scopeId] : undefined;
     if (scope?.spec.defaultPath && scope.spec.defaultPath.length > 0) {
@@ -183,35 +158,26 @@ export class ScopesSelectorService extends ScopesServiceBase<ScopesSelectorServi
       // Fall back to node-based path resolution
       nodePath = await this.getNodePath(scopeNodeId);
     }
-
     const newTree = insertPathNodesIntoTree(tree, nodePath);
-
     this.updateState({ tree: newTree });
-
     return { path: nodePath, tree: newTree };
   };
-
   // Resets query and toggles expanded state of a node
   public toggleExpandedNode = async (scopeNodeId: string) => {
     this.interactionProfiler?.startInteraction('scopeToggleExpandedNode');
-
     try {
       const path = getPathOfNode(scopeNodeId, this.state.nodes);
       const nodeToToggle = treeNodeAtPath(this.state.tree, path);
-
       if (!nodeToToggle) {
         throw new Error(`Node ${scopeNodeId} not found in tree`);
       }
-
       if (nodeToToggle.scopeNodeId !== '' && !isNodeExpandable(this.state.nodes[nodeToToggle.scopeNodeId])) {
         throw new Error(`Trying to expand node at id ${scopeNodeId} that is not expandable`);
       }
-
       const newTree = modifyTreeNodeAtPath(this.state.tree, path, (treeNode) => {
         treeNode.expanded = !nodeToToggle.expanded;
         treeNode.query = '';
       });
-
       this.updateState({ tree: newTree });
       // If we are collapsing, we need to make sure that all the parent's children are available
       if (nodeToToggle.expanded) {
@@ -231,28 +197,22 @@ export class ScopesSelectorService extends ScopesServiceBase<ScopesSelectorServi
       this.interactionProfiler?.stopInteraction();
     }
   };
-
   public filterNode = async (scopeNodeId: string, query: string) => {
     this.interactionProfiler?.startInteraction('scopeNodeFilter');
-
     try {
       const path = getPathOfNode(scopeNodeId, this.state.nodes);
       const nodeToFilter = treeNodeAtPath(this.state.tree, path);
-
       if (!nodeToFilter) {
         throw new Error(`Trying to filter node at path or id ${scopeNodeId} not found`);
       }
-
       if (nodeToFilter.scopeNodeId !== '' && !isNodeExpandable(this.state.nodes[nodeToFilter.scopeNodeId])) {
         throw new Error(`Trying to filter node at id ${scopeNodeId} that is not expandable`);
       }
-
       const newTree = modifyTreeNodeAtPath(this.state.tree, path, (treeNode) => {
         treeNode.expanded = true;
         treeNode.query = query;
       });
       this.updateState({ tree: newTree });
-
       await this.loadNodeChildren(path, nodeToFilter, query);
       // Catch and throw error so we can ensure the profiler is stopped
     } catch (error) {
@@ -261,23 +221,17 @@ export class ScopesSelectorService extends ScopesServiceBase<ScopesSelectorServi
       this.interactionProfiler?.stopInteraction();
     }
   };
-
   private loadNodeChildren = async (path: string[], treeNode: TreeNode, query?: string) => {
     this.updateState({ loadingNodeName: treeNode.scopeNodeId });
-
     const childNodes = await this.apiClient.fetchNodes({ parent: treeNode.scopeNodeId, query });
-
     const newNodes = { ...this.state.nodes };
-
     for (const node of childNodes) {
       newNodes[node.metadata.name] = node;
     }
-
     const newTree = modifyTreeNodeAtPath(this.state.tree, path, (treeNode) => {
       // Preserve existing children that have nested structure (from insertPathNodesIntoTree)
       const existingChildren = treeNode.children || {};
       const childrenToPreserve: Record<string, TreeNode> = {};
-
       // Keep children that have a children property (object, not undefined)
       // This includes both empty objects {} (from path insertion) and populated ones
       for (const [key, child] of Object.entries(existingChildren)) {
@@ -286,10 +240,8 @@ export class ScopesSelectorService extends ScopesServiceBase<ScopesSelectorServi
           childrenToPreserve[key] = child;
         }
       }
-
       // Start with preserved children, then add/update with fetched children
       treeNode.children = { ...childrenToPreserve };
-
       for (const node of childNodes) {
         // If this child was preserved, merge with fetched data
         if (childrenToPreserve[node.metadata.name]) {
@@ -311,12 +263,10 @@ export class ScopesSelectorService extends ScopesServiceBase<ScopesSelectorServi
       // Set loaded to true if node is a container
       treeNode.childrenLoaded = true;
     });
-
     // TODO: we might not want to update the tree as a side effect of this function
     this.updateState({ tree: newTree, nodes: newNodes, loadingNodeName: undefined });
     return { newTree };
   };
-
   /**
    * Selecting a scope means we add it to a temporary list of scopes that are waiting to be applied. We make sure
    * that the selection makes sense (like not allowing selection from multiple categories) and prefetch the scope.
@@ -324,15 +274,12 @@ export class ScopesSelectorService extends ScopesServiceBase<ScopesSelectorServi
    */
   public selectScope = async (scopeNodeId: string) => {
     let scopeNode = this.state.nodes[scopeNodeId];
-
     if (!isNodeSelectable(scopeNode)) {
       throw new Error(`Trying to select node with id ${scopeNodeId} that is not selectable`);
     }
-
     if (!scopeNode.spec.linkId) {
       throw new Error(`Trying to select node id ${scopeNodeId} that does not have a linkId`);
     }
-
     // We prefetch the scope metadata to make sure we have it cached before we apply the scope.
     this.apiClient.fetchScope(scopeNode.spec.linkId).then((scope) => {
       // We don't need to wait for the update here, so we can use then instead of await.
@@ -340,7 +287,6 @@ export class ScopesSelectorService extends ScopesServiceBase<ScopesSelectorServi
         this.updateState({ scopes: { ...this.state.scopes, [scope.metadata.name]: scope } });
       }
     });
-
     // TODO: if we do global search we may not have a parent node loaded. We have the ID but there is not an API that
     //   would allow us to load scopeNode by ID right now so this can be undefined which means we skip the
     //   disableMultiSelect check.
@@ -349,14 +295,12 @@ export class ScopesSelectorService extends ScopesServiceBase<ScopesSelectorServi
       scopeId: scopeNode.spec.linkId,
       scopeNodeId: scopeNode.metadata.name,
     };
-
     // if something is selected we look at parent and see if we are selecting in the same category or not. As we
     // cannot select in multiple categories we only need to check the first selected node. It is possible we have
     // something selected without knowing the parent so we default to assuming it's not the same parent.
     const sameParent =
       this.state.selectedScopes[0]?.scopeNodeId &&
       this.state.nodes[this.state.selectedScopes[0].scopeNodeId]?.spec.parentName === scopeNode.spec.parentName;
-
     if (
       !sameParent ||
       // Parent says we can only select one scope at a time.
@@ -369,14 +313,12 @@ export class ScopesSelectorService extends ScopesServiceBase<ScopesSelectorServi
       this.updateState({ selectedScopes: [...this.state.selectedScopes, selectedScope] });
     }
   };
-
   /**
    * Deselect a selected scope.
    * @param scopeIdOrScopeNodeId This can be either a scopeId or a scopeNodeId.
    */
   public deselectScope = async (scopeIdOrScopeNodeId: string) => {
     const node = this.state.nodes[scopeIdOrScopeNodeId];
-
     // This is a bit complicated because there are multiple cases where we can deselect a scope without having enough
     // information.
     const filter: (s: SelectedScope) => boolean = node
@@ -386,11 +328,9 @@ export class ScopesSelectorService extends ScopesServiceBase<ScopesSelectorServi
       : // This is when we scopeId, or scopeNodeId and the nodes aren't loaded yet. So we just try to match the id to the
         // scopes.
         (s) => s.scopeNodeId !== scopeIdOrScopeNodeId && s.scopeId !== scopeIdOrScopeNodeId;
-
     let newSelectedScopes = this.state.selectedScopes.filter(filter);
     this.updateState({ selectedScopes: newSelectedScopes });
   };
-
   changeScopes = (scopeNames: string[], parentNodeId?: string, scopeNodeId?: string, redirectOnApply?: boolean) => {
     return this.applyScopes(
       scopeNames.map((id, index) => ({
@@ -402,7 +342,6 @@ export class ScopesSelectorService extends ScopesServiceBase<ScopesSelectorServi
       redirectOnApply
     );
   };
-
   /**
    * Apply the selected scopes. Apart from setting the scopes it also fetches the scope metadata and also loads the
    * related dashboards.
@@ -415,10 +354,8 @@ export class ScopesSelectorService extends ScopesServiceBase<ScopesSelectorServi
     ) {
       return;
     }
-
     // Apply the scopes right away even though we don't have the metadata yet.
     this.updateState({ appliedScopes: scopes, selectedScopes: scopes, loading: scopes.length > 0 });
-
     // Fetches both dashboards and scope navigations
     // We call this even if we have 0 scope because in that case it also closes the dashboard drawer.
     // Only fetch dashboards based on the scopes if we don't have a navigation scope set.
@@ -430,34 +367,27 @@ export class ScopesSelectorService extends ScopesServiceBase<ScopesSelectorServi
         }
       });
     }
-
     if (scopes.length > 0) {
       const fetchedScopes = await this.apiClient.fetchMultipleScopes(scopes.map((s) => s.scopeId));
-
       // Fetch the scope node if it is not available
       let newNodesState = { ...this.state.nodes };
       let scopeNode = scopes[0]?.scopeNodeId ? this.state.nodes[scopes[0]?.scopeNodeId] : undefined;
-
       if (!scopeNode && config.featureToggles.useScopeSingleNodeEndpoint && scopes[0]?.scopeNodeId) {
         scopeNode = await this.apiClient.fetchScopeNode(scopes[0]?.scopeNodeId);
         if (scopeNode) {
           newNodesState[scopeNode.metadata.name] = scopeNode;
         }
       }
-
       const newScopesState = { ...this.state.scopes };
-
       // Validate API response is an array
       if (!Array.isArray(fetchedScopes)) {
-        console.error('Expected fetchedScopes to be an array, got:', typeof fetchedScopes);
+        structLog('error', 'Expected fetchedScopes to be an array, got:', typeof fetchedScopes);
         this.updateState({ scopes: newScopesState, loading: false });
         return;
       }
-
       for (const scope of fetchedScopes) {
         newScopesState[scope.metadata.name] = scope;
       }
-
       // Pre-fetch the first scope's defaultPath to improve performance
       // This makes the selector open instantly since all nodes are already cached
       // We only need the first scope since that's what's used for expansion
@@ -466,55 +396,45 @@ export class ScopesSelectorService extends ScopesServiceBase<ScopesSelectorServi
         // Deduplicate and filter out already cached nodes
         const uniqueNodeIds = [...new Set(firstScope.spec.defaultPath)];
         const nodesToFetch = uniqueNodeIds.filter((nodeId) => !this.state.nodes[nodeId]);
-
         if (nodesToFetch.length > 0) {
           await this.getScopeNodes(nodesToFetch);
         }
       }
-
       // Get scopeNode and parentNode, preferring defaultPath as the source of truth
       let parentNode: ScopeNode | undefined;
       let scopeNodeId: string | undefined;
-
       if (firstScope?.spec.defaultPath && firstScope.spec.defaultPath.length > 1) {
         // Extract from defaultPath (most reliable source)
         // defaultPath format: ['', 'parent-id', 'scope-node-id', ...]
         scopeNodeId = firstScope.spec.defaultPath[firstScope.spec.defaultPath.length - 1];
         const parentNodeId = firstScope.spec.defaultPath[firstScope.spec.defaultPath.length - 2];
-
         scopeNode = scopeNodeId ? this.state.nodes[scopeNodeId] : undefined;
         parentNode = parentNodeId && parentNodeId !== '' ? this.state.nodes[parentNodeId] : undefined;
       } else {
         // Fallback to next in priority order
         scopeNodeId = scopes[0]?.scopeNodeId;
         scopeNode = scopeNodeId ? this.state.nodes[scopeNodeId] : undefined;
-
         const parentNodeId = scopes[0]?.parentNodeId ?? scopeNode?.spec.parentName;
         parentNode = parentNodeId ? this.state.nodes[parentNodeId] : undefined;
       }
-
       this.addRecentScopes(fetchedScopes, parentNode, scopeNodeId);
       this.updateState({ scopes: newScopesState, loading: false });
     }
   };
-
   // Redirect to the scope node's redirect URL if it exists, otherwise redirect to the first scope navigation.
   private redirectAfterApply = (scopeNode: ScopeNode | undefined) => {
     if (!this.redirectEnabled) {
       return;
     }
-
     // Check if we are currently on an active scope navigation
     const location = locationService.getLocation();
     const currentPath = location.pathname;
-
     const activeScopeNavigation = this.dashboardsService.state.scopeNavigations.find((s) => {
       if (!('url' in s.spec)) {
         return false;
       }
       return isCurrentPath(currentPath, s.spec.url);
     });
-
     // Only redirect to redirectPath if we are not currently on an active scope navigation
     if (
       !activeScopeNavigation &&
@@ -526,12 +446,10 @@ export class ScopesSelectorService extends ScopesServiceBase<ScopesSelectorServi
       locationService.push(scopeNode.spec.redirectPath);
       return;
     }
-
     // Redirect to first scopeNavigation if current URL isn't a scopeNavigation
     if (!activeScopeNavigation && this.dashboardsService.state.scopeNavigations.length > 0) {
       // Redirect to the first available scopeNavigation
       const firstScopeNavigation = this.dashboardsService.state.scopeNavigations[0];
-
       if (
         firstScopeNavigation &&
         'url' in firstScopeNavigation.spec &&
@@ -544,17 +462,14 @@ export class ScopesSelectorService extends ScopesServiceBase<ScopesSelectorServi
       }
     }
   };
-
   public removeAllScopes = () => {
     this.applyScopes([], false);
     this.dashboardsService.setNavigationScope(undefined, undefined, undefined);
   };
-
   private addRecentScopes = (scopes: Scope[], parentNode?: ScopeNode, scopeNodeId?: string) => {
     if (scopes.length === 0) {
       return;
     }
-
     const newScopes: RecentScope[] = structuredClone(scopes);
     // Set parent node and scopeNodeId for the first scope. We don't currently support multiple parent nodes being displayed, hence we only add for the first one
     if (parentNode) {
@@ -563,14 +478,11 @@ export class ScopesSelectorService extends ScopesServiceBase<ScopesSelectorServi
     if (scopeNodeId) {
       newScopes[0].scopeNodeId = scopeNodeId;
     }
-
     const RECENT_SCOPES_MAX_LENGTH = 5;
-
     const recentScopes = this.getRecentScopes();
     recentScopes.unshift(newScopes);
     this.store.set(RECENT_SCOPES_KEY, JSON.stringify(recentScopes.slice(0, RECENT_SCOPES_MAX_LENGTH - 1)));
   };
-
   /**
    * Returns recent scopes from local storage. It is array of array cause each item can represent application of
    * multiple different scopes.
@@ -578,7 +490,6 @@ export class ScopesSelectorService extends ScopesServiceBase<ScopesSelectorServi
   public getRecentScopes = (): RecentScope[][] => {
     const content: string | undefined = this.store.get(RECENT_SCOPES_KEY);
     const recentScopes = parseScopesFromLocalStorage(content);
-
     // Filter out the current selection from recent scopes to avoid duplicates
     return recentScopes.filter((scopes: RecentScope[]) => {
       if (scopes.length !== this.state.appliedScopes.length) {
@@ -588,11 +499,9 @@ export class ScopesSelectorService extends ScopesServiceBase<ScopesSelectorServi
       return !this.state.appliedScopes.every((s) => scopeSet.has(s.scopeId));
     });
   };
-
   private getNodesFromRecentScopes = (): Record<string, ScopeNode> => {
     const content: string | undefined = this.store.get(RECENT_SCOPES_KEY);
     const recentScopes = parseScopesFromLocalStorage(content);
-
     // Load parent nodes for recent scopes
     return Object.fromEntries(
       recentScopes
@@ -600,7 +509,6 @@ export class ScopesSelectorService extends ScopesServiceBase<ScopesSelectorServi
         .filter(([key, parentNode]) => parentNode !== undefined && key !== undefined)
     );
   };
-
   /**
    * Opens the scopes selector drawer and loads the root nodes if they are not loaded yet.
    */
@@ -612,7 +520,6 @@ export class ScopesSelectorService extends ScopesServiceBase<ScopesSelectorServi
     ) {
       await this.filterNode('', '');
     }
-
     // If the scopeNode isn't avilable, fetch it and add it to the nodes cache
     if (
       config.featureToggles.useScopeSingleNodeEndpoint &&
@@ -624,10 +531,8 @@ export class ScopesSelectorService extends ScopesServiceBase<ScopesSelectorServi
         this.updateState({ nodes: { ...this.state.nodes, [scopeNode.metadata.name]: scopeNode } });
       }
     }
-
     // First close all nodes
     let newTree = closeNodes(this.state.tree);
-
     if (this.state.selectedScopes.length && this.state.selectedScopes[0].scopeNodeId) {
       try {
         // Get the path for the selected scope, preferring defaultPath from scope metadata
@@ -635,61 +540,49 @@ export class ScopesSelectorService extends ScopesServiceBase<ScopesSelectorServi
           this.state.selectedScopes[0].scopeId,
           this.state.selectedScopes[0].scopeNodeId
         );
-
         if (pathNodes.length > 0) {
           // Convert to string path
           const stringPath = pathNodes.map((n) => n.metadata.name);
           stringPath.unshift(''); // Add root segment
-
           // Check if nodes are in tree
           let nodeAtPath = treeNodeAtPath(newTree, stringPath);
-
           // If nodes aren't in tree yet, insert them
           if (!nodeAtPath) {
             newTree = insertPathNodesIntoTree(newTree, pathNodes);
             // Update state so loadNodeChildren can see the inserted nodes
             this.updateState({ tree: newTree });
           }
-
           // Load children of the parent node if needed to show all siblings
           const parentPath = stringPath.slice(0, -1);
           const parentNodeAtPath = treeNodeAtPath(newTree, parentPath);
-
           if (parentNodeAtPath && !parentNodeAtPath.childrenLoaded) {
             const { newTree: newTreeWithChildren } = await this.loadNodeChildren(parentPath, parentNodeAtPath, '');
             newTree = newTreeWithChildren;
           }
-
           // Expand the nodes to show the selected scope
           newTree = expandNodes(newTree, parentPath);
         }
       } catch (error) {
-        console.error('Failed to expand to selected scope', error);
+        structLog('error', 'Failed to expand to selected scope', error);
       }
     }
-
     this.resetSelection();
     this.updateState({ tree: newTree, opened: true });
   };
-
   public closeAndReset = () => {
     this.updateState({ opened: false });
     this.resetSelection();
   };
-
   public closeAndApply = () => {
     this.updateState({ opened: false });
     return this.apply();
   };
-
   public apply = () => {
     return this.applyScopes(this.state.selectedScopes);
   };
-
   public resetSelection = () => {
     this.updateState({ selectedScopes: [...this.state.appliedScopes] });
   };
-
   public searchAllNodes = async (query: string, limit: number) => {
     const scopeNodes = await this.apiClient.fetchNodes({ query, limit });
     const newNodes = { ...this.state.nodes };
@@ -699,7 +592,6 @@ export class ScopesSelectorService extends ScopesServiceBase<ScopesSelectorServi
     this.updateState({ nodes: newNodes });
     return scopeNodes;
   };
-
   public getScopeNodes = async (scopeNodeNames: string[]): Promise<ScopeNode[]> => {
     const nodesMap: NodesMap = {};
     // Get nodes that are already in the cache
@@ -708,10 +600,8 @@ export class ScopesSelectorService extends ScopesServiceBase<ScopesSelectorServi
         nodesMap[name] = this.state.nodes[name];
       }
     }
-
     // Get nodes that are not in the cache
     const nodesToFetch = scopeNodeNames.filter((name) => !nodesMap[name]);
-
     if (nodesToFetch.length > 0) {
       const nodes = await this.apiClient.fetchMultipleScopeNodes(nodesToFetch);
       // Handle case where API returns undefined or non-array
@@ -721,46 +611,46 @@ export class ScopesSelectorService extends ScopesServiceBase<ScopesSelectorServi
         }
       }
     }
-
     const newNodes = { ...this.state.nodes, ...nodesMap };
-
     // Return both caches and fetches nodes in the correct order
     this.updateState({ nodes: newNodes });
     return scopeNodeNames.map((name) => nodesMap[name]).filter((node) => node !== undefined);
   };
 }
-
-function isScopeLocalStorageV1(obj: unknown): obj is { scope: Scope } {
+function isScopeLocalStorageV1(obj: unknown): obj is {
+  scope: Scope;
+} {
   return typeof obj === 'object' && obj !== null && 'scope' in obj && isScopeObj(obj['scope']);
 }
-
 function isScopeObj(obj: unknown): obj is Scope {
   return ScopeSchema.safeParse(obj).success;
 }
-
 function hasValidScopeParentNode(obj: unknown): obj is RecentScope {
   return RecentScopeSchema.safeParse(obj).success;
 }
-
 function parseScopesFromLocalStorage(content: string | undefined): RecentScope[][] {
   let recentScopes;
   try {
     recentScopes = JSON.parse(content || '[]');
   } catch (e) {
-    console.error('Failed to parse recent scopes', e, content);
+    structLog('error', 'Failed to parse recent scopes', e, content);
     return [];
   }
   if (!(Array.isArray(recentScopes) && Array.isArray(recentScopes[0]))) {
     return [];
   }
-
   if (isScopeLocalStorageV1(recentScopes[0]?.[0])) {
     // Backward compatibility
-    recentScopes = recentScopes.map((s: Array<{ scope: Scope }>) => s.map((scope) => scope.scope));
+    recentScopes = recentScopes.map(
+      (
+        s: Array<{
+          scope: Scope;
+        }>
+      ) => s.map((scope) => scope.scope)
+    );
   } else if (!isScopeObj(recentScopes[0]?.[0])) {
     return [];
   }
-
   // Verify the structure of the parent node for all recent scope sets, and remove it if it is not valid
   for (const scopeSet of recentScopes) {
     if (scopeSet[0]?.parentNode) {
@@ -769,6 +659,5 @@ function parseScopesFromLocalStorage(content: string | undefined): RecentScope[]
       }
     }
   }
-
   return recentScopes;
 }

--- a/public/app/features/scopes/selector/scopesTreeUtils.ts
+++ b/public/app/features/scopes/selector/scopesTreeUtils.ts
@@ -1,7 +1,6 @@
+import { structLog } from '@grafana/data';
 import { type ScopeNode } from '@grafana/data';
-
 import { type NodesMap, type TreeNode } from './types';
-
 /**
  * Creates a deep copy of the node tree with expanded prop set to false.
  */
@@ -16,38 +15,31 @@ export function closeNodes(tree: TreeNode): TreeNode {
   }
   return node;
 }
-
 export function expandNodes(tree: TreeNode, path: string[]): TreeNode {
   let newTree = { ...tree };
   let currentTree = newTree;
   currentTree.expanded = true;
   // Remove the root segment
   const newPath = path.slice(1);
-
   for (const segment of newPath) {
     const node = currentTree.children?.[segment];
     if (!node) {
       throw new Error(`Node ${segment} not found in tree`);
     }
-
     const newNode = { ...node };
     currentTree.children = { ...currentTree.children };
     currentTree.children[segment] = newNode;
     newNode.expanded = true;
     currentTree = newNode;
   }
-
   return newTree;
 }
-
 export function isNodeExpandable(node: ScopeNode) {
   return node.spec.nodeType === 'container';
 }
-
 export function isNodeSelectable(node: ScopeNode) {
   return node.spec.linkType === 'scope';
 }
-
 export function getPathOfNode(scopeNodeId: string, nodes: NodesMap): string[] {
   if (scopeNodeId === '') {
     return [''];
@@ -61,62 +53,48 @@ export function getPathOfNode(scopeNodeId: string, nodes: NodesMap): string[] {
   path.unshift('');
   return path;
 }
-
 export function modifyTreeNodeAtPath(tree: TreeNode, path: string[], modifier: (treeNode: TreeNode) => void) {
   if (path.length < 1) {
     return tree;
   }
-
   const newTree = { ...tree };
   let currentNode = newTree;
-
   if (path.length === 1 && path[0] === '') {
     modifier(currentNode);
     return newTree;
   }
-
   for (const section of path.slice(1)) {
     if (!currentNode.children?.[section]) {
       return newTree;
     }
-
     currentNode.children = { ...currentNode.children };
     currentNode.children[section] = { ...currentNode.children[section] };
     currentNode = currentNode.children[section];
   }
-
   modifier(currentNode);
   return newTree;
 }
-
 export function treeNodeAtPath(tree: TreeNode, path: string[]) {
   if (path.length < 1) {
     return undefined;
   }
-
   if (path.length === 1 && path[0] === '') {
     return tree;
   }
-
   let treeNode: TreeNode | undefined = tree;
-
   for (const section of path.slice(1)) {
     treeNode = treeNode.children?.[section];
     if (!treeNode) {
       return undefined;
     }
   }
-
   return treeNode;
 }
-
 // Path starts with root node and goes down
 export const insertPathNodesIntoTree = (tree: TreeNode, path: ScopeNode[]) => {
   const stringPath = path.map((n) => n.metadata.name);
   stringPath.unshift('');
-
   let newTree = tree;
-
   // Go down the tree, don't iterate over the last node
   for (let index = 0; index < stringPath.length - 1; index++) {
     const childNodeName = stringPath[index + 1];
@@ -125,7 +103,7 @@ export const insertPathNodesIntoTree = (tree: TreeNode, path: ScopeNode[]) => {
     newTree = modifyTreeNodeAtPath(newTree, pathSlice, (treeNode) => {
       treeNode.children = { ...treeNode.children };
       if (!childNodeName) {
-        console.warn('Failed to insert full path into tree. Did not find child to' + stringPath[index]);
+        structLog('warn', 'Failed to insert full path into tree. Did not find child to' + stringPath[index]);
         treeNode.childrenLoaded = treeNode.childrenLoaded ?? false;
         return;
       }

--- a/public/app/features/scopes/selector/useScopeNode.ts
+++ b/public/app/features/scopes/selector/useScopeNode.ts
@@ -1,15 +1,12 @@
+import { structLog } from '@grafana/data';
 import { useEffect, useState } from 'react';
-
 import { type ScopeNode } from '@grafana/data';
-
 import { useScopesServices } from '../ScopesContextProvider';
-
 // Light wrapper around the scopesSelectorService.getScopeNode to make it easier to use in the UI.
 export function useScopeNode(scopeNodeId?: string) {
   const [node, setNode] = useState<ScopeNode | undefined>(undefined);
   const [isLoading, setIsLoading] = useState(false);
   const scopesSelectorService = useScopesServices()?.scopesSelectorService;
-
   useEffect(() => {
     const loadNode = async () => {
       if (!scopeNodeId || !scopesSelectorService) {
@@ -21,13 +18,12 @@ export function useScopeNode(scopeNodeId?: string) {
         const node = await scopesSelectorService.getScopeNode(scopeNodeId);
         setNode(node);
       } catch (error) {
-        console.error('Failed to load node', error);
+        structLog('error', 'Failed to load node', error);
       } finally {
         setIsLoading(false);
       }
     };
     loadNode();
   }, [scopeNodeId, scopesSelectorService]);
-
   return { node, isLoading };
 }

--- a/public/app/features/search/service/deletedDashboardsCache.ts
+++ b/public/app/features/search/service/deletedDashboardsCache.ts
@@ -1,11 +1,10 @@
+import { structLog } from '@grafana/data';
 import { isResourceList } from 'app/features/apiserver/guards';
 import { type ResourceList } from 'app/features/apiserver/types';
 import { getDashboardAPI } from 'app/features/dashboard/api/dashboard_api';
 import { type DashboardDataDTO } from 'app/types/dashboard';
-
 import { type SearchHit } from './unified';
 import { resourceToSearchResult } from './utils';
-
 /**
  * Store deleted dashboards in the cache to avoid multiple calls to the API.
  */
@@ -14,18 +13,14 @@ class DeletedDashboardsCache {
   private promise: Promise<SearchHit[]> | null = null;
   private resourceListCache: ResourceList<DashboardDataDTO> | null = null;
   private resourceListPromise: Promise<ResourceList<DashboardDataDTO>> | null = null;
-
   async get(): Promise<SearchHit[]> {
     if (this.cache !== null) {
       return this.cache;
     }
-
     if (this.promise !== null) {
       return this.promise;
     }
-
     this.promise = this.fetch();
-
     try {
       this.cache = await this.promise;
       return this.cache;
@@ -34,18 +29,14 @@ class DeletedDashboardsCache {
       throw error;
     }
   }
-
   async getAsResourceList(): Promise<ResourceList<DashboardDataDTO>> {
     if (this.resourceListCache !== null) {
       return this.resourceListCache;
     }
-
     if (this.resourceListPromise !== null) {
       return this.resourceListPromise;
     }
-
     this.resourceListPromise = this.fetchResourceList();
-
     try {
       this.resourceListCache = await this.resourceListPromise;
       return this.resourceListCache;
@@ -54,23 +45,19 @@ class DeletedDashboardsCache {
       throw error;
     }
   }
-
   clear(): void {
     this.cache = null;
     this.promise = null;
     this.resourceListCache = null;
     this.resourceListPromise = null;
   }
-
   private async fetchResourceList(): Promise<ResourceList<DashboardDataDTO>> {
     try {
       const api = await getDashboardAPI();
       const deletedResponse = await api.listDeletedDashboards({ limit: 1000 });
-
       if (isResourceList<DashboardDataDTO>(deletedResponse)) {
         return deletedResponse;
       }
-
       // Return empty ResourceList if not a valid ResourceList
       return {
         apiVersion: 'v1',
@@ -79,7 +66,7 @@ class DeletedDashboardsCache {
         items: [],
       };
     } catch (error) {
-      console.error('Failed to fetch deleted dashboards:', error);
+      structLog('error', 'Failed to fetch deleted dashboards:', error);
       return {
         apiVersion: 'v1',
         kind: 'List',
@@ -88,11 +75,9 @@ class DeletedDashboardsCache {
       };
     }
   }
-
   private async fetch(): Promise<SearchHit[]> {
     const resourceList = await this.getAsResourceList();
     return resourceToSearchResult(resourceList);
   }
 }
-
 export const deletedDashboardsCache = new DeletedDashboardsCache();

--- a/public/app/features/search/service/unified.ts
+++ b/public/app/features/search/service/unified.ts
@@ -1,5 +1,5 @@
+import { structLog } from '@grafana/data';
 import { isEmpty } from 'lodash';
-
 import { generatedAPI as legacyUserAPI } from '@grafana/api-clients/internal/rtkq/legacy/user';
 import {
   API_GROUP as DASHBOARD_API_GROUP,
@@ -21,7 +21,6 @@ import { type TermCount } from 'app/core/components/TagFilter/TagFilter';
 import { contextSrv } from 'app/core/services/context_srv';
 import kbn from 'app/core/utils/kbn';
 import { dispatch } from 'app/store/store';
-
 import { deletedDashboardsCache } from './deletedDashboardsCache';
 import {
   type DashboardQueryResult,
@@ -32,13 +31,10 @@ import {
   type SearchResultMeta,
 } from './types';
 import { appendFrame, filterSearchResults, replaceCurrentFolderQuery } from './utils';
-
 // The backend returns an empty frame with a special name to indicate that the indexing engine is being rebuilt,
 // and that it can not serve any search requests. We are temporarily using the old SQL Search API as a fallback when that happens.
 const loadingFrameName = 'Loading';
-
 const searchURI = `${v0alphaBaseURL}/search`;
-
 export type SearchHit = {
   resource: string; // dashboards | folders
   name: string;
@@ -46,14 +42,11 @@ export type SearchHit = {
   location: string;
   folder: string;
   tags: string[];
-
   field: Record<string, string | number>; // extra fields from the backend - sort fields included here as well
-
   // calculated in the frontend
   url: string;
   managedBy?: ManagedBy;
 };
-
 export type SearchAPIResponse = {
   totalHits: number;
   hits: SearchHit[];
@@ -66,23 +59,18 @@ export type SearchAPIResponse = {
     };
   };
 };
-
 const folderViewSort = 'name_sort';
-
 export class UnifiedSearcher implements GrafanaSearcher {
   locationInfo: Promise<Record<string, LocationInfo>>;
-
   constructor(private fallbackSearcher: GrafanaSearcher) {
     this.locationInfo = loadLocationInfo();
   }
-
   async search(query: SearchQuery): Promise<QueryResponse> {
     if (query.facet?.length) {
       throw new Error('facets not supported!');
     }
     return this.doSearchQuery(query);
   }
-
   async starred(query: SearchQuery): Promise<QueryResponse> {
     if (query.facet?.length) {
       throw new Error('facets not supported!');
@@ -91,7 +79,9 @@ export class UnifiedSearcher implements GrafanaSearcher {
     let starsIds: string[] | undefined = [];
     if (config.featureToggles.starsFromAPIServer) {
       const name = `user-${contextSrv.user.uid}`;
-      const result: { data: ListStarsApiResponse } = await dispatch(
+      const result: {
+        data: ListStarsApiResponse;
+      } = await dispatch(
         generatedAPI.endpoints.listStars.initiate({
           fieldSelector: `metadata.name=${name}`,
         })
@@ -104,7 +94,6 @@ export class UnifiedSearcher implements GrafanaSearcher {
     } else {
       starsIds = await dispatch(legacyUserAPI.endpoints.getStars.initiate()).unwrap();
     }
-
     if (starsIds?.length) {
       return this.doSearchQuery({
         ...query,
@@ -115,18 +104,15 @@ export class UnifiedSearcher implements GrafanaSearcher {
     // Nothing is starred
     return noDataResponse();
   }
-
   async tags(query: SearchQuery): Promise<TermCount[]> {
     const qry = query.query ?? '*';
     let uri = `${searchURI}?facet=tags&facetLimit=1000&query=${qry}&limit=1`;
     const resp = await getBackendSrv().get<SearchAPIResponse>(uri);
     return resp.facets?.tags?.terms || [];
   }
-
   async getLocationInfo() {
     return this.locationInfo;
   }
-
   // TODO: Implement this correctly
   getSortOptions(): Promise<SelectableValue[]> {
     const opts: SelectableValue[] = [
@@ -136,22 +122,17 @@ export class UnifiedSearcher implements GrafanaSearcher {
       },
       { value: '-name_sort', label: t('search.unified-searcher.opts.label.alphabetically-za', 'Alphabetically (Z-A)') },
     ];
-
     if (config.licenseInfo.enabledFeatures.analytics) {
       for (const sf of sortFields) {
         opts.push({ value: `-${sf.name}`, label: `${sf.display} (most)` });
         opts.push({ value: `${sf.name}`, label: `${sf.display} (least)` });
       }
     }
-
     return Promise.resolve(opts);
   }
-
   async doSearchQuery(query: SearchQuery): Promise<QueryResponse> {
     const uri = await this.newRequest(query);
-
     let rsp: SearchAPIResponse;
-
     if (query.deleted) {
       const data = await deletedDashboardsCache.get();
       const results = filterSearchResults(data, query);
@@ -159,12 +140,10 @@ export class UnifiedSearcher implements GrafanaSearcher {
     } else {
       rsp = await this.fetchResponse(uri);
     }
-
     const first = toDashboardResults(rsp, query.sort ?? '');
     if (first.name === loadingFrameName) {
       return this.fallbackSearcher.search(query);
     }
-
     // We add parent folder information into meta.custom of the data frame. This is loaded separately in
     // loadLocationInfo. Used to show parent information upstream.
     const customMeta = first.meta?.custom;
@@ -175,12 +154,10 @@ export class UnifiedSearcher implements GrafanaSearcher {
       sortBy: customMeta?.sortBy,
     };
     meta.locationInfo = await this.locationInfo;
-
     // Update the DataFrame meta to point to the typed meta object
     if (first.meta) {
       first.meta.custom = meta;
     }
-
     // Set the field name to a better display name
     if (meta.sortBy?.length) {
       const field = first.fields.find((f) => f.name === meta.sortBy);
@@ -191,14 +168,11 @@ export class UnifiedSearcher implements GrafanaSearcher {
         field.config.displayName = name;
       }
     }
-
     let loadMax = 0;
     let pending: Promise<void> | undefined = undefined;
-
     // This is the frame we will return. We keep this in closure of the getNextPage function, which may be appending
     // to it if called upstream.
     const view = new DataFrameView<DashboardQueryResult>(first);
-
     const getNextPage = async () => {
       while (loadMax > view.dataFrame.length) {
         const offset = view.dataFrame.length;
@@ -209,14 +183,12 @@ export class UnifiedSearcher implements GrafanaSearcher {
         const resp = await this.fetchResponse(nextPageUrl);
         const frame = toDashboardResults(resp, query.sort ?? '');
         if (!frame) {
-          console.log('no results', frame);
+          structLog('log', 'no results', frame);
           return;
         }
-
         // We append the frames and align the fields here, but if there are new fields, view won't know about them
         // and won't be accessible by doing `view.get(0).newField` for example
         appendFrame(view.dataFrame, frame);
-
         // Add all the location lookup info
         const submeta = frame.meta?.custom;
         if (submeta?.locationInfo && meta) {
@@ -229,13 +201,10 @@ export class UnifiedSearcher implements GrafanaSearcher {
       }
       pending = undefined;
     };
-
     return {
       totalRows: meta.count ?? first.length,
-
       // This will be mutated when loadMoreItems is called.
       view,
-
       // Not using the startIndex because it is required to satisfy the typing that is shared between this and SQL
       // searcher. The SQL searcher though does not support loadMoreItems at all though so I guess it's just weird.
       // TODO: maybe we can just remove it. SearchResultsTable seems to be using it but obviously it does not do
@@ -247,22 +216,18 @@ export class UnifiedSearcher implements GrafanaSearcher {
         }
         return pending;
       },
-
       isItemLoaded: (index: number): boolean => {
         return index < view.dataFrame.length;
       },
     };
   }
-
   async fetchResponse(uri: string) {
     // TODO: use API client for this
     const rsp = await getBackendSrv().get<SearchAPIResponse>(uri);
-
     // we check the locationInfo staleness by whether we have all the folders info. This does not mean though
     // that we actually have the latest info about the folders (like changed labels). Also we will never actually
     // have folder access to folders in "shared with me" folder. We deal with it here, but it triggers a
     // loadLocationInfo that is unneccessary.
-
     const isFolderCacheStale = await this.isFolderCacheStale(rsp.hits);
     if (!isFolderCacheStale) {
       return rsp;
@@ -274,110 +239,85 @@ export class UnifiedSearcher implements GrafanaSearcher {
     if (!hasMissing) {
       return rsp;
     }
-
     const locationInfo = await this.locationInfo;
     const hits = rsp.hits.map((hit) => {
       if (hit.folder === undefined) {
         return { ...hit, location: 'general', folder: 'general' };
       }
-
       // this means a user has permission to see this dashboard, but not the folder contents
       if (locationInfo[hit.folder] === undefined) {
         return { ...hit, location: 'sharedwithme', folder: 'sharedwithme' };
       }
-
       return hit;
     });
-
     const totalHits = rsp.totalHits - (rsp.hits.length - hits.length);
     return { ...rsp, hits, totalHits };
   }
-
   async isFolderCacheStale(hits: SearchHit[]): Promise<boolean> {
     const locationInfo = await this.locationInfo;
     return hits.some((hit) => {
       return hit.folder !== undefined && locationInfo[hit.folder] === undefined;
     });
   }
-
   private async newRequest(query: SearchQuery): Promise<string> {
     query = await replaceCurrentFolderQuery(query);
-
     let uri = searchURI;
     uri += `?query=${encodeURIComponent(query.query ?? '*')}`;
     uri += `&limit=${query.limit ?? pageSize}`;
-
     if (query.offset) {
       uri += `&offset=${query.offset}`;
     }
-
     if (!isEmpty(query.location)) {
       uri += `&folder=${query.location}`;
     }
-
     if (query.kind) {
       // filter resource types
       uri += '&' + query.kind.map((kind) => `type=${kind}`).join('&');
     }
-
     if (query.ds_type?.length) {
       uri += '&dataSourceType=' + query.ds_type;
     }
-
     if (query.panel_type?.length) {
       uri += '&panelType=' + query.panel_type;
     }
-
     if (query.createdBy?.length) {
       uri += '&createdBy=' + encodeURIComponent(query.createdBy);
     }
-
     if (query.ownerReference?.length) {
       uri += '&' + query.ownerReference.map((ref) => `ownerReference=${encodeURIComponent(ref)}`).join('&');
     }
-
     if (query.panelTitleSearch) {
       uri += '&panelTitleSearch=true';
     }
-
     if (query.tags?.length) {
       uri += '&' + query.tags.map((tag) => `tag=${encodeURIComponent(tag)}`).join('&');
     }
-
     if (query.sort) {
       const sort = query.sort.replace('_sort', '').replace('name', 'title');
       uri += `&sort=${sort}`;
       const sortField = sort.startsWith('-') ? sort.substring(1) : sort;
-
       uri += `&field=${sortField}`; // we want to the sort field to be included in the response
     }
-
     if (query.name?.length) {
       uri += '&' + query.name.map((name) => `name=${encodeURIComponent(name)}`).join('&');
     }
-
     if (query.uid?.length) {
       // legacy support for filtering by dashboard uid
       uri += '&' + query.uid.map((name) => `name=${encodeURIComponent(name)}`).join('&');
     }
-
     if (query.permission) {
       uri += `&permission=${query.permission}`;
     }
-
     if (query.deleted) {
       uri = `${getAPIBaseURL(DASHBOARD_API_GROUP, 'v1beta1')}/dashboards/?labelSelector=grafana.app/get-trash=true`;
     }
     return uri;
   }
-
   getFolderViewSort(): string {
     return 'name_sort';
   }
 }
-
 const pageSize = 50;
-
 // Enterprise only sort field values for dashboards
 const sortFields = [
   { name: 'views_total', display: 'Views total' },
@@ -385,7 +325,6 @@ const sortFields = [
   { name: 'errors_total', display: 'Errors total' },
   { name: 'errors_last_30_days', display: 'Errors 30 days' },
 ];
-
 function noDataResponse(): QueryResponse | PromiseLike<QueryResponse> {
   return {
     view: new DataFrameView({ length: 0, fields: [] }),
@@ -398,7 +337,6 @@ function noDataResponse(): QueryResponse | PromiseLike<QueryResponse> {
     },
   };
 }
-
 /** Given the internal field name, this gives a reasonable display name for the table colum header */
 function getSortFieldDisplayName(name: string) {
   for (const sf of sortFields) {
@@ -408,7 +346,6 @@ function getSortFieldDisplayName(name: string) {
   }
   return name;
 }
-
 export function toDashboardResults(rsp: SearchAPIResponse, sort: string): DataFrame {
   const hits = rsp.hits;
   if (hits.length < 1) {
@@ -419,12 +356,10 @@ export function toDashboardResults(rsp: SearchAPIResponse, sort: string): DataFr
     if (hit.resource === 'dashboards' && isEmpty(location)) {
       location = 'general';
     }
-
     // display null field values as "-"
     const field = Object.fromEntries(
       Object.entries(hit.field ?? {}).map(([key, value]) => [key, value == null ? '-' : value])
     );
-
     return {
       ...hit,
       uid: hit.name,
@@ -451,13 +386,11 @@ export function toDashboardResults(rsp: SearchAPIResponse, sort: string): DataFr
     // trim the "-" from sort if it exists
     frame.meta.custom.sortBy = sort.startsWith('-') ? sort.substring(1) : sort;
   }
-
   for (const field of frame.fields) {
     field.display = getDisplayProcessor({ field, theme: config.theme2 });
   }
   return frame;
 }
-
 async function loadLocationInfo(): Promise<Record<string, LocationInfo>> {
   // TODO: use proper pagination and API client for search.
   // TODO: This tries to load all the folders upfront even though it may not be neccessary if user does not render all
@@ -489,7 +422,6 @@ async function loadLocationInfo(): Promise<Record<string, LocationInfo>> {
     });
   return rsp;
 }
-
 function toURL(resource: string, name: string, title: string): string {
   if (resource === 'folders') {
     return `${config.appSubUrl}/dashboards/f/${name}`;

--- a/public/app/features/search/service/utils.ts
+++ b/public/app/features/search/service/utils.ts
@@ -1,10 +1,10 @@
+import { structLog } from '@grafana/data';
 import { type ManagedBy } from '@grafana/api-clients/rtkq/dashboard/v0alpha1';
 import { type DataFrame, type DataFrameView, type IconName, fuzzySearch } from '@grafana/data';
 import { type DashboardViewItemWithUIItems } from 'app/features/browse-dashboards/types';
 import { isSharedWithMe, isVirtualTeamFolder } from 'app/features/browse-dashboards/utils/dashboards';
 import { getDashboardSrv } from 'app/features/dashboard/services/DashboardSrv';
 import { type DashboardDataDTO } from 'app/types/dashboard';
-
 import { AnnoKeyFolder, type ManagerKind, type ResourceList } from '../../apiserver/types';
 import {
   type DashboardSearchHit,
@@ -12,10 +12,8 @@ import {
   type DashboardViewItem,
   type DashboardViewItemKind,
 } from '../types';
-
 import { type DashboardQueryResult, type SearchQuery, type SearchResultMeta } from './types';
 import { type SearchHit } from './unified';
-
 /** prepare the query replacing folder:current */
 export async function replaceCurrentFolderQuery(query: SearchQuery): Promise<SearchQuery> {
   if (query.query && query.query.indexOf('folder:current') >= 0) {
@@ -30,7 +28,6 @@ export async function replaceCurrentFolderQuery(query: SearchQuery): Promise<Sea
   }
   return Promise.resolve(query);
 }
-
 async function getCurrentFolderUID(): Promise<string | undefined> {
   try {
     let dash = getDashboardSrv().getCurrent();
@@ -40,43 +37,34 @@ async function getCurrentFolderUID(): Promise<string | undefined> {
     }
     return Promise.resolve(dash?.meta?.folderUid);
   } catch (e) {
-    console.error(e);
+    structLog('error', e);
   }
   return undefined;
 }
-
 function delay(ms: number) {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
-
 export function getIconForKind(kind: string, isOpen?: boolean): IconName {
   if (kind === 'dashboard') {
     return 'apps';
   }
-
   if (kind === 'folder') {
     return isOpen ? 'folder-open' : 'folder';
   }
-
   if (kind === 'sharedwithme') {
     return 'users-alt';
   }
-
   return 'question-circle';
 }
-
 export function getIconForItem(item: DashboardViewItemWithUIItems, isOpen?: boolean): IconName {
   if (item && isSharedWithMe(item.uid)) {
     return 'user-arrows';
   }
-
   if (item && isVirtualTeamFolder(item.uid)) {
     return 'users-alt';
   }
-
   return getIconForKind(item.kind, isOpen);
 }
-
 function parseKindString(kind: string): DashboardViewItemKind {
   switch (kind) {
     case 'dashboard':
@@ -87,16 +75,13 @@ function parseKindString(kind: string): DashboardViewItemKind {
       return 'dashboard'; // not a great fallback, but it's the previous behaviour
   }
 }
-
 function isSearchResultMeta(obj: unknown): obj is SearchResultMeta {
   return obj !== null && typeof obj === 'object' && 'locationInfo' in obj;
 }
-
 export function extractManagerKind(managedBy?: ManagedBy | ManagerKind): ManagerKind | undefined {
   // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
   return typeof managedBy === 'string' ? managedBy : (managedBy?.kind as ManagerKind);
 }
-
 export function queryResultToViewItem(
   item: DashboardQueryResult,
   view?: DataFrameView<DashboardQueryResult>
@@ -104,7 +89,6 @@ export function queryResultToViewItem(
   const customMeta = view?.dataFrame.meta?.custom;
   const meta: SearchResultMeta | undefined = isSearchResultMeta(customMeta) ? customMeta : undefined;
   const managedByStr = extractManagerKind(item.managedBy);
-
   const viewItem: DashboardViewItem = {
     kind: parseKindString(item.kind),
     uid: item.uid,
@@ -113,7 +97,6 @@ export function queryResultToViewItem(
     tags: item.tags ?? [],
     managedBy: managedByStr,
   };
-
   // Set enterprise sort value property
   const sortFieldName = meta?.sortBy;
   if (sortFieldName) {
@@ -123,7 +106,6 @@ export function queryResultToViewItem(
       viewItem.sortMeta = sortFieldValue;
     }
   }
-
   if (item.location) {
     const ancestors = item.location.split('/');
     const parentUid = ancestors[ancestors.length - 1];
@@ -134,17 +116,14 @@ export function queryResultToViewItem(
       viewItem.parentUID = parentUid;
     }
   }
-
   return viewItem;
 }
-
 export function resourceToSearchResult(resource: ResourceList<DashboardDataDTO>): SearchHit[] {
   return resource.items.map((item) => {
     const field: Record<string, string | number> = {};
     if (item.metadata.deletionTimestamp) {
       field.deletionTimestamp = item.metadata.deletionTimestamp;
     }
-
     const hit = {
       resource: 'dashboards',
       name: item.metadata.name,
@@ -158,11 +137,9 @@ export function resourceToSearchResult(resource: ResourceList<DashboardDataDTO>)
     if (!hit.folder) {
       return { ...hit, location: 'general', folder: 'general' };
     }
-
     return hit;
   });
 }
-
 export function searchHitsToDashboardSearchHits(searchHits: SearchHit[]): DashboardSearchHit[] {
   return searchHits.map((hit) => {
     const dashboardHit: DashboardSearchHit = {
@@ -174,15 +151,12 @@ export function searchHitsToDashboardSearchHits(searchHits: SearchHit[]): Dashbo
       isDeleted: true, // All results from trash are deleted
       sortMeta: 0, // Default value for deleted items
     };
-
     if (hit.folder && hit.folder !== 'general') {
       dashboardHit.folderUid = hit.folder;
     }
-
     return dashboardHit;
   });
 }
-
 /**
  * Filters search results based on query parameters
  * This is used when backend filtering is not available (e.g., for deleted dashboards)
@@ -197,21 +171,18 @@ export function filterSearchResults(
   }
 ): SearchHit[] {
   let filtered = results;
-
   if ((query.query && query.query.trim() !== '' && query.query !== '*') || (query.tag && query.tag.length > 0)) {
     const searchString = query.query || query.tag?.join(',') || '';
     const haystack = results.map((hit) => `${hit.title},${hit.tags.join(',')}`);
     const indices = fuzzySearch(haystack, searchString);
     filtered = indices.map((index) => results[index]);
   }
-
   if (query.sort) {
     if (query.sort === 'deleted-asc' || query.sort === 'deleted-desc') {
       const mult = query.sort === 'deleted-desc' ? -1 : 1;
       filtered.sort((a, b) => {
         const timestampA = a.field.deletionTimestamp;
         const timestampB = b.field.deletionTimestamp;
-
         // Handle missing or invalid timestamps - items without timestamps go to the end
         if (typeof timestampA !== 'string' && typeof timestampB !== 'string') {
           return 0;
@@ -222,7 +193,6 @@ export function filterSearchResults(
         if (typeof timestampB !== 'string') {
           return -1;
         }
-
         const timeA = Date.parse(timestampA);
         const timeB = Date.parse(timestampB);
         return mult * (timeA - timeB);
@@ -234,10 +204,8 @@ export function filterSearchResults(
       filtered.sort((a, b) => mult * collator.compare(a.title, b.title));
     }
   }
-
   return filtered;
 }
-
 /**
  * Appends rows from `frame` into `target`, aligning fields that may differ between frames.
  * New fields are backfilled with null for existing rows; missing fields are padded with null for new rows.
@@ -245,7 +213,6 @@ export function filterSearchResults(
 export function appendFrame(target: DataFrame, frame: DataFrame): void {
   const existingLength = target.length;
   const newLength = existingLength + frame.length;
-
   // Add new fields from the incoming frame that don't exist in the target yet
   for (const f of frame.fields) {
     if (!target.fields.find((vf) => vf.name === f.name)) {
@@ -255,7 +222,6 @@ export function appendFrame(target: DataFrame, frame: DataFrame): void {
       });
     }
   }
-
   // Append values from matching fields
   for (const f of frame.fields) {
     const field = target.fields.find((vf) => vf.name === f.name);
@@ -263,13 +229,11 @@ export function appendFrame(target: DataFrame, frame: DataFrame): void {
       field.values.push(...f.values);
     }
   }
-
   // Pad fields that don't exist in the incoming frame with null
   for (const field of target.fields) {
     while (field.values.length < newLength) {
       field.values.push(null);
     }
   }
-
   target.length = newLength;
 }

--- a/public/app/features/serviceaccounts/ServiceAccountCreatePage.tsx
+++ b/public/app/features/serviceaccounts/ServiceAccountCreatePage.tsx
@@ -1,6 +1,6 @@
+import { structLog } from '@grafana/data';
 import { useCallback, useEffect, useState, type JSX } from 'react';
 import { FormProvider, useForm } from 'react-hook-form';
-
 import { OrgRole } from '@grafana/data';
 import { Trans, t } from '@grafana/i18n';
 import { config, getBackendSrv, locationService } from '@grafana/runtime';
@@ -13,20 +13,15 @@ import { RolePickerSelect } from 'app/core/components/RolePickerDrawer/RolePicke
 import { contextSrv } from 'app/core/services/context_srv';
 import { type Role, AccessControlAction } from 'app/types/accessControl';
 import { type ServiceAccountDTO, type ServiceAccountCreateApiResponse } from 'app/types/serviceaccount';
-
 import { OrgRolePicker } from '../admin/OrgRolePicker';
-
 export interface Props {}
-
 const createServiceAccount = async (sa: ServiceAccountDTO) => {
   const result = await getBackendSrv().post('/api/serviceaccounts/', sa);
   await contextSrv.fetchUserPermissions();
   return result;
 };
-
 const updateServiceAccount = async (uid: string, sa: ServiceAccountDTO) =>
   getBackendSrv().patch(`/api/serviceaccounts/${uid}`, sa);
-
 const defaultServiceAccount = {
   id: 0,
   uid: '',
@@ -39,11 +34,9 @@ const defaultServiceAccount = {
   createdAt: '',
   teams: [],
 };
-
 export const ServiceAccountCreatePage = ({}: Props): JSX.Element => {
   const [roleOptions, setRoleOptions] = useState<Role[]>([]);
   const [pendingRoles, setPendingRoles] = useState<Role[]>([]);
-
   const methods = useForm({
     defaultValues: {
       name: '',
@@ -56,10 +49,8 @@ export const ServiceAccountCreatePage = ({}: Props): JSX.Element => {
     formState: { errors },
     register,
   } = methods;
-
   const currentOrgId = contextSrv.user.orgId;
   const [serviceAccount, setServiceAccount] = useState<ServiceAccountDTO>(defaultServiceAccount);
-
   useEffect(() => {
     async function fetchOptions() {
       try {
@@ -68,14 +59,13 @@ export const ServiceAccountCreatePage = ({}: Props): JSX.Element => {
           setRoleOptions(options);
         }
       } catch (e) {
-        console.error('Error loading options', e); // TODO: handle error
+        structLog('error', 'Error loading options', e); // TODO: handle error
       }
     }
     if (contextSrv.licensedAccessControlEnabled()) {
       fetchOptions();
     }
   }, [currentOrgId]);
-
   const onSubmit = useCallback(
     async (data: ServiceAccountDTO) => {
       data.role = serviceAccount.role;
@@ -101,25 +91,22 @@ export const ServiceAccountCreatePage = ({}: Props): JSX.Element => {
           await updateUserRoles(pendingRoles, newAccount.id, newAccount.orgId);
         }
       } catch (e) {
-        console.error(e); // TODO: handle error
+        structLog('error', e); // TODO: handle error
       }
       locationService.push(`/org/serviceaccounts/${response.uid}`);
     },
     [serviceAccount.role, pendingRoles]
   );
-
   const onRoleChange = (role: OrgRole) => {
     setServiceAccount({
       ...serviceAccount,
       role: role,
     });
   };
-
   const onPendingRolesUpdate = (roles: Role[], userId: number, orgId: number | undefined) => {
     // keep the new role assignments for user
     setPendingRoles(roles);
   };
-
   return (
     <Page
       navId="serviceaccounts"
@@ -204,5 +191,4 @@ export const ServiceAccountCreatePage = ({}: Props): JSX.Element => {
     </Page>
   );
 };
-
 export default ServiceAccountCreatePage;

--- a/public/app/features/serviceaccounts/components/ServiceAccountProfile.tsx
+++ b/public/app/features/serviceaccounts/components/ServiceAccountProfile.tsx
@@ -1,6 +1,6 @@
+import { structLog } from '@grafana/data';
 import { css } from '@emotion/css';
 import { useEffect, useState, type JSX } from 'react';
-
 import { type GrafanaTheme2, type OrgRole, type TimeZone, dateTimeFormat } from '@grafana/data';
 import { Trans, t } from '@grafana/i18n';
 import { Label, TextLink, useStyles2 } from '@grafana/ui';
@@ -8,29 +8,23 @@ import { fetchRoleOptions } from 'app/core/components/RolePicker/api';
 import { contextSrv } from 'app/core/services/context_srv';
 import { AccessControlAction, type Role } from 'app/types/accessControl';
 import { type ServiceAccountDTO } from 'app/types/serviceaccount';
-
 import { ServiceAccountProfileRow } from './ServiceAccountProfileRow';
 import { ServiceAccountRoleRow } from './ServiceAccountRoleRow';
-
 interface Props {
   serviceAccount: ServiceAccountDTO;
   timeZone: TimeZone;
   onChange: (serviceAccount: ServiceAccountDTO) => void;
 }
-
 export function ServiceAccountProfile({ serviceAccount, timeZone, onChange }: Props): JSX.Element {
   const styles = useStyles2(getStyles);
   const ableToWrite = contextSrv.hasPermission(AccessControlAction.ServiceAccountsWrite);
   const [roles, setRoleOptions] = useState<Role[]>([]);
-
   const onRoleChange = (role: OrgRole) => {
     onChange({ ...serviceAccount, role: role });
   };
-
   const onNameChange = (newValue: string) => {
     onChange({ ...serviceAccount, name: newValue });
   };
-
   useEffect(() => {
     async function fetchOptions() {
       try {
@@ -39,14 +33,13 @@ export function ServiceAccountProfile({ serviceAccount, timeZone, onChange }: Pr
           setRoleOptions(options);
         }
       } catch (e) {
-        console.error('Error loading options for service account');
+        structLog('error', 'Error loading options for service account');
       }
     }
     if (contextSrv.licensedAccessControlEnabled()) {
       fetchOptions();
     }
   }, [serviceAccount.orgId]);
-
   return (
     <div className={styles.section}>
       <h3>
@@ -100,7 +93,6 @@ export function ServiceAccountProfile({ serviceAccount, timeZone, onChange }: Pr
     </div>
   );
 }
-
 export const getStyles = (theme: GrafanaTheme2) => ({
   section: css({
     marginBottom: theme.spacing(4),

--- a/public/app/features/serviceaccounts/state/actions.ts
+++ b/public/app/features/serviceaccounts/state/actions.ts
@@ -1,14 +1,12 @@
+import { structLog } from '@grafana/data';
 import { debounce } from 'lodash';
-
 import { getBackendSrv } from '@grafana/runtime';
 import { fetchRoleOptions } from 'app/core/components/RolePicker/api';
 import { contextSrv } from 'app/core/services/context_srv';
 import { AccessControlAction } from 'app/types/accessControl';
 import { type ServiceAccountDTO, ServiceAccountStateFilter } from 'app/types/serviceaccount';
 import { type ThunkResult } from 'app/types/store';
-
 import { type ServiceAccountToken } from '../components/CreateTokenModal';
-
 import {
   acOptionsLoaded,
   pageChanged,
@@ -20,9 +18,7 @@ import {
   serviceAccountsFetchEnd,
   stateFilterChanged,
 } from './reducers';
-
 const BASE_URL = `/api/serviceaccounts`;
-
 export function fetchACOptions(): ThunkResult<void> {
   return async (dispatch) => {
     try {
@@ -31,15 +27,13 @@ export function fetchACOptions(): ThunkResult<void> {
         dispatch(acOptionsLoaded(options));
       }
     } catch (error) {
-      console.error(error);
+      structLog('error', error);
     }
   };
 }
-
 interface FetchServiceAccountsParams {
   withLoadingIndicator: boolean;
 }
-
 export function fetchServiceAccounts(
   { withLoadingIndicator }: FetchServiceAccountsParams = { withLoadingIndicator: false }
 ): ThunkResult<void> {
@@ -51,11 +45,8 @@ export function fetchServiceAccounts(
         }
         const { perPage, page, query, serviceAccountStateFilter } = getState().serviceAccounts;
         const result = await getBackendSrv().get(
-          `/api/serviceaccounts/search?perpage=${perPage}&page=${page}&query=${query}${getStateFilter(
-            serviceAccountStateFilter
-          )}&accesscontrol=true`
+          `/api/serviceaccounts/search?perpage=${perPage}&page=${page}&query=${query}${getStateFilter(serviceAccountStateFilter)}&accesscontrol=true`
         );
-
         if (
           contextSrv.licensedAccessControlEnabled() &&
           contextSrv.hasPermission(AccessControlAction.ActionUserRolesList)
@@ -72,21 +63,18 @@ export function fetchServiceAccounts(
           });
           dispatch(rolesFetchEnd());
         }
-
         dispatch(serviceAccountsFetched(result));
       }
     } catch (error) {
-      console.error(error);
+      structLog('error', error);
     } finally {
       dispatch(serviceAccountsFetchEnd());
     }
   };
 }
-
 const fetchServiceAccountsWithDebounce = debounce((dispatch) => dispatch(fetchServiceAccounts()), 500, {
   leading: true,
 });
-
 export function updateServiceAccount(serviceAccount: ServiceAccountDTO): ThunkResult<void> {
   return async (dispatch) => {
     await getBackendSrv().patch(`${BASE_URL}/${serviceAccount.uid}?accesscontrol=true`, {
@@ -95,14 +83,12 @@ export function updateServiceAccount(serviceAccount: ServiceAccountDTO): ThunkRe
     dispatch(fetchServiceAccounts());
   };
 }
-
 export function deleteServiceAccount(serviceAccountUid: string): ThunkResult<void> {
   return async (dispatch) => {
     await getBackendSrv().delete(`${BASE_URL}/${serviceAccountUid}`);
     dispatch(fetchServiceAccounts());
   };
 }
-
 export function createServiceAccountToken(
   saUid: string,
   token: ServiceAccountToken,
@@ -114,7 +100,6 @@ export function createServiceAccountToken(
     dispatch(fetchServiceAccounts());
   };
 }
-
 // search / filtering of serviceAccounts
 const getStateFilter = (value: ServiceAccountStateFilter) => {
   switch (value) {
@@ -128,21 +113,18 @@ const getStateFilter = (value: ServiceAccountStateFilter) => {
       return '';
   }
 };
-
 export function changeQuery(query: string): ThunkResult<void> {
   return async (dispatch) => {
     dispatch(queryChanged(query));
     fetchServiceAccountsWithDebounce(dispatch);
   };
 }
-
 export function changeStateFilter(filter: ServiceAccountStateFilter): ThunkResult<void> {
   return async (dispatch) => {
     dispatch(stateFilterChanged(filter));
     dispatch(fetchServiceAccounts());
   };
 }
-
 export function changePage(page: number): ThunkResult<void> {
   return async (dispatch) => {
     dispatch(pageChanged(page));

--- a/public/app/features/serviceaccounts/state/actionsServiceAccountPage.ts
+++ b/public/app/features/serviceaccounts/state/actionsServiceAccountPage.ts
@@ -1,19 +1,16 @@
+import { structLog } from '@grafana/data';
 import { getBackendSrv, locationService } from '@grafana/runtime';
 import { accessControlQueryParam } from 'app/core/utils/accessControl';
 import { type ServiceAccountDTO } from 'app/types/serviceaccount';
 import { type ThunkResult } from 'app/types/store';
-
 import { type ServiceAccountToken } from '../components/CreateTokenModal';
-
 import {
   serviceAccountFetchBegin,
   serviceAccountFetchEnd,
   serviceAccountLoaded,
   serviceAccountTokensLoaded,
 } from './reducers';
-
 const BASE_URL = `/api/serviceaccounts`;
-
 export function loadServiceAccount(saUid: string): ThunkResult<void> {
   return async (dispatch) => {
     dispatch(serviceAccountFetchBegin());
@@ -21,13 +18,12 @@ export function loadServiceAccount(saUid: string): ThunkResult<void> {
       const response = await getBackendSrv().get(`${BASE_URL}/${saUid}`, accessControlQueryParam());
       dispatch(serviceAccountLoaded(response));
     } catch (error) {
-      console.error(error);
+      structLog('error', error);
     } finally {
       dispatch(serviceAccountFetchEnd());
     }
   };
 }
-
 export function updateServiceAccount(serviceAccount: ServiceAccountDTO): ThunkResult<void> {
   return async (dispatch) => {
     await getBackendSrv().patch(`${BASE_URL}/${serviceAccount.uid}?accesscontrol=true`, {
@@ -36,14 +32,12 @@ export function updateServiceAccount(serviceAccount: ServiceAccountDTO): ThunkRe
     dispatch(loadServiceAccount(serviceAccount.uid));
   };
 }
-
 export function deleteServiceAccount(serviceAccountUid: string): ThunkResult<void> {
   return async () => {
     await getBackendSrv().delete(`${BASE_URL}/${serviceAccountUid}`);
     locationService.push('/org/serviceaccounts');
   };
 }
-
 export function createServiceAccountToken(
   saUid: string,
   token: ServiceAccountToken,
@@ -55,21 +49,19 @@ export function createServiceAccountToken(
     dispatch(loadServiceAccountTokens(saUid));
   };
 }
-
 export function deleteServiceAccountToken(saUid: string, id: number): ThunkResult<void> {
   return async (dispatch) => {
     await getBackendSrv().delete(`${BASE_URL}/${saUid}/tokens/${id}`);
     dispatch(loadServiceAccountTokens(saUid));
   };
 }
-
 export function loadServiceAccountTokens(saUid: string): ThunkResult<void> {
   return async (dispatch) => {
     try {
       const response = await getBackendSrv().get(`${BASE_URL}/${saUid}/tokens`);
       dispatch(serviceAccountTokensLoaded(response));
     } catch (error) {
-      console.error(error);
+      structLog('error', error);
     }
   };
 }

--- a/public/app/features/teams/TeamList.tsx
+++ b/public/app/features/teams/TeamList.tsx
@@ -1,8 +1,8 @@
+import { structLog } from '@grafana/data';
 import { css } from '@emotion/css';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import Skeleton from 'react-loading-skeleton';
 import { type SortingRule } from 'react-table';
-
 import { type DashboardHit } from '@grafana/api-clients/rtkq/dashboard/v0alpha1';
 import { Trans, t } from '@grafana/i18n';
 import { config, reportInteraction } from '@grafana/runtime';
@@ -30,21 +30,16 @@ import { useAppNotification } from 'app/core/copy/appNotification';
 import { contextSrv } from 'app/core/services/context_srv';
 import { type Role, AccessControlAction } from 'app/types/accessControl';
 import { type TeamWithRoles } from 'app/types/teams';
-
 import { appEvents } from '../../core/app_events';
 import { TeamRolePicker } from '../../core/components/RolePicker/TeamRolePicker';
 import { ShowModalReactEvent } from '../../types/events';
 import { EnterpriseAuthFeaturesCard } from '../admin/EnterpriseAuthFeaturesCard';
-
 import { TeamDeleteModal } from './TeamDeleteModal';
 import { useDeleteTeam, useGetTeams } from './hooks';
-
 type Cell<T extends keyof TeamWithRoles = keyof TeamWithRoles> = CellProps<TeamWithRoles, TeamWithRoles[T]>;
-
 export interface State {
   roleOptions: Role[];
 }
-
 // this is dummy data to pass to the table while the real data is loading
 const skeletonData: TeamWithRoles[] = new Array(3).fill(null).map((_, index) => ({
   id: index,
@@ -54,12 +49,10 @@ const skeletonData: TeamWithRoles[] = new Array(3).fill(null).map((_, index) => 
   orgId: 0,
   isProvisioned: false,
 }));
-
 const TeamList = () => {
   const canCreate = contextSrv.hasPermission(AccessControlAction.ActionTeamsCreate);
   const displayRolePicker = shouldDisplayRolePicker();
   const pageSize = 20;
-
   const [roleOptions, setRoleOptions] = useState<Role[]>([]);
   const styles = useStyles2(getStyles);
   const [query, setQuery] = useState('');
@@ -70,7 +63,6 @@ const TeamList = () => {
   const [triggerFoldersQuery] = useLazySearchDashboardsAndFoldersQuery();
   const notifyApp = useAppNotification();
   const foldersQueryRef = useRef<ReturnType<typeof triggerFoldersQuery> | null>(null);
-
   const teams = teamData?.teams || [];
   const totalPages = Math.ceil((teamData?.totalCount || 0) / pageSize) || 0;
   const noTeams = teams?.length === 0;
@@ -83,13 +75,11 @@ const TeamList = () => {
   const changePage = (page: number) => {
     setPage(page);
   };
-
   useEffect(() => {
     if (contextSrv.licensedAccessControlEnabled() && contextSrv.hasPermission(AccessControlAction.ActionRolesList)) {
       fetchRoleOptions().then((roles) => setRoleOptions(roles));
     }
   }, []);
-
   useEffect(() => {
     return () => {
       if (foldersQueryRef.current) {
@@ -97,7 +87,6 @@ const TeamList = () => {
       }
     };
   }, []);
-
   const columns: Array<Column<TeamWithRoles>> = useMemo(
     () => [
       {
@@ -108,7 +97,6 @@ const TeamList = () => {
           if (isLoading) {
             return <Skeleton containerClassName={styles.blockSkeleton} width={24} height={24} circle />;
           }
-
           return value && <Avatar src={value} alt="User avatar" />;
         },
       },
@@ -119,12 +107,10 @@ const TeamList = () => {
           if (isLoading) {
             return <Skeleton width={100} />;
           }
-
           const canReadTeam = contextSrv.hasPermissionInMetadata(AccessControlAction.ActionTeamsRead, original);
           if (!canReadTeam) {
             return value;
           }
-
           return (
             <TextLink
               color="primary"
@@ -211,10 +197,8 @@ const TeamList = () => {
               </Stack>
             );
           }
-
           const canReadTeam = contextSrv.hasPermissionInMetadata(AccessControlAction.ActionTeamsRead, original);
           const canDelete = contextSrv.hasPermissionInMetadata(AccessControlAction.ActionTeamsDelete, original);
-
           const showDeleteModal = async () => {
             let ownedFolders: DashboardHit[] = [];
             if (config.featureToggles.teamFolders) {
@@ -223,11 +207,8 @@ const TeamList = () => {
                 ownerReference: [`iam.grafana.app/Team/${original.uid}`],
                 limit: 1,
               });
-
               const { data: foldersData, isError, error } = await foldersQueryRef.current;
-
               const isAbortError = error && typeof error === 'object' && 'name' in error && error.name === 'AbortError';
-
               if (isError && !isAbortError) {
                 notifyApp.error(
                   t(
@@ -235,19 +216,16 @@ const TeamList = () => {
                     'Failed to check if the team owns folders. Please try again.'
                   )
                 );
-                console.error(error);
+                structLog('error', error);
                 return;
               }
-
               if (isAbortError) {
                 return;
               }
-
               if (foldersData?.hits) {
                 ownedFolders = foldersData.hits;
               }
             }
-
             reportInteraction('grafana_teams_list_delete_button_clicked', {
               ownedFolder: ownedFolders && ownedFolders.length > 0,
             });
@@ -300,7 +278,6 @@ const TeamList = () => {
     ],
     [displayRolePicker, isLoading, styles.blockSkeleton, roleOptions, deleteTeam, triggerFoldersQuery, notifyApp]
   );
-
   return (
     <Page
       navId="teams"
@@ -375,7 +352,6 @@ const TeamList = () => {
     </Page>
   );
 };
-
 function shouldDisplayRolePicker(): boolean {
   return (
     contextSrv.licensedAccessControlEnabled() &&
@@ -383,9 +359,7 @@ function shouldDisplayRolePicker(): boolean {
     contextSrv.hasPermission(AccessControlAction.ActionRolesList)
   );
 }
-
 export default TeamList;
-
 const getStyles = () => ({
   blockSkeleton: css({
     lineHeight: 1,

--- a/public/app/features/templating/LegacyVariableWrapper.ts
+++ b/public/app/features/templating/LegacyVariableWrapper.ts
@@ -1,43 +1,37 @@
+import { structLog } from '@grafana/data';
 import { type VariableValue, type FormatVariable } from '@grafana/scenes';
 import { type VariableModel, type VariableType } from '@grafana/schema';
-
 import { ALL_VARIABLE_TEXT, ALL_VARIABLE_VALUE } from '../variables/constants';
-
 export class LegacyVariableWrapper implements FormatVariable {
-  state: { name: string; value: VariableValue; text: VariableValue; type: VariableType };
-
+  state: {
+    name: string;
+    value: VariableValue;
+    text: VariableValue;
+    type: VariableType;
+  };
   constructor(variable: VariableModel, value: VariableValue, text: VariableValue) {
     this.state = { name: variable.name, value, text, type: variable.type };
   }
-
   getValue(_fieldPath: string): VariableValue {
     let { value } = this.state;
-
     if (value === 'string' || value === 'number' || value === 'boolean') {
       return value;
     }
-
     return String(value);
   }
-
   getValueText(): string {
     const { value, text } = this.state;
-
     if (typeof text === 'string') {
       return value === ALL_VARIABLE_VALUE ? ALL_VARIABLE_TEXT : text;
     }
-
     if (Array.isArray(text)) {
       return text.join(' + ');
     }
-
-    console.log('value', text);
+    structLog('log', 'value', text);
     return String(text);
   }
 }
-
 let legacyVariableWrapper: LegacyVariableWrapper | undefined;
-
 /**
  * Reuses a single instance to avoid unnecessary memory allocations
  */
@@ -52,6 +46,5 @@ export function getVariableWrapper(variable: VariableModel, value: VariableValue
     legacyVariableWrapper.state.value = value;
     legacyVariableWrapper.state.text = text;
   }
-
   return legacyVariableWrapper;
 }

--- a/public/app/features/templating/formatVariableValue.ts
+++ b/public/app/features/templating/formatVariableValue.ts
@@ -1,35 +1,27 @@
+import { structLog } from '@grafana/data';
 import { formatRegistry } from '@grafana/scenes';
 import { VariableFormatID } from '@grafana/schema';
-
 import { isAdHoc } from '../variables/guard';
-
 import { getVariableWrapper } from './LegacyVariableWrapper';
-
 export function formatVariableValue(value: any, format?: any, variable?: any, text?: string): string {
   // for some scopedVars there is no variable
   variable = variable || {};
-
   if (value === null || value === undefined) {
     return '';
   }
-
   if (isAdHoc(variable) && format !== VariableFormatID.QueryParam) {
     return '';
   }
-
   // if it's an object transform value to string
   if (!Array.isArray(value) && typeof value === 'object') {
     value = `${value}`;
   }
-
   if (typeof format === 'function') {
     return format(value, variable, formatVariableValue);
   }
-
   if (!format) {
     format = VariableFormatID.Glob;
   }
-
   // some formats have arguments that come after ':' character
   let args = format.split(':');
   if (args.length > 1) {
@@ -38,14 +30,11 @@ export function formatVariableValue(value: any, format?: any, variable?: any, te
   } else {
     args = [];
   }
-
   let formatItem = formatRegistry.getIfExists(format);
-
   if (!formatItem) {
-    console.error(`Variable format ${format} not found. Using glob format as fallback.`);
+    structLog('error', `Variable format ${format} not found. Using glob format as fallback.`);
     formatItem = formatRegistry.get(VariableFormatID.Glob);
   }
-
   const formatVariable = getVariableWrapper(variable, value, text ?? value);
   return formatItem.formatter(value, args, formatVariable);
 }

--- a/public/app/features/theme-playground/ThemePlayground.tsx
+++ b/public/app/features/theme-playground/ThemePlayground.tsx
@@ -1,6 +1,6 @@
+import { structLog } from '@grafana/data';
 import { css } from '@emotion/css';
 import { useId, useState } from 'react';
-
 import { createTheme, type GrafanaTheme2, type NewThemeOptions } from '@grafana/data';
 import { NewThemeOptionsSchema } from '@grafana/data/internal';
 import aubergine from '@grafana/data/themes/definitions/aubergine.json';
@@ -25,14 +25,12 @@ import { useChromeHeaderHeight } from '@grafana/runtime';
 import { CodeEditor, Combobox, Field, Stack, useStyles2 } from '@grafana/ui';
 import { ThemeDemo } from '@grafana/ui/internal';
 import { Page } from 'app/core/components/Page/Page';
-
 import { createErrorNotification } from '../../core/copy/appNotification';
 import { notifyApp } from '../../core/reducers/appNotification';
 import { HOME_NAV_ID } from '../../core/reducers/navModel';
 import { getNavModel } from '../../core/selectors/navModel';
 import { ThemeProvider } from '../../core/utils/ConfigProvider';
 import { useDispatch, useSelector } from '../../types/store';
-
 const themeMap: Record<string, NewThemeOptions> = {
   dark: {
     name: 'Dark',
@@ -49,7 +47,6 @@ const themeMap: Record<string, NewThemeOptions> = {
     },
   },
 };
-
 const experimentalDefinitions: Record<string, unknown> = {
   aubergine,
   debug,
@@ -68,22 +65,19 @@ const experimentalDefinitions: Record<string, unknown> = {
   victorian,
   zen,
 };
-
 // Add additional themes
 for (const [name, json] of Object.entries(experimentalDefinitions)) {
   const result = NewThemeOptionsSchema.safeParse(json);
   if (!result.success) {
-    console.error(`Invalid theme definition for theme ${name}: ${result.error.message}`);
+    structLog('error', `Invalid theme definition for theme ${name}: ${result.error.message}`);
   } else {
     themeMap[result.data.id] = result.data;
   }
 }
-
 const themeOptions = Object.entries(themeMap).map(([key, theme]) => ({
   label: theme.name,
   value: key,
 }));
-
 export default function ThemePlayground() {
   const navIndex = useSelector((state) => state.navIndex);
   const homeNav = getNavModel(navIndex, HOME_NAV_ID).main;
@@ -95,10 +89,8 @@ export default function ThemePlayground() {
   const chromeHeaderHeight = useChromeHeaderHeight();
   const styles = useStyles2(getStyles, chromeHeaderHeight);
   const dispatch = useDispatch();
-
   const [baseThemeId, setBaseThemeId] = useState(Object.keys(themeMap)[0]);
   const [theme, setTheme] = useState(createTheme(themeMap[baseThemeId]));
-
   const updateThemePreview = (themeInput: NewThemeOptions) => {
     try {
       const theme = createTheme(themeInput);
@@ -107,7 +99,6 @@ export default function ThemePlayground() {
       dispatch(notifyApp(createErrorNotification('Failed to create theme', `${error}`)));
     }
   };
-
   const onEditorBlur = (value: string) => {
     try {
       const themeInput = NewThemeOptionsSchema.safeParse(JSON.parse(value));
@@ -120,7 +111,6 @@ export default function ThemePlayground() {
       dispatch(notifyApp(createErrorNotification('Failed to parse JSON', `${error}`)));
     }
   };
-
   return (
     <Page
       navModel={{
@@ -184,7 +174,6 @@ export default function ThemePlayground() {
     </Page>
   );
 }
-
 const getStyles = (theme: GrafanaTheme2, chromeHeaderHeight: number | undefined) => ({
   left: css({
     background: theme.colors.background.primary,

--- a/public/app/features/transformers/editors/FilterByNameTransformerEditor.tsx
+++ b/public/app/features/transformers/editors/FilterByNameTransformerEditor.tsx
@@ -1,5 +1,5 @@
+import { structLog } from '@grafana/data';
 import * as React from 'react';
-
 import {
   DataTransformerID,
   type KeyValue,
@@ -15,12 +15,9 @@ import { type FilterFieldsByNameTransformerOptions } from '@grafana/data/interna
 import { t } from '@grafana/i18n';
 import { getTemplateSrv } from '@grafana/runtime';
 import { Input, FilterPill, InlineFieldRow, InlineField, InlineSwitch, Select } from '@grafana/ui';
-
 import darkImage from '../images/dark/filterFieldsByName.svg';
 import lightImage from '../images/light/filterFieldsByName.svg';
-
 interface FilterByNameTransformerEditorProps extends TransformerUIProps<FilterFieldsByNameTransformerOptions> {}
-
 interface FilterByNameTransformerEditorState {
   include: string[];
   options: FieldNameInfo[];
@@ -31,7 +28,6 @@ interface FilterByNameTransformerEditorState {
   byVariable: boolean;
   isRegexValid?: boolean;
 }
-
 interface FieldNameInfo {
   name: string;
   count: number;
@@ -53,32 +49,26 @@ export class FilterByNameTransformerEditor extends React.PureComponent<
       isRegexValid: true,
     };
   }
-
   componentDidMount() {
     this.initOptions();
   }
-
   componentDidUpdate(oldProps: FilterByNameTransformerEditorProps) {
     if (this.props.input !== oldProps.input) {
       this.initOptions();
     }
   }
-
   private initOptions() {
     const { input, options } = this.props;
     const configuredOptions = Array.from(options.include?.names ?? []);
-
     const variables = getTemplateSrv()
       .getVariables()
       .map((v) => ({ label: '$' + v.name, value: '$' + v.name }));
     const allNames: FieldNameInfo[] = [];
     const byName: KeyValue<FieldNameInfo> = {};
-
     for (const frame of input) {
       for (const field of frame.fields) {
         const displayName = getFieldDisplayName(field, frame, input);
         let v = byName[displayName];
-
         if (!v) {
           v = byName[displayName] = {
             name: displayName,
@@ -86,28 +76,23 @@ export class FilterByNameTransformerEditor extends React.PureComponent<
           };
           allNames.push(v);
         }
-
         v.count++;
       }
     }
-
     if (options.include?.pattern) {
       try {
         const regex = stringToJsRegex(options.include.pattern);
-
         for (const info of allNames) {
           if (regex.test(info.name)) {
             configuredOptions.push(info.name);
           }
         }
       } catch (error) {
-        console.error(error);
+        structLog('error', error);
       }
     }
-
     if (configuredOptions.length) {
       const selected: FieldNameInfo[] = allNames.filter((n) => configuredOptions.includes(n.name));
-
       this.setState({
         options: allNames,
         selected: selected.map((s) => s.name),
@@ -127,7 +112,6 @@ export class FilterByNameTransformerEditor extends React.PureComponent<
       });
     }
   }
-
   onFieldToggle = (fieldName: string) => {
     const { selected } = this.state;
     if (selected.indexOf(fieldName) > -1) {
@@ -136,28 +120,23 @@ export class FilterByNameTransformerEditor extends React.PureComponent<
       this.onChange([...selected, fieldName]);
     }
   };
-
   onChange = (selected: string[]) => {
     const { regex, isRegexValid } = this.state;
     const options: FilterFieldsByNameTransformerOptions = {
       ...this.props.options,
       include: { names: selected },
     };
-
     if (regex && isRegexValid) {
       options.include = options.include ?? {};
       options.include.pattern = regex;
     }
-
     this.setState({ selected }, () => {
       this.props.onChange(options);
     });
   };
-
   onInputBlur = (e: React.FocusEvent<HTMLInputElement>) => {
     const { selected, regex } = this.state;
     let isRegexValid = true;
-
     try {
       if (regex) {
         stringToJsRegex(regex);
@@ -165,7 +144,6 @@ export class FilterByNameTransformerEditor extends React.PureComponent<
     } catch (e) {
       isRegexValid = false;
     }
-
     if (isRegexValid) {
       this.props.onChange({
         ...this.props.options,
@@ -177,25 +155,20 @@ export class FilterByNameTransformerEditor extends React.PureComponent<
         include: { names: selected },
       });
     }
-
     this.setState({ isRegexValid });
   };
-
   onVariableChange = (selected: SelectableValue) => {
     this.props.onChange({
       ...this.props.options,
       include: { variable: selected.value },
     });
-
     this.setState({ variable: selected.value });
   };
-
   onFromVariableChange = (e: React.FormEvent<HTMLInputElement>) => {
     const val = e.currentTarget.checked;
     this.props.onChange({ ...this.props.options, byVariable: val });
     this.setState({ byVariable: val });
   };
-
   render() {
     const { options, selected, isRegexValid } = this.state;
     return (
@@ -253,7 +226,6 @@ export class FilterByNameTransformerEditor extends React.PureComponent<
     );
   }
 }
-
 export const getFilterFieldsByNameTransformRegistryItem: () => TransformerRegistryItem<FilterFieldsByNameTransformerOptions> =
   () => ({
     id: DataTransformerID.filterFieldsByName,

--- a/public/app/features/transformers/extractFields/fieldExtractors.ts
+++ b/public/app/features/transformers/extractFields/fieldExtractors.ts
@@ -1,13 +1,10 @@
+import { structLog } from '@grafana/data';
 import { escapeStringForRegex, Registry, type RegistryItem, stringStartsAsRegEx, stringToJsRegex } from '@grafana/data';
-
 import { type ExtractFieldsOptions, FieldExtractorID } from './types';
-
 type Parser = (v: string) => Record<string, any> | undefined;
-
 export interface FieldExtractor extends RegistryItem {
   getParser: (opts: ExtractFieldsOptions) => Parser;
 }
-
 const extJSON: FieldExtractor = {
   id: FieldExtractorID.JSON,
   name: 'JSON',
@@ -16,28 +13,24 @@ const extJSON: FieldExtractor = {
     return JSON.parse(v);
   },
 };
-
 const extRegExp: FieldExtractor = {
   id: FieldExtractorID.RegExp,
   name: 'RegExp',
   description: 'Parse with RegExp',
   getParser: (options) => {
     let regex: RegExp | null = /(?<NewField>.*)/;
-
     if (stringStartsAsRegEx(options.regExp!)) {
       try {
         regex = stringToJsRegex(options.regExp!);
       } catch (error) {
         if (error instanceof Error) {
-          console.warn(error.message);
+          structLog('warn', error.message);
         }
       }
     }
-
     return (v: string) => v.match(regex)?.groups;
   },
 };
-
 function parseKeyValuePairs(raw: string): Record<string, string> {
   const buff: string[] = []; // array of characters
   let esc = '';
@@ -49,22 +42,18 @@ function parseKeyValuePairs(raw: string): Record<string, string> {
       esc = '';
       c = raw[++i];
     }
-
     const isEscaped = c === '\\';
     if (isEscaped) {
       c = raw[++i];
     }
-
     // When escaped just append
     if (isEscaped || esc.length) {
       buff.push(c);
       continue;
     }
-
     if (c === `"` || c === `'`) {
       esc = c;
     }
-
     switch (c) {
       case ':':
       case '=':
@@ -76,7 +65,6 @@ function parseKeyValuePairs(raw: string): Record<string, string> {
           buff.length = 0; // clear values
         }
         break;
-
       // escape chars
       case `"`:
       case `'`:
@@ -106,7 +94,6 @@ function parseKeyValuePairs(raw: string): Record<string, string> {
           buff.length = 0; // clear values
         }
         break;
-
       // append our buffer
       default:
         buff.push(c);
@@ -118,20 +105,17 @@ function parseKeyValuePairs(raw: string): Record<string, string> {
         }
     }
   }
-
   if (key.length) {
     obj[key] = buff.join('');
   }
   return obj;
 }
-
 const extLabels: FieldExtractor = {
   id: FieldExtractorID.KeyValues,
   name: 'Key+value pairs',
   description: 'Look for a=b, c: d values in the line',
   getParser: (options) => parseKeyValuePairs,
 };
-
 const extDelimiter: FieldExtractor = {
   id: FieldExtractorID.Delimiter,
   name: 'Split by delimiter',
@@ -139,7 +123,6 @@ const extDelimiter: FieldExtractor = {
   getParser: ({ delimiter = ',' }) => {
     // Match for delimiter with surrounding whitesapce (\s)
     const splitRegExp = new RegExp(`\\s*${escapeStringForRegex(delimiter)}\\s*`, 'g');
-
     return (raw: string) => {
       // Try to split delimited values
       const parts = raw.trim().split(splitRegExp);
@@ -151,16 +134,13 @@ const extDelimiter: FieldExtractor = {
     };
   },
 };
-
 const fmts = [extJSON, extLabels, extDelimiter, extRegExp];
-
 const extAuto: FieldExtractor = {
   id: FieldExtractorID.Auto,
   name: 'Auto',
   description: 'parse new fields automatically',
   getParser: (options) => {
     const parsers = fmts.map((fmt) => fmt.getParser(options));
-
     return (v: string) => {
       for (const parse of parsers) {
         try {
@@ -174,5 +154,4 @@ const extAuto: FieldExtractor = {
     };
   },
 };
-
 export const fieldExtractors = new Registry<FieldExtractor>(() => [...fmts, extAuto]);

--- a/public/app/features/transformers/spatial/SpatialTransformerEditor.tsx
+++ b/public/app/features/transformers/spatial/SpatialTransformerEditor.tsx
@@ -1,6 +1,6 @@
+import { structLog } from '@grafana/data';
 import { css } from '@emotion/css';
 import { useEffect } from 'react';
-
 import {
   DataTransformerID,
   type GrafanaTheme2,
@@ -15,21 +15,17 @@ import { t } from '@grafana/i18n';
 import { FrameGeometrySourceMode } from '@grafana/schema';
 import { useTheme2 } from '@grafana/ui';
 import { addLocationFields } from 'app/features/geo/editor/locationEditor';
-
 import darkImage from '../images/dark/spatial.svg';
 import lightImage from '../images/light/spatial.svg';
-
 import { SpatialCalculation, SpatialOperation, SpatialAction, type SpatialTransformOptions } from './models.gen';
 import { getDefaultOptions, getTransformerOptionPane } from './optionsHelper';
 import { isLineBuilderOption, getSpatialTransformer } from './spatialTransformer';
-
 // Nothing defined in state
 const supplier = (
   builder: PanelOptionsEditorBuilder<SpatialTransformOptions>,
   context: StandardEditorContext<SpatialTransformOptions>
 ) => {
   const options = context.options ?? {};
-
   builder.addSelect({
     path: `action`,
     name: 'Action',
@@ -61,7 +57,6 @@ const supplier = (
       ],
     },
   });
-
   if (options.action === SpatialAction.Calculate) {
     builder.addSelect({
       path: `calculate.calc`,
@@ -101,7 +96,6 @@ const supplier = (
       },
     });
   }
-
   if (isLineBuilderOption(options)) {
     builder.addNestedOptions({
       category: ['Source'],
@@ -113,7 +107,6 @@ const supplier = (
         addLocationFields('Point', '', b, loc);
       },
     });
-
     builder.addNestedOptions({
       category: ['Target'],
       path: 'modify',
@@ -128,22 +121,18 @@ const supplier = (
     addLocationFields('Location', 'source.', builder, options.source);
   }
 };
-
 type Props = TransformerUIProps<SpatialTransformOptions>;
-
 export const SetGeometryTransformerEditor = (props: Props) => {
   // a new component is created with every change :(
   useEffect(() => {
     if (!props.options.source?.mode) {
       const opts = getDefaultOptions(supplier);
       props.onChange({ ...opts, ...props.options });
-      console.log('geometry useEffect', opts);
+      structLog('log', 'geometry useEffect', opts);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
-
   const styles = getStyles(useTheme2());
-
   const pane = getTransformerOptionPane<SpatialTransformOptions>(props, supplier);
   return (
     <div>
@@ -161,7 +150,6 @@ export const SetGeometryTransformerEditor = (props: Props) => {
     </div>
   );
 };
-
 const getStyles = (theme: GrafanaTheme2) => {
   return {
     wrap: css({
@@ -173,7 +161,6 @@ const getStyles = (theme: GrafanaTheme2) => {
     }),
   };
 };
-
 export const getSpatialTransformRegistryItem: () => TransformerRegistryItem<SpatialTransformOptions> = () => {
   const spatialTransformer = getSpatialTransformer();
   return {

--- a/public/app/features/variables/adhoc/AdHocVariableEditor.tsx
+++ b/public/app/features/variables/adhoc/AdHocVariableEditor.tsx
@@ -1,43 +1,33 @@
+import { structLog } from '@grafana/data';
 import { memo, useEffect } from 'react';
-
 import { type AdHocVariableModel, type DataSourceInstanceSettings, getDataSourceRef } from '@grafana/data';
 import { AdHocVariableForm } from 'app/features/dashboard-scene/settings/variables/components/AdHocVariableForm';
 import { type StoreState, useDispatch, useSelector } from 'app/types/store';
-
 import { initialVariableEditorState } from '../editor/reducer';
 import { getAdhocVariableEditorState } from '../editor/selectors';
 import { type VariableEditorProps } from '../editor/types';
 import { getVariablesState } from '../state/selectors';
 import { toKeyedVariableIdentifier } from '../utils';
-
 import { changeVariableDatasource } from './actions';
-
 interface Props extends VariableEditorProps<AdHocVariableModel> {}
-
 export const AdHocVariableEditor = memo(function AdHocVariableEditor({ variable }: Props) {
   const dispatch = useDispatch();
-
   const extended = useSelector((state: StoreState) => {
     const { rootStateKey } = variable;
-
     if (!rootStateKey) {
       return getAdhocVariableEditorState(initialVariableEditorState);
     }
-
     const { editor } = getVariablesState(rootStateKey, state);
     return getAdhocVariableEditorState(editor);
   });
-
   useEffect(() => {
     if (!variable.rootStateKey) {
-      console.error('AdHocVariableEditor: variable has no rootStateKey');
+      structLog('error', 'AdHocVariableEditor: variable has no rootStateKey');
     }
   }, [variable.rootStateKey]);
-
   const onDatasourceChanged = (ds: DataSourceInstanceSettings) => {
     dispatch(changeVariableDatasource(toKeyedVariableIdentifier(variable), getDataSourceRef(ds)));
   };
-
   return (
     <AdHocVariableForm
       datasource={variable.datasource ?? undefined}

--- a/public/app/features/variables/datasource/DataSourceVariableEditor.tsx
+++ b/public/app/features/variables/datasource/DataSourceVariableEditor.tsx
@@ -1,44 +1,35 @@
+import { structLog } from '@grafana/data';
 import { type FormEvent, memo, useEffect } from 'react';
-
 import { type DataSourceVariableModel, type SelectableValue, type VariableWithMultiSupport } from '@grafana/data';
 import { DataSourceVariableForm } from 'app/features/dashboard-scene/settings/variables/components/DataSourceVariableForm';
 import { type StoreState, useDispatch, useSelector } from 'app/types/store';
-
 import { initialVariableEditorState } from '../editor/reducer';
 import { getDatasourceVariableEditorState } from '../editor/selectors';
 import { type OnPropChangeArguments, type VariableEditorProps } from '../editor/types';
 import { changeVariableMultiValue } from '../state/actions';
 import { getVariablesState } from '../state/selectors';
 import { toKeyedVariableIdentifier } from '../utils';
-
 import { initDataSourceVariableEditor } from './actions';
-
 interface Props extends VariableEditorProps<DataSourceVariableModel> {}
-
 export const DataSourceVariableEditor = memo(function DataSourceVariableEditor({ variable, onPropChange }: Props) {
   const dispatch = useDispatch();
-
   const extended = useSelector((state: StoreState) => {
     const { rootStateKey } = variable;
     if (!rootStateKey) {
-      console.error('DataSourceVariableEditor: variable has no rootStateKey');
+      structLog('error', 'DataSourceVariableEditor: variable has no rootStateKey');
       return getDatasourceVariableEditorState(initialVariableEditorState);
     }
-
     const { editor } = getVariablesState(rootStateKey, state);
     return getDatasourceVariableEditorState(editor);
   });
-
   useEffect(() => {
     const { rootStateKey } = variable;
     if (!rootStateKey) {
-      console.error('DataSourceVariableEditor: variable has no rootStateKey');
+      structLog('error', 'DataSourceVariableEditor: variable has no rootStateKey');
       return;
     }
-
     dispatch(initDataSourceVariableEditor(rootStateKey));
   }, [dispatch, variable]);
-
   const onRegExBlur = (event: FormEvent<HTMLInputElement>) => {
     onPropChange({
       propName: 'regex',
@@ -46,31 +37,24 @@ export const DataSourceVariableEditor = memo(function DataSourceVariableEditor({
       updateOptions: true,
     });
   };
-
   const onSelectionOptionsChange = ({ propValue, propName }: OnPropChangeArguments<VariableWithMultiSupport>) => {
     onPropChange({ propName, propValue, updateOptions: true });
   };
-
   const onMultiChanged = (event: FormEvent<HTMLInputElement>) => {
     dispatch(changeVariableMultiValue(toKeyedVariableIdentifier(variable), event.currentTarget.checked));
   };
-
   const onIncludeAllChanged = (event: FormEvent<HTMLInputElement>) => {
     onSelectionOptionsChange({ propName: 'includeAll', propValue: event.currentTarget.checked });
   };
-
   const onAllValueChanged = (event: FormEvent<HTMLInputElement>) => {
     onSelectionOptionsChange({ propName: 'allValue', propValue: event.currentTarget.value });
   };
-
   const onDataSourceTypeChanged = (option: SelectableValue<string>) => {
     onPropChange({ propName: 'query', propValue: option.value, updateOptions: true });
   };
-
   const typeOptions = extended?.dataSourceTypes?.length
     ? extended.dataSourceTypes?.map((ds) => ({ value: ds.value ?? '', label: ds.text }))
     : [];
-
   return (
     <DataSourceVariableForm
       query={variable.query}

--- a/public/app/features/variables/pickers/OptionsPicker/OptionsPicker.tsx
+++ b/public/app/features/variables/pickers/OptionsPicker/OptionsPicker.tsx
@@ -1,8 +1,8 @@
+import { structLog } from '@grafana/data';
 import { css } from '@emotion/css';
 import { type ComponentType, PureComponent } from 'react';
 import { connect, type ConnectedProps } from 'react-redux';
 import { bindActionCreators } from 'redux';
-
 import {
   LoadingState,
   type VariableOption,
@@ -12,7 +12,6 @@ import {
 import { selectors } from '@grafana/e2e-selectors';
 import { ClickOutsideWrapper } from '@grafana/ui';
 import { type StoreState, type ThunkDispatch } from 'app/types/store';
-
 import { VARIABLE_PREFIX } from '../../constants';
 import { isMulti } from '../../guard';
 import { getVariableQueryRunner } from '../../query/VariableQueryRunner';
@@ -25,10 +24,8 @@ import { VariableInput } from '../shared/VariableInput';
 import { VariableLink } from '../shared/VariableLink';
 import { VariableOptions } from '../shared/VariableOptions';
 import { type NavigationKey, type VariablePickerProps } from '../types';
-
 import { commitChangesToVariable, filterOrSearchOptions, navigateOptions, openOptions } from './actions';
 import { initialOptionPickerState, type OptionsPickerState, toggleAllOptions, toggleOption } from './reducer';
-
 export const optionPickerFactory = <Model extends VariableWithOptions | VariableWithMultiSupport>(): ComponentType<
   VariablePickerProps<Model>
 > => {
@@ -48,39 +45,31 @@ export const optionPickerFactory = <Model extends VariableWithOptions | Variable
       ) => dispatch(toKeyedAction(identifier.rootStateKey, toggleOption({ option, clearOthers, forceSelect }))),
     };
   };
-
   const mapStateToProps = (state: StoreState, ownProps: OwnProps) => {
     const { rootStateKey } = ownProps.variable;
     if (!rootStateKey) {
-      console.error('OptionPickerFactory: variable has no rootStateKey');
+      structLog('error', 'OptionPickerFactory: variable has no rootStateKey');
       return {
         picker: initialOptionPickerState,
       };
     }
-
     return {
       picker: getVariablesState(rootStateKey, state).optionsPicker,
     };
   };
-
   const connector = connect(mapStateToProps, mapDispatchToProps);
-
   interface OwnProps extends VariablePickerProps<Model> {}
-
   type Props = OwnProps & ConnectedProps<typeof connector>;
-
   class OptionsPickerUnconnected extends PureComponent<Props> {
     onShowOptions = () =>
       this.props.openOptions(toKeyedVariableIdentifier(this.props.variable), this.props.onVariableChange);
     onHideOptions = () => {
       if (!this.props.variable.rootStateKey) {
-        console.error('Variable has no rootStateKey');
+        structLog('error', 'Variable has no rootStateKey');
         return;
       }
-
       this.props.commitChangesToVariable(this.props.variable.rootStateKey, this.props.onVariableChange);
     };
-
     onToggleOption = (option: VariableOption, clearOthers: boolean) => {
       const toggleFunc =
         isMulti(this.props.variable) && this.props.variable.multi
@@ -88,49 +77,39 @@ export const optionPickerFactory = <Model extends VariableWithOptions | Variable
           : this.onToggleSingleValueVariable;
       toggleFunc(option, clearOthers);
     };
-
     onToggleSingleValueVariable = (option: VariableOption, clearOthers: boolean) => {
       this.props.toggleOption(toKeyedVariableIdentifier(this.props.variable), option, clearOthers, false);
       this.onHideOptions();
     };
-
     onToggleMultiValueVariable = (option: VariableOption, clearOthers: boolean) => {
       this.props.toggleOption(toKeyedVariableIdentifier(this.props.variable), option, clearOthers, false);
     };
-
     onToggleAllOptions = () => {
       this.props.toggleAllOptions(toKeyedVariableIdentifier(this.props.variable));
     };
-
     onFilterOrSearchOptions = (filter: string) => {
       this.props.filterOrSearchOptions(toKeyedVariableIdentifier(this.props.variable), filter);
     };
-
     onNavigate = (key: NavigationKey, clearOthers: boolean) => {
       if (!this.props.variable.rootStateKey) {
-        console.error('Variable has no rootStateKey');
+        structLog('error', 'Variable has no rootStateKey');
         return;
       }
-
       this.props.navigateOptions(this.props.variable.rootStateKey, key, clearOthers);
     };
-
     render() {
       const { variable, picker } = this.props;
       const showOptions = picker.id === variable.id;
       const styles = getStyles();
-
       return (
         <div className={styles.variableLinkWrapper} data-testid={selectors.components.Variables.variableLinkWrapper}>
           {showOptions ? this.renderOptions(picker) : this.renderLink(variable)}
         </div>
       );
     }
-
     renderLink(variable: VariableWithOptions) {
       const linkText = formatVariableLabel(variable);
       const loading = variable.state === LoadingState.Loading;
-
       return (
         <VariableLink
           id={VARIABLE_PREFIX + variable.id}
@@ -142,11 +121,9 @@ export const optionPickerFactory = <Model extends VariableWithOptions | Variable
         />
       );
     }
-
     onCancel = () => {
       getVariableQueryRunner().cancelRequest(toKeyedVariableIdentifier(this.props.variable));
     };
-
     renderOptions(picker: OptionsPickerState) {
       const { id } = this.props.variable;
       return (
@@ -172,13 +149,10 @@ export const optionPickerFactory = <Model extends VariableWithOptions | Variable
       );
     }
   }
-
   const OptionsPicker = connector(OptionsPickerUnconnected);
   OptionsPicker.displayName = 'OptionsPicker';
-
   return OptionsPicker;
 };
-
 const getStyles = () => ({
   variableLinkWrapper: css({
     display: 'inline-block',

--- a/public/app/features/variables/pickers/OptionsPicker/actions.ts
+++ b/public/app/features/variables/pickers/OptionsPicker/actions.ts
@@ -1,8 +1,7 @@
+import { structLog } from '@grafana/data';
 import { debounce, trim } from 'lodash';
-
 import { isEmptyObject, containsSearchFilter, type VariableWithOptions, type VariableOption } from '@grafana/data';
 import { type StoreState, type ThunkDispatch, type ThunkResult } from 'app/types/store';
-
 import { variableAdapters } from '../../adapters';
 import { hasOptions } from '../../guard';
 import { toKeyedAction } from '../../state/keyedVariablesReducer';
@@ -11,7 +10,6 @@ import { changeVariableProp, setCurrentVariableValue } from '../../state/sharedR
 import { type KeyedVariableIdentifier } from '../../state/types';
 import { getCurrentValue, toVariablePayload } from '../../utils';
 import { NavigationKey } from '../types';
-
 import {
   hideOptions,
   moveOptionsHighlight,
@@ -22,39 +20,31 @@ import {
   updateOptionsFromSearch,
   updateSearchQuery,
 } from './reducer';
-
 export const navigateOptions = (rootStateKey: string, key: NavigationKey, clearOthers: boolean): ThunkResult<void> => {
   return async (dispatch, getState) => {
     if (key === NavigationKey.cancel) {
       return await dispatch(commitChangesToVariable(rootStateKey));
     }
-
     if (key === NavigationKey.select) {
       return dispatch(toggleOptionByHighlight(rootStateKey, clearOthers));
     }
-
     if (key === NavigationKey.selectAndClose) {
       const picker = getVariablesState(rootStateKey, getState()).optionsPicker;
-
       if (picker.multi) {
         return dispatch(toggleOptionByHighlight(rootStateKey, clearOthers));
       }
       dispatch(toggleOptionByHighlight(rootStateKey, clearOthers, true));
       return dispatch(commitChangesToVariable(rootStateKey));
     }
-
     if (key === NavigationKey.moveDown) {
       return dispatch(toKeyedAction(rootStateKey, moveOptionsHighlight(1)));
     }
-
     if (key === NavigationKey.moveUp) {
       return dispatch(toKeyedAction(rootStateKey, moveOptionsHighlight(-1)));
     }
-
     return undefined;
   };
 };
-
 export const filterOrSearchOptions = (
   passedIdentifier: KeyedVariableIdentifier,
   searchQuery = ''
@@ -64,38 +54,29 @@ export const filterOrSearchOptions = (
     const { id, queryValue } = getVariablesState(rootStateKey, getState()).optionsPicker;
     const identifier: KeyedVariableIdentifier = { id, rootStateKey: rootStateKey, type: 'query' };
     const variable = getVariable(identifier, getState());
-
     if (!('options' in variable)) {
       return;
     }
-
     dispatch(toKeyedAction(rootStateKey, updateSearchQuery(searchQuery)));
-
     if (trim(queryValue) === trim(searchQuery)) {
       return;
     }
-
     const { query, options } = variable;
-
     const queryTarget = typeof query === 'string' ? query : query.target;
     if (containsSearchFilter(queryTarget)) {
       return searchForOptionsWithDebounce(dispatch, getState, searchQuery, rootStateKey);
     }
-
     return dispatch(toKeyedAction(rootStateKey, updateOptionsAndFilter(options)));
   };
 };
-
 const setVariable = async (updated: VariableWithOptions) => {
   if (isEmptyObject(updated.current)) {
     return;
   }
-
   const adapter = variableAdapters.get(updated.type);
   await adapter.setValue(updated, updated.current, true);
   return;
 };
-
 export const commitChangesToVariable = (key: string, callback?: (updated: any) => void): ThunkResult<void> => {
   return async (dispatch, getState) => {
     const picker = getVariablesState(key, getState()).optionsPicker;
@@ -104,50 +85,38 @@ export const commitChangesToVariable = (key: string, callback?: (updated: any) =
     if (!hasOptions(existing)) {
       return;
     }
-
     const currentPayload = { option: mapToCurrent(picker) };
     const searchQueryPayload = { propName: 'queryValue', propValue: picker.queryValue };
-
     dispatch(toKeyedAction(key, setCurrentVariableValue(toVariablePayload(existing, currentPayload))));
     dispatch(toKeyedAction(key, changeVariableProp(toVariablePayload(existing, searchQueryPayload))));
-
     const updated = getVariable(identifier, getState());
     if (!hasOptions(updated)) {
       return;
     }
-
     dispatch(toKeyedAction(key, hideOptions()));
-
     if (getCurrentValue(existing) === getCurrentValue(updated)) {
       return;
     }
-
     if (callback) {
       return callback(updated);
     }
-
     return await setVariable(updated);
   };
 };
-
 export const openOptions =
   (identifier: KeyedVariableIdentifier, callback?: (updated: any) => void): ThunkResult<void> =>
   async (dispatch, getState) => {
     const { id, rootStateKey: uid } = identifier;
     const picker = getVariablesState(uid, getState()).optionsPicker;
-
     if (picker.id && picker.id !== id) {
       await dispatch(commitChangesToVariable(uid, callback));
     }
-
     const variable = getVariable(identifier, getState());
     if (!hasOptions(variable)) {
       return;
     }
-
     dispatch(toKeyedAction(uid, showOptions(variable)));
   };
-
 export const toggleOptionByHighlight = (key: string, clearOthers: boolean, forceSelect = false): ThunkResult<void> => {
   return (dispatch, getState) => {
     const { highlightIndex, options } = getVariablesState(key, getState()).optionsPicker;
@@ -155,7 +124,6 @@ export const toggleOptionByHighlight = (key: string, clearOthers: boolean, force
     dispatch(toKeyedAction(key, toggleOption({ option, forceSelect, clearOthers })));
   };
 };
-
 const searchForOptions = async (
   dispatch: ThunkDispatch,
   getState: () => StoreState,
@@ -169,46 +137,35 @@ const searchForOptions = async (
     if (!hasOptions(existing)) {
       return;
     }
-
     const adapter = variableAdapters.get(existing.type);
     await adapter.updateOptions(existing, searchQuery);
-
     const updated = getVariable(identifier, getState());
     if (!hasOptions(updated)) {
       return;
     }
-
     dispatch(toKeyedAction(key, updateOptionsFromSearch(updated.options)));
   } catch (error) {
-    console.error(error);
+    structLog('error', error);
   }
 };
-
 const searchForOptionsWithDebounce = debounce(searchForOptions, 500);
-
 export function mapToCurrent(picker: OptionsPickerState): VariableOption | undefined {
   const { options, selectedValues, queryValue: searchQuery, multi } = picker;
-
   if (options.length === 0 && searchQuery && searchQuery.length > 0) {
     return { text: searchQuery, value: searchQuery, selected: false };
   }
-
   if (!multi) {
     return selectedValues.find((o) => o.selected);
   }
-
   const texts: string[] = [];
   const values: string[] = [];
-
   for (const option of selectedValues) {
     if (!option.selected) {
       continue;
     }
-
     texts.push(option.text.toString());
     values.push(option.value.toString());
   }
-
   return {
     value: values,
     text: texts,

--- a/public/app/features/variables/query/QueryVariableEditor.tsx
+++ b/public/app/features/variables/query/QueryVariableEditor.tsx
@@ -1,6 +1,6 @@
+import { structLog } from '@grafana/data';
 import { type FormEvent, PureComponent } from 'react';
 import { connect, type ConnectedProps } from 'react-redux';
-
 import {
   type DataSourceInstanceSettings,
   getDataSourceRef,
@@ -11,7 +11,6 @@ import {
 } from '@grafana/data';
 import { QueryVariableEditorForm } from 'app/features/dashboard-scene/settings/variables/components/QueryVariableForm';
 import { type StoreState } from 'app/types/store';
-
 import { getTimeSrv } from '../../dashboard/services/TimeSrv';
 import { initialVariableEditorState } from '../editor/reducer';
 import { getQueryVariableEditorState } from '../editor/selectors';
@@ -19,55 +18,43 @@ import { type VariableEditorProps } from '../editor/types';
 import { changeVariableMultiValue } from '../state/actions';
 import { getVariablesState } from '../state/selectors';
 import { toKeyedVariableIdentifier } from '../utils';
-
 import { changeQueryVariableDataSource, changeQueryVariableQuery, initQueryVariableEditor } from './actions';
-
 const mapStateToProps = (state: StoreState, ownProps: OwnProps) => {
   const { rootStateKey } = ownProps.variable;
   if (!rootStateKey) {
-    console.error('QueryVariableEditor: variable has no rootStateKey');
+    structLog('error', 'QueryVariableEditor: variable has no rootStateKey');
     return {
       extended: getQueryVariableEditorState(initialVariableEditorState),
     };
   }
-
   const { editor } = getVariablesState(rootStateKey, state);
-
   return {
     extended: getQueryVariableEditorState(editor),
   };
 };
-
 const mapDispatchToProps = {
   initQueryVariableEditor,
   changeQueryVariableDataSource,
   changeQueryVariableQuery,
   changeVariableMultiValue,
 };
-
 const connector = connect(mapStateToProps, mapDispatchToProps);
-
 export interface OwnProps extends VariableEditorProps<QueryVariableModel> {}
-
 export type Props = OwnProps & ConnectedProps<typeof connector>;
-
 export interface State {
   regex: string | null;
   tagsQuery: string | null;
   tagValuesQuery: string | null;
 }
-
 export class QueryVariableEditorUnConnected extends PureComponent<Props, State> {
   state: State = {
     regex: null,
     tagsQuery: null,
     tagValuesQuery: null,
   };
-
   async componentDidMount() {
     await this.props.initQueryVariableEditor(toKeyedVariableIdentifier(this.props.variable));
   }
-
   componentDidUpdate(prevProps: Readonly<Props>): void {
     if (prevProps.variable.datasource !== this.props.variable.datasource) {
       this.props.changeQueryVariableDataSource(
@@ -76,67 +63,53 @@ export class QueryVariableEditorUnConnected extends PureComponent<Props, State> 
       );
     }
   }
-
   onDataSourceChange = (dsSettings: DataSourceInstanceSettings) => {
     this.props.onPropChange({
       propName: 'datasource',
       propValue: dsSettings.isDefault ? null : getDataSourceRef(dsSettings),
     });
   };
-
   onLegacyQueryChange = async (query: any, definition: string) => {
     if (this.props.variable.query !== query) {
       this.props.changeQueryVariableQuery(toKeyedVariableIdentifier(this.props.variable), query, definition);
     }
   };
-
   onQueryChange = async (query: any) => {
     if (this.props.variable.query !== query) {
       let definition = '';
-
       if (query && query.hasOwnProperty('query') && typeof query.query === 'string') {
         definition = query.query;
       }
-
       this.props.changeQueryVariableQuery(toKeyedVariableIdentifier(this.props.variable), query, definition);
     }
   };
-
   onRegExBlur = async (event: FormEvent<HTMLTextAreaElement>) => {
     const regex = event.currentTarget.value;
     if (this.props.variable.regex !== regex) {
       this.props.onPropChange({ propName: 'regex', propValue: regex, updateOptions: true });
     }
   };
-
   onRefreshChange = (option: VariableRefresh) => {
     this.props.onPropChange({ propName: 'refresh', propValue: option });
   };
-
   onSortChange = async (option: SelectableValue<VariableSort>) => {
     this.props.onPropChange({ propName: 'sort', propValue: option.value, updateOptions: true });
   };
-
   onMultiChange = (event: FormEvent<HTMLInputElement>) => {
     this.props.onPropChange({ propName: 'multi', propValue: event.currentTarget.checked });
   };
-
   onIncludeAllChange = (event: FormEvent<HTMLInputElement>) => {
     this.props.onPropChange({ propName: 'includeAll', propValue: event.currentTarget.checked });
   };
-
   onAllValueChange = (event: FormEvent<HTMLInputElement>) => {
     this.props.onPropChange({ propName: 'allValue', propValue: event.currentTarget.value });
   };
-
   render() {
     const { extended, variable } = this.props;
     if (!extended || !extended.dataSource) {
       return null;
     }
-
     const timeRange = getTimeSrv().timeRange();
-
     return (
       <QueryVariableEditorForm
         datasource={variable.datasource ?? undefined}
@@ -166,5 +139,4 @@ export class QueryVariableEditorUnConnected extends PureComponent<Props, State> 
     );
   }
 }
-
 export const QueryVariableEditor = connector(QueryVariableEditorUnConnected);

--- a/public/app/features/variables/query/actions.ts
+++ b/public/app/features/variables/query/actions.ts
@@ -1,9 +1,8 @@
+import { structLog } from '@grafana/data';
 import { Subscription } from 'rxjs';
-
 import { type DataSourceRef } from '@grafana/data';
 import { getDataSourceSrv, toDataQueryError } from '@grafana/runtime';
 import { type ThunkResult } from 'app/types/store';
-
 import { getVariableQueryEditor } from '../editor/getVariableQueryEditor';
 import { addVariableEditorError, changeVariableEditorExtended, removeVariableEditorError } from '../editor/reducer';
 import { getQueryVariableEditorState } from '../editor/selectors';
@@ -13,10 +12,8 @@ import { getVariable, getVariablesState } from '../state/selectors';
 import { changeVariableProp } from '../state/sharedReducer';
 import { type KeyedVariableIdentifier } from '../state/types';
 import { hasOngoingTransaction, toKeyedVariableIdentifier, toVariablePayload } from '../utils';
-
 import { getVariableQueryRunner } from './VariableQueryRunner';
 import { variableQueryObserver } from './variableQueryObserver';
-
 export const updateQueryVariableOptions = (
   identifier: KeyedVariableIdentifier,
   searchFilter?: string
@@ -28,17 +25,14 @@ export const updateQueryVariableOptions = (
         // we might have cancelled a batch so then variable state is removed
         return;
       }
-
       const variableInState = getVariable(identifier, getState());
       if (variableInState.type !== 'query') {
         return;
       }
-
       if (getVariablesState(rootStateKey, getState()).editor.id === variableInState.id) {
         dispatch(toKeyedAction(rootStateKey, removeVariableEditorError({ errorProp: 'update' })));
       }
       const datasource = await getDataSourceSrv().get(variableInState.datasource ?? '');
-
       // We need to await the result from variableQueryRunner before moving on otherwise variables dependent on this
       // variable will have the wrong current value as input
       await new Promise((resolve, reject) => {
@@ -46,7 +40,6 @@ export const updateQueryVariableOptions = (
         const observer = variableQueryObserver(resolve, reject, subscription);
         const responseSubscription = getVariableQueryRunner().getResponse(identifier).subscribe(observer);
         subscription.add(responseSubscription);
-
         getVariableQueryRunner().queueRequest({ identifier, datasource, searchFilter });
       });
     } catch (err) {
@@ -58,13 +51,11 @@ export const updateQueryVariableOptions = (
             toKeyedAction(rootStateKey, addVariableEditorError({ errorProp: 'update', errorText: error.message ?? '' }))
           );
         }
-
         throw error;
       }
     }
   };
 };
-
 export const initQueryVariableEditor =
   (identifier: KeyedVariableIdentifier): ThunkResult<void> =>
   async (dispatch, getState) => {
@@ -72,10 +63,8 @@ export const initQueryVariableEditor =
     if (variable.type !== 'query') {
       return;
     }
-
     await dispatch(changeQueryVariableDataSource(toKeyedVariableIdentifier(variable), variable.datasource));
   };
-
 export const changeQueryVariableDataSource = (
   identifier: KeyedVariableIdentifier,
   name: DataSourceRef | null
@@ -87,7 +76,6 @@ export const changeQueryVariableDataSource = (
       const extendedEditorState = getQueryVariableEditorState(editor);
       const previousDatasource = extendedEditorState?.dataSource;
       const dataSource = await getDataSourceSrv().get(name ?? '');
-
       if (previousDatasource && previousDatasource.type !== dataSource?.type) {
         dispatch(
           toKeyedAction(
@@ -96,9 +84,7 @@ export const changeQueryVariableDataSource = (
           )
         );
       }
-
       const VariableQueryEditor = await getVariableQueryEditor(dataSource);
-
       dispatch(
         toKeyedAction(
           rootStateKey,
@@ -109,11 +95,10 @@ export const changeQueryVariableDataSource = (
         )
       );
     } catch (err) {
-      console.error(err);
+      structLog('error', err);
     }
   };
 };
-
 export const changeQueryVariableQuery =
   (identifier: KeyedVariableIdentifier, query: any, definition?: string): ThunkResult<void> =>
   async (dispatch, getState) => {
@@ -122,13 +107,11 @@ export const changeQueryVariableQuery =
     if (variableInState.type !== 'query') {
       return;
     }
-
     if (hasSelfReferencingQuery(variableInState.name, query)) {
       const errorText = 'Query cannot contain a reference to itself. Variable: $' + variableInState.name;
       dispatch(toKeyedAction(rootStateKey, addVariableEditorError({ errorProp: 'query', errorText })));
       return;
     }
-
     dispatch(toKeyedAction(rootStateKey, removeVariableEditorError({ errorProp: 'query' })));
     dispatch(
       toKeyedAction(
@@ -136,7 +119,6 @@ export const changeQueryVariableQuery =
         changeVariableProp(toVariablePayload(identifier, { propName: 'query', propValue: query }))
       )
     );
-
     if (definition !== undefined) {
       dispatch(
         toKeyedAction(
@@ -152,17 +134,13 @@ export const changeQueryVariableQuery =
         )
       );
     }
-
     await dispatch(updateOptions(identifier));
   };
-
 export function hasSelfReferencingQuery(name: string, query: any): boolean {
   if (typeof query === 'string' && query.match(new RegExp('\\$' + name + '(/| |$)'))) {
     return true;
   }
-
   const flattened = flattenQuery(query);
-
   for (let prop in flattened) {
     if (flattened.hasOwnProperty(prop)) {
       const value = flattened[prop];
@@ -171,10 +149,8 @@ export function hasSelfReferencingQuery(name: string, query: any): boolean {
       }
     }
   }
-
   return false;
 }
-
 /*
  * Function that takes any object and flattens all props into one level deep object
  * */
@@ -182,7 +158,6 @@ export function flattenQuery(query: any) {
   if (typeof query !== 'object' || query === null) {
     return { query };
   }
-
   const keys = Object.keys(query);
   const flattened = keys.reduce<Record<string, any>>((all, key) => {
     const value = query[key];
@@ -190,16 +165,13 @@ export function flattenQuery(query: any) {
       all[key] = value;
       return all;
     }
-
     const result = flattenQuery(value);
     for (let childProp in result) {
       if (result.hasOwnProperty(childProp)) {
         all[`${key}_${childProp}`] = result[childProp];
       }
     }
-
     return all;
   }, {});
-
   return flattened;
 }

--- a/public/app/features/variables/query/operators.ts
+++ b/public/app/features/variables/query/operators.ts
@@ -1,6 +1,6 @@
+import { structLog } from '@grafana/data';
 import { from, of, type OperatorFunction } from 'rxjs';
 import { map, mergeMap } from 'rxjs/operators';
-
 import {
   FieldType,
   getFieldDisplayName,
@@ -11,52 +11,40 @@ import {
   type QueryVariableModel,
 } from '@grafana/data';
 import { type ThunkDispatch } from 'app/types/store';
-
 import { validateVariableSelectionState } from '../state/actions';
 import { toKeyedAction } from '../state/keyedVariablesReducer';
 import { type getTemplatedRegex, toKeyedVariableIdentifier, toVariablePayload } from '../utils';
-
 import { updateVariableOptions } from './reducer';
-
 export function toMetricFindValuesOperator(): OperatorFunction<PanelData, MetricFindValue[]> {
   return (source) => source.pipe(map(toMetricFindValues));
 }
-
 export function toMetricFindValues(panelData: PanelData): MetricFindValue[] {
   const frames = panelData.series;
   if (!frames || !frames.length) {
     return [];
   }
-
   if (areMetricFindValues(frames)) {
     return frames;
   }
-
   const processedDataFrames = getProcessedDataFrames(frames);
   const metrics: MetricFindValue[] = [];
-
   let valueIndex = -1;
   let textIndex = -1;
   let stringIndex = -1;
   let expandableIndex = -1;
-
   for (const frame of processedDataFrames) {
     for (let index = 0; index < frame.fields.length; index++) {
       const field = frame.fields[index];
       const fieldName = getFieldDisplayName(field, frame, frames).toLowerCase();
-
       if (field.type === FieldType.string && stringIndex === -1) {
         stringIndex = index;
       }
-
       if (fieldName === 'text' && field.type === FieldType.string && textIndex === -1) {
         textIndex = index;
       }
-
       if (fieldName === 'value' && field.type === FieldType.string && valueIndex === -1) {
         valueIndex = index;
       }
-
       if (
         fieldName === 'expandable' &&
         (field.type === FieldType.boolean || field.type === FieldType.number) &&
@@ -66,40 +54,32 @@ export function toMetricFindValues(panelData: PanelData): MetricFindValue[] {
       }
     }
   }
-
   if (stringIndex === -1) {
     throw new Error("Couldn't find any field of type string in the results.");
   }
-
   for (const frame of processedDataFrames) {
     for (let index = 0; index < frame.length; index++) {
       const expandable = expandableIndex !== -1 ? frame.fields[expandableIndex].values[index] : undefined;
       const string = frame.fields[stringIndex].values[index];
       const text = textIndex !== -1 ? frame.fields[textIndex].values[index] : null;
       const value = valueIndex !== -1 ? frame.fields[valueIndex].values[index] : null;
-
       if (valueIndex === -1 && textIndex === -1) {
         metrics.push({ text: string, value: string, expandable });
         continue;
       }
-
       if (valueIndex === -1 && textIndex !== -1) {
         metrics.push({ text, value: text, expandable });
         continue;
       }
-
       if (valueIndex !== -1 && textIndex === -1) {
         metrics.push({ text: value, value, expandable });
         continue;
       }
-
       metrics.push({ text, value, expandable });
     }
   }
-
   return metrics;
 }
-
 export function updateOptionsState(args: {
   variable: QueryVariableModel;
   dispatch: ThunkDispatch;
@@ -110,7 +90,7 @@ export function updateOptionsState(args: {
       map((results) => {
         const { variable, dispatch, getTemplatedRegexFunc } = args;
         if (!variable.rootStateKey) {
-          console.error('updateOptionsState: variable.rootStateKey is not defined');
+          structLog('error', 'updateOptionsState: variable.rootStateKey is not defined');
           return;
         }
         const templatedRegex = getTemplatedRegexFunc(variable);
@@ -119,7 +99,6 @@ export function updateOptionsState(args: {
       })
     );
 }
-
 export function validateVariableSelection(args: {
   variable: QueryVariableModel;
   dispatch: ThunkDispatch;
@@ -129,7 +108,6 @@ export function validateVariableSelection(args: {
     source.pipe(
       mergeMap(() => {
         const { dispatch, variable, searchFilter } = args;
-
         // If we are searching options there is no need to validate selection state
         // This condition was added to as validateVariableSelectionState will update the current value of the variable
         // So after search and selection the current value is already update so no setValue, refresh and URL update is performed
@@ -137,32 +115,25 @@ export function validateVariableSelection(args: {
         if (!searchFilter) {
           return from(dispatch(validateVariableSelectionState(toKeyedVariableIdentifier(variable))));
         }
-
         return of<void>();
       })
     );
 }
-
 export function areMetricFindValues(data: unknown[]): data is MetricFindValue[] {
   if (!data) {
     return false;
   }
-
   if (!data.length) {
     return true;
   }
-
   const firstValue: any = data[0];
-
   if (isDataFrame(firstValue)) {
     return false;
   }
-
   for (const firstValueKey in firstValue) {
     if (!firstValue.hasOwnProperty(firstValueKey)) {
       continue;
     }
-
     if (
       firstValue[firstValueKey] !== null &&
       typeof firstValue[firstValueKey] !== 'string' &&
@@ -170,13 +141,10 @@ export function areMetricFindValues(data: unknown[]): data is MetricFindValue[] 
     ) {
       continue;
     }
-
     const key = firstValueKey.toLowerCase();
-
     if (key === 'text' || key === 'value') {
       return true;
     }
   }
-
   return false;
 }

--- a/public/app/features/variables/state/actions.ts
+++ b/public/app/features/variables/state/actions.ts
@@ -1,5 +1,5 @@
+import { structLog } from '@grafana/data';
 import { castArray, isEqual } from 'lodash';
-
 import {
   type DataQuery,
   getDataSourceRef,
@@ -28,7 +28,6 @@ import { type DashboardModel } from 'app/features/dashboard/state/DashboardModel
 import { store } from 'app/store/store';
 import { type AppNotification } from 'app/types/appNotifications';
 import { type ThunkResult, type StoreState } from 'app/types/store';
-
 import { appEvents } from '../../../core/app_events';
 import { createErrorNotification } from '../../../core/copy/appNotification';
 import { getBackendSrv } from '../../../core/services/backend_srv';
@@ -61,7 +60,6 @@ import {
   toKeyedVariableIdentifier,
   toVariablePayload,
 } from '../utils';
-
 import { findVariableNodeInList, isVariableOnTimeRangeConfigured } from './helpers';
 import { toKeyedAction } from './keyedVariablesReducer';
 import { getIfExistsLastKey, getVariable, getVariablesByKey, getVariablesState } from './selectors';
@@ -81,7 +79,6 @@ import {
 } from './transactionReducer';
 import { type KeyedVariableIdentifier } from './types';
 import { cleanVariables } from './variablesReducer';
-
 export const initDashboardTemplating = (key: string, dashboard: DashboardModel): ThunkResult<void> => {
   return (dispatch, getState) => {
     let orderIndex = 0;
@@ -92,26 +89,21 @@ export const initDashboardTemplating = (key: string, dashboard: DashboardModel):
       if (!variableAdapters.getIfExists(model.type)) {
         continue;
       }
-
       dispatch(
         toKeyedAction(key, addVariable(toVariablePayload(model, { global: false, index: orderIndex++, model })))
       );
     }
-
     getTemplateSrv().updateTimeRange(getTimeSrv().timeRange());
-
     const variables = getVariablesByKey(key, getState());
     for (const variable of variables) {
       dispatch(toKeyedAction(key, variableStateNotStarted(toVariablePayload(variable))));
     }
   };
 };
-
 export function fixSelectedInconsistency(model: TypedVariableModel): TypedVariableModel | VariableWithOptions {
   if (!hasOptions(model)) {
     return model;
   }
-
   let found = false;
   for (const option of model.options) {
     option.selected = false;
@@ -125,14 +117,11 @@ export function fixSelectedInconsistency(model: TypedVariableModel): TypedVariab
       option.selected = found = true;
     }
   }
-
   if (!found && model.options.length) {
     model.options[0].selected = true;
   }
-
   return model;
 }
-
 export const addSystemTemplateVariables = (key: string, dashboard: DashboardModel): ThunkResult<void> => {
   return (dispatch) => {
     const dashboardModel: DashboardVariableModel = {
@@ -151,7 +140,6 @@ export const addSystemTemplateVariables = (key: string, dashboard: DashboardMode
         },
       },
     };
-
     dispatch(
       toKeyedAction(
         key,
@@ -164,7 +152,6 @@ export const addSystemTemplateVariables = (key: string, dashboard: DashboardMode
         )
       )
     );
-
     const orgModel: OrgVariableModel = {
       ...initialVariableModelState,
       id: '__org',
@@ -181,14 +168,12 @@ export const addSystemTemplateVariables = (key: string, dashboard: DashboardMode
         },
       },
     };
-
     dispatch(
       toKeyedAction(
         key,
         addVariable(toVariablePayload(orgModel, { global: orgModel.global, index: orgModel.index, model: orgModel }))
       )
     );
-
     const userModel: UserVariableModel = {
       ...initialVariableModelState,
       id: '__user',
@@ -206,7 +191,6 @@ export const addSystemTemplateVariables = (key: string, dashboard: DashboardMode
         },
       },
     };
-
     dispatch(
       toKeyedAction(
         key,
@@ -217,7 +201,6 @@ export const addSystemTemplateVariables = (key: string, dashboard: DashboardMode
     );
   };
 };
-
 export const changeVariableMultiValue = (identifier: KeyedVariableIdentifier, multi: boolean): ThunkResult<void> => {
   return (dispatch, getState) => {
     const { rootStateKey: key } = identifier;
@@ -225,9 +208,7 @@ export const changeVariableMultiValue = (identifier: KeyedVariableIdentifier, mu
     if (!isMulti(variable) || isEmptyObject(variable.current)) {
       return;
     }
-
     const current = alignCurrentWithMulti(variable.current, multi);
-
     dispatch(
       toKeyedAction(key, changeVariableProp(toVariablePayload(identifier, { propName: 'multi', propValue: multi })))
     );
@@ -236,28 +217,22 @@ export const changeVariableMultiValue = (identifier: KeyedVariableIdentifier, mu
     );
   };
 };
-
 export const processVariableDependencies = async (variable: TypedVariableModel, state: StoreState) => {
   if (!variable.rootStateKey) {
     throw new Error(`rootStateKey not found for variable with id:${variable.id}`);
   }
-
   if (isDependencyGraphCircular(variable, state)) {
     throw new Error('Circular dependency in dashboard variables detected. Dashboard may not work as expected.');
   }
-
   const dependencies = getDirectDependencies(variable, state);
-
   if (!isWaitingForDependencies(variable.rootStateKey, dependencies, state)) {
     return;
   }
-
   await new Promise<void>((resolve) => {
     const unsubscribe = store.subscribe(() => {
       if (!variable.rootStateKey) {
         throw new Error(`rootStateKey not found for variable with id:${variable.id}`);
       }
-
       if (!isWaitingForDependencies(variable.rootStateKey, dependencies, store.getState())) {
         unsubscribe();
         resolve();
@@ -265,7 +240,6 @@ export const processVariableDependencies = async (variable: TypedVariableModel, 
     });
   });
 };
-
 const isDependencyGraphCircular = (
   variable: TypedVariableModel,
   state: StoreState,
@@ -274,49 +248,38 @@ const isDependencyGraphCircular = (
   if (encounteredDependencyIds.has(variable.id)) {
     return true;
   }
-
   encounteredDependencyIds = new Set([...encounteredDependencyIds, variable.id]);
-
   return getDirectDependencies(variable, state).some((dependency) => {
     return isDependencyGraphCircular(dependency, state, encounteredDependencyIds);
   });
 };
-
 const getDirectDependencies = (variable: TypedVariableModel, state: StoreState) => {
   if (!variable.rootStateKey) {
     return [];
   }
-
   const directDependencies: TypedVariableModel[] = [];
-
   for (const otherVariable of getVariablesByKey(variable.rootStateKey, state)) {
     if (variable === otherVariable) {
       continue;
     }
-
     if (variableAdapters.getIfExists(variable.type)) {
       if (variableAdapters.get(variable.type).dependsOn(variable, otherVariable)) {
         directDependencies.push(otherVariable);
       }
     }
   }
-
   return directDependencies;
 };
-
 const isWaitingForDependencies = (key: string, dependencies: TypedVariableModel[], state: StoreState): boolean => {
   if (dependencies.length === 0) {
     return false;
   }
-
   const variables = getVariablesByKey(key, state);
   const notCompletedDependencies = dependencies.filter((d) =>
     variables.some((v) => v.id === d.id && (v.state === LoadingState.NotStarted || v.state === LoadingState.Loading))
   );
-
   return notCompletedDependencies.length > 0;
 };
-
 export const processVariable = (
   identifier: KeyedVariableIdentifier,
   queryParams: UrlQueryMap
@@ -324,14 +287,12 @@ export const processVariable = (
   return async (dispatch, getState) => {
     const variable = getVariable(identifier, getState());
     await processVariableDependencies(variable, getState());
-
     const urlValue = queryParams[VARIABLE_PREFIX + variable.name];
     if (urlValue !== void 0) {
       const stringUrlValue = ensureStringValues(urlValue);
       await variableAdapters.get(variable.type).setValueFromUrl(variable, stringUrlValue);
       return;
     }
-
     if (variable.hasOwnProperty('refresh')) {
       const refreshableVariable = variable as QueryVariableModel;
       if (
@@ -342,28 +303,23 @@ export const processVariable = (
         return;
       }
     }
-
     if (variable.type === 'custom') {
       await dispatch(updateOptions(toKeyedVariableIdentifier(variable)));
       return;
     }
-
     // for variables that aren't updated via URL or refresh, let's simulate the same state changes
     dispatch(completeVariableLoading(identifier));
   };
 };
-
 export const processVariables = (key: string): ThunkResult<Promise<void>> => {
   return async (dispatch, getState) => {
     const queryParams = locationService.getSearchObject();
     const promises = getVariablesByKey(key, getState()).map(
       async (variable) => await dispatch(processVariable(toKeyedVariableIdentifier(variable), queryParams))
     );
-
     await Promise.all(promises);
   };
 };
-
 export const setOptionFromUrl = (
   identifier: KeyedVariableIdentifier,
   urlValue: UrlQueryValue
@@ -375,13 +331,11 @@ export const setOptionFromUrl = (
       // updates options
       await dispatch(updateOptions(toKeyedVariableIdentifier(variable)));
     }
-
     // get variable from state
     const variableFromState = getVariable(toKeyedVariableIdentifier(variable), getState());
     if (!hasOptions(variableFromState)) {
       return;
     }
-
     if (!variableFromState) {
       throw new Error(`Couldn't find variable with name: ${variable.name}`);
     }
@@ -389,17 +343,14 @@ export const setOptionFromUrl = (
     let option = variableFromState.options.find((op) => {
       return op.text === stringUrlValue || op.value === stringUrlValue;
     });
-
     if (!option && isMulti(variableFromState)) {
       if (variableFromState.allValue && stringUrlValue === variableFromState.allValue) {
         option = { text: ALL_VARIABLE_TEXT, value: ALL_VARIABLE_VALUE, selected: false };
       }
     }
-
     if (!option) {
       let defaultText = stringUrlValue;
       const defaultValue = stringUrlValue;
-
       if (Array.isArray(stringUrlValue)) {
         // Multiple values in the url. We construct text as a list of texts from all matched options.
         defaultText = stringUrlValue.reduce((acc: string[], item: string) => {
@@ -409,18 +360,15 @@ export const setOptionFromUrl = (
             // TODO: investigate this further or refactor code
             return [].concat(acc, [item]);
           }
-
           // @ts-ignore according to strict null errors this can never happen
           // TODO: investigate this further or refactor code
           return [].concat(acc, [foundOption.text]);
         }, []);
       }
-
       // It is possible that we did not match the value to any existing option. In that case the URL value will be
       // used anyway for both text and value.
       option = { text: defaultText, value: defaultValue, selected: false };
     }
-
     if (isMulti(variableFromState)) {
       // In case variable is multiple choice, we cast to array to preserve the same behavior as when selecting
       // the option directly, which will return even single value in an array.
@@ -429,15 +377,12 @@ export const setOptionFromUrl = (
         variableFromState.multi
       );
     }
-
     await variableAdapters.get(variable.type).setValue(variableFromState, option);
   };
 };
-
 export const selectOptionsForCurrentValue = (variable: VariableWithOptions): VariableOption[] => {
   let i, y, value, option;
   const selected: VariableOption[] = [];
-
   for (i = 0; i < variable.options.length; i++) {
     option = { ...variable.options[i] };
     option.selected = false;
@@ -454,10 +399,8 @@ export const selectOptionsForCurrentValue = (variable: VariableWithOptions): Var
       selected.push(option);
     }
   }
-
   return selected;
 };
-
 export const validateVariableSelectionState = (
   identifier: KeyedVariableIdentifier,
   defaultValue?: string
@@ -467,13 +410,10 @@ export const validateVariableSelectionState = (
     if (!hasOptions(variableInState)) {
       return Promise.resolve();
     }
-
     const current = variableInState.current || ({} as unknown as VariableOption);
     const setValue = variableAdapters.get(variableInState.type).setValue;
-
     if (Array.isArray(current.value)) {
       const selected = selectOptionsForCurrentValue(variableInState);
-
       // if none pick first
       if (selected.length === 0) {
         const option = variableInState.options[0];
@@ -483,7 +423,6 @@ export const validateVariableSelectionState = (
           selected: true,
         });
       }
-
       const option: VariableOption = {
         value: selected.map((v) => v.value) as string[],
         text: selected.map((v) => v.text) as string[],
@@ -491,18 +430,14 @@ export const validateVariableSelectionState = (
       };
       return setValue(variableInState, option);
     }
-
     let option: VariableOption | undefined | null = null;
-
     // 1. find the current value
     const text = getCurrentText(variableInState);
     const value = getCurrentValue(variableInState);
-
     option = variableInState.options?.find((v: VariableOption) => v.text === text || v.value === value);
     if (option) {
       return setValue(variableInState, option);
     }
-
     // 2. find the default value
     if (defaultValue) {
       option = variableInState.options?.find((v) => v.text === defaultValue || v.value === defaultValue);
@@ -510,7 +445,6 @@ export const validateVariableSelectionState = (
         return setValue(variableInState, option);
       }
     }
-
     // 3. use the first value
     if (variableInState.options) {
       const option = variableInState.options[0];
@@ -518,12 +452,10 @@ export const validateVariableSelectionState = (
         return setValue(variableInState, option);
       }
     }
-
     // 4... give up
     return Promise.resolve();
   };
 };
-
 export const setOptionAsCurrent = (
   identifier: KeyedVariableIdentifier,
   current: VariableOption,
@@ -535,20 +467,16 @@ export const setOptionAsCurrent = (
     return await dispatch(variableUpdated(identifier, emitChanges));
   };
 };
-
 export const createGraph = (variables: TypedVariableModel[]) => {
   const g = new Graph();
-
   variables.forEach((v) => {
     g.createNode(v.name);
   });
-
   variables.forEach((v1) => {
     variables.forEach((v2) => {
       if (v1 === v2) {
         return;
       }
-
       if (variableAdapters.get(v1.type).dependsOn(v1, v2)) {
         try {
           // link might fail if it would create a circular dependency
@@ -561,10 +489,8 @@ export const createGraph = (variables: TypedVariableModel[]) => {
       }
     });
   });
-
   return g;
 };
-
 export const variableUpdated = (
   identifier: KeyedVariableIdentifier,
   emitChangeEvents: boolean,
@@ -574,7 +500,6 @@ export const variableUpdated = (
     const state = getState();
     const { rootStateKey } = identifier;
     const variableInState = getVariable(identifier, state);
-
     // if we're initializing variables ignore cascading update because we are in a boot up scenario
     if (getVariablesState(rootStateKey, state).transaction.status === TransactionStatus.Fetching) {
       if (getVariableRefresh(variableInState) === VariableRefresh.never) {
@@ -584,12 +509,10 @@ export const variableUpdated = (
       }
       return Promise.resolve();
     }
-
     const variables = getVariablesByKey(rootStateKey, state);
     const g = createGraph(variables);
     const panels = state.dashboard?.getModel()?.panels ?? [];
     const panelVars = getPanelVars(panels);
-
     const event: VariablesChangedEvent =
       variableInState.type === 'adhoc'
         ? { refreshAll: true, panelIds: [] } // for adhoc variables we don't know which panels that will be impacted
@@ -598,7 +521,6 @@ export const variableUpdated = (
             panelIds: Array.from(getAllAffectedPanelIdsForVariableChange([variableInState.id], g, panelVars)),
             variable: getVariable(identifier, state),
           };
-
     const node = g.getNode(variableInState.name);
     let promises: Array<Promise<void>> = [];
     if (node) {
@@ -607,11 +529,9 @@ export const variableUpdated = (
         if (!variable) {
           return Promise.resolve();
         }
-
         return dispatch(updateOptions(toKeyedVariableIdentifier(variable)));
       });
     }
-
     return Promise.all(promises).then(() => {
       if (emitChangeEvents) {
         reportInteraction('grafana_dashboards_variable_changed');
@@ -621,12 +541,10 @@ export const variableUpdated = (
     });
   };
 };
-
 export interface OnTimeRangeUpdatedDependencies {
   templateSrv: TemplateSrv;
   events: typeof appEvents;
 }
-
 const dfs = (
   node: Node,
   visited: string[],
@@ -655,7 +573,6 @@ const dfs = (
   });
   return variablesRefreshTimeRange;
 };
-
 // verify if the output edges of a node are not time range dependent
 const areOuputEdgesNotTimeRange = (node: Node, variables: TypedVariableModel[]) => {
   return node.outputEdges.every((e) => {
@@ -669,7 +586,6 @@ const areOuputEdgesNotTimeRange = (node: Node, variables: TypedVariableModel[]) 
     return true;
   });
 };
-
 /**
  * This function returns a list of variables that need to be refreshed when the time range changes
  * It follows this logic
@@ -684,10 +600,8 @@ const areOuputEdgesNotTimeRange = (node: Node, variables: TypedVariableModel[]) 
  * ----- 2. skip all the dependent nodes (B, C).
  *       Here, we should traverse the tree using DFS (Depth First Search), as the dependent nodes will be updated in cascade when the parent variable is updated.
  */
-
 export const getVariablesThatNeedRefreshNew = (key: string, state: StoreState): TypedVariableModel[] => {
   const allVariables = getVariablesByKey(key, state);
-
   //create dependency graph
   const g = createGraph(allVariables);
   // create a list of nodes that were visited
@@ -708,7 +622,6 @@ export const getVariablesThatNeedRefreshNew = (key: string, state: StoreState): 
       if (isVariableTimeRange && node.outputEdges.length === 0) {
         variablesRefreshTimeRange.push(parentVariableNode);
       }
-
       // if variable is time range and other variables depend on it (output edges) add it to the list of variables that need refresh and dont visit its dependents
       if (
         isVariableTimeRange &&
@@ -718,7 +631,6 @@ export const getVariablesThatNeedRefreshNew = (key: string, state: StoreState): 
         variablesRefreshTimeRange.push(parentVariableNode);
         dfs(node, visitedDfs, allVariables, variablesRefreshTimeRange);
       }
-
       // If is variable time range, has outputEdges, but the output edges are not time range configured, it means this
       // is the top variable that need to be refreshed
       if (isVariableTimeRange && node.outputEdges.length > 0 && areOuputEdgesNotTimeRange(node, allVariables)) {
@@ -726,21 +638,17 @@ export const getVariablesThatNeedRefreshNew = (key: string, state: StoreState): 
           variablesRefreshTimeRange.push(parentVariableNode);
         }
       }
-
       // if variable is not time range but has dependents (output edges) visit its dependants and repeat the process
       if (!isVariableTimeRange && node.outputEdges.length > 0) {
         dfs(node, visitedDfs, allVariables, variablesRefreshTimeRange);
       }
     }
   });
-
   return variablesRefreshTimeRange;
 };
-
 // old approach of refreshing variables that need refresh
 const getVariablesThatNeedRefreshOld = (key: string, state: StoreState): VariableWithOptions[] => {
   const allVariables = getVariablesByKey(key, state);
-
   const variablesThatNeedRefresh = allVariables.filter((variable) => {
     if ('refresh' in variable && 'options' in variable) {
       const variableWithRefresh = variable;
@@ -748,10 +656,8 @@ const getVariablesThatNeedRefreshOld = (key: string, state: StoreState): Variabl
     }
     return false;
   }) as VariableWithOptions[];
-
   return variablesThatNeedRefresh;
 };
-
 export const onTimeRangeUpdated =
   (
     key: string,
@@ -760,7 +666,6 @@ export const onTimeRangeUpdated =
   ): ThunkResult<Promise<void>> =>
   async (dispatch, getState) => {
     dependencies.templateSrv.updateTimeRange(timeRange);
-
     // approach # 2, get variables that need refresh but use the dependency graph to only update the ones that are affected
     // TODO: remove the VariableWithOptions type once the feature flag is on GA
     let variablesThatNeedRefresh: VariableWithOptions[] | TypedVariableModel[] = [];
@@ -769,21 +674,18 @@ export const onTimeRangeUpdated =
     } else {
       variablesThatNeedRefresh = getVariablesThatNeedRefreshOld(key, getState());
     }
-
     const variableIds = variablesThatNeedRefresh.map((variable) => variable.id);
     const promises = variablesThatNeedRefresh.map((variable) =>
       dispatch(timeRangeUpdated(toKeyedVariableIdentifier(variable)))
     );
-
     try {
       await Promise.all(promises);
       dependencies.events.publish(new VariablesTimeRangeProcessDone({ variableIds }));
     } catch (error) {
-      console.error(error);
+      structLog('error', error);
       dispatch(notifyApp(createVariableErrorNotification('Template variable service failed', error)));
     }
   };
-
 export const timeRangeUpdated =
   (identifier: KeyedVariableIdentifier): ThunkResult<Promise<void>> =>
   async (dispatch, getState) => {
@@ -791,43 +693,34 @@ export const timeRangeUpdated =
     if (!hasOptions(variableInState)) {
       return;
     }
-
     const previousOptions = variableInState.options.slice();
-
     await dispatch(updateOptions(toKeyedVariableIdentifier(variableInState), true));
-
     const updatedVariable = getVariable(identifier, getState());
     if (!hasOptions(updatedVariable)) {
       return;
     }
-
     const updatedOptions = updatedVariable.options;
-
     if (JSON.stringify(previousOptions) !== JSON.stringify(updatedOptions)) {
       const dashboard = getState().dashboard.getModel();
       dashboard?.templateVariableValueUpdated();
     }
   };
-
 export const templateVarsChangedInUrl =
   (key: string, vars: ExtendedUrlQueryMap, events: typeof appEvents = appEvents): ThunkResult<void> =>
   async (dispatch, getState) => {
     const update: Array<Promise<void>> = [];
     const dashboard = getState().dashboard.getModel();
     const variables = getVariablesByKey(key, getState());
-
     for (const variable of variables) {
       const key = VARIABLE_PREFIX + variable.name;
       if (!vars.hasOwnProperty(key)) {
         // key not found quick exit
         continue;
       }
-
       if (!isVariableUrlValueDifferentFromCurrent(variable, vars[key].value)) {
         // variable values doesn't differ quick exit
         continue;
       }
-
       let value = vars[key].value; // as the default the value is set to the value passed into templateVarsChangedInUrl
       if (vars[key].removed) {
         // for some reason (panel|data link without variable) the variable url value (var-xyz) has been removed from the url
@@ -836,16 +729,13 @@ export const templateVarsChangedInUrl =
         if (variableInModel && hasCurrent(variableInModel)) {
           value = variableInModel.current.value; // revert value to the value stored in dashboard json
         }
-
         if (variableInModel && variableInModel.type === 'constant') {
           value = variableInModel.query; // revert value to the value stored in dashboard json, constants don't store current values in dashboard json
         }
       }
-
       const promise = variableAdapters.get(variable.type).setValueFromUrl(variable, value);
       update.push(promise);
     }
-
     const filteredVars = variables.filter((v) => {
       const key = VARIABLE_PREFIX + v.name;
       return (
@@ -859,10 +749,8 @@ export const templateVarsChangedInUrl =
       varGraph,
       panelVars
     );
-
     if (update.length) {
       await Promise.all(update);
-
       events.publish(
         new VariablesChangedInUrl({
           refreshAll: affectedPanels.size === 0,
@@ -871,7 +759,6 @@ export const templateVarsChangedInUrl =
       );
     }
   };
-
 export function isVariableUrlValueDifferentFromCurrent(variable: TypedVariableModel, urlValue: unknown): boolean {
   const variableValue = variableAdapters.get(variable.type).getValueForUrl(variable);
   let stringUrlValue = ensureStringValues(urlValue);
@@ -881,29 +768,23 @@ export function isVariableUrlValueDifferentFromCurrent(variable: TypedVariableMo
   // lodash isEqual handles array of value equality checks as well
   return !isEqual(variableValue, stringUrlValue);
 }
-
 const getQueryWithVariables = (key: string, getState: () => StoreState): UrlQueryMap => {
   const queryParams = locationService.getSearchObject();
-
   const queryParamsNew = Object.keys(queryParams)
     .filter((key) => key.indexOf(VARIABLE_PREFIX) === -1)
     .reduce<UrlQueryMap>((obj, key) => {
       obj[key] = queryParams[key];
       return obj;
     }, {});
-
   for (const variable of getVariablesByKey(key, getState())) {
     if (variable.skipUrlSync) {
       continue;
     }
-
     const adapter = variableAdapters.get(variable.type);
     queryParamsNew[VARIABLE_PREFIX + variable.name] = adapter.getValueForUrl(variable);
   }
-
   return queryParamsNew;
 };
-
 export const initVariablesTransaction =
   (urlUid: string, dashboard: DashboardModel): ThunkResult<Promise<void>> =>
   async (dispatch, getState) => {
@@ -918,7 +799,6 @@ export const initVariablesTransaction =
           dispatch(cancelVariables(lastKey));
         }
       }
-
       // Start init transaction
       dispatch(toKeyedAction(uid, variablesInitTransaction({ uid })));
       // Add system variables like __dashboard and __user
@@ -933,10 +813,9 @@ export const initVariablesTransaction =
       dispatch(toKeyedAction(uid, variablesCompleteTransaction({ uid })));
     } catch (err) {
       dispatch(notifyApp(createVariableErrorNotification('Templating init failed', err)));
-      console.error(err);
+      structLog('error', err);
     }
   };
-
 export function migrateVariablesDatasourceNameToRef(
   key: string,
   getDatasourceSrvFunc = getDatasourceSrv
@@ -947,13 +826,10 @@ export function migrateVariablesDatasourceNameToRef(
       if (variable.type !== 'adhoc' && variable.type !== 'query') {
         continue;
       }
-
       const { datasource: nameOrRef } = variable;
-
       if (isDataSourceRef(nameOrRef)) {
         continue;
       }
-
       // the call to getInstanceSettings needs to be done after initDashboardTemplating because we might have
       // datasource variables that need to be resolved
       const ds = getDatasourceSrvFunc().getInstanceSettings(nameOrRef);
@@ -967,7 +843,6 @@ export function migrateVariablesDatasourceNameToRef(
     }
   };
 }
-
 export const cleanUpVariables =
   (key: string): ThunkResult<void> =>
   (dispatch) => {
@@ -976,15 +851,15 @@ export const cleanUpVariables =
     dispatch(toKeyedAction(key, cleanPickerState()));
     dispatch(toKeyedAction(key, variablesClearTransaction()));
   };
-
-type CancelVariablesDependencies = { getBackendSrv: typeof getBackendSrv };
+type CancelVariablesDependencies = {
+  getBackendSrv: typeof getBackendSrv;
+};
 export const cancelVariables =
   (key: string, dependencies: CancelVariablesDependencies = { getBackendSrv: getBackendSrv }): ThunkResult<void> =>
   (dispatch) => {
     dependencies.getBackendSrv().cancelAllInFlightRequests();
     dispatch(cleanUpVariables(key));
   };
-
 export const updateOptions =
   (identifier: KeyedVariableIdentifier, rethrow = false): ThunkResult<Promise<void>> =>
   async (dispatch, getState) => {
@@ -994,7 +869,6 @@ export const updateOptions =
         // we might have cancelled a batch so then variable state is removed
         return;
       }
-
       const variableInState = getVariable(identifier, getState());
       dispatch(toKeyedAction(rootStateKey, variableStateFetching(toVariablePayload(variableInState))));
       await dispatch(upgradeLegacyQueries(toKeyedVariableIdentifier(variableInState)));
@@ -1002,18 +876,15 @@ export const updateOptions =
       dispatch(completeVariableLoading(identifier));
     } catch (error) {
       dispatch(toKeyedAction(rootStateKey, variableStateFailed(toVariablePayload(identifier, { error }))));
-
       if (!rethrow) {
-        console.error(error);
+        structLog('error', error);
         dispatch(notifyApp(createVariableErrorNotification('Error updating options:', error, identifier)));
       }
-
       if (rethrow) {
         throw error;
       }
     }
   };
-
 export const createVariableErrorNotification = (
   message: string,
   error: unknown,
@@ -1023,7 +894,6 @@ export const createVariableErrorNotification = (
     `${identifier ? `Templating [${identifier.id}]` : 'Templating'}`,
     error instanceof Error ? `${message} ${error.message}` : `${message}`
   );
-
 export const completeVariableLoading =
   (identifier: KeyedVariableIdentifier): ThunkResult<void> =>
   (dispatch, getState) => {
@@ -1032,14 +902,11 @@ export const completeVariableLoading =
       // we might have cancelled a batch so then variable state is removed
       return;
     }
-
     const variableInState = getVariable(identifier, getState());
-
     if (variableInState.state !== LoadingState.Done) {
       dispatch(toKeyedAction(identifier.rootStateKey, variableStateCompleted(toVariablePayload(variableInState))));
     }
   };
-
 export function upgradeLegacyQueries(
   identifier: KeyedVariableIdentifier,
   getDatasourceSrvFunc: typeof getDatasourceSrv = getDatasourceSrv
@@ -1050,32 +917,25 @@ export function upgradeLegacyQueries(
       // we might have cancelled a batch so then variable state is removed
       return;
     }
-
     const variable = getVariable(identifier, getState());
     if (variable.type !== 'query') {
       return;
     }
-
     try {
       const datasource = await getDatasourceSrvFunc().get(variable.datasource ?? '');
-
       if (hasLegacyVariableSupport(datasource)) {
         return;
       }
-
       if (!hasStandardVariableSupport(datasource)) {
         return;
       }
-
       if (isDataQueryType(variable.query)) {
         return;
       }
-
       const query = {
         refId: `${datasource.name}-${id}-Variable-Query`,
         query: variable.query,
       };
-
       dispatch(
         toKeyedAction(
           rootStateKey,
@@ -1084,11 +944,10 @@ export function upgradeLegacyQueries(
       );
     } catch (err) {
       dispatch(notifyApp(createVariableErrorNotification('Failed to upgrade legacy queries', err)));
-      console.error(err);
+      structLog('error', err);
     }
   };
 }
-
 function isDataQueryType(query: unknown): query is DataQuery {
   return isObject(query) && 'refId' in query && typeof query.refId === 'string';
 }

--- a/public/app/features/variables/switch/SwitchVariablePicker.tsx
+++ b/public/app/features/variables/switch/SwitchVariablePicker.tsx
@@ -1,27 +1,21 @@
+import { structLog } from '@grafana/data';
 import { type ChangeEvent, type ReactElement, useCallback } from 'react';
-
 import { type SwitchVariableModel } from '@grafana/data';
 import { Switch } from '@grafana/ui';
-
 import { variableAdapters } from '../adapters';
 import { type VariablePickerProps } from '../pickers/types';
-
 export interface Props extends VariablePickerProps<SwitchVariableModel> {}
-
 export function SwitchVariablePicker({ variable, onVariableChange }: Props): ReactElement {
   const updateVariable = useCallback(
     (event: ChangeEvent<HTMLInputElement>) => {
       if (!variable.rootStateKey) {
-        console.error('Cannot update variable without rootStateKey');
+        structLog('error', 'Cannot update variable without rootStateKey');
         return;
       }
-
       const newValue = event!.currentTarget.checked ? variable.options[0] : variable.options[1];
-
       if (variable.current.value === newValue.value) {
         return;
       }
-
       if (onVariableChange) {
         onVariableChange({
           ...variable,
@@ -29,12 +23,10 @@ export function SwitchVariablePicker({ variable, onVariableChange }: Props): Rea
         });
         return;
       }
-
       variableAdapters.get(variable.type).updateOptions(variable);
     },
     [variable, onVariableChange]
   );
-
   return (
     <Switch
       id={`var-${variable.id}`}

--- a/public/app/features/variables/textbox/TextBoxVariablePicker.tsx
+++ b/public/app/features/variables/textbox/TextBoxVariablePicker.tsx
@@ -1,3 +1,4 @@
+import { structLog } from '@grafana/data';
 import {
   type ChangeEvent,
   type FocusEvent,
@@ -7,38 +8,31 @@ import {
   useEffect,
   useState,
 } from 'react';
-
 import { type TextBoxVariableModel, isEmptyObject } from '@grafana/data';
 import { t } from '@grafana/i18n';
 import { Input } from '@grafana/ui';
 import { useDispatch } from 'app/types/store';
-
 import { variableAdapters } from '../adapters';
 import { VARIABLE_PREFIX } from '../constants';
 import { type VariablePickerProps } from '../pickers/types';
 import { toKeyedAction } from '../state/keyedVariablesReducer';
 import { changeVariableProp } from '../state/sharedReducer';
 import { toVariablePayload } from '../utils';
-
 export interface Props extends VariablePickerProps<TextBoxVariableModel> {}
-
 export function TextBoxVariablePicker({ variable, onVariableChange, readOnly }: Props): ReactElement {
   const dispatch = useDispatch();
   const [updatedValue, setUpdatedValue] = useState(variable.current.value);
   useEffect(() => {
     setUpdatedValue(variable.current.value);
   }, [variable]);
-
   const updateVariable = useCallback(() => {
     if (!variable.rootStateKey) {
-      console.error('Cannot update variable without rootStateKey');
+      structLog('error', 'Cannot update variable without rootStateKey');
       return;
     }
-
     if (variable.current.value === updatedValue) {
       return;
     }
-
     dispatch(
       toKeyedAction(
         variable.rootStateKey,
@@ -47,7 +41,6 @@ export function TextBoxVariablePicker({ variable, onVariableChange, readOnly }: 
         )
       )
     );
-
     if (onVariableChange) {
       onVariableChange({
         ...variable,
@@ -55,15 +48,12 @@ export function TextBoxVariablePicker({ variable, onVariableChange, readOnly }: 
       });
       return;
     }
-
     variableAdapters.get(variable.type).updateOptions(variable);
   }, [variable, updatedValue, dispatch, onVariableChange]);
-
   const onChange = useCallback(
     (event: ChangeEvent<HTMLInputElement>) => setUpdatedValue(event.target.value),
     [setUpdatedValue]
   );
-
   const onBlur = (e: FocusEvent<HTMLInputElement>) => updateVariable();
   const onKeyDown = (event: KeyboardEvent<HTMLInputElement>) => {
     if (event.keyCode === 13) {
@@ -71,7 +61,6 @@ export function TextBoxVariablePicker({ variable, onVariableChange, readOnly }: 
       updateVariable();
     }
   };
-
   return (
     <Input
       type="text"

--- a/public/app/index.ts
+++ b/public/app/index.ts
@@ -1,38 +1,32 @@
+import { structLog } from '@grafana/data';
 // The new index.html fetches window.grafanaBootData asynchronously.
 // Since much of Grafana depends on it in includes side effects at import time,
 // we delay loading the rest of the app using import() until the boot data is ready.
-
 // Check if we are hosting files on cdn and set webpack public path
 if (window.public_cdn_path) {
   __webpack_public_path__ = window.public_cdn_path;
 }
-
 // This is a path to the public folder without '/build'
 window.__grafana_public_path__ =
   __webpack_public_path__.substring(0, __webpack_public_path__.lastIndexOf('build/')) || __webpack_public_path__;
-
 if (window.nonce) {
   __webpack_nonce__ = window.nonce;
 }
-
 // This is an indication to the window.onLoad failure check that the app bundle has loaded.
 window.__grafana_app_bundle_loaded = true;
-
 async function bootstrapWindowData() {
   // Wait for window.grafanaBootData is ready. The new index.html loads it from
   // an API call, but the old one just sets an immediately resolving promise.
   await window.__grafana_boot_data_promise;
-
   // Use eager to ensure the app is included in the initial chunk and does not
   // require additional network requests to load.
   await import(/* webpackMode: "eager" */ './initApp');
 }
-
 bootstrapWindowData().catch((error) => {
   const isRedirect = error && error.redirect && typeof error.redirect === 'string';
   // If a redirect was thrown, just ignore this. The index.html will handle the redirect
   if (!isRedirect) {
-    console.error('Error bootstrapping Grafana', error);
+    structLog('error', 'Error bootstrapping Grafana', error);
     window.__grafana_load_failed();
   }
 });

--- a/public/app/plugins/datasource/azuremonitor/azure_monitor/azure_monitor_datasource.ts
+++ b/public/app/plugins/datasource/azuremonitor/azure_monitor/azure_monitor_datasource.ts
@@ -1,9 +1,8 @@
+import { structLog } from '@grafana/data';
 import { find } from 'lodash';
-
 import { type AzureCredentials } from '@grafana/azure-sdk';
 import { type ScopedVars } from '@grafana/data';
 import { DataSourceWithBackend, getTemplateSrv, type TemplateSrv } from '@grafana/runtime';
-
 import { getCredentials } from '../credentials';
 import { type AzureMetricQuery, AzureQueryType } from '../dataquery.gen';
 import TimegrainConverter from '../time_grain_converter';
@@ -29,16 +28,12 @@ import {
 } from '../types/types';
 import { replaceTemplateVariables, routeNames } from '../utils/common';
 import migrateQuery from '../utils/migrateQuery';
-
 import ResponseParser from './response_parser';
 import UrlBuilder from './url_builder';
-
 const defaultDropdownValue = 'select';
-
 function hasValue(item?: string) {
   return !!(item && item !== defaultDropdownValue);
 }
-
 export default class AzureMonitorDatasource extends DataSourceWithBackend<
   AzureMonitorQuery,
   AzureMonitorDataSourceJsonData
@@ -54,25 +49,20 @@ export default class AzureMonitorDatasource extends DataSourceWithBackend<
   resourcePath: string;
   declare resourceGroup: string;
   declare resourceName: string;
-
   constructor(
     instanceSettings: AzureMonitorDataSourceInstanceSettings,
     private readonly templateSrv: TemplateSrv = getTemplateSrv()
   ) {
     super(instanceSettings);
     this.credentials = getCredentials(instanceSettings);
-
     this.defaultSubscriptionId = instanceSettings.jsonData.subscriptionId;
     this.basicLogsEnabled = instanceSettings.jsonData.basicLogsEnabled;
-
     this.resourcePath = routeNames.azureMonitor;
   }
-
   isConfigured(): boolean {
     // If validation didn't return any error then the data source is properly configured
     return !this.validateDatasource();
   }
-
   filterQuery(item: AzureMonitorQuery): boolean {
     const hasResource =
       item?.azureMonitor?.resources &&
@@ -80,7 +70,6 @@ export default class AzureMonitorDatasource extends DataSourceWithBackend<
       item.azureMonitor.resources.every((r) => hasValue(r.resourceGroup) && hasValue(r.resourceName)) &&
       hasValue(item?.azureMonitor?.metricDefinition || item?.azureMonitor?.metricNamespace);
     const hasResourceUri = hasValue(item.azureMonitor?.resourceUri);
-
     return !!(
       item.hide !== true &&
       (hasResource || hasResourceUri) &&
@@ -88,14 +77,11 @@ export default class AzureMonitorDatasource extends DataSourceWithBackend<
       hasValue(item?.azureMonitor?.aggregation)
     );
   }
-
   applyTemplateVariables(target: AzureMonitorQuery, scopedVars: ScopedVars): AzureMonitorQuery {
     const preMigrationQuery = target.azureMonitor;
-
     if (!preMigrationQuery) {
       throw new Error('Query is not a valid Azure Monitor Metrics query');
     }
-
     // These properties need to be replaced pre-migration to ensure values are correctly interpolated
     if (preMigrationQuery.resourceUri) {
       preMigrationQuery.resourceUri = this.templateSrv.replace(preMigrationQuery.resourceUri, scopedVars);
@@ -103,7 +89,6 @@ export default class AzureMonitorDatasource extends DataSourceWithBackend<
     if (preMigrationQuery.metricDefinition) {
       preMigrationQuery.metricDefinition = this.templateSrv.replace(preMigrationQuery.metricDefinition, scopedVars);
     }
-
     // fix for timeGrainUnit which is a deprecated/removed field name
     if (preMigrationQuery.timeGrain && preMigrationQuery.timeGrainUnit && preMigrationQuery.timeGrain !== 'auto') {
       preMigrationQuery.timeGrain = TimegrainConverter.createISO8601Duration(
@@ -111,14 +96,12 @@ export default class AzureMonitorDatasource extends DataSourceWithBackend<
         preMigrationQuery.timeGrainUnit
       );
     }
-
     const migratedTarget = migrateQuery(target);
     const migratedQuery = migratedTarget.azureMonitor;
     // This should never be triggered because the above error would've been thrown
     if (!migratedQuery) {
       throw new Error('Query is not a valid Azure Monitor Metrics query');
     }
-
     const subscriptionId = this.templateSrv.replace(
       migratedTarget.subscription || this.defaultSubscriptionId,
       scopedVars
@@ -131,7 +114,6 @@ export default class AzureMonitorDatasource extends DataSourceWithBackend<
     const timeGrain = this.templateSrv.replace((migratedQuery.timeGrain || '').toString(), scopedVars);
     const aggregation = this.templateSrv.replace(migratedQuery.aggregation, scopedVars);
     const top = this.templateSrv.replace(migratedQuery.top || '', scopedVars);
-
     const dimensionFilters = (migratedQuery.dimensionFilters ?? [])
       .filter((f) => f.dimension && f.dimension !== 'None')
       .map((f) => {
@@ -142,7 +124,6 @@ export default class AzureMonitorDatasource extends DataSourceWithBackend<
           filters: filters || [],
         };
       });
-
     const azMonitorQuery: AzureMetricQuery = {
       ...migratedQuery,
       resources,
@@ -157,7 +138,6 @@ export default class AzureMonitorDatasource extends DataSourceWithBackend<
       top: top || '10',
       alias: migratedQuery.alias,
     };
-
     return {
       ...target,
       subscription: subscriptionId,
@@ -165,19 +145,21 @@ export default class AzureMonitorDatasource extends DataSourceWithBackend<
       azureMonitor: azMonitorQuery,
     };
   }
-
-  async getSubscriptions(): Promise<Array<{ text: string; value: string }>> {
+  async getSubscriptions(): Promise<
+    Array<{
+      text: string;
+      value: string;
+    }>
+  > {
     if (!this.isConfigured()) {
       return [];
     }
-
     return this.getResource<AzureAPIResponse<Subscription>>(
       `${this.resourcePath}/subscriptions?api-version=2019-03-01`
     ).then((result) => {
       return ResponseParser.parseSubscriptions(result);
     });
   }
-
   // Note globalRegion should be false when querying custom metric namespaces
   getMetricNamespaces(query: GetMetricNamespacesQuery, globalRegion: boolean, region?: string, custom?: boolean) {
     const url = UrlBuilder.buildAzureMonitorGetMetricNamespacesUrl(
@@ -218,11 +200,10 @@ export default class AzureMonitorDatasource extends DataSourceWithBackend<
         return result;
       })
       .catch((reason) => {
-        console.error(`Failed to get metric namespaces: ${reason}`);
+        structLog('error', `Failed to get metric namespaces: ${reason}`);
         return [];
       });
   }
-
   getMetricNames(query: GetMetricNamesQuery, multipleResources?: boolean, region?: string) {
     const apiVersion = multipleResources ? this.apiPreviewVersion : this.apiVersion;
     const url = UrlBuilder.buildAzureMonitorGetMetricNamesUrl(
@@ -238,7 +219,6 @@ export default class AzureMonitorDatasource extends DataSourceWithBackend<
       return ResponseParser.parseResponseValues(result, 'name.localizedValue', 'name.value');
     });
   }
-
   getMetricMetadata(query: GetMetricMetadataQuery, multipleResources?: boolean, region?: string) {
     const { metricName } = query;
     const apiVersion = multipleResources ? this.apiPreviewVersion : this.apiVersion;
@@ -255,7 +235,6 @@ export default class AzureMonitorDatasource extends DataSourceWithBackend<
       return ResponseParser.parseMetadata(result, this.templateSrv.replace(metricName));
     });
   }
-
   private validateDatasource(): DatasourceValidationResult | undefined {
     if (this.credentials.authType === 'clientsecret') {
       if (!this.isValidConfigField(this.credentials.tenantId)) {
@@ -264,7 +243,6 @@ export default class AzureMonitorDatasource extends DataSourceWithBackend<
           message: 'The Tenant Id field is required.',
         };
       }
-
       if (!this.isValidConfigField(this.credentials.clientId)) {
         return {
           status: 'error',
@@ -272,45 +250,39 @@ export default class AzureMonitorDatasource extends DataSourceWithBackend<
         };
       }
     }
-
     return undefined;
   }
-
   async getWorkspaceTablePlan(resources: string[], tableName: string): Promise<TablePlan> {
     let workspaceUri = '';
-
     if (resources) {
       workspaceUri = resources[0];
     }
-
     if (!workspaceUri) {
       return TablePlan.Analytics;
     }
-
     if (workspaceUri && !workspaceUri.toLowerCase().includes('microsoft.operationalinsights/workspaces')) {
       // Not a Log Analytics workspace so default to Analytics
       return TablePlan.Analytics;
     }
-
     const url = UrlBuilder.buildAzureMonitorGetLogsTableUrl(
       this.resourcePath,
       this.templateSrv.replace(workspaceUri),
       this.templateSrv.replace(tableName)
     );
     const tableResult = await this.getResource<GetLogAnalyticsTableResponse>(url);
-
     if (!tableResult || instanceOfLogAnalyticsTableError(tableResult)) {
       return TablePlan.Analytics;
     }
-
     return tableResult.properties.plan || TablePlan.Analytics;
   }
-
   private isValidConfigField(field?: string): boolean {
     return typeof field === 'string' && field.length > 0;
   }
-
-  private replaceSingleTemplateVariables<T extends { [K in keyof T]: string }>(query: T, scopedVars?: ScopedVars) {
+  private replaceSingleTemplateVariables<
+    T extends {
+      [K in keyof T]: string;
+    },
+  >(query: T, scopedVars?: ScopedVars) {
     // This method evaluates template variables supporting multiple values but only returns the first value.
     // This will work as far as the first combination of variables is valid.
     // For example if 'rg1' contains 'res1' and 'rg2' contains 'res2' then
@@ -320,28 +292,23 @@ export default class AzureMonitorDatasource extends DataSourceWithBackend<
     // { resourceGroup: 'rg1', resourceName: 'res2' } which is not.
     return replaceTemplateVariables(this.templateSrv, query, scopedVars)[0];
   }
-
   async getProvider(providerName: string) {
     return await this.getResource<AzureMonitorProvidersResponse>(
       `${routeNames.azureMonitor}/providers/${providerName}?api-version=${this.providerApiVersion}`
     );
   }
-
   async getLocations(subscriptions: string[]) {
     const locationMap = new Map<string, AzureMonitorLocations>();
     for (const subscription of subscriptions) {
       const subLocations = ResponseParser.parseLocations(
         await this.getResource<AzureAPIResponse<Location>>(
-          `${routeNames.azureMonitor}/subscriptions/${this.templateSrv.replace(subscription)}/locations?api-version=${
-            this.locationsApiVersion
-          }`
+          `${routeNames.azureMonitor}/subscriptions/${this.templateSrv.replace(subscription)}/locations?api-version=${this.locationsApiVersion}`
         )
       );
       for (const location of subLocations) {
         locationMap.set(location.name, location);
       }
     }
-
     return locationMap;
   }
 }

--- a/public/app/plugins/datasource/azuremonitor/components/LogsQueryEditor/LogsQueryEditor.tsx
+++ b/public/app/plugins/datasource/azuremonitor/components/LogsQueryEditor/LogsQueryEditor.tsx
@@ -1,11 +1,10 @@
+import { structLog } from '@grafana/data';
 import { useEffect, useState } from 'react';
-
 import { type PanelData, type TimeRange } from '@grafana/data';
 import { Trans } from '@grafana/i18n';
 import { EditorFieldGroup, EditorRow, EditorRows } from '@grafana/plugin-ui';
 import { config, getTemplateSrv } from '@grafana/runtime';
 import { Alert, LinkButton, Space, Text, TextLink } from '@grafana/ui';
-
 import { LogsEditorMode, ResultFormat } from '../../dataquery.gen';
 import type Datasource from '../../datasource';
 import { selectors } from '../../e2e/selectors';
@@ -17,7 +16,6 @@ import ResourceField from '../ResourceField/ResourceField';
 import { type ResourceRow, type ResourceRowGroup, ResourceRowType } from '../ResourcePicker/types';
 import { parseResourceDetails } from '../ResourcePicker/utils';
 import FormatAsField from '../shared/FormatAsField';
-
 import AdvancedResourcePicker from './AdvancedResourcePicker';
 import { LogsManagement } from './LogsManagement';
 import QueryField from './QueryField';
@@ -25,7 +23,6 @@ import { TimeManagement } from './TimeManagement';
 import { onLoad, setBasicLogsQuery, setFormatAs, setKustoQuery } from './setQueryValue';
 import useMigrations from './useMigrations';
 import { shouldShowBasicLogsToggle } from './utils';
-
 interface LogsQueryEditorProps {
   query: AzureMonitorQuery;
   datasource: Datasource;
@@ -33,13 +30,15 @@ interface LogsQueryEditorProps {
   subscriptionId?: string;
   onChange: (newQuery: AzureMonitorQuery) => void;
   onQueryChange: (newQuery: AzureMonitorQuery) => void;
-  variableOptionGroup: { label: string; options: AzureMonitorOption[] };
+  variableOptionGroup: {
+    label: string;
+    options: AzureMonitorOption[];
+  };
   setError: (source: string, error: AzureMonitorErrorish | undefined) => void;
   hideFormatAs?: boolean;
   timeRange?: TimeRange;
   data?: PanelData;
 }
-
 const LogsQueryEditor = ({
   query,
   datasource,
@@ -64,18 +63,15 @@ const LogsQueryEditor = ({
   const templateVariableOptions = templateSrv.getVariables();
   const isBasicLogsQuery = (basicLogsEnabled && query.azureLogAnalytics?.basicLogsQuery) ?? false;
   const [isLoadingSchema, setIsLoadingSchema] = useState<boolean>(false);
-
   const disableRow = (row: ResourceRow, selectedRows: ResourceRowGroup) => {
     if (selectedRows.length === 0) {
       // Only if there is some resource(s) selected we should disable rows
       return false;
     }
-
     if (isBasicLogsQuery && selectedRows.length === 1) {
       // Basic logs queries can only have one resource selected
       return true;
     }
-
     const rowResourceNS = parseResourceDetails(row.uri, row.location).metricNamespace?.toLowerCase();
     const selectedRowSampleNs = parseResourceDetails(
       selectedRows[0].uri,
@@ -85,7 +81,6 @@ const LogsQueryEditor = ({
     return rowResourceNS !== selectedRowSampleNs;
   };
   const [schema, setSchema] = useState<EngineSchema | undefined>();
-
   useEffect(() => {
     const resources = query.azureLogAnalytics?.resources;
     if (resources) {
@@ -98,7 +93,6 @@ const LogsQueryEditor = ({
             plan: await datasource.azureMonitorDatasource.getWorkspaceTablePlan(resources, table.name),
           });
         }
-
         const tablesWithPlan = await Promise.all(promises);
         return tablesWithPlan;
       };
@@ -120,7 +114,6 @@ const LogsQueryEditor = ({
     datasource.azureMonitorDatasource,
     query.azureLogAnalytics?.mode,
   ]);
-
   useEffect(() => {
     if (shouldShowBasicLogsToggle(query.azureLogAnalytics?.resources || [], basicLogsEnabled)) {
       setShowBasicLogsToggle(true);
@@ -128,19 +121,16 @@ const LogsQueryEditor = ({
       setShowBasicLogsToggle(false);
     }
   }, [basicLogsEnabled, query.azureLogAnalytics?.resources, templateSrv]);
-
   useEffect(() => {
     if ((!basicLogsEnabled || !showBasicLogsToggle) && query.azureLogAnalytics?.basicLogsQuery) {
       const updatedBasicLogsQuery = setBasicLogsQuery(query, false);
       onChange(setKustoQuery(updatedBasicLogsQuery, ''));
     }
   }, [basicLogsEnabled, onChange, query, showBasicLogsToggle]);
-
   useEffect(() => {
     const hasRawKql = !!query.azureLogAnalytics?.query;
     const hasNoBuilder = !query.azureLogAnalytics?.builderQuery;
     const modeUnset = query.azureLogAnalytics?.mode === undefined;
-
     if (hasRawKql && hasNoBuilder && modeUnset) {
       onChange({
         ...query,
@@ -151,7 +141,6 @@ const LogsQueryEditor = ({
       });
     }
   }, [query, onChange]);
-
   useEffect(() => {
     if (query.azureLogAnalytics?.mode === LogsEditorMode.Raw && query.azureLogAnalytics?.builderQuery !== undefined) {
       onQueryChange({
@@ -164,7 +153,6 @@ const LogsQueryEditor = ({
       });
     }
   }, [query.azureLogAnalytics?.mode, onQueryChange, query]);
-
   useEffect(() => {
     const getBasicLogsUsage = async (query: AzureMonitorQuery) => {
       try {
@@ -193,14 +181,12 @@ const LogsQueryEditor = ({
           setDataIngestedWarning(null);
         }
       } catch (err) {
-        console.error(err);
+        structLog('error', err);
       }
     };
-
-    getBasicLogsUsage(query).catch((err) => console.error(err));
+    getBasicLogsUsage(query).catch((err) => structLog('error', err));
   }, [datasource.azureLogAnalyticsDatasource, query, showBasicLogsToggle, from, to]);
   let portalLinkButton = null;
-
   if (data?.series) {
     const querySeries = data.series.find((result) => result.refId === query.refId);
     if (querySeries && querySeries.meta?.custom?.azurePortalLink) {
@@ -218,7 +204,6 @@ const LogsQueryEditor = ({
       );
     }
   }
-
   return (
     <span data-testid={selectors.components.queryEditor.logsQueryEditor.container.input}>
       <EditorRows>
@@ -329,5 +314,4 @@ const LogsQueryEditor = ({
     </span>
   );
 };
-
 export default LogsQueryEditor;

--- a/public/app/plugins/datasource/azuremonitor/components/LogsQueryEditor/QueryField.tsx
+++ b/public/app/plugins/datasource/azuremonitor/components/LogsQueryEditor/QueryField.tsx
@@ -1,25 +1,19 @@
+import { structLog } from '@grafana/data';
 import { type EngineSchema, getKustoWorker } from '@kusto/monaco-kusto';
 import { useCallback, useEffect, useState } from 'react';
-
 import { CodeEditor, type Monaco, type MonacoEditor } from '@grafana/ui';
-
 import { type AzureQueryEditorFieldProps } from '../../types/types';
-
 import { setKustoQuery } from './setQueryValue';
-
 interface MonacoEditorValues {
   editor: MonacoEditor;
   monaco: Monaco;
 }
-
 const QueryField = ({ query, onQueryChange, schema }: AzureQueryEditorFieldProps) => {
   const [monaco, setMonaco] = useState<MonacoEditorValues | undefined>();
-
   useEffect(() => {
     if (!schema || !monaco) {
       return;
     }
-
     const setupEditor = async ({ monaco, editor }: MonacoEditorValues, schema: EngineSchema) => {
       try {
         const model = editor.getModel();
@@ -29,24 +23,20 @@ const QueryField = ({ query, onQueryChange, schema }: AzureQueryEditorFieldProps
           await kustoMode.setSchema(schema);
         }
       } catch (err) {
-        console.error(err);
+        structLog('error', err);
       }
     };
-
-    setupEditor(monaco, schema).catch((err) => console.error(err));
+    setupEditor(monaco, schema).catch((err) => structLog('error', err));
   }, [schema, monaco]);
-
   const handleEditorMount = useCallback((editor: MonacoEditor, monaco: Monaco) => {
     setMonaco({ monaco, editor });
   }, []);
-
   const onChange = useCallback(
     (newQuery: string) => {
       onQueryChange(setKustoQuery(query, newQuery));
     },
     [onQueryChange, query]
   );
-
   return (
     <CodeEditor
       value={query.azureLogAnalytics?.query ?? ''}
@@ -60,5 +50,4 @@ const QueryField = ({ query, onQueryChange, schema }: AzureQueryEditorFieldProps
     />
   );
 };
-
 export default QueryField;

--- a/public/app/plugins/datasource/azuremonitor/credentials.ts
+++ b/public/app/plugins/datasource/azuremonitor/credentials.ts
@@ -1,3 +1,4 @@
+import { structLog } from '@grafana/data';
 import {
   type AzureCredentials,
   getDatasourceCredentials,
@@ -7,9 +8,7 @@ import {
   updateDatasourceCredentials,
 } from '@grafana/azure-sdk';
 import { config } from '@grafana/runtime';
-
 import { type AzureMonitorDataSourceInstanceSettings, type AzureMonitorDataSourceSettings } from './types/types';
-
 export function getCredentials(
   options: AzureMonitorDataSourceSettings | AzureMonitorDataSourceInstanceSettings
 ): AzureCredentials {
@@ -19,17 +18,14 @@ export function getCredentials(
   if (creds) {
     return creds;
   }
-
   return getLegacyCredentials(options) || getDefaultCredentials();
 }
-
 export function updateCredentials(
   options: AzureMonitorDataSourceSettings,
   credentials: AzureCredentials
 ): AzureMonitorDataSourceSettings {
   return updateDatasourceCredentials(options, credentials);
 }
-
 function getLegacyCredentials(
   options: AzureMonitorDataSourceSettings | AzureMonitorDataSourceInstanceSettings
 ): AzureCredentials | undefined {
@@ -48,21 +44,18 @@ function getLegacyCredentials(
         clientSecret: getClientSecret(options),
       };
     }
-
     // If the authentication type is not set, then no legacy credentials exist so return undefined
     if (!options.jsonData.azureAuthType) {
       return undefined;
     }
-
     return { authType: options.jsonData.azureAuthType };
   } catch (e) {
     if (e instanceof Error) {
-      console.error('Unable to restore legacy credentials: %s', e.message);
+      structLog('error', 'Unable to restore legacy credentials: %s', e.message);
     }
     return undefined;
   }
 }
-
 function getDefaultCredentials(): AzureCredentials {
   if (config.azure.managedIdentityEnabled) {
     return { authType: 'msi' };

--- a/public/app/plugins/datasource/cloud-monitoring/CloudMonitoringMetricFindQuery.ts
+++ b/public/app/plugins/datasource/cloud-monitoring/CloudMonitoringMetricFindQuery.ts
@@ -1,5 +1,5 @@
+import { structLog } from '@grafana/data';
 import { isString } from 'lodash';
-
 import { ALIGNMENT_PERIODS, SELECTORS } from './constants';
 import { MetricFindQueryTypes, type ValueTypes } from './dataquery.gen';
 import type CloudMonitoringDatasource from './datasource';
@@ -11,16 +11,13 @@ import {
   getMetricTypesByService,
 } from './functions';
 import { type CloudMonitoringVariableQuery, type MetricDescriptor } from './types/types';
-
 export default class CloudMonitoringMetricFindQuery {
   constructor(private datasource: CloudMonitoringDatasource) {}
-
   async execute(query: CloudMonitoringVariableQuery) {
     try {
       if (!query.projectName) {
         query.projectName = this.datasource.getDefaultProject();
       }
-
       switch (query.selectedQueryType) {
         case MetricFindQueryTypes.Projects:
           return this.handleProjectsQuery();
@@ -50,11 +47,10 @@ export default class CloudMonitoringMetricFindQuery {
           return [];
       }
     } catch (error) {
-      console.error(`Could not run CloudMonitoringMetricFindQuery ${query}`, error);
+      structLog('error', `Could not run CloudMonitoringMetricFindQuery ${query}`, error);
       return [];
     }
   }
-
   async handleProjectsQuery() {
     const projects = await this.datasource.getProjects();
     return projects.map((s) => ({
@@ -63,7 +59,6 @@ export default class CloudMonitoringMetricFindQuery {
       expandable: true,
     }));
   }
-
   async handleServiceQuery({ projectName }: CloudMonitoringVariableQuery) {
     const metricDescriptors = await this.datasource.getMetricTypes(projectName);
     const services: MetricDescriptor[] = extractServicesFromMetricDescriptors(metricDescriptors);
@@ -73,7 +68,6 @@ export default class CloudMonitoringMetricFindQuery {
       expandable: true,
     }));
   }
-
   async handleMetricTypesQuery({ selectedService, projectName }: CloudMonitoringVariableQuery) {
     if (!selectedService) {
       return [];
@@ -87,7 +81,6 @@ export default class CloudMonitoringMetricFindQuery {
       })
     );
   }
-
   async handleLabelKeysQuery({ selectedMetricType, projectName }: CloudMonitoringVariableQuery) {
     if (!selectedMetricType) {
       return [];
@@ -95,7 +88,6 @@ export default class CloudMonitoringMetricFindQuery {
     const labelKeys = await getLabelKeys(this.datasource, selectedMetricType, projectName);
     return labelKeys.map(this.toFindQueryResult);
   }
-
   async handleLabelValuesQuery({ selectedMetricType, labelKey, projectName }: CloudMonitoringVariableQuery) {
     if (!selectedMetricType) {
       return [];
@@ -110,7 +102,6 @@ export default class CloudMonitoringMetricFindQuery {
     const values = labels.hasOwnProperty(interpolatedKey) ? labels[interpolatedKey] : [];
     return values.map(this.toFindQueryResult);
   }
-
   async handleResourceTypeQuery({ selectedMetricType, projectName }: CloudMonitoringVariableQuery) {
     if (!selectedMetricType) {
       return [];
@@ -119,7 +110,6 @@ export default class CloudMonitoringMetricFindQuery {
     const labels = await this.datasource.getLabels(selectedMetricType, refId, projectName);
     return labels['resource.type']?.map(this.toFindQueryResult) ?? [];
   }
-
   async handleAlignersQuery({ selectedMetricType, projectName }: CloudMonitoringVariableQuery) {
     if (!selectedMetricType) {
       return [];
@@ -128,51 +118,40 @@ export default class CloudMonitoringMetricFindQuery {
     const descriptor = metricDescriptors.find(
       (m) => m.type === this.datasource.templateSrv.replace(selectedMetricType)
     );
-
     if (!descriptor) {
       return [];
     }
-
     return getAlignmentOptionsByMetric(descriptor.valueType, descriptor.metricKind).map(this.toFindQueryResult);
   }
-
   async handleAggregationQuery({ selectedMetricType, projectName }: CloudMonitoringVariableQuery) {
     if (!selectedMetricType) {
       return [];
     }
-
     const metricDescriptors = await this.datasource.getMetricTypes(projectName);
     const descriptor = metricDescriptors.find(
       (m) => m.type === this.datasource.templateSrv.replace(selectedMetricType)
     );
-
     if (!descriptor) {
       return [];
     }
-
     return getAggregationOptionsByMetric(descriptor.valueType as ValueTypes, descriptor.metricKind).map(
       this.toFindQueryResult
     );
   }
-
   async handleSLOServicesQuery({ projectName }: CloudMonitoringVariableQuery) {
     const services = await this.datasource.getSLOServices(projectName);
     return services.map(this.toFindQueryResult);
   }
-
   async handleSLOQuery({ selectedSLOService, projectName }: CloudMonitoringVariableQuery) {
     const slos = await this.datasource.getServiceLevelObjectives(projectName, selectedSLOService);
     return slos.map(this.toFindQueryResult);
   }
-
   async handleSelectorQuery() {
     return SELECTORS.map(this.toFindQueryResult);
   }
-
   handleAlignmentPeriodQuery() {
     return ALIGNMENT_PERIODS.map(this.toFindQueryResult);
   }
-
   toFindQueryResult(x: any) {
     return isString(x) ? { text: x, expandable: true } : { ...x, text: x.label || x.value, expandable: true };
   }

--- a/public/app/plugins/datasource/cloudwatch/components/shared/LogGroups/LogGroupsField.tsx
+++ b/public/app/plugins/datasource/cloudwatch/components/shared/LogGroups/LogGroupsField.tsx
@@ -1,15 +1,13 @@
+import { structLog } from '@grafana/data';
 import { useEffect, useState } from 'react';
-
 import { EditorField, EditorRow } from '@grafana/plugin-ui';
 import { config } from '@grafana/runtime';
 import { Box, Stack } from '@grafana/ui';
-
 import { type LogGroup, type LogGroupClass, LogsQueryLanguage, type LogsQueryScope } from '../../../dataquery.gen';
 import { type CloudWatchDatasource } from '../../../datasource';
 import { useAccountOptions, useIsMonitoringAccount } from '../../../hooks';
 import { type DescribeLogGroupsRequest } from '../../../resources/types';
 import { isTemplateVariable } from '../../../utils/templateVariableUtils';
-
 import { AccountsSelector } from './AccountsSelector';
 import { LegacyLogGroupSelection } from './LegacyLogGroupNamesSelection';
 import { LogGroupClassSelector } from './LogGroupClassSelector';
@@ -17,7 +15,6 @@ import { LogGroupPrefixInput } from './LogGroupPrefixInput';
 import { LogGroupQueryScopeSelector } from './LogGroupQueryScopeSelector';
 import { LogGroupsSelector } from './LogGroupsSelector';
 import { SelectedLogGroups } from './SelectedLogGroups';
-
 type Props = {
   datasource: CloudWatchDatasource;
   onChange: (logGroups: LogGroup[]) => void;
@@ -37,7 +34,6 @@ type Props = {
   selectedAccountIds?: string[];
   onSelectedAccountIdsChange?: (accountIds: string[]) => void;
 };
-
 export const LogGroupsField = ({
   datasource,
   onChange,
@@ -60,21 +56,17 @@ export const LogGroupsField = ({
   const accountState = useAccountOptions(datasource?.resources, region);
   const isMonitoringAccount = useIsMonitoringAccount(datasource?.resources, region);
   const [loadingLogGroupsStarted, setLoadingLogGroupsStarted] = useState(false);
-
   const effectiveScope = logsQueryScope ?? 'logGroupName';
   const shouldShowQueryScopeSelector =
     showQueryScopeSelector ?? (queryLanguage === LogsQueryLanguage.CWLI || queryLanguage === undefined);
-
   useEffect(() => {
     // If log group names are stored in the query model, make a new DescribeLogGroups request for each log group to load the arn. Then update the query model.
     if (datasource && !loadingLogGroupsStarted && !logGroups?.length && legacyLogGroupNames?.length) {
       setLoadingLogGroupsStarted(true);
-
       const variables = legacyLogGroupNames.filter((lgn) => isTemplateVariable(datasource.resources.templateSrv, lgn));
       const legacyLogGroupNameValues = legacyLogGroupNames.filter(
         (lgn) => !isTemplateVariable(datasource.resources.templateSrv, lgn)
       );
-
       Promise.all(
         legacyLogGroupNameValues.map((lg) =>
           datasource.resources.getLogGroups({ region: region, logGroupNamePrefix: lg })
@@ -88,15 +80,13 @@ export const LogGroupsField = ({
               accountId: lg.accountId,
             }))
           );
-
           onChange([...logGroups, ...variables.map((v) => ({ name: v, arn: v }))]);
         })
         .catch((err) => {
-          console.error(err);
+          structLog('error', err);
         });
     }
   }, [datasource, legacyLogGroupNames, logGroups, onChange, region, loadingLogGroupsStarted]);
-
   const renderLogGroupNameMode = () => (
     <Stack direction="column" gap={1}>
       <LogGroupsSelector
@@ -116,7 +106,6 @@ export const LogGroupsField = ({
       />
     </Stack>
   );
-
   const renderPrefixFields = () => (
     <Stack direction="row" gap={2} wrap="wrap" alignItems="flex-start">
       <LogGroupPrefixInput
@@ -134,7 +123,6 @@ export const LogGroupsField = ({
       )}
     </Stack>
   );
-
   const renderAllLogGroupsFields = () => (
     <Stack direction="row" gap={2} wrap="wrap" alignItems="flex-start">
       <LogGroupClassSelector value={logGroupClass} onChange={onLogGroupClassChange ?? (() => {})} />
@@ -147,7 +135,6 @@ export const LogGroupsField = ({
       )}
     </Stack>
   );
-
   if (!shouldShowQueryScopeSelector) {
     return (
       <Box marginTop={1} marginBottom={1}>
@@ -155,7 +142,6 @@ export const LogGroupsField = ({
       </Box>
     );
   }
-
   return (
     <Box marginTop={1} marginBottom={1}>
       <Stack direction="column" gap={1}>
@@ -172,7 +158,6 @@ export const LogGroupsField = ({
     </Box>
   );
 };
-
 type WrapperProps = {
   datasource: CloudWatchDatasource;
   onChange: (logGroups: LogGroup[]) => void;
@@ -182,9 +167,7 @@ type WrapperProps = {
   maxNoOfVisibleLogGroups?: number;
   onBeforeOpen?: () => void;
   showQueryScopeSelector?: boolean;
-
   legacyOnChange: (logGroups: string[]) => void;
-
   queryLanguage?: LogsQueryLanguage;
   logsQueryScope?: LogsQueryScope;
   onLogsQueryScopeChange?: (scope: LogsQueryScope) => void;
@@ -195,7 +178,6 @@ type WrapperProps = {
   selectedAccountIds?: string[];
   onSelectedAccountIdsChange?: (accountIds: string[]) => void;
 };
-
 export const LogGroupsFieldWrapper = (props: WrapperProps) => {
   if (!config.featureToggles.cloudWatchCrossAccountQuerying) {
     return (
@@ -206,6 +188,5 @@ export const LogGroupsFieldWrapper = (props: WrapperProps) => {
       />
     );
   }
-
   return <LogGroupsField {...props} />;
 };

--- a/public/app/plugins/datasource/cloudwatch/tracking.ts
+++ b/public/app/plugins/datasource/cloudwatch/tracking.ts
@@ -1,6 +1,6 @@
+import { structLog } from '@grafana/data';
 import { type DashboardLoadedEvent } from '@grafana/data';
 import { config, reportInteraction } from '@grafana/runtime';
-
 import {
   type CloudWatchLogsQuery,
   type CloudWatchLogsAnomaliesQuery,
@@ -15,82 +15,62 @@ import { migrateMetricQuery } from './migrations/metricQueryMigrations';
 import pluginJson from './plugin.json';
 import { type CloudWatchQuery } from './types';
 import { filterMetricsQuery } from './utils/utils';
-
 type CloudWatchOnDashboardLoadedTrackingEvent = {
   grafana_version?: string;
   dashboard_id?: string;
   org_id?: number;
-
   /* The number of CloudWatch logs queries present in the dashboard*/
   logs_queries_count: number;
-
   /* The number of Logs queries that use Logs Insights query language */
   logs_cwli_queries_count: number;
-
   /* The number of Logs queries that use SQL language */
   logs_sql_queries_count: number;
-
   /* The number of Logs queries that use PPL language */
   logs_ppl_queries_count: number;
-
   /* The number of log anomalies queries */
   log_anomalies_queries_count: number;
-
   /* The number of CloudWatch metrics queries present in the dashboard*/
   metrics_queries_count: number;
-
-  /* The number of queries using the "Search" mode. 
-  Should be measured in relation to metrics_queries_count, e.g metrics_search_count + metrics_query_count = metrics_queries_count */
+  /* The number of queries using the "Search" mode.
+    Should be measured in relation to metrics_queries_count, e.g metrics_search_count + metrics_query_count = metrics_queries_count */
   metrics_search_count: number;
-
-  /* The number of search queries that are using the builder mode. 
-  Should be measured in relation to metrics_search_count, e.g metrics_search_builder_count + metrics_search_code_count = metrics_search_count */
+  /* The number of search queries that are using the builder mode.
+    Should be measured in relation to metrics_search_count, e.g metrics_search_builder_count + metrics_search_code_count = metrics_search_count */
   metrics_search_builder_count: number;
-
-  /* The number of search queries that are using the code mode. 
-  Should be measured in relation to metrics_search_count, e.g metrics_search_builder_count + metrics_search_code_count = metrics_search_count */
+  /* The number of search queries that are using the code mode.
+    Should be measured in relation to metrics_search_count, e.g metrics_search_builder_count + metrics_search_code_count = metrics_search_count */
   metrics_search_code_count: number;
-
-  /* The number of search queries that have enabled the `match exact` toggle in the builder mode. 
-  Should be measured in relation to metrics_search_builder_count. 
-  E.g 'Out of 5 metric seach queries (metrics_search_builder_count), 2 had match exact toggle (metrics_search_match_exact_count) enabled */
+  /* The number of search queries that have enabled the `match exact` toggle in the builder mode.
+    Should be measured in relation to metrics_search_builder_count.
+    E.g 'Out of 5 metric seach queries (metrics_search_builder_count), 2 had match exact toggle (metrics_search_match_exact_count) enabled */
   metrics_search_match_exact_count: number;
-
-  /* The number of queries using the "Query" mode (AKA Metric Insights). 
-  Should be measured in relation to metrics_queries_count, e.g metrics_search_count + metrics_query_count = metrics_queries_count */
+  /* The number of queries using the "Query" mode (AKA Metric Insights).
+    Should be measured in relation to metrics_queries_count, e.g metrics_search_count + metrics_query_count = metrics_queries_count */
   metrics_query_count: number;
-
-  /* The number of "Insights" queries that are using the builder mode. 
-  Should be measured in relation to metrics_query_count, e.g metrics_query_builder_count + metrics_query_code_count = metrics_query_count */
+  /* The number of "Insights" queries that are using the builder mode.
+    Should be measured in relation to metrics_query_count, e.g metrics_query_builder_count + metrics_query_code_count = metrics_query_count */
   metrics_query_builder_count: number;
-
-  /* The number of "Insights" queries that are using the code mode. 
-  Should be measured in relation to metrics_query_count, e.g metrics_query_builder_count + metrics_query_code_count = metrics_query_count */
+  /* The number of "Insights" queries that are using the code mode.
+    Should be measured in relation to metrics_query_count, e.g metrics_query_builder_count + metrics_query_code_count = metrics_query_count */
   metrics_query_code_count: number;
-
   /* The number of CloudWatch metrics queries that have specified an account in its cross account metric stat query */
   metrics_queries_with_account_count: number;
 };
-
 export const onDashboardLoadedHandler = ({
   payload: { dashboardId, orgId, grafanaVersion, queries },
 }: DashboardLoadedEvent<CloudWatchQuery>) => {
   try {
     const cloudWatchQueries = queries[pluginJson.id];
-
     if (!cloudWatchQueries?.length) {
       return;
     }
-
     let logsInsightsQueries: CloudWatchLogsQuery[] = [];
     let logAnomaliesQueries: CloudWatchLogsAnomaliesQuery[] = [];
     let metricsQueries: CloudWatchMetricsQuery[] = [];
-
     for (const query of cloudWatchQueries) {
       if (query.hide) {
         continue;
       }
-
       const isLogsInsightsQuery =
         isCloudWatchLogsQuery(query) && (!query.logsMode || query.logsMode === LogsMode.Insights);
       if (isLogsInsightsQuery) {
@@ -102,7 +82,6 @@ export const onDashboardLoadedHandler = ({
         filterMetricsQuery(migratedQuery) && metricsQueries.push(query);
       }
     }
-
     const e: CloudWatchOnDashboardLoadedTrackingEvent = {
       grafana_version: grafanaVersion,
       dashboard_id: dashboardId,
@@ -124,7 +103,6 @@ export const onDashboardLoadedHandler = ({
       metrics_query_code_count: 0,
       metrics_queries_with_account_count: 0,
     };
-
     for (const q of metricsQueries) {
       e.metrics_search_count += +Boolean(q.metricQueryType === MetricQueryType.Search);
       e.metrics_search_builder_count += +isMetricSearchBuilder(q);
@@ -143,22 +121,18 @@ export const onDashboardLoadedHandler = ({
         config.featureToggles.cloudWatchCrossAccountQuerying && isMetricSearchBuilder(q) && q.accountId
       );
     }
-
     reportInteraction('grafana_ds_cloudwatch_dashboard_loaded', e);
   } catch (error) {
-    console.error('error in cloudwatch tracking handler', error);
+    structLog('error', 'error in cloudwatch tracking handler', error);
   }
 };
-
 type SampleQueryTrackingEvent = {
   queryLanguage: LogsQueryLanguage;
   queryCategory: string;
 };
-
 export const trackSampleQuerySelection = (props: SampleQueryTrackingEvent) => {
   const { queryLanguage, queryCategory } = props;
   reportInteraction('cloudwatch-logs-cheat-sheet-query-clicked', { queryLanguage, queryCategory });
 };
-
 const isMetricSearchBuilder = (q: CloudWatchMetricsQuery) =>
   Boolean(q.metricQueryType === MetricQueryType.Search && q.metricEditorMode === MetricEditorMode.Builder);

--- a/public/app/plugins/datasource/cloudwatch/utils/datalinks.ts
+++ b/public/app/plugins/datasource/cloudwatch/utils/datalinks.ts
@@ -1,3 +1,4 @@
+import { structLog } from '@grafana/data';
 import {
   type DataFrame,
   type DataLink,
@@ -8,18 +9,15 @@ import {
   type TimeRange,
 } from '@grafana/data';
 import { getDataSourceSrv } from '@grafana/runtime';
-
 import { type AwsUrl, encodeUrl } from '../aws_url';
 import { type CloudWatchLogsQuery } from '../dataquery.gen';
 import { type CloudWatchQuery } from '../types';
-
 type ReplaceFn = (
   target?: string,
   scopedVars?: ScopedVars,
   displayErrorIfIsMultiTemplateVariable?: boolean,
   fieldName?: string
 ) => string;
-
 export async function addDataLinksToLogsResponse(
   response: DataQueryResponse,
   request: DataQueryRequest<CloudWatchQuery>,
@@ -30,11 +28,9 @@ export async function addDataLinksToLogsResponse(
 ): Promise<void> {
   const replace = (target: string, fieldName?: string) => replaceFn(target, request.scopedVars, false, fieldName);
   const getVariableValue = (target: string) => getVariableValueFn(target, request.scopedVars);
-
   for (const dataFrame of response.data as DataFrame[]) {
     const curTarget = request.targets.find((target) => target.refId === dataFrame.refId) as CloudWatchLogsQuery;
     const interpolatedRegion = getRegion(replace(curTarget.region ?? '', 'region'));
-
     for (const field of dataFrame.fields) {
       if (field.name === '@xrayTraceId' && tracingDatasourceUid) {
         getRegion(replace(curTarget.region ?? '', 'region'));
@@ -44,7 +40,6 @@ export async function addDataLinksToLogsResponse(
         }
       }
     }
-
     // add a link to the cloudwatch console as a separate field that will be displayed as a link
     if (dataFrame.fields.length) {
       dataFrame.fields.push({
@@ -60,16 +55,14 @@ export async function addDataLinksToLogsResponse(
     }
   }
 }
-
 async function createInternalXrayLink(datasourceUid: string, region: string): Promise<DataLink | undefined> {
   let ds;
   try {
     ds = await getDataSourceSrv().get(datasourceUid);
   } catch (e) {
-    console.error('Could not load linked xray data source, it was probably deleted after it was linked', e);
+    structLog('error', 'Could not load linked xray data source, it was probably deleted after it was linked', e);
     return undefined;
   }
-
   return {
     title: ds.name,
     url: '',
@@ -80,7 +73,6 @@ async function createInternalXrayLink(datasourceUid: string, region: string): Pr
     },
   };
 }
-
 function createAwsConsoleLink(
   target: CloudWatchLogsQuery,
   range: TimeRange,
@@ -95,7 +87,6 @@ function createAwsConsoleLink(
   const sources = arns?.length ? arns : logGroupNames;
   const interpolatedExpression = target.expression ? replace(target.expression) : '';
   const interpolatedGroups = sources?.flatMap(getVariableValue);
-
   const urlProps: AwsUrl = {
     end: range.to.toISOString(),
     start: range.from.toISOString(),
@@ -105,7 +96,6 @@ function createAwsConsoleLink(
     isLiveTail: false,
     source: interpolatedGroups,
   };
-
   const encodedUrl = encodeUrl(urlProps, region);
   return {
     url: encodedUrl,

--- a/public/app/plugins/datasource/cloudwatch/variables.ts
+++ b/public/app/plugins/datasource/cloudwatch/variables.ts
@@ -1,6 +1,6 @@
+import { structLog } from '@grafana/data';
 import { from, type Observable } from 'rxjs';
 import { map } from 'rxjs/operators';
-
 import {
   CustomVariableSupport,
   type DataQueryRequest,
@@ -8,7 +8,6 @@ import {
   type MetricFindValue,
   type SelectableValue,
 } from '@grafana/data';
-
 import { VariableQueryEditor } from './components/VariableQueryEditor/VariableQueryEditor';
 import { ALL_ACCOUNTS_OPTION } from './components/shared/Account';
 import { type CloudWatchDatasource } from './datasource';
@@ -17,19 +16,15 @@ import { migrateVariableQuery } from './migrations/variableQueryMigrations';
 import { type ResourcesAPI } from './resources/ResourcesAPI';
 import { standardStatistics } from './standardStatistics';
 import { type VariableQuery, VariableQueryType } from './types';
-
 export class CloudWatchVariableSupport extends CustomVariableSupport<CloudWatchDatasource, VariableQuery> {
   constructor(private readonly resources: ResourcesAPI) {
     super();
   }
-
   editor = VariableQueryEditor;
-
   query(request: DataQueryRequest<VariableQuery>): Observable<DataQueryResponse> {
     const queryObj = migrateVariableQuery(request.targets[0]);
     return from(this.execute(queryObj)).pipe(map((data) => ({ data })));
   }
-
   async execute(query: VariableQuery) {
     try {
       switch (query.queryType) {
@@ -57,11 +52,10 @@ export class CloudWatchVariableSupport extends CustomVariableSupport<CloudWatchD
           return this.handleAccountsQuery(query);
       }
     } catch (error) {
-      console.error(`Could not run CloudWatchMetricFindQuery ${query}`, error);
+      structLog('error', `Could not run CloudWatchMetricFindQuery ${query}`, error);
       return [];
     }
   }
-
   async handleLogGroupsQuery({ region, logGroupPrefix, accountId }: VariableQuery) {
     const interpolatedPrefix = this.resources.templateSrv.replace(logGroupPrefix);
     return this.resources
@@ -81,27 +75,22 @@ export class CloudWatchVariableSupport extends CustomVariableSupport<CloudWatchD
         })
       );
   }
-
   async handleRegionsQuery() {
     return this.resources.getRegions().then((regions) => regions.map(selectableValueToMetricFindOption));
   }
-
   async handleNamespacesQuery() {
     return this.resources.getNamespaces().then((namespaces) => namespaces.map(selectableValueToMetricFindOption));
   }
-
   async handleMetricsQuery({ namespace, region, accountId }: VariableQuery) {
     return this.resources
       .getMetrics({ namespace, region, accountId })
       .then((metrics) => metrics.map(selectableValueToMetricFindOption));
   }
-
   async handleDimensionKeysQuery({ namespace, region, accountId }: VariableQuery) {
     return this.resources
       .getDimensionKeys({ namespace, region, accountId })
       .then((keys) => keys.map(selectableValueToMetricFindOption));
   }
-
   async handleDimensionValuesQuery({
     namespace,
     accountId,
@@ -124,14 +113,12 @@ export class CloudWatchVariableSupport extends CustomVariableSupport<CloudWatchD
       })
       .then((values) => values.map(selectableValueToMetricFindOption));
   }
-
   async handleEbsVolumeIdsQuery({ region, instanceID }: VariableQuery) {
     if (!instanceID) {
       return [];
     }
     return this.resources.getEbsVolumeIds(region, instanceID).then((ids) => ids.map(selectableValueToMetricFindOption));
   }
-
   async handleEc2InstanceAttributeQuery({ region, attributeName, ec2Filters }: VariableQuery) {
     if (!attributeName) {
       return [];
@@ -140,7 +127,6 @@ export class CloudWatchVariableSupport extends CustomVariableSupport<CloudWatchD
       .getEc2InstanceAttribute(region, attributeName, ec2Filters ?? {})
       .then((values) => values.map(selectableValueToMetricFindOption));
   }
-
   async handleResourceARNsQuery({ region, resourceType, tags }: VariableQuery) {
     if (!resourceType) {
       return [];
@@ -148,7 +134,6 @@ export class CloudWatchVariableSupport extends CustomVariableSupport<CloudWatchD
     const keys = await this.resources.getResourceARNs(region, resourceType, tags ?? {});
     return keys.map(selectableValueToMetricFindOption);
   }
-
   async handleStatisticsQuery() {
     return standardStatistics.map((s: string) => ({
       text: s,
@@ -156,7 +141,6 @@ export class CloudWatchVariableSupport extends CustomVariableSupport<CloudWatchD
       expandable: true,
     }));
   }
-
   allMetricFindValue: MetricFindValue = { text: 'All', value: ALL_ACCOUNTS_OPTION.value, expandable: true };
   async handleAccountsQuery({ region }: VariableQuery) {
     return this.resources.getAccounts({ region }).then((accounts) => {
@@ -165,16 +149,13 @@ export class CloudWatchVariableSupport extends CustomVariableSupport<CloudWatchD
         value: account.id,
         expandable: true,
       }));
-
       return metricFindOptions.length ? [this.allMetricFindValue, ...metricFindOptions] : [];
     });
   }
-
   getDefaultQuery(): Partial<VariableQuery> {
     return DEFAULT_VARIABLE_QUERY;
   }
 }
-
 function selectableValueToMetricFindOption({ label, value }: SelectableValue<string>): MetricFindValue {
   return { text: label ?? value ?? '', value: value, expandable: true };
 }

--- a/public/app/plugins/datasource/dashboard/datasource.ts
+++ b/public/app/plugins/datasource/dashboard/datasource.ts
@@ -1,5 +1,5 @@
+import { structLog } from '@grafana/data';
 import { type Observable, debounce, debounceTime, defer, finalize, first, interval, map, of } from 'rxjs';
-
 import {
   DataSourceApi,
   type DataQueryRequest,
@@ -26,11 +26,8 @@ import {
   findVizPanelByKey,
   getVizPanelKeyForPanelId,
 } from 'app/features/dashboard-scene/utils/utils';
-
 import { MIXED_REQUEST_PREFIX } from '../mixed/MixedDataSource';
-
 import { type DashboardQuery } from './types';
-
 /**
  * This should not really be called
  */
@@ -38,64 +35,48 @@ export class DashboardDatasource extends DataSourceApi<DashboardQuery> {
   constructor(instanceSettings: DataSourceInstanceSettings) {
     super(instanceSettings);
   }
-
   getCollapsedText(query: DashboardQuery) {
     return `Dashboard Reference: ${query.panelId}`;
   }
-
   query(options: DataQueryRequest<DashboardQuery>): Observable<DataQueryResponse> {
     const sceneScopedVar: ScopedVar | undefined = options.scopedVars?.__sceneObject;
     const sceneScopedVarValue: unknown | undefined = sceneScopedVar?.value.valueOf();
     const scene: SceneObject | undefined =
       sceneScopedVarValue && isSceneObject(sceneScopedVarValue) ? sceneScopedVarValue : undefined;
-
     if (!scene) {
       throw new Error('Can only be called from a scene');
     }
-
     const query = options.targets[0];
     if (!query) {
       return of({ data: [] });
     }
-
     const panelId = query.panelId;
-
     if (!panelId) {
       return of({ data: [] });
     }
-
     let sourcePanel = findVizPanelByKey(scene, getVizPanelKeyForPanelId(panelId));
-
     if (!sourcePanel) {
       return of({ data: [], error: { message: 'Could not find source panel' } });
     }
-
     let sourceDataProvider: SceneDataProvider | undefined = sourcePanel.state.$data;
-
     if (!query.withTransforms && sourceDataProvider instanceof SceneDataTransformer) {
       sourceDataProvider = sourceDataProvider.state.$data;
     }
-
     if (!sourceDataProvider || !sourceDataProvider.getResultsStream) {
       return of({ data: [] });
     }
-
     // Extract AdHoc filters from the request
     const adHocFilters = options.filters || [];
-
     return defer(() => {
       if (!sourceDataProvider!.isActive && sourceDataProvider?.setContainerWidth) {
         sourceDataProvider?.setContainerWidth(500);
       }
-
       /**
        * Ignore the isInView flag on the original data provider
        * This allows queries to be run even if the original datasource is outside the viewport
        */
       sourceDataProvider?.bypassIsInViewChanged?.(true);
-
       const activateCleanUp = activateSceneObjectAndParentTree(sourceDataProvider!);
-
       return sourceDataProvider!.getResultsStream!().pipe(
         debounceTime(50),
         map((result) => {
@@ -110,13 +91,11 @@ export class DashboardDatasource extends DataSourceApi<DashboardQuery> {
         this.emitFirstLoadedDataIfMixedDS(options.requestId),
         finalize(() => {
           sourceDataProvider?.bypassIsInViewChanged?.(false);
-
           activateCleanUp?.();
         })
       );
     });
   }
-
   private getDataFramesForQueryTopic(
     data: PanelData,
     query: DashboardQuery,
@@ -133,7 +112,6 @@ export class DashboardDatasource extends DataSourceApi<DashboardQuery> {
         },
       }));
     }
-
     // For regular queries, only return series data
     const series = data.series.map((s) => {
       return {
@@ -153,15 +131,12 @@ export class DashboardDatasource extends DataSourceApi<DashboardQuery> {
         })),
       };
     });
-
     if (!query.adHocFiltersEnabled || filters.length === 0) {
       return series;
     }
-
     // Apply AdHoc filters to series data
     return series.map((frame) => this.applyAdHocFilters(frame, filters));
   }
-
   /**
    * Apply AdHoc filters to a DataFrame
    * Optimized version with pre-computed field indices and value matchers for better performance
@@ -170,15 +145,12 @@ export class DashboardDatasource extends DataSourceApi<DashboardQuery> {
     if (filters.length === 0 || frame.length === 0) {
       return frame;
     }
-
     // Filter out non-applicable filters for this specific DataFrame
     const applicableFilters = this.getApplicableFiltersForFrame(frame, filters);
-
     // If no filters remain after filtering, return original frame
     if (applicableFilters.length === 0) {
       return frame;
     }
-
     // Check for impossible filters (missing field with '=' operator)
     const hasImpossibleFilter = applicableFilters.some(
       ({ fieldIndex, filter }) => fieldIndex === -1 && filter.operator === '='
@@ -186,38 +158,35 @@ export class DashboardDatasource extends DataSourceApi<DashboardQuery> {
     if (hasImpossibleFilter) {
       return this.reconstructDataFrame(frame);
     }
-
     const matchingRows = new Set<number>();
-
     // Check each row to see if it matches all filters (AND logic)
     for (let rowIndex = 0; rowIndex < frame.length; rowIndex++) {
       const rowMatches = applicableFilters.every(({ matcher, fieldIndex }) => {
         const field = frame.fields[fieldIndex];
-
         // Use Grafana's value matcher system
         return matcher?.(rowIndex, field, frame, [frame]) ?? false;
       });
-
       if (rowMatches) {
         matchingRows.add(rowIndex);
       }
     }
-
     // Early return if no filtering occurred
     if (matchingRows.size === frame.length) {
       return frame;
     }
-
     return this.reconstructDataFrame(frame, matchingRows);
   }
-
   /**
    * Get applicable filters for a specific DataFrame, considering field existence and type compatibility.
    */
   private getApplicableFiltersForFrame(
     frame: DataFrame,
     filters: AdHocVariableFilter[]
-  ): Array<{ filter: AdHocVariableFilter; fieldIndex: number; matcher: ReturnType<typeof getValueMatcher> | null }> {
+  ): Array<{
+    filter: AdHocVariableFilter;
+    fieldIndex: number;
+    matcher: ReturnType<typeof getValueMatcher> | null;
+  }> {
     return filters
       .map((filter) => {
         const fieldIndex = frame.fields.findIndex((f) => f.name === filter.key);
@@ -234,7 +203,6 @@ export class DashboardDatasource extends DataSourceApi<DashboardQuery> {
         return matcher !== null;
       });
   }
-
   /**
    * Create a value matcher from an AdHoc filter.
    */
@@ -243,14 +211,11 @@ export class DashboardDatasource extends DataSourceApi<DashboardQuery> {
     if (fieldIndex === -1) {
       return null;
     }
-
     const field = frame.fields[fieldIndex];
-
     // Only support string and numeric fields
     if (field.type !== FieldType.string && field.type !== FieldType.number) {
       return null;
     }
-
     // Map operator to matcher ID
     let matcherId: ValueMatcherID;
     switch (filter.operator) {
@@ -263,18 +228,16 @@ export class DashboardDatasource extends DataSourceApi<DashboardQuery> {
       default:
         return null; // Unknown operator
     }
-
     try {
       return getValueMatcher({
         id: matcherId,
         options: { value: filter.value },
       });
     } catch (error) {
-      console.warn('Failed to create value matcher for filter:', filter, error);
+      structLog('warn', 'Failed to create value matcher for filter:', filter, error);
       return null;
     }
   }
-
   /**
    * Reconstruct DataFrame with only matching rows
    * Optimized to avoid repeated array operations
@@ -282,7 +245,6 @@ export class DashboardDatasource extends DataSourceApi<DashboardQuery> {
   private reconstructDataFrame(frame: DataFrame, matchingRows?: Set<number>): DataFrame {
     // Default to empty set if no matching rows provided (reject all rows)
     const rows = matchingRows ?? new Set<number>();
-
     const fields: Field[] = frame.fields.map((field) => {
       // Pre-allocate array and use direct assignment for better performance with large datasets
       const newValues = new Array(rows.size);
@@ -290,28 +252,24 @@ export class DashboardDatasource extends DataSourceApi<DashboardQuery> {
       for (const rowIndex of rows) {
         newValues[i++] = field.values[rowIndex];
       }
-
       return {
         ...field,
         values: newValues,
         state: {}, // Clean the state as it's being recalculated
       };
     });
-
     return {
       ...frame,
       fields: fields,
       length: rows.size,
     };
   }
-
   private emitFirstLoadedDataIfMixedDS(
     requestId: string
   ): (source: Observable<DataQueryResponse>) => Observable<DataQueryResponse> {
     return (source: Observable<DataQueryResponse>) => {
       if (requestId.includes(MIXED_REQUEST_PREFIX)) {
         let count = 0;
-
         return source.pipe(
           /*
            * We can have the following piped values scenarios:
@@ -339,15 +297,12 @@ export class DashboardDatasource extends DataSourceApi<DashboardQuery> {
           first((val) => val.state === LoadingState.Done || val.state === LoadingState.Error)
         );
       }
-
       return source;
     };
   }
-
   testDatasource(): Promise<TestDataSourceResponse> {
     return Promise.resolve({ message: '', status: '' });
   }
-
   /**
    * Check which AdHoc filters are applicable based on operator and field type support
    */
@@ -356,13 +311,10 @@ export class DashboardDatasource extends DataSourceApi<DashboardQuery> {
   ): Promise<DrilldownsApplicability[]> {
     // Check if any query has adhoc filters enabled
     const hasAdHocFiltersEnabled = options?.queries?.some((query) => query.adHocFiltersEnabled);
-
     if (!hasAdHocFiltersEnabled) {
       return [];
     }
-
     const filters = options?.filters || [];
-
     return filters.map((filter): DrilldownsApplicability => {
       // Check operator support
       if (filter.operator !== '=' && filter.operator !== '!=') {
@@ -372,7 +324,6 @@ export class DashboardDatasource extends DataSourceApi<DashboardQuery> {
           reason: `Operator '${filter.operator}' is not supported. Only '=' and '!=' operators are supported.`,
         };
       }
-
       // For dashboard datasource, we can't determine field existence/type
       // without the actual DataFrame context, so we assume applicable here
       // and let the actual filtering logic handle field-specific checks
@@ -382,7 +333,6 @@ export class DashboardDatasource extends DataSourceApi<DashboardQuery> {
       };
     });
   }
-
   getTagKeys(): Promise<MetricFindValue[]> {
     // Stub implementation to indicate AdHoc filter support
     // Full implementation will be added in future PRs

--- a/public/app/plugins/datasource/grafana-testdata-datasource/components/RawFrameEditor.tsx
+++ b/public/app/plugins/datasource/grafana-testdata-datasource/components/RawFrameEditor.tsx
@@ -1,16 +1,13 @@
+import { structLog } from '@grafana/data';
 import { isArray } from 'lodash';
 import { useState } from 'react';
-
 import { dataFrameToJSON, toDataFrame, toDataFrameDTO } from '@grafana/data';
 import { toDataQueryResponse } from '@grafana/runtime';
 import { Alert, CodeEditor } from '@grafana/ui';
-
 import { type EditorProps } from '../QueryEditor';
-
 export const RawFrameEditor = ({ onChange, query }: EditorProps) => {
   const [error, setError] = useState<string>();
   const [warning, setWarning] = useState<string>();
-
   const onSaveFrames = (rawFrameContent: string) => {
     try {
       const json = JSON.parse(rawFrameContent);
@@ -20,9 +17,7 @@ export const RawFrameEditor = ({ onChange, query }: EditorProps) => {
         onChange({ ...query, rawFrameContent });
         return;
       }
-
       let data = undefined;
-
       // Copy paste from panel json
       if (isArray(json.series) && json.state) {
         data = json.series.map((v: unknown) => toDataFrameDTO(toDataFrame(v)));
@@ -33,24 +28,21 @@ export const RawFrameEditor = ({ onChange, query }: EditorProps) => {
           data = v.data.map((f) => dataFrameToJSON(f));
         }
       }
-
       if (data) {
-        console.log('Original', json);
-        console.log('Save', data);
+        structLog('log', 'Original', json);
+        structLog('log', 'Save', data);
         setError(undefined);
         setWarning('Converted to direct frame result');
         onChange({ ...query, rawFrameContent: JSON.stringify(data, null, 2) });
         return;
       }
-
       setError('Unable to read dataframes in text');
     } catch (e) {
-      console.log('Error parsing json', e);
+      structLog('log', 'Error parsing json', e);
       setError('Enter JSON array of data frames (or raw query results body)');
       setWarning(undefined);
     }
   };
-
   return (
     <>
       {error && <Alert title={error} severity="error" />}

--- a/public/app/plugins/datasource/grafana-testdata-datasource/runStreams.ts
+++ b/public/app/plugins/datasource/grafana-testdata-datasource/runStreams.ts
@@ -1,7 +1,7 @@
+import { structLog } from '@grafana/data';
 import { defaults } from 'lodash';
 import { Observable, throwError } from 'rxjs';
 import { v4 as uuidv4 } from 'uuid';
-
 import {
   type DataQueryRequest,
   type DataQueryResponse,
@@ -19,10 +19,8 @@ import {
   createTheme,
 } from '@grafana/data';
 import { getBackendSrv } from '@grafana/runtime';
-
 import { getRandomLine } from './LogIpsum';
 import { type TestDataDataQuery, type StreamingQuery } from './dataquery';
-
 export const defaultStreamQuery: StreamingQuery = {
   type: 'signal',
   speed: 250, // ms
@@ -30,7 +28,6 @@ export const defaultStreamQuery: StreamingQuery = {
   noise: 2.2,
   bands: 1,
 };
-
 export function runStream(
   target: TestDataDataQuery,
   req: DataQueryRequest<TestDataDataQuery>
@@ -50,7 +47,6 @@ export function runStream(
   }
   throw new Error(`Unknown Stream Type: ${query.type}`);
 }
-
 export function runSignalStream(
   target: TestDataDataQuery,
   query: StreamingQuery,
@@ -59,7 +55,6 @@ export function runSignalStream(
   return new Observable<DataQueryResponse>((subscriber) => {
     const streamId = `signal-${req.panelId || 'explore'}-${target.refId}`;
     const maxDataPoints = req.maxDataPoints || 1000;
-
     const schema: DataFrameSchema = {
       refId: target.refId,
       fields: [
@@ -67,49 +62,38 @@ export function runSignalStream(
         { name: target.alias ?? 'value', type: FieldType.number },
       ],
     };
-
     const { spread, speed, bands = 0, noise } = query;
     for (let i = 0; i < bands; i++) {
       const suffix = bands > 1 ? ` ${i + 1}` : '';
       schema.fields.push({ name: 'Min' + suffix, type: FieldType.number });
       schema.fields.push({ name: 'Max' + suffix, type: FieldType.number });
     }
-
     const frame = StreamingDataFrame.fromDataFrameJSON({ schema }, { maxLength: maxDataPoints });
-
     let value = Math.random() * 100;
     let timeoutId: ReturnType<typeof setTimeout>;
     let lastSent = -1;
-
     const addNextRow = (time: number) => {
       value += (Math.random() - 0.5) * spread;
-
       const data: DataFrameData = {
         values: [[time], [value]],
       };
-
       let min = value;
       let max = value;
-
       for (let i = 0; i < bands; i++) {
         min = min - Math.random() * noise;
         max = max + Math.random() * noise;
-
         data.values.push([min]);
         data.values.push([max]);
       }
-
       const event = { data };
       return frame.push(event);
     };
-
     // Fill the buffer on init
     let time = Date.now() - maxDataPoints * speed;
     for (let i = 0; i < maxDataPoints; i++) {
       addNextRow(time);
       time += speed;
     }
-
     const pushNextEvent = () => {
       lastSent = Date.now();
       addNextRow(lastSent);
@@ -120,17 +104,14 @@ export function runSignalStream(
       });
       timeoutId = setTimeout(pushNextEvent, speed);
     };
-
     // Send first event in 5ms
     setTimeout(pushNextEvent, 5);
-
     return () => {
-      console.log('unsubscribing to stream ' + streamId);
+      structLog('log', 'unsubscribing to stream ' + streamId);
       clearTimeout(timeoutId);
     };
   });
 }
-
 export function runLogsStream(
   target: TestDataDataQuery,
   query: StreamingQuery,
@@ -139,7 +120,6 @@ export function runLogsStream(
   return new Observable<DataQueryResponse>((subscriber) => {
     const streamId = `logs-${req.panelId || 'explore'}-${target.refId}`;
     const maxDataPoints = req.maxDataPoints || 1000;
-
     const data = new CircularDataFrame({
       append: 'tail',
       capacity: maxDataPoints,
@@ -149,40 +129,31 @@ export function runLogsStream(
     data.addField({ name: 'line', type: FieldType.string });
     data.addField({ name: 'time', type: FieldType.time });
     data.meta = { preferredVisualisationType: 'logs' };
-
     const { speed } = query;
-
     let timeoutId: ReturnType<typeof setTimeout>;
-
     const pushNextEvent = () => {
       data.fields[0].values.push(getRandomLine());
       data.fields[1].values.push(Date.now());
-
       subscriber.next({
         data: [data],
         key: streamId,
         state: LoadingState.Streaming,
       });
-
       timeoutId = setTimeout(pushNextEvent, speed);
     };
-
     // Send first event in 5ms
     setTimeout(pushNextEvent, 5);
-
     return () => {
-      console.log('unsubscribing to stream ' + streamId);
+      structLog('log', 'unsubscribing to stream ' + streamId);
       clearTimeout(timeoutId);
     };
   });
 }
-
 interface StreamMessage {
   message: number; // incrementing number
   time: number;
   value: number;
 }
-
 export function runWatchStream(
   target: TestDataDataQuery,
   query: StreamingQuery,
@@ -192,7 +163,6 @@ export function runWatchStream(
   if (!uid) {
     return throwError(() => new Error('expected datasource uid'));
   }
-
   return new Observable<DataQueryResponse>((subscriber) => {
     const streamId = `watch-${req.panelId || 'explore'}-${target.refId}`;
     const data = new CircularDataFrame({
@@ -205,7 +175,6 @@ export function runWatchStream(
     data.addField({ name: 'message', type: FieldType.number });
     data.addField({ name: 'value', type: FieldType.number });
     const decoder = new TextDecoder();
-
     const sub = getBackendSrv()
       .chunked({
         url: `api/datasources/uid/${uid}/resources/stream`,
@@ -219,7 +188,7 @@ export function runWatchStream(
       .subscribe({
         next: (chunk) => {
           if (!chunk.data || !chunk.ok) {
-            console.info('chunk missing data', chunk);
+            structLog('info', 'chunk missing data', chunk);
             return;
           }
           decoder
@@ -229,37 +198,33 @@ export function runWatchStream(
               if (line?.length) {
                 try {
                   const msg: StreamMessage = JSON.parse(line);
-
                   data.fields[0].values.push(msg.time);
                   data.fields[1].values.push(msg.message);
                   data.fields[2].values.push(msg.value);
-
                   subscriber.next({
                     data: [data],
                     key: streamId,
                     state: LoadingState.Streaming,
                   });
                 } catch (err) {
-                  console.warn('error parsing line', line, err);
+                  structLog('warn', 'error parsing line', line, err);
                 }
               }
             });
         },
         error: (err) => {
-          console.warn('error in stream', streamId, err);
+          structLog('warn', 'error in stream', streamId, err);
         },
         complete: () => {
-          console.info('complete stream', streamId);
+          structLog('info', 'complete stream', streamId);
         },
       });
-
     return () => {
-      console.log('unsubscribing to stream', streamId);
+      structLog('log', 'unsubscribing to stream', streamId);
       sub.unsubscribe();
     };
   });
 }
-
 export function runFetchStream(
   target: TestDataDataQuery,
   query: StreamingQuery,
@@ -268,14 +233,12 @@ export function runFetchStream(
   return new Observable<DataQueryResponse>((subscriber) => {
     const streamId = `fetch-${req.panelId || 'explore'}-${target.refId}`;
     const maxDataPoints = req.maxDataPoints || 1000;
-
     let data = new CircularDataFrame({
       append: 'tail',
       capacity: maxDataPoints,
     });
     data.refId = target.refId;
     data.name = target.alias || 'Fetch ' + target.refId;
-
     let reader: ReadableStreamDefaultReader<Uint8Array>;
     const csv = new CSVReader({
       callback: {
@@ -298,7 +261,6 @@ export function runFetchStream(
         },
       },
     });
-
     const processChunk = async (
       value: ReadableStreamReadResult<Uint8Array>
     ): Promise<ReadableStreamReadResult<Uint8Array> | undefined> => {
@@ -306,40 +268,33 @@ export function runFetchStream(
         const text = new TextDecoder().decode(value.value);
         csv.readCSV(text);
       }
-
       subscriber.next({
         data: [data],
         key: streamId,
         state: value.done ? LoadingState.Done : LoadingState.Streaming,
       });
-
       if (value.done) {
-        console.log('Finished stream');
+        structLog('log', 'Finished stream');
         subscriber.complete(); // necessary?
         return;
       }
-
       return reader.read().then(processChunk);
     };
-
     if (!query.url) {
       throw new Error('query.url is not defined');
     }
-
     fetch(new Request(query.url)).then((response) => {
       if (response.body) {
         reader = response.body.getReader();
         reader.read().then(processChunk);
       }
     });
-
     return () => {
       // Cancel fetch?
-      console.log('unsubscribing to stream ' + streamId);
+      structLog('log', 'unsubscribing to stream ' + streamId);
     };
   });
 }
-
 export function runTracesStream(
   target: TestDataDataQuery,
   query: StreamingQuery,
@@ -349,31 +304,25 @@ export function runTracesStream(
     const streamId = `traces-${req.panelId || 'explore'}-${target.refId}`;
     const data = createMainTraceFrame(target, req.maxDataPoints);
     let timeoutId: ReturnType<typeof setTimeout>;
-
     const pushNextEvent = () => {
       const subframe = createTraceSubFrame();
       addRow(subframe, [uuidv4(), Date.now(), 'Grafana', 1500]);
       addRow(data, [uuidv4(), Date.now(), 'Grafana', 'HTTP GET /explore', 1500, [subframe]]);
-
       subscriber.next({
         data: [data],
         key: streamId,
         state: LoadingState.Streaming,
       });
-
       timeoutId = setTimeout(pushNextEvent, query.speed);
     };
-
     // Send first event in 5ms
     setTimeout(pushNextEvent, 5);
-
     return () => {
-      console.log('unsubscribing to stream ' + streamId);
+      structLog('log', 'unsubscribing to stream ' + streamId);
       clearTimeout(timeoutId);
     };
   });
 }
-
 function createMainTraceFrame(target: TestDataDataQuery, maxDataPoints = 1000) {
   const data = new CircularDataFrame({
     append: 'head',
@@ -393,7 +342,6 @@ function createMainTraceFrame(target: TestDataDataQuery, maxDataPoints = 1000) {
   };
   return data;
 }
-
 function createTraceSubFrame() {
   const frame = createDataFrame({
     fields: [
@@ -403,7 +351,6 @@ function createTraceSubFrame() {
       { name: 'duration', type: FieldType.number },
     ],
   });
-
   // TODO: this should be removed later but right now there is an issue that applyFieldOverrides does not consider
   //  nested frames.
   for (const f of frame.fields) {
@@ -411,5 +358,4 @@ function createTraceSubFrame() {
   }
   return frame;
 }
-
 const theme = createTheme();

--- a/public/app/plugins/datasource/grafana/components/QueryEditor.tsx
+++ b/public/app/plugins/datasource/grafana/components/QueryEditor.tsx
@@ -1,6 +1,6 @@
+import { structLog } from '@grafana/data';
 import pluralize from 'pluralize';
 import * as React from 'react';
-
 import {
   type QueryEditorProps,
   type SelectableValue,
@@ -22,25 +22,18 @@ import {
 } from '@grafana/ui';
 import { getManagedChannelInfo } from 'app/features/live/info';
 import { type SearchQuery } from 'app/features/search/service/types';
-
 import { type GrafanaDatasource } from '../datasource';
 import { defaultQuery, type GrafanaQuery, GrafanaQueryType } from '../types';
-
 import { RandomWalkEditor } from './RandomWalkEditor';
-
 interface Props extends QueryEditorProps<GrafanaDatasource, GrafanaQuery>, Themeable2 {}
-
 const labelWidth = 12;
-
 interface State {
   channels: Array<SelectableValue<string>>;
   channelFields: Record<string, Array<SelectableValue<string>>>;
   folders?: Array<SelectableValue<string>>;
 }
-
 export class UnthemedQueryEditor extends React.PureComponent<Props, State> {
   state: State = { channels: [], channelFields: {} };
-
   queryTypes: Array<SelectableValue<GrafanaQueryType>> = [
     {
       label: 'Random Walk',
@@ -58,22 +51,18 @@ export class UnthemedQueryEditor extends React.PureComponent<Props, State> {
       description: 'Show directory listings for public resources',
     },
   ];
-
   constructor(props: Props) {
     super(props);
   }
-
   loadChannelInfo() {
     getManagedChannelInfo().then((v) => {
       this.setState(v);
     });
   }
-
   loadFolderInfo() {
     const query: DataQueryRequest<GrafanaQuery> = {
       targets: [{ queryType: GrafanaQueryType.List, refId: 'A' }],
     } as DataQueryRequest<GrafanaQuery>;
-
     getDataSourceSrv()
       .get('-- Grafana --')
       .then((ds) => {
@@ -92,26 +81,21 @@ export class UnthemedQueryEditor extends React.PureComponent<Props, State> {
         });
       });
   }
-
   componentDidMount() {
     this.loadChannelInfo();
   }
-
   onQueryTypeChange = (sel: SelectableValue<GrafanaQueryType>) => {
     const { onChange, query, onRunQuery } = this.props;
     onChange({ ...query, queryType: sel.value! });
     onRunQuery();
-
     // Reload the channel list
     this.loadChannelInfo();
   };
-
   onChannelChange = (sel: SelectableValue<string>) => {
     const { onChange, query, onRunQuery } = this.props;
     onChange({ ...query, channel: sel?.value });
     onRunQuery();
   };
-
   onFieldNamesChange = (item: SelectableValue<string>) => {
     const { onChange, query, onRunQuery } = this.props;
     let fields: string[] = [];
@@ -120,7 +104,6 @@ export class UnthemedQueryEditor extends React.PureComponent<Props, State> {
     } else if (item.value) {
       fields = [item.value];
     }
-
     // When adding the first field, also add time (if it exists)
     if (fields.length === 1 && !query.filter?.fields?.length && query.channel) {
       const names = this.state.channelFields[query.channel] ?? [];
@@ -129,7 +112,6 @@ export class UnthemedQueryEditor extends React.PureComponent<Props, State> {
         fields = [tf.value, ...fields];
       }
     }
-
     onChange({
       ...query,
       filter: {
@@ -139,7 +121,6 @@ export class UnthemedQueryEditor extends React.PureComponent<Props, State> {
     });
     onRunQuery();
   };
-
   checkAndUpdateValue = (key: keyof GrafanaQuery, txt: string) => {
     const { onChange, query, onRunQuery } = this.props;
     if (key === 'buffer') {
@@ -148,7 +129,7 @@ export class UnthemedQueryEditor extends React.PureComponent<Props, State> {
         try {
           buffer = rangeUtil.intervalToSeconds(txt) * 1000;
         } catch (err) {
-          console.warn('ERROR', err);
+          structLog('warn', 'ERROR', err);
         }
       }
       onChange({
@@ -163,18 +144,15 @@ export class UnthemedQueryEditor extends React.PureComponent<Props, State> {
     }
     onRunQuery();
   };
-
   handleEnterKey = (e: React.KeyboardEvent<HTMLInputElement>) => {
     if (e.key !== 'Enter') {
       return;
     }
     this.checkAndUpdateValue('buffer', e.currentTarget.value);
   };
-
   handleBlur = (e: React.FocusEvent<HTMLInputElement>) => {
     this.checkAndUpdateValue('buffer', e.currentTarget.value);
   };
-
   renderMeasurementsQuery() {
     let { channel, filter, buffer } = this.props.query;
     let { channels, channelFields } = this.state;
@@ -187,7 +165,6 @@ export class UnthemedQueryEditor extends React.PureComponent<Props, State> {
       };
       channels = [currentChannel, ...channels];
     }
-
     const distinctFields = new Set<string>();
     const fields: Array<SelectableValue<string>> = channel ? (channelFields[channel] ?? []) : [];
     // if (data && data.series?.length) {
@@ -217,12 +194,10 @@ export class UnthemedQueryEditor extends React.PureComponent<Props, State> {
         }
       }
     }
-
     let formattedTime = '';
     if (buffer) {
       formattedTime = rangeUtil.secondsToHms(buffer / 1000);
     }
-
     return (
       <>
         <InlineField label="Channel" grow={true} labelWidth={labelWidth}>
@@ -276,13 +251,11 @@ export class UnthemedQueryEditor extends React.PureComponent<Props, State> {
       </>
     );
   }
-
   onFolderChanged = (sel: SelectableValue<string>) => {
     const { onChange, query, onRunQuery } = this.props;
     onChange({ ...query, path: sel?.value });
     onRunQuery();
   };
-
   renderListPublicFiles() {
     let { path } = this.props.query;
     let { folders } = this.state;
@@ -300,7 +273,6 @@ export class UnthemedQueryEditor extends React.PureComponent<Props, State> {
         },
       ];
     }
-
     return (
       <InlineFieldRow>
         <InlineField label="Path" grow={true} labelWidth={labelWidth}>
@@ -318,10 +290,8 @@ export class UnthemedQueryEditor extends React.PureComponent<Props, State> {
       </InlineFieldRow>
     );
   }
-
   renderSnapshotQuery() {
     const { query } = this.props;
-
     return (
       <>
         <InlineFieldRow>
@@ -332,40 +302,32 @@ export class UnthemedQueryEditor extends React.PureComponent<Props, State> {
       </>
     );
   }
-
   onSearchChange = (search: SearchQuery) => {
     const { query, onChange, onRunQuery } = this.props;
-
     onChange({
       ...query,
       search,
     });
     onRunQuery();
   };
-
   onSearchNextChange = (search: SearchQuery) => {
     const { query, onChange, onRunQuery } = this.props;
-
     onChange({
       ...query,
       searchNext: search,
     });
     onRunQuery();
   };
-
   renderRandomWalkQuery() {
     const { query, onChange, onRunQuery } = this.props;
     return <RandomWalkEditor query={query} onChange={onChange} onRunQuery={onRunQuery} />;
   }
-
   render() {
     const query = {
       ...defaultQuery,
       ...this.props.query,
     };
-
     const { queryType } = query;
-
     // Only show "snapshot" when it already exists
     let queryTypes = this.queryTypes;
     if (queryType === GrafanaQueryType.Snapshot) {
@@ -377,7 +339,6 @@ export class UnthemedQueryEditor extends React.PureComponent<Props, State> {
         },
       ];
     }
-
     return (
       <>
         <InlineFieldRow>
@@ -399,5 +360,4 @@ export class UnthemedQueryEditor extends React.PureComponent<Props, State> {
     );
   }
 }
-
 export const QueryEditor = withTheme2(UnthemedQueryEditor);

--- a/public/app/plugins/datasource/graphite/datasource.ts
+++ b/public/app/plugins/datasource/graphite/datasource.ts
@@ -1,9 +1,9 @@
+import { structLog } from '@grafana/data';
 import { map as _map, each, indexOf, isArray, isString } from 'lodash';
 import moment from 'moment';
 import { lastValueFrom, merge, Observable, of, type OperatorFunction, pipe, throwError } from 'rxjs';
 import { catchError, map } from 'rxjs/operators';
 import { coerce, gte, SemVer, valid } from 'semver';
-
 import {
   type AbstractLabelMatcher,
   AbstractLabelOperator,
@@ -32,7 +32,6 @@ import {
   type TemplateSrv,
 } from '@grafana/runtime';
 import { type TimeZone } from '@grafana/schema';
-
 import { AnnotationEditor } from './components/AnnotationsEditor';
 import { convertToGraphiteQueryObject } from './components/helpers';
 import gfunc, { type FuncDef, type FuncDefs, type FuncInstance } from './gfunc';
@@ -54,14 +53,12 @@ import {
 } from './types';
 import { reduceError } from './utils';
 import { DEFAULT_GRAPHITE_VERSION } from './versions';
-
 const GRAPHITE_TAG_COMPARATORS = {
   '=': AbstractLabelOperator.Equal,
   '!=': AbstractLabelOperator.NotEqual,
   '=~': AbstractLabelOperator.EqualRegEx,
   '!=~': AbstractLabelOperator.NotEqualRegEx,
 };
-
 /**
  * Converts Graphite glob-like pattern to a regular expression
  */
@@ -72,7 +69,6 @@ function convertGlobToRegEx(text: string): string {
     return text;
   }
 }
-
 export class GraphiteDatasource
   extends DataSourceWithBackend<GraphiteQuery, GraphiteOptions>
   implements DataSourceWithQueryExportSupport<GraphiteQuery>
@@ -91,7 +87,6 @@ export class GraphiteDatasource
   _seriesRefLetters: string;
   requestCounter = 100;
   private readonly metricMappings: GraphiteLokiMapping[];
-
   constructor(
     instanceSettings: any,
     private readonly templateSrv: TemplateSrv = getTemplateSrv()
@@ -117,7 +112,6 @@ export class GraphiteDatasource
       prepareAnnotation,
     };
   }
-
   getQueryOptionsInfo() {
     return {
       maxDataPoints: true,
@@ -130,7 +124,6 @@ export class GraphiteDatasource
       ],
     };
   }
-
   getImportQueryConfiguration(): GraphiteQueryImportConfiguration {
     return {
       loki: {
@@ -138,11 +131,9 @@ export class GraphiteDatasource
       },
     };
   }
-
   async exportToAbstractQueries(queries: GraphiteQuery[]): Promise<AbstractQuery[]> {
     return queries.map((query) => this.exportToAbstractQuery(query));
   }
-
   exportToAbstractQuery(query: GraphiteQuery): AbstractQuery {
     const graphiteQuery: GraphiteQueryModel = new GraphiteQueryModel(
       this,
@@ -154,10 +145,8 @@ export class GraphiteDatasource
       this.templateSrv
     );
     graphiteQuery.parseTarget();
-
     let labels: AbstractLabelMatcher[] = [];
     const config = this.getImportQueryConfiguration().loki;
-
     if (graphiteQuery.seriesByTagUsed) {
       graphiteQuery.tags.forEach((tag) => {
         labels.push({
@@ -169,18 +158,14 @@ export class GraphiteDatasource
     } else {
       const targetNodes = graphiteQuery.segments.map((segment) => segment.value);
       let mappings = config.mappings.filter((mapping) => mapping.matchers.length <= targetNodes.length);
-
       for (let mapping of mappings) {
         const matchers = mapping.matchers.concat();
-
         matchers.every((matcher: GraphiteMetricLokiMatcher, index: number) => {
           if (matcher.labelName) {
             let value = (targetNodes[index] as string)!;
-
             if (value === '*') {
               return true;
             }
-
             const converted = convertGlobToRegEx(value);
             labels.push({
               name: matcher.labelName,
@@ -193,21 +178,17 @@ export class GraphiteDatasource
         });
       }
     }
-
     return {
       refId: query.refId,
       labelMatchers: labels,
     };
   }
-
   filterQuery(item: GraphiteQuery): boolean {
     if (!item.target && !item.fromAnnotations) {
       return false;
     }
-
     return true;
   }
-
   // Note that we do not omit queries with the hide flag set to true to avoid breaking nested series replacement
   // e.g. sumSeries(#A) where A is hidden
   applyTemplateVariables(target: GraphiteQuery, scopedVars: ScopedVars) {
@@ -217,11 +198,14 @@ export class GraphiteDatasource
       targetFull: this.templateSrv.replace(target.targetFull ?? '', scopedVars),
     };
   }
-
   frontendQuery(
     options: DataQueryRequest<GraphiteQuery>,
-    originalTargetMap: { [key: string]: string },
-    formattedRefIdsMap: { [key: string]: string }
+    originalTargetMap: {
+      [key: string]: string;
+    },
+    formattedRefIdsMap: {
+      [key: string]: string;
+    }
   ): Observable<DataQueryResponse> {
     // handle the queries here
     const graphOptions = {
@@ -232,16 +216,13 @@ export class GraphiteDatasource
       cacheTimeout: options.cacheTimeout || this.cacheTimeout,
       maxDataPoints: options.maxDataPoints,
     };
-
     const params = this.buildGraphiteParams(graphOptions, originalTargetMap, options.scopedVars);
     if (params.length === 0) {
       return of({ data: [] });
     }
-
     if (this.isMetricTank) {
       params.push('meta=true');
     }
-
     const httpOptions: BackendSrvRequest = {
       method: 'POST',
       url: '/render',
@@ -250,58 +231,48 @@ export class GraphiteDatasource
         'Content-Type': 'application/x-www-form-urlencoded',
       },
     };
-
     this.addTracingHeaders(httpOptions, options);
-
     if (options.panelId) {
       httpOptions.requestId = this.name + '.panelId.' + options.panelId;
     }
-
     return this.doGraphiteRequest(httpOptions).pipe(
       map((result) => this.convertResponseToDataFrames(result, formattedRefIdsMap))
     );
   }
-
   backendBuildGraphiteQueries(
     options: DataQueryRequest<GraphiteQuery>,
-    originalTargetMap: { [key: string]: string }
+    originalTargetMap: {
+      [key: string]: string;
+    }
   ): GraphiteQuery[] {
     const referenceTargets: Record<string, string> = {};
     const finalTargets: GraphiteQuery[] = [];
     let target: GraphiteQuery, targetValue, i, targetFullValue;
-
     for (i = 0; i < options.targets.length; i++) {
       target = options.targets[i];
       if (!target.target) {
         continue;
       }
-
       if (!target.refId) {
         target.refId = this._seriesRefLetters[i];
       }
-
       referenceTargets[target.refId] = target.target;
     }
-
     const seriesReferenceRegex = /\#([A-Z])/g;
-
     function nestedSeriesRegexReplacer(match: string, g1: string) {
       // Handle the case where a query references itself to prevent infinite recursion
       if (target.refId === g1) {
         return referenceTargets[g1] || match;
       }
-
       // Recursively replace all nested series references
       return originalTargetMap[g1].replace(seriesReferenceRegex, nestedSeriesRegexReplacer) || match;
     }
-
     for (i = 0; i < options.targets.length; i++) {
       const targetClone = { ...options.targets[i] };
       target = options.targets[i];
       if (!targetClone.target) {
         continue;
       }
-
       targetValue = this.templateSrv.replace(
         referenceTargets[target.refId].replace(seriesReferenceRegex, nestedSeriesRegexReplacer),
         options.scopedVars
@@ -310,25 +281,20 @@ export class GraphiteDatasource
         referenceTargets[target.refId].replace(seriesReferenceRegex, nestedSeriesRegexReplacer),
         options.scopedVars
       );
-
       targetClone.target = targetValue;
       targetClone.targetFull = targetFullValue;
       if (this.isMetricTank) {
         targetClone.isMetricTank = true;
       }
-
       if (!targetClone.hide) {
         finalTargets.push(targetClone);
       }
     }
-
     return finalTargets;
   }
-
   query(options: DataQueryRequest<GraphiteQuery>): Observable<DataQueryResponse> {
     if (options.targets.some((target: GraphiteQuery) => target.fromAnnotations)) {
       const streams: Array<Observable<DataQueryResponse>> = [];
-
       for (const target of options.targets) {
         streams.push(
           new Observable((subscriber) => {
@@ -339,14 +305,16 @@ export class GraphiteDatasource
           })
         );
       }
-
       return merge(...streams);
     }
-
     // Use this object to map the sanitised refID to the original
-    const formattedRefIdsMap: { [key: string]: string } = {};
+    const formattedRefIdsMap: {
+      [key: string]: string;
+    } = {};
     // Use this object to map the original refID to the original target
-    const originalTargetMap: { [key: string]: string } = {};
+    const originalTargetMap: {
+      [key: string]: string;
+    } = {};
     for (const target of options.targets) {
       // Sanitise the refID otherwise the Graphite query will fail
       const formattedRefId = target.refId.replaceAll(' ', '_');
@@ -356,7 +324,6 @@ export class GraphiteDatasource
       // Suppose a query has three targets: A: metric1 B: sumSeries(#A) and C: asPercent(#A, #B)
       // We want the targets to be interpolated to: A: aliasSub(metric1, "(^.*$)", "\\1 A"), B: aliasSub(sumSeries(metric1), "(^.*$)", "\\1 B") and C: asPercent(metric1, sumSeries(metric1))
       originalTargetMap[target.refId] = target.target || '';
-
       // We only need to alias queries in frontend mode
       if (!config.featureToggles.graphiteBackendMode) {
         // Use aliasSub to include the refID in the response series name. This allows us to set the refID on the frame.
@@ -364,18 +331,13 @@ export class GraphiteDatasource
         target.target = updatedTarget;
       }
     }
-
     if (config.featureToggles.graphiteBackendMode) {
       const graphiteQueries = this.backendBuildGraphiteQueries(options, originalTargetMap);
-
       options.targets = graphiteQueries;
-
       return super.query(options);
     }
-
     return this.frontendQuery(options, originalTargetMap, formattedRefIdsMap);
   }
-
   addTracingHeaders(httpOptions: BackendSrvRequest, options: Partial<DataQueryRequest<GraphiteQuery>>) {
     const proxyMode = !this.url?.match(/^http/);
     if (!httpOptions.headers) {
@@ -393,13 +355,16 @@ export class GraphiteDatasource
       }
     }
   }
-
-  convertResponseToDataFrames = (result: FetchResponse, refIdMap: { [key: string]: string }): DataQueryResponse => {
+  convertResponseToDataFrames = (
+    result: FetchResponse,
+    refIdMap: {
+      [key: string]: string;
+    }
+  ): DataQueryResponse => {
     const data: DataFrame[] = [];
     if (!result || !result.data) {
       return { data };
     }
-
     // Series are either at the root or under a node called 'series'
     const series: Array<{
       target: string;
@@ -408,14 +373,11 @@ export class GraphiteDatasource
       datapoints: Array<[number, number]>;
       meta: MetricTankSeriesMeta[];
     }> = result.data.series || result.data;
-
     if (!isArray(series)) {
       throw { message: 'Missing series in result', data: result };
     }
-
     for (let i = 0; i < series.length; i++) {
       const s = series[i];
-
       let refId = '';
       // Retrieve the original refID of the query
       const splitTarget = s.target.split(' ');
@@ -426,15 +388,12 @@ export class GraphiteDatasource
       }
       // Disables Grafana own series naming
       s.title = s.target;
-
       for (let y = 0; y < s.datapoints.length; y++) {
         s.datapoints[y][1] *= 1000;
       }
-
       const frame = toDataFrame(s);
       // Set the refID value on the frame
       frame.refId = refIdMap[refId];
-
       // Metrictank metadata
       if (s.meta) {
         frame.meta = {
@@ -443,46 +402,35 @@ export class GraphiteDatasource
             seriesMetaList: s.meta, // Array of metadata
           },
         };
-
         if (this.rollupIndicatorEnabled) {
           const rollupNotice = getRollupNotice(s.meta);
           const runtimeNotice = getRuntimeConsolidationNotice(s.meta);
-
           if (rollupNotice) {
             frame.meta.notices = [rollupNotice];
           } else if (runtimeNotice) {
             frame.meta.notices = [runtimeNotice];
           }
         }
-
         // only add the request stats to the first frame
         if (i === 0 && result.data.meta.stats) {
           frame.meta.stats = this.getRequestStats(result.data.meta);
         }
       }
-
       data.push(frame);
     }
-
     return { data };
   };
-
   getRequestStats(meta: MetricTankRequestMeta): QueryResultMetaStat[] {
     const stats: QueryResultMetaStat[] = [];
-
     for (const key in meta.stats) {
       let unit: string | undefined = undefined;
-
       if (key.endsWith('.ms')) {
         unit = 'ms';
       }
-
       stats.push({ displayName: key, value: meta.stats[key], unit });
     }
-
     return stats;
   }
-
   parseTags(tagString: string) {
     let tags: string[] = [];
     tags = tagString.split(',');
@@ -494,7 +442,6 @@ export class GraphiteDatasource
     }
     return tags;
   }
-
   interpolateVariablesInQueries(queries: GraphiteQuery[], scopedVars: ScopedVars): GraphiteQuery[] {
     let expandedQueries = queries;
     if (queries && queries.length > 0) {
@@ -509,7 +456,6 @@ export class GraphiteDatasource
     }
     return expandedQueries;
   }
-
   annotationEvents(range: TimeRange, target: GraphiteQuery) {
     if (target.target) {
       // Graphite query as target as annotation
@@ -520,23 +466,18 @@ export class GraphiteDatasource
         format: 'json',
         maxDataPoints: 100,
       } as unknown as DataQueryRequest<GraphiteQuery>;
-
       return lastValueFrom(
         this.query(graphiteQuery).pipe(
           map((result) => {
             const list = [];
-
             for (let i = 0; i < result.data.length; i++) {
               const target = result.data[i];
-
               for (let y = 0; y < target.length; y++) {
                 const time = target.fields[0].values[y];
                 const value = target.fields[1].values[y];
-
                 if (!value) {
                   continue;
                 }
-
                 list.push({
                   annotation: target,
                   time,
@@ -544,7 +485,6 @@ export class GraphiteDatasource
                 });
               }
             }
-
             return list;
           })
         )
@@ -555,17 +495,15 @@ export class GraphiteDatasource
       return this.events({ range: range, tags: tags }).then((results) => {
         const list = [];
         if (!isArray(results.data)) {
-          console.error(`Unable to get annotations.`);
+          structLog('error', `Unable to get annotations.`);
           return [];
         }
         for (let i = 0; i < results.data.length; i++) {
           const e = results.data[i];
-
           let tags = e.tags;
           if (isString(e.tags)) {
             tags = this.parseTags(e.tags);
           }
-
           list.push({
             annotation: target,
             time: e.when * 1000,
@@ -574,23 +512,24 @@ export class GraphiteDatasource
             text: e.data,
           });
         }
-
         return list;
       });
     }
   }
-
-  async events(options: {
-    range: TimeRange;
-    tags: string;
-    timezone?: TimeZone;
-  }): Promise<{ data: GraphiteEvents[] } | FetchResponse<GraphiteEvents>> {
+  async events(options: { range: TimeRange; tags: string; timezone?: TimeZone }): Promise<
+    | {
+        data: GraphiteEvents[];
+      }
+    | FetchResponse<GraphiteEvents>
+  > {
     try {
       const tags = options.tags || '';
       const from = this.translateTime(options.range.raw.from, false, options.timezone);
       const until = this.translateTime(options.range.raw.to, true, options.timezone);
       if (config.featureToggles.graphiteBackendMode) {
-        return await this.postResource<{ data: GraphiteEvents[] }>('events', {
+        return await this.postResource<{
+          data: GraphiteEvents[];
+        }>('events', {
           from: typeof from === 'string' ? from : `${from}`,
           until: typeof until === 'string' ? until : `${until}`,
           tags,
@@ -608,11 +547,9 @@ export class GraphiteDatasource
       return Promise.reject(err);
     }
   }
-
   targetContainsTemplate(target: GraphiteQuery) {
     return this.templateSrv.containsTemplate(target.target ?? '');
   }
-
   translateTime(date: DateTime | string, roundUp?: boolean, timezone?: TimeZone) {
     const parseDate = () => {
       if (isString(date)) {
@@ -622,25 +559,20 @@ export class GraphiteDatasource
           return date.substring(3).replace('m', 'min').replace('M', 'mon');
         }
         const parsedDate = dateMath.toDateTime(date, { roundUp, timezone });
-
         // If the date is invalid return the original string
         // e.g. if an empty string is passed in or if the roundng is invalid e.g. now/2y
         if (!parsedDate || parsedDate.isValid() === false) {
           return date;
         }
-
         return moment(parsedDate.toDate());
       } else {
         return moment(date.toDate());
       }
     };
-
     const parsedDate = parseDate();
-
     if (typeof parsedDate === 'string') {
       return parsedDate;
     }
-
     // graphite' s from filter is exclusive
     // here we step back one minute in order
     // to guarantee that we get all the data that
@@ -654,26 +586,20 @@ export class GraphiteDatasource
         parsedDate.subtract(1, 's');
       }
     }
-
     return parsedDate.unix();
   }
-
   metricFindQuery(findQuery: string | GraphiteQuery, optionalOptions?: any): Promise<MetricFindValue[]> {
     const options = optionalOptions || {};
-
     const queryObject = convertToGraphiteQueryObject(findQuery);
     if (queryObject.queryType === GraphiteQueryType.Value || queryObject.queryType === GraphiteQueryType.MetricName) {
       return this.requestMetricRender(queryObject, options, queryObject.queryType);
     }
-
     let query = queryObject.target ?? '';
-
     // First attempt to check for tag-related functions (using empty wildcard for interpolation)
     let interpolatedQuery = this.templateSrv.replace(
       query,
       getSearchFilterScopedVar({ query, wildcardChar: '', options: optionalOptions })
     );
-
     // special handling for tag_values(<tag>[,<expression>]*), this is used for template variables
     let allParams = interpolatedQuery.match(/^tag_values\((.*)\)$/);
     let expressions = allParams ? allParams[1].split(/,(?![^{]*\})/).filter((p) => !!p) : undefined;
@@ -681,7 +607,6 @@ export class GraphiteDatasource
       options.limit = 10000;
       return this.getTagValuesAutoComplete(expressions.slice(1), expressions[0], undefined, options);
     }
-
     // special handling for tags(<expression>[,<expression>]*), this is used for template variables
     allParams = interpolatedQuery.match(/^tags\((.*)\)$/);
     expressions = allParams ? allParams[1].split(',').filter((p) => !!p) : undefined;
@@ -689,16 +614,13 @@ export class GraphiteDatasource
       options.limit = 10000;
       return this.getTagsAutoComplete(expressions, undefined, options);
     }
-
     // If no tag-related query was found, perform metric-based search (using * as the wildcard for interpolation)
     let useExpand = query.match(/^expand\((.*)\)$/);
     query = useExpand ? useExpand[1] : query;
-
     interpolatedQuery = this.templateSrv.replace(
       query,
       getSearchFilterScopedVar({ query, wildcardChar: '*', options: optionalOptions })
     );
-
     let range;
     if (options.range) {
       range = {
@@ -706,14 +628,12 @@ export class GraphiteDatasource
         until: this.translateTime(options.range.to, true, options.timezone),
       };
     }
-
     if (useExpand) {
       return this.requestMetricExpand(interpolatedQuery, options.requestId, range);
     } else {
       return this.requestMetricFind(interpolatedQuery, options.requestId, range);
     }
   }
-
   /**
    * Search for metrics matching giving pattern using /metrics/render endpoint.
    * It will return all possible values or names and parse them based on queryType.
@@ -753,9 +673,7 @@ export class GraphiteDatasource
       range,
     };
     const data: DataQueryResponse = await lastValueFrom(this.query(queryReq));
-
     let result: MetricFindValue[];
-
     if (queryType === GraphiteQueryType.Value) {
       if (!data.data || data.data.length === 0) {
         return Promise.resolve([]);
@@ -784,10 +702,8 @@ export class GraphiteDatasource
     } else {
       result = [];
     }
-
     return Promise.resolve(result);
   }
-
   /**
    * Search for metrics matching giving pattern using /metrics/find endpoint. It will
    * return all possible values at the last level of the query, for example:
@@ -801,15 +717,16 @@ export class GraphiteDatasource
   private async requestMetricFind(
     query: string,
     requestId: string,
-    range?: { from: string | number; until: string | number }
+    range?: {
+      from: string | number;
+      until: string | number;
+    }
   ): Promise<MetricFindValue[]> {
     const params: BackendSrvRequest['params'] = {};
-
     if (range) {
       params.from = range.from;
       params.until = range.until;
     }
-
     if (config.featureToggles.graphiteBackendMode) {
       return await this.postResource<MetricFindValue[]>('metrics/find', {
         from: params.from ? (typeof params.from === 'string' ? params.from : `${params.from}`) : undefined,
@@ -817,7 +734,6 @@ export class GraphiteDatasource
         query,
       });
     }
-
     const httpOptions: BackendSrvRequest = {
       method: 'POST',
       url: '/metrics/find',
@@ -829,7 +745,6 @@ export class GraphiteDatasource
       // for cancellations
       requestId: requestId,
     };
-
     return lastValueFrom(
       this.doGraphiteRequest(httpOptions).pipe(
         map((results: FetchResponse) => {
@@ -843,7 +758,6 @@ export class GraphiteDatasource
       )
     );
   }
-
   /**
    * Search for metrics matching giving pattern using /metrics/expand endpoint.
    * The result will contain all metrics (with full name) matching provided query.
@@ -852,14 +766,16 @@ export class GraphiteDatasource
   private async requestMetricExpand(
     query: string,
     requestId: string,
-    range?: { from: string | number; until: string | number }
+    range?: {
+      from: string | number;
+      until: string | number;
+    }
   ): Promise<MetricFindValue[]> {
     const params: BackendSrvRequest['params'] = { query };
     if (range) {
       params.from = range.from;
       params.until = range.until;
     }
-
     if (config.featureToggles.graphiteBackendMode) {
       const metrics = await this.postResource<MetricFindValue[]>('metrics/expand', {
         from: params.from ? (typeof params.from === 'string' ? params.from : `${params.from}`) : undefined,
@@ -871,7 +787,6 @@ export class GraphiteDatasource
         expandable: false,
       }));
     }
-
     const httpOptions: BackendSrvRequest = {
       method: 'GET',
       url: '/metrics/expand',
@@ -882,7 +797,6 @@ export class GraphiteDatasource
       // for cancellations
       requestId,
     };
-
     return lastValueFrom(
       this.doGraphiteRequest(httpOptions).pipe(
         map((results: FetchResponse) => {
@@ -896,13 +810,11 @@ export class GraphiteDatasource
       )
     );
   }
-
   async getTagsAutoComplete(expressions: string[], tagPrefix?: string, optionalOptions?: any) {
     const options = optionalOptions || {};
     const params: BackendSrvRequest['params'] = {
       expr: _map(expressions, (expression) => this.templateSrv.replace((expression || '').trim())),
     };
-
     if (tagPrefix) {
       params.tagPrefix = tagPrefix;
     }
@@ -913,7 +825,6 @@ export class GraphiteDatasource
       params.from = this.translateTime(options.range.from, false, options.timezone);
       params.until = this.translateTime(options.range.to, true, options.timezone);
     }
-
     if (config.featureToggles.graphiteBackendMode) {
       const tags = await this.postResource<string[]>('tags/autoComplete/tags', {
         from: typeof params.from === 'string' ? params.from : `${params.from}`,
@@ -925,7 +836,6 @@ export class GraphiteDatasource
         text: tag,
       }));
     }
-
     const httpOptions: BackendSrvRequest = {
       method: 'GET',
       url: '/tags/autoComplete/tags',
@@ -933,10 +843,8 @@ export class GraphiteDatasource
       // for cancellations
       requestId: options.requestId,
     };
-
     return lastValueFrom(this.doGraphiteRequest(httpOptions).pipe(mapToTags()));
   }
-
   async getTagValuesAutoComplete(expressions: string[], tag: string, valuePrefix?: string, optionalOptions?: any) {
     const options = optionalOptions || {};
     const params: BackendSrvRequest['params'] = {
@@ -953,7 +861,6 @@ export class GraphiteDatasource
       params.from = this.translateTime(options.range.from, false, options.timezone);
       params.until = this.translateTime(options.range.to, true, options.timezone);
     }
-
     if (config.featureToggles.graphiteBackendMode) {
       const tagValues = await this.postResource<string[]>('tags/autoComplete/values', {
         from: typeof params.from === 'string' ? params.from : `${params.from}`,
@@ -967,7 +874,6 @@ export class GraphiteDatasource
         text: tag,
       }));
     }
-
     const httpOptions: BackendSrvRequest = {
       method: 'GET',
       url: '/tags/autoComplete/values',
@@ -975,25 +881,20 @@ export class GraphiteDatasource
       // for cancellations
       requestId: options.requestId,
     };
-
     return lastValueFrom(this.doGraphiteRequest(httpOptions).pipe(mapToTags()));
   }
-
   async getVersion(optionalOptions: any) {
     const options = optionalOptions || {};
-
     const httpOptions = {
       method: 'GET',
       url: '/version',
       requestId: options.requestId,
     };
-
     if (config.featureToggles.graphiteBackendMode) {
       const version = await this.getResource<string>('version');
       const semver = new SemVer(version);
       return valid(semver) ? version : '';
     }
-
     return lastValueFrom(
       this.doGraphiteRequest(httpOptions).pipe(
         map((results: FetchResponse) => {
@@ -1009,30 +910,29 @@ export class GraphiteDatasource
       )
     );
   }
-
-  createFuncInstance(funcDef: string | FuncDef, options?: { withDefaultParams: boolean }): FuncInstance {
+  createFuncInstance(
+    funcDef: string | FuncDef,
+    options?: {
+      withDefaultParams: boolean;
+    }
+  ): FuncInstance {
     return gfunc.createFuncInstance(funcDef, options, this.funcDefs);
   }
-
   getFuncDef(name: string) {
     return gfunc.getFuncDef(name, this.funcDefs);
   }
-
   waitForFuncDefsLoaded() {
     return this.getFuncDefs();
   }
-
   async getFuncDefs() {
     if (this.funcDefsPromise !== null) {
       return this.funcDefsPromise;
     }
-
     if (!supportsFunctionIndex(this.graphiteVersion)) {
       this.funcDefs = gfunc.getFuncDefs(this.graphiteVersion);
       this.funcDefsPromise = Promise.resolve(this.funcDefs);
       return this.funcDefsPromise;
     }
-
     const httpOptions = {
       method: 'GET',
       url: '/functions',
@@ -1040,19 +940,17 @@ export class GraphiteDatasource
       // backend_srv defaults to json
       responseType: 'text' as const,
     };
-
     if (config.featureToggles.graphiteBackendMode) {
       try {
         const functions = await this.getResource<string>('functions');
         this.funcDefs = gfunc.parseFuncDefs(functions);
         return this.funcDefs;
       } catch (error) {
-        console.error('Fetching graphite functions error', error);
+        structLog('error', 'Fetching graphite functions error', error);
         this.funcDefs = gfunc.getFuncDefs(this.graphiteVersion);
         return this.funcDefs;
       }
     }
-
     return lastValueFrom(
       this.doGraphiteRequest(httpOptions).pipe(
         map((results: FetchResponse) => {
@@ -1066,14 +964,13 @@ export class GraphiteDatasource
           return this.funcDefs;
         }),
         catchError((error) => {
-          console.error('Fetching graphite functions error', error);
+          structLog('error', 'Fetching graphite functions error', error);
           this.funcDefs = gfunc.getFuncDefs(this.graphiteVersion);
           return of(this.funcDefs);
         })
       )
     );
   }
-
   testDatasource() {
     if (config.featureToggles.graphiteBackendMode) {
       return super.testDatasource();
@@ -1096,10 +993,8 @@ export class GraphiteDatasource
       targets: [{ refId: 'A', target: 'constantLine(100)' }],
       maxDataPoints: 300,
     };
-
     return lastValueFrom(this.query(query)).then(() => ({ status: 'success', message: 'Data source is working' }));
   }
-
   doGraphiteRequest<T>(
     options: BackendSrvRequest & {
       inspect?: any;
@@ -1112,10 +1007,8 @@ export class GraphiteDatasource
       options.headers = options.headers || {};
       options.headers.Authorization = this.basicAuth;
     }
-
     options.url = this.url + options.url;
     options.inspect = { type: 'graphite' };
-
     return getBackendSrv()
       .fetch<T>(options)
       .pipe(
@@ -1127,65 +1020,58 @@ export class GraphiteDatasource
         })
       );
   }
-
   // Can be removed when the frontend query path is removed
-  buildGraphiteParams(options: any, originalTargetMap: { [key: string]: string }, scopedVars?: ScopedVars): string[] {
+  buildGraphiteParams(
+    options: any,
+    originalTargetMap: {
+      [key: string]: string;
+    },
+    scopedVars?: ScopedVars
+  ): string[] {
     const graphiteOptions = ['from', 'until', 'rawData', 'format', 'maxDataPoints', 'cacheTimeout'];
     const cleanOptions = [],
       targets: Record<string, string> = {};
     let target: GraphiteQuery, targetValue, i;
     const intervalFormatFixRegex = /'(\d+)m'/gi;
     let hasTargets = false;
-
     options['format'] = 'json';
-
     function fixIntervalFormat(match: string) {
       return match.replace('m', 'min').replace('M', 'mon');
     }
-
     for (i = 0; i < options.targets.length; i++) {
       target = options.targets[i];
       if (!target.target) {
         continue;
       }
-
       if (!target.refId) {
         target.refId = this._seriesRefLetters[i];
       }
-
       targetValue = this.templateSrv.replace(target.target, scopedVars);
       targetValue = targetValue.replace(intervalFormatFixRegex, fixIntervalFormat);
       targets[target.refId] = targetValue;
     }
-
     const regex = /\#([A-Z])/g;
-
     function nestedSeriesRegexReplacer(match: string, g1: string) {
       // Handle the case where a query references itself to prevent infinite recursion
       if (target.refId === g1) {
         return targets[g1] || match;
       }
-
       // Recursively replace all nested series references
       return originalTargetMap[g1].replace(regex, nestedSeriesRegexReplacer) || match;
     }
-
     for (i = 0; i < options.targets.length; i++) {
       target = options.targets[i];
       if (!target.target) {
         continue;
       }
-
       targetValue = targets[target.refId];
       targetValue = this.templateSrv.replace(targetValue.replace(regex, nestedSeriesRegexReplacer), scopedVars);
       targets[target.refId] = targetValue;
-
       if (!target.hide) {
         hasTargets = true;
         cleanOptions.push('target=' + encodeURIComponent(targetValue));
       }
     }
-
     each(options, (value, key) => {
       if (indexOf(graphiteOptions, key) === -1) {
         return;
@@ -1194,15 +1080,12 @@ export class GraphiteDatasource
         cleanOptions.push(key + '=' + encodeURIComponent(value));
       }
     });
-
     if (!hasTargets) {
       return [];
     }
-
     return cleanOptions;
   }
 }
-
 function supportsTags(version: string): boolean {
   const fullVersion = coerce(version);
   if (!fullVersion) {
@@ -1210,7 +1093,6 @@ function supportsTags(version: string): boolean {
   }
   return gte(fullVersion, '1.1.0');
 }
-
 function supportsFunctionIndex(version: string): boolean {
   const fullVersion = coerce(version);
   if (!fullVersion) {
@@ -1218,8 +1100,12 @@ function supportsFunctionIndex(version: string): boolean {
   }
   return gte(fullVersion, '1.1.0');
 }
-
-function mapToTags(): OperatorFunction<FetchResponse, Array<{ text: string }>> {
+function mapToTags(): OperatorFunction<
+  FetchResponse,
+  Array<{
+    text: string;
+  }>
+> {
   return pipe(
     map((results) => {
       if (results.data) {

--- a/public/app/plugins/datasource/graphite/graphite_query.ts
+++ b/public/app/plugins/datasource/graphite/graphite_query.ts
@@ -1,22 +1,18 @@
+import { structLog } from '@grafana/data';
 import { compact, each, findIndex, flatten, get, join, keyBy, last, map, reduce, without } from 'lodash';
-
 import { type ScopedVars } from '@grafana/data';
 import { type TemplateSrv } from '@grafana/runtime';
-
 import { type GraphiteDatasource } from './datasource';
 import { type FuncInstance } from './gfunc';
 import { type AstNode, Parser } from './parser';
 import { type GraphiteSegment } from './types';
 import { arrayMove } from './utils';
-
 export type GraphiteTagOperator = '=' | '=~' | '!=' | '!=~';
-
 export type GraphiteTag = {
   key: string;
   operator: GraphiteTagOperator;
   value: string;
 };
-
 export type GraphiteTarget = {
   refId: string | number;
   target: string;
@@ -27,7 +23,6 @@ export type GraphiteTarget = {
   textEditor: boolean;
   paused: boolean;
 };
-
 export default class GraphiteQuery {
   datasource: GraphiteDatasource;
   target: GraphiteTarget;
@@ -40,47 +35,39 @@ export default class GraphiteQuery {
   removeTagValue: string;
   templateSrv: TemplateSrv | undefined;
   scopedVars?: ScopedVars;
-
   constructor(datasource: GraphiteDatasource, target: any, templateSrv?: TemplateSrv, scopedVars?: ScopedVars) {
     this.datasource = datasource;
     this.target = target;
     this.templateSrv = templateSrv;
     this.scopedVars = scopedVars;
     this.parseTarget();
-
     this.removeTagValue = '-- remove tag --';
   }
-
   parseTarget() {
     this.functions = [];
     this.segments = [];
     this.tags = [];
     this.seriesByTagUsed = false;
     this.error = null;
-
     if (this.target.textEditor) {
       return;
     }
-
     const parser = new Parser(this.target.target);
     const astNode = parser.getAst();
     if (astNode === null) {
       this.checkOtherSegmentsIndex = 0;
       return;
     }
-
     if (astNode.type === 'error') {
       this.error = astNode.message + ' at position: ' + astNode.pos;
       this.target.textEditor = true;
       return;
     }
-
     try {
       this.parseTargetRecursive(astNode, null);
       if (this.target.target) {
         const oldQuery = this.target.target;
         const newQuery = this.generateQueryString();
-
         // Spaces, quotes, and commas are used when rendering the AST back into a string.
         // We are removing these for less false positives of query changes.
         const sanitizeQuery = (o: string): string => o.replace(/\s|'|"|,/g, '');
@@ -94,18 +81,15 @@ export default class GraphiteQuery {
       }
     } catch (err) {
       if (err instanceof Error) {
-        console.error('error parsing target:', err.message);
+        structLog('error', 'error parsing target:', err.message);
         this.error = err.message;
       }
       this.target.textEditor = true;
     }
-
     this.checkOtherSegmentsIndex = this.segments.length - 1;
   }
-
   getSegmentPathUpTo(index: number) {
     const arr = this.segments.slice(0, index);
-
     return reduce(
       arr,
       (result, segment) => {
@@ -114,37 +98,29 @@ export default class GraphiteQuery {
       ''
     );
   }
-
   parseTargetRecursive(astNode: any, func: any): any {
     if (astNode === null) {
       return null;
     }
-
     switch (astNode.type) {
       case 'function':
         const innerFunc = this.datasource.createFuncInstance(astNode.name, {
           withDefaultParams: false,
         });
-
         // bug fix for parsing multiple functions as params
         handleMultipleSeriesByTagsParams(astNode);
-
         handleDivideSeriesListsNestedFunctions(astNode);
-
         each(astNode.params, (param) => {
           this.parseTargetRecursive(param, innerFunc);
         });
-
         innerFunc.updateText();
         this.functions.push(innerFunc);
-
         // extract tags from seriesByTag function and hide function
         if (innerFunc.def.name === 'seriesByTag' && !this.seriesByTagUsed) {
           this.seriesByTagUsed = true;
           innerFunc.hidden = true;
           this.tags = this.splitSeriesByTagParams(innerFunc);
         }
-
         break;
       case 'series-ref':
         if (this.segments.length > 0 || this.getSeriesByTagFuncIndex() >= 0) {
@@ -167,35 +143,28 @@ export default class GraphiteQuery {
         break;
     }
   }
-
   updateSegmentValue(segment: GraphiteSegment, index: number) {
     this.segments[index].value = segment.value;
   }
-
   addSelectMetricSegment() {
     this.segments.push({ value: 'select metric' });
   }
-
   addFunction(newFunc: FuncInstance) {
     this.functions.push(newFunc);
   }
-
   addFunctionParameter(func: FuncInstance, value: string) {
     if (func.params.length >= func.def.params.length && !get(last(func.def.params), 'multiple', false)) {
       throw { message: 'too many parameters for function ' + func.def.name };
     }
     func.params.push(value);
   }
-
   removeFunction(func: FuncInstance) {
     this.functions = without(this.functions, func);
   }
-
   moveFunction(func: FuncInstance, offset: number) {
     const index = this.functions.indexOf(func);
     arrayMove(this.functions, index, index + offset);
   }
-
   generateQueryString(): string {
     const wrapFunction = (target: string, func: FuncInstance) => {
       return func.render(target, (value: string) => {
@@ -205,32 +174,32 @@ export default class GraphiteQuery {
     const metricPath = this.getSegmentPathUpTo(this.segments.length).replace(/\.?select metric$/, '');
     return reduce(this.functions, wrapFunction, metricPath);
   }
-
   updateModelTarget(targets: any) {
     if (!this.target.textEditor) {
       this.target.target = this.generateQueryString();
     }
-
     this.updateRenderedTarget(this.target, targets);
-
     // loop through other queries and update targetFull as needed
     for (const target of targets || []) {
       if (target.refId !== this.target.refId) {
         this.updateRenderedTarget(target, targets);
       }
     }
-
     // clean-up added param
     this.functions.forEach((func) => (func.added = false));
   }
-
-  updateRenderedTarget(target: { refId: string | number; target: string; targetFull: any }, targets: any) {
+  updateRenderedTarget(
+    target: {
+      refId: string | number;
+      target: string;
+      targetFull: any;
+    },
+    targets: any
+  ) {
     // render nested query
     const targetsByRefId = keyBy(targets, 'refId');
-
     const nestedSeriesRefRegex = /\#([A-Z])/g;
     let targetWithNestedQueries = target.target;
-
     // Use ref count to track circular references
     each(targetsByRefId, (t, id) => {
       const regex = RegExp(`\#(${id})`, 'g');
@@ -243,7 +212,6 @@ export default class GraphiteQuery {
       });
       t.refCount = refCount;
     });
-
     // Keep interpolating until there are no query references
     // The reason for the loop is that the referenced query might contain another reference to another query
     while (targetWithNestedQueries.match(nestedSeriesRefRegex)) {
@@ -252,29 +220,23 @@ export default class GraphiteQuery {
         if (!t) {
           return match;
         }
-
         // no circular references
         if (t.refCount === 0) {
           delete targetsByRefId[g1];
         }
         t.refCount--;
-
         return t.target;
       });
-
       if (updated === targetWithNestedQueries) {
         break;
       }
-
       targetWithNestedQueries = updated;
     }
-
     delete target.targetFull;
     if (target.target !== targetWithNestedQueries) {
       target.targetFull = targetWithNestedQueries;
     }
   }
-
   splitSeriesByTagParams(func: { params: any }) {
     const tagPattern = /([^\!=~]+)(\!?=~?)(.*)/;
     return flatten(
@@ -294,11 +256,9 @@ export default class GraphiteQuery {
       })
     );
   }
-
   getSeriesByTagFuncIndex() {
     return findIndex(this.functions, (func) => func.def.name === 'seriesByTag');
   }
-
   getSeriesByTagFunc() {
     const seriesByTagFuncIndex = this.getSeriesByTagFuncIndex();
     if (seriesByTagFuncIndex >= 0) {
@@ -307,21 +267,24 @@ export default class GraphiteQuery {
       return undefined;
     }
   }
-
   addTag(tag: { key: string; operator: GraphiteTagOperator; value: string }) {
     const newTagParam = renderTagString(tag);
     this.getSeriesByTagFunc()!.params.push(newTagParam);
     this.tags.push(tag);
   }
-
   removeTag(index: number) {
     this.getSeriesByTagFunc()!.params.splice(index, 1);
     this.tags.splice(index, 1);
   }
-
-  updateTag(tag: { key: string; operator: GraphiteTagOperator; value: string }, tagIndex: number) {
+  updateTag(
+    tag: {
+      key: string;
+      operator: GraphiteTagOperator;
+      value: string;
+    },
+    tagIndex: number
+  ) {
     this.error = null;
-
     if (tag.key === this.removeTagValue) {
       this.removeTag(tagIndex);
       if (this.tags.length === 0) {
@@ -334,11 +297,9 @@ export default class GraphiteQuery {
       }
       return;
     }
-
     this.getSeriesByTagFunc()!.params[tagIndex] = renderTagString(tag);
     this.tags[tagIndex] = tag;
   }
-
   renderTagExpressions(excludeIndex = -1) {
     return compact(
       map(this.tags, (tagExpr, index) => {
@@ -352,11 +313,9 @@ export default class GraphiteQuery {
     );
   }
 }
-
 function renderTagString(tag: { key: string; operator?: GraphiteTagOperator; value?: string }) {
   return tag.key + tag.operator + tag.value;
 }
-
 /**
  * mutates the second seriesByTag function into a string to fix a parsing bug
  * @param astNode
@@ -370,7 +329,6 @@ function handleMultipleSeriesByTagsParams(astNode: AstNode) {
       if (p.type === 'function') {
         count += 1;
       }
-
       if (count === 2 && p.type === 'function' && p.name === 'seriesByTag') {
         // convert second function to a string
         const stringParams =
@@ -379,21 +337,17 @@ function handleMultipleSeriesByTagsParams(astNode: AstNode) {
             if (idx === 0 || idx !== paramsArr.length - 1) {
               return `${acc}'${p.value}',`;
             }
-
             return `${acc}'${p.value}'`;
           }, '');
-
         return {
           type: 'string',
           value: `${p.name}(${stringParams})`,
         };
       }
-
       return p;
     });
   }
 }
-
 /**
  * Converts all nested functions as parametors (recursively) to strings
  */
@@ -410,27 +364,21 @@ function handleDivideSeriesListsNestedFunctions(astNode: AstNode) {
         // then wrap them in the function
         let functionString = '';
         let s = p.name + '(' + nestedFunctionsToString(p, functionString);
-
         p = {
           type: 'string',
           value: s,
         };
       }
-
       return p;
     });
   }
-
   return astNode;
 }
-
 function nestedFunctionsToString(node: AstNode, functionString: string): string | undefined {
   let count = 0;
   if (node.params) {
     count++;
-
     const paramsLength = node.params?.length ?? 0;
-
     node.params.forEach((innerNode: AstNode, idx: number) => {
       if (idx < paramsLength - 1) {
         functionString += switchCase(innerNode, functionString) + ',';
@@ -438,13 +386,11 @@ function nestedFunctionsToString(node: AstNode, functionString: string): string 
         functionString += switchCase(innerNode, functionString);
       }
     });
-
     return functionString + ')';
   } else {
     return (functionString += switchCase(node, functionString));
   }
 }
-
 function switchCase(node: AstNode, functionString: string) {
   switch (node.type) {
     case 'function':

--- a/public/app/plugins/datasource/influxdb/components/editor/config-v2/UrlAndAuthenticationSection.tsx
+++ b/public/app/plugins/datasource/influxdb/components/editor/config-v2/UrlAndAuthenticationSection.tsx
@@ -1,6 +1,6 @@
+import { structLog } from '@grafana/data';
 import { css } from '@emotion/css';
 import { firstValueFrom } from 'rxjs';
-
 import { onUpdateDatasourceJsonDataOptionSelect, onUpdateDatasourceOption } from '@grafana/data';
 import { getBackendSrv } from '@grafana/runtime';
 import {
@@ -17,9 +17,7 @@ import {
   Alert,
   useStyles2,
 } from '@grafana/ui';
-
 import { InfluxVersion } from '../../../types';
-
 import { AdvancedHttpSettings } from './AdvancedHttpSettings';
 import { AuthSettings } from './AuthSettings';
 import { CONFIG_SECTION_HEADERS, CONTAINER_MIN_WIDTH } from './constants';
@@ -30,19 +28,19 @@ import {
 } from './tracking';
 import { type Props } from './types';
 import { INFLUXDB_VERSION_MAP, type InfluxDBProduct } from './versions';
-
-const getQueryLanguageOptions = (productName: string): Array<{ value: string }> => {
+const getQueryLanguageOptions = (
+  productName: string
+): Array<{
+  value: string;
+}> => {
   const product = INFLUXDB_VERSION_MAP.find(({ name }) => name === productName);
   return product?.queryLanguages?.map(({ name }) => ({ value: name })) ?? [];
 };
-
 export const UrlAndAuthenticationSection = (props: Props) => {
   const { options, onOptionsChange } = props;
   const styles = useStyles2(getStyles);
-
   const isInfluxVersion = (v: string): v is InfluxVersion =>
     typeof v === 'string' && (v === InfluxVersion.Flux || v === InfluxVersion.InfluxQL || v === InfluxVersion.SQL);
-
   // Database + Retention Policy (DBRP) mapping is required for InfluxDB OSS 1.x and 2.x when using InfluxQL
   const requiresDbrpMapping =
     options.jsonData.product &&
@@ -54,31 +52,25 @@ export const UrlAndAuthenticationSection = (props: Props) => {
       'InfluxDB Cloud (TSM)',
       'InfluxDB Cloud Serverless',
     ].includes(options.jsonData.product);
-
   const onProductChange = ({ value }: ComboboxOption) => {
     trackInfluxDBConfigV2ProductSelected({ product: value });
     onOptionsChange({ ...options, jsonData: { ...options.jsonData, product: value, version: undefined } });
   };
-
   const onQueryLanguageChange = (option: ComboboxOption) => {
     const { value } = option;
     trackInfluxDBConfigV2QueryLanguageSelected({ version: value });
-
     if (isInfluxVersion(value)) {
       onUpdateDatasourceJsonDataOptionSelect(props, 'version')(option);
     }
   };
-
   const onUrlChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     onUpdateDatasourceOption(props, 'url')(event);
   };
-
   const pingInfluxForProductDetection = async (urlValue: string) => {
     const dsUID = options.uid;
     if (!dsUID) {
       return;
     }
-
     try {
       const res = await firstValueFrom(
         getBackendSrv().fetch({
@@ -93,23 +85,19 @@ export const UrlAndAuthenticationSection = (props: Props) => {
       if (res.ok) {
         let product: string | undefined;
         let version: string | undefined;
-
         if (res.headers && typeof res.headers.get === 'function') {
           product = res.headers.get('x-influxdb-build') ?? undefined;
           version = res.headers.get('x-influxdb-version') ?? undefined;
         }
-
         if (product || version) {
           return { product, version };
         }
       }
     } catch (err) {
-      console.error('Failed to get InfluxDB version:', err);
+      structLog('error', 'Failed to get InfluxDB version:', err);
     }
-
     return { product: undefined, version: undefined };
   };
-
   const matchUrlContains = async (urlValue: string) => {
     let product: InfluxDBProduct | undefined;
     product = INFLUXDB_VERSION_MAP.find((product: InfluxDBProduct) => {
@@ -120,10 +108,8 @@ export const UrlAndAuthenticationSection = (props: Props) => {
       }
       return false;
     });
-
     if (!product) {
       const pingUrl = await pingInfluxForProductDetection(urlValue);
-
       if (pingUrl) {
         product = INFLUXDB_VERSION_MAP.find((product: InfluxDBProduct) => {
           if (product.detectionMethod?.pingHeaderResponse) {
@@ -139,7 +125,6 @@ export const UrlAndAuthenticationSection = (props: Props) => {
         });
       }
     }
-
     onOptionsChange({
       ...options,
       jsonData: {
@@ -149,11 +134,9 @@ export const UrlAndAuthenticationSection = (props: Props) => {
       },
     });
   };
-
   const detectProductFromUrl = (event: React.ChangeEvent<HTMLInputElement>) => {
     matchUrlContains(event.target.value);
   };
-
   return (
     <Box
       borderStyle="solid"
@@ -259,7 +242,6 @@ export const UrlAndAuthenticationSection = (props: Props) => {
     </Box>
   );
 };
-
 const getStyles = () => {
   return {
     dropdown: css({

--- a/public/app/plugins/datasource/influxdb/components/editor/query/influxql/visual/TagsSection.tsx
+++ b/public/app/plugins/datasource/influxdb/components/editor/query/influxql/visual/TagsSection.tsx
@@ -1,31 +1,24 @@
+import { structLog } from '@grafana/data';
 import type { JSX } from 'react';
-
 import { type SelectableValue } from '@grafana/data';
 import { AccessoryButton } from '@grafana/plugin-ui';
-
 import { type InfluxQueryTag } from '../../../../../types';
 import { adjustOperatorIfNeeded, getCondition, getOperator } from '../utils/tagUtils';
 import { toSelectableValue } from '../utils/toSelectableValue';
-
 import { AddButton } from './AddButton';
 import { Seg } from './Seg';
-
 type KnownOperator = '=' | '!=' | '<>' | '<' | '>' | '>=' | '<=' | '=~' | '!~' | 'Is' | 'Is Not';
 const knownOperators: KnownOperator[] = ['=', '!=', '<>', '<', '>', '>=', '<=', '=~', '!~', 'Is', 'Is Not'];
-
 type KnownCondition = 'AND' | 'OR';
 const knownConditions: KnownCondition[] = ['AND', 'OR'];
-
 const operatorOptions: Array<SelectableValue<KnownOperator>> = knownOperators.map(toSelectableValue);
 const condititonOptions: Array<SelectableValue<KnownCondition>> = knownConditions.map(toSelectableValue);
-
 type Props = {
   tags: InfluxQueryTag[];
   onChange: (tags: InfluxQueryTag[]) => void;
   getTagKeyOptions: () => Promise<string[]>;
   getTagValueOptions: (key: string) => Promise<string[]>;
 };
-
 type TagProps = {
   tag: InfluxQueryTag;
   isFirst: boolean;
@@ -34,15 +27,11 @@ type TagProps = {
   getTagKeyOptions: () => Promise<string[]>;
   getTagValueOptions: (key: string) => Promise<string[]>;
 };
-
 const loadConditionOptions = () => Promise.resolve(condititonOptions);
-
 const loadOperatorOptions = () => Promise.resolve(operatorOptions);
-
 const Tag = ({ tag, isFirst, onRemove, onChange, getTagKeyOptions, getTagValueOptions }: TagProps): JSX.Element => {
   const operator = getOperator(tag);
   const condition = getCondition(tag, isFirst);
-
   const getTagKeySegmentOptions = () => {
     return getTagKeyOptions()
       .catch((err) => {
@@ -54,18 +43,15 @@ const Tag = ({ tag, isFirst, onRemove, onChange, getTagKeyOptions, getTagValueOp
         // to avoid it, we catch any potential errors coming from `getTagKeyOptions`,
         // log the error, and pretend that the list of options is an empty list.
         // this way the remove-item option can always be added to the list.
-        console.error(err);
+        structLog('error', err);
         return [];
       })
       .then((tags) => tags.map(toSelectableValue));
   };
-
   const getTagValueSegmentOptions = () => {
     return getTagValueOptions(tag.key).then((tags) => tags.map(toSelectableValue));
   };
-
   const isRegexOperator = operator === '=~' || operator === '!~';
-
   return (
     <div className="gf-form">
       {condition != null && (
@@ -118,7 +104,6 @@ const Tag = ({ tag, isFirst, onRemove, onChange, getTagKeyOptions, getTagValueOp
     </div>
   );
 };
-
 export const TagsSection = ({ tags, onChange, getTagKeyOptions, getTagValueOptions }: Props): JSX.Element => {
   const onTagChange = (newTag: InfluxQueryTag, index: number) => {
     const newTags = tags.map((tag, i) => {
@@ -126,32 +111,26 @@ export const TagsSection = ({ tags, onChange, getTagKeyOptions, getTagValueOptio
     });
     onChange(newTags);
   };
-
   const onTagRemove = (index: number) => {
     const newTags = tags.filter((t, i) => i !== index);
     onChange(newTags);
   };
-
   const getTagKeySegmentOptions = () => {
     return getTagKeyOptions().then((tags) => tags.map(toSelectableValue));
   };
-
   const addNewTag = (tagKey: string, isFirst: boolean) => {
     const minimalTag: InfluxQueryTag = {
       key: tagKey,
       value: 'select tag value',
     };
-
     const newTag: InfluxQueryTag = {
       key: minimalTag.key,
       value: minimalTag.value,
       operator: getOperator(minimalTag),
       condition: getCondition(minimalTag, isFirst),
     };
-
     onChange([...tags, newTag]);
   };
-
   return (
     <>
       {tags.map((t, i) => (

--- a/public/app/plugins/datasource/influxdb/datasource.ts
+++ b/public/app/plugins/datasource/influxdb/datasource.ts
@@ -1,7 +1,7 @@
+import { structLog } from '@grafana/data';
 import { map as _map, cloneDeep, extend, has, isString, omit, pick, reduce } from 'lodash';
 import { lastValueFrom, merge, Observable, of, throwError } from 'rxjs';
 import { catchError, map } from 'rxjs/operators';
-
 import {
   type AdHocVariableFilter,
   type AnnotationEvent,
@@ -36,7 +36,6 @@ import {
 } from '@grafana/runtime';
 import { QueryFormat, type SQLQuery } from '@grafana/sql';
 import config from 'app/core/config';
-
 import { AnnotationEditor } from './components/editor/annotation/AnnotationEditor';
 import { FluxQueryEditor } from './components/editor/query/flux/FluxQueryEditor';
 import { BROWSER_MODE_DISABLED_MESSAGE } from './constants';
@@ -49,7 +48,6 @@ import { buildRawQuery, removeRegexWrapper } from './queryUtils';
 import ResponseParser from './response_parser';
 import { DEFAULT_POLICY, type InfluxOptions, type InfluxQuery, type InfluxVariableQuery, InfluxVersion } from './types';
 import { InfluxVariableSupport } from './variables';
-
 export default class InfluxDatasource extends DataSourceWithBackend<InfluxQuery, InfluxOptions> {
   type: string;
   urls: string[];
@@ -65,18 +63,15 @@ export default class InfluxDatasource extends DataSourceWithBackend<InfluxQuery,
   version?: InfluxVersion;
   isProxyAccess: boolean;
   showTagTime: string;
-
   constructor(
     instanceSettings: DataSourceInstanceSettings<InfluxOptions>,
     readonly templateSrv: TemplateSrv = getTemplateSrv()
   ) {
     super(instanceSettings);
-
     this.type = 'influxdb';
     this.urls = (instanceSettings.url ?? '').split(',').map((url) => {
       return url.trim();
     });
-
     this.username = instanceSettings.username ?? '';
     this.password = instanceSettings.password ?? '';
     this.name = instanceSettings.name;
@@ -92,7 +87,6 @@ export default class InfluxDatasource extends DataSourceWithBackend<InfluxQuery,
     this.version = settingsData.version ?? InfluxVersion.InfluxQL;
     this.isProxyAccess = instanceSettings.access === 'proxy';
     this.variables = new InfluxVariableSupport(this, this.templateSrv);
-
     if (this.version === InfluxVersion.Flux) {
       // When flux, use an annotation processor rather than the `annotationQuery` lifecycle
       this.annotations = {
@@ -105,16 +99,13 @@ export default class InfluxDatasource extends DataSourceWithBackend<InfluxQuery,
       };
     }
   }
-
   query(request: DataQueryRequest<InfluxQuery>): Observable<DataQueryResponse> {
     if (!this.isProxyAccess) {
       const error = new Error(BROWSER_MODE_DISABLED_MESSAGE);
       return throwError(() => error);
     }
-
     return this._query(request);
   }
-
   _query(request: DataQueryRequest<InfluxQuery>): Observable<DataQueryResponse> {
     // for not-flux queries we call `this.classicQuery`, and that
     // handles the is-hidden situation.
@@ -123,11 +114,9 @@ export default class InfluxDatasource extends DataSourceWithBackend<InfluxQuery,
       ...request,
       targets: request.targets.filter((t) => t.hide !== true),
     };
-
     // migrate annotations
     if (filteredRequest.targets.some((target: InfluxQuery) => target.fromAnnotations)) {
       const streams: Array<Observable<DataQueryResponse>> = [];
-
       for (const target of filteredRequest.targets) {
         if (target.query) {
           streams.push(
@@ -140,18 +129,14 @@ export default class InfluxDatasource extends DataSourceWithBackend<InfluxQuery,
           );
         }
       }
-
       return merge(...streams);
     }
-
     if (this.version === InfluxVersion.InfluxQL && !this.isMigrationToggleOnAndIsAccessProxy()) {
       // Fallback to classic query support
       return this.classicQuery(request);
     }
-
     return super.query(filteredRequest);
   }
-
   getQueryDisplayText(query: InfluxQuery) {
     switch (this.version) {
       case InfluxVersion.Flux:
@@ -164,7 +149,6 @@ export default class InfluxDatasource extends DataSourceWithBackend<InfluxQuery,
         return '';
     }
   }
-
   /**
    * Returns false if the query should be skipped
    */
@@ -174,14 +158,12 @@ export default class InfluxDatasource extends DataSourceWithBackend<InfluxQuery,
     }
     return true;
   }
-
   applyTemplateVariables(
     query: InfluxQuery,
     scopedVars: ScopedVars,
     filters?: AdHocVariableFilter[]
   ): InfluxQuery & SQLQuery {
     const variables = scopedVars || {};
-
     // We want to interpolate these variables on backend.
     // The pre-calculated values are replaced with the variable strings.
     variables.__interval = {
@@ -190,14 +172,12 @@ export default class InfluxDatasource extends DataSourceWithBackend<InfluxQuery,
     variables.__interval_ms = {
       value: '$__interval_ms',
     };
-
     if (this.version === InfluxVersion.Flux) {
       return {
         ...query,
         query: this.templateSrv.replace(query.query ?? '', variables), // The raw query text
       };
     }
-
     if (this.version === InfluxVersion.SQL || this.isMigrationToggleOnAndIsAccessProxy()) {
       query = this.applyVariables(query, variables, filters);
       if (query.adhocFilters?.length) {
@@ -209,18 +189,14 @@ export default class InfluxDatasource extends DataSourceWithBackend<InfluxQuery,
         query.tags = [...(query.tags ?? []), ...query.adhocFilters];
       }
     }
-
     return query;
   }
-
   targetContainsTemplate(target: InfluxQuery) {
     // for flux-mode we just take target.query,
     // for influxql-mode we use InfluxQueryModel to create the text-representation
     const queryText = this.version === InfluxVersion.Flux ? target.query : buildRawQuery(target);
-
     return this.templateSrv.containsTemplate(queryText);
   }
-
   interpolateVariablesInQueries(
     queries: InfluxQuery[],
     scopedVars: ScopedVars,
@@ -229,7 +205,6 @@ export default class InfluxDatasource extends DataSourceWithBackend<InfluxQuery,
     if (!queries || queries.length === 0) {
       return [];
     }
-
     return queries.map((query) => {
       if (this.version === InfluxVersion.Flux) {
         return {
@@ -243,7 +218,6 @@ export default class InfluxDatasource extends DataSourceWithBackend<InfluxQuery,
           ), // The raw query text
         };
       }
-
       const queryWithVariables = this.applyVariables(query, scopedVars, filters);
       if (queryWithVariables.adhocFilters?.length) {
         queryWithVariables.adhocFilters = (queryWithVariables.adhocFilters ?? []).map((af) => {
@@ -253,14 +227,12 @@ export default class InfluxDatasource extends DataSourceWithBackend<InfluxQuery,
         });
         queryWithVariables.tags = [...(queryWithVariables.tags ?? []), ...queryWithVariables.adhocFilters];
       }
-
       return {
         ...queryWithVariables,
         datasource: this.getRef(),
       };
     });
   }
-
   applyVariables(query: InfluxQuery & SQLQuery, scopedVars: ScopedVars, filters?: AdHocVariableFilter[]) {
     const expandedQuery = { ...query };
     if (query.groupBy) {
@@ -271,7 +243,6 @@ export default class InfluxDatasource extends DataSourceWithBackend<InfluxQuery,
         };
       });
     }
-
     if (query.select) {
       expandedQuery.select = query.select.map((selects) => {
         return selects.map((select) => {
@@ -282,14 +253,12 @@ export default class InfluxDatasource extends DataSourceWithBackend<InfluxQuery,
         });
       });
     }
-
     if (query.tags) {
       expandedQuery.tags = query.tags.map((tag) => {
         // Remove the regex wrapper if the operator is not a regex operator
         if (tag.operator !== '=~' && tag.operator !== '!~') {
           tag.value = removeRegexWrapper(tag.value);
         }
-
         return {
           ...tag,
           key: this.templateSrv.replace(tag.key, scopedVars),
@@ -302,7 +271,6 @@ export default class InfluxDatasource extends DataSourceWithBackend<InfluxQuery,
         };
       });
     }
-
     return {
       ...expandedQuery,
       adhocFilters: filters ?? [],
@@ -331,7 +299,6 @@ export default class InfluxDatasource extends DataSourceWithBackend<InfluxQuery,
       tz: this.templateSrv.replace(query.tz ?? '', scopedVars),
     };
   }
-
   interpolateQueryExpr(value: string | string[] = [], variable: QueryVariableModel, query?: string) {
     if (typeof value === 'string') {
       // Check the value is a number. If not run to escape special characters
@@ -339,7 +306,6 @@ export default class InfluxDatasource extends DataSourceWithBackend<InfluxQuery,
         return value;
       }
     }
-
     // If template variable is a multi-value variable
     // we always want to deal with special chars.
     if (variable.multi) {
@@ -350,12 +316,10 @@ export default class InfluxDatasource extends DataSourceWithBackend<InfluxQuery,
         }
         return value;
       }
-
       // If the value is a string array first escape them then join them with pipe
       // then put inside parenthesis.
       return `(${value.map((v) => escapeRegex(v)).join('|')})`;
     }
-
     // If the variable is not a multi-value variable
     // we want to see how it's been used. If it is used in a regex expression
     // we escape it. Otherwise, we return it directly.
@@ -364,12 +328,10 @@ export default class InfluxDatasource extends DataSourceWithBackend<InfluxQuery,
     // If matches are found this regex is evaluated to check if the variable is contained in the regex /^...$/ (^ and $ is optional)
     // i.e. /^$myVar$/ or /$myVar/ or /^($myVar)$/
     const regex = new RegExp(`\\/(?:\\^)?(.*)(\\$${variable.name})(.*)(?:\\$)?\\/`, 'gm');
-
     // We need to validate the type of the query as some legacy cases can pass a query value with a different type
     if (!query || typeof query !== 'string') {
       return value;
     }
-
     const queryMatches = query.match(regexMatcher);
     if (!queryMatches) {
       return value;
@@ -383,18 +345,15 @@ export default class InfluxDatasource extends DataSourceWithBackend<InfluxQuery,
       // we also validate that the expression compiles before assuming it is a regular expression.
       try {
         new RegExp(match);
-
         // If the value is a string array first escape them then join them with pipe
         // then put inside parenthesis.
         return typeof value === 'string' ? escapeRegex(value) : `(${value.map((v) => escapeRegex(v)).join('|')})`;
       } catch (e) {
-        console.warn(`Supplied match is not valid regex: ${match}`);
+        structLog('warn', `Supplied match is not valid regex: ${match}`);
       }
     }
-
     return value;
   }
-
   async runMetadataQuery(target: InfluxQuery): Promise<MetricFindValue[]> {
     return lastValueFrom(
       super.query({
@@ -402,7 +361,6 @@ export default class InfluxDatasource extends DataSourceWithBackend<InfluxQuery,
       } as DataQueryRequest)
     ).then(this.toMetricFindValue);
   }
-
   async metricFindQuery(query: InfluxVariableQuery, options?: any): Promise<MetricFindValue[]> {
     if (
       this.version === InfluxVersion.Flux ||
@@ -423,19 +381,16 @@ export default class InfluxDatasource extends DataSourceWithBackend<InfluxQuery,
         })
       ).then(this.toMetricFindValue);
     }
-
     const interpolated = this.templateSrv.replace(
       query.query,
       options?.scopedVars,
       (value: string | string[] = [], variable: QueryVariableModel) =>
         this.interpolateQueryExpr(value, variable, query.query)
     );
-
     return lastValueFrom(this._seriesQuery(interpolated, options)).then((resp) => {
       return this.responseParser.parse(query.query, resp);
     });
   }
-
   toMetricFindValue(rsp: DataQueryResponse): MetricFindValue[] {
     const valueMap = new Map<string, MetricFindValue>();
     // Create MetricFindValue object for all frames
@@ -463,10 +418,8 @@ export default class InfluxDatasource extends DataSourceWithBackend<InfluxQuery,
       database: this.database,
       withTimeFilter: this.showTagTime,
     });
-
     return this.metricFindQuery({ refId: 'get-tag-keys', query });
   }
-
   getTagValues(options: DataSourceGetTagValuesOptions<InfluxQuery>) {
     const query = buildMetadataQuery({
       type: 'TAG_VALUES',
@@ -475,10 +428,8 @@ export default class InfluxDatasource extends DataSourceWithBackend<InfluxQuery,
       withKey: options.key,
       withTimeFilter: this.showTagTime,
     });
-
     return this.metricFindQuery({ refId: 'get-tag-values', query });
   }
-
   /**
    * @deprecated
    */
@@ -486,15 +437,12 @@ export default class InfluxDatasource extends DataSourceWithBackend<InfluxQuery,
     if (!query) {
       return of({ results: [] });
     }
-
     if (options && options.range) {
       const timeFilter = this.getTimeFilter({ rangeRaw: options.range, timezone: options.timezone });
       query = query.replace('$timeFilter', timeFilter);
     }
-
     return this._influxRequest(this.httpMode, '/query', { q: query, epoch: 'ms' }, options);
   }
-
   /**
    * @deprecated
    */
@@ -502,7 +450,6 @@ export default class InfluxDatasource extends DataSourceWithBackend<InfluxQuery,
     if (!params) {
       return '';
     }
-
     return reduce(
       params,
       (memo: string[], value, key) => {
@@ -515,33 +462,26 @@ export default class InfluxDatasource extends DataSourceWithBackend<InfluxQuery,
       []
     ).join('&');
   }
-
   /**
    * @deprecated
    */
   _influxRequest(method: string, url: string, data: any, options?: any) {
     const currentUrl = this.urls.shift()!;
     this.urls.push(currentUrl);
-
     const params: any = {};
-
     if (this.username) {
       params.u = this.username;
       params.p = this.password;
     }
-
     if (options && options.database) {
       params.db = options.database;
     } else if (this.database) {
       params.db = this.database;
     }
-
     if (options?.policy && options.policy !== DEFAULT_POLICY) {
       params.rp = options.policy;
     }
-
     const { q } = data;
-
     if (method === 'POST' && has(data, 'q')) {
       // verb is POST and 'q' param is defined
       extend(params, omit(data, ['q']));
@@ -551,7 +491,6 @@ export default class InfluxDatasource extends DataSourceWithBackend<InfluxQuery,
       extend(params, data);
       data = null;
     }
-
     const req: any = {
       method: method,
       url: currentUrl + url,
@@ -561,7 +500,6 @@ export default class InfluxDatasource extends DataSourceWithBackend<InfluxQuery,
       inspect: { type: 'influxdb' },
       paramSerializer: this.serializeParams,
     };
-
     req.headers = req.headers || {};
     if (this.basicAuth || this.withCredentials) {
       req.withCredentials = true;
@@ -569,11 +507,9 @@ export default class InfluxDatasource extends DataSourceWithBackend<InfluxQuery,
     if (this.basicAuth) {
       req.headers.Authorization = this.basicAuth;
     }
-
     if (method === 'POST') {
       req.headers['Content-type'] = 'application/x-www-form-urlencoded';
     }
-
     return getBackendSrv()
       .fetch(req)
       .pipe(
@@ -583,7 +519,6 @@ export default class InfluxDatasource extends DataSourceWithBackend<InfluxQuery,
             data.executedQueryString = q;
             if (data.results) {
               const errors = result.data.results.filter((elem: any) => elem.error);
-
               if (errors.length > 0) {
                 throw {
                   message: 'InfluxDB Error: ' + errors[0].error,
@@ -598,12 +533,10 @@ export default class InfluxDatasource extends DataSourceWithBackend<InfluxQuery,
           if (err.cancelled) {
             return of(err);
           }
-
           return throwError(this.handleErrors(err));
         })
       );
   }
-
   /**
    * @deprecated
    */
@@ -614,7 +547,6 @@ export default class InfluxDatasource extends DataSourceWithBackend<InfluxQuery,
         (err && err.message) ||
         'Unknown error during query transaction. Please check JS console logs.',
     };
-
     if ((Number.isInteger(err.status) && err.status !== 0) || err.status >= 300) {
       if (err.data && err.data.error) {
         error.message = 'InfluxDB Error: ' + err.data.error;
@@ -628,24 +560,19 @@ export default class InfluxDatasource extends DataSourceWithBackend<InfluxQuery,
         error.config = err.config;
       }
     }
-
     return error;
   }
-
   getTimeFilter(options: { rangeRaw: RawTimeRange; timezone: string }) {
     const from = this.getInfluxTime(options.rangeRaw.from, false, options.timezone);
     const until = this.getInfluxTime(options.rangeRaw.to, true, options.timezone);
-
     return 'time >= ' + from + ' and time <= ' + until;
   }
-
   getInfluxTime(date: DateTime | string, roundUp: boolean, timezone: string) {
     let outPutDate;
     if (isString(date)) {
       if (date === 'now') {
         return 'now()';
       }
-
       const parts = /^now-(\d+)([dhms])$/.exec(date);
       if (parts) {
         const amount = parseInt(parts[1], 10);
@@ -658,16 +585,12 @@ export default class InfluxDatasource extends DataSourceWithBackend<InfluxQuery,
       }
       date = outPutDate;
     }
-
     return date.valueOf() + 'ms';
   }
-
   // ------------------------ Legacy Code - Before Backend Migration ---------------
-
   isMigrationToggleOnAndIsAccessProxy() {
     return config.featureToggles.influxdbBackendMigration && this.access === 'proxy';
   }
-
   /**
    * The unchanged pre 7.1 query implementation
    * @deprecated
@@ -677,19 +600,14 @@ export default class InfluxDatasource extends DataSourceWithBackend<InfluxQuery,
     const scopedVars = options.scopedVars;
     const targets = cloneDeep(options.targets);
     const queryTargets: any[] = [];
-
     let i, y;
-
     let allQueries = _map(targets, (target) => {
       if (target.hide) {
         return '';
       }
-
       queryTargets.push(target);
-
       // backward compatibility
       scopedVars.interval = scopedVars.__interval;
-
       return new InfluxQueryModel(target, this.templateSrv, scopedVars).render(true);
     }).reduce((acc, current) => {
       if (current !== '') {
@@ -697,11 +615,9 @@ export default class InfluxDatasource extends DataSourceWithBackend<InfluxQuery,
       }
       return acc;
     });
-
     if (allQueries === '') {
       return of({ data: [] });
     }
-
     // add global adhoc filters to timeFilter
     const adhocFilters = options.filters;
     const adhocFiltersFromDashboard = options.targets.flatMap((target: InfluxQuery) => target.adhocFilters ?? []);
@@ -712,40 +628,33 @@ export default class InfluxDatasource extends DataSourceWithBackend<InfluxQuery,
     }
     // replace grafana variables
     scopedVars.timeFilter = { value: timeFilter };
-
     // replace templated variables
     allQueries = this.templateSrv.replace(allQueries, scopedVars);
-
     return this._seriesQuery(allQueries, options).pipe(
       map((data) => {
         if (!data || !data.results) {
           return { data: [] };
         }
-
         const seriesList = [];
         for (i = 0; i < data.results.length; i++) {
           const result = data.results[i];
           if (!result || !result.series) {
             continue;
           }
-
           const target = queryTargets[i];
           let alias = target.alias;
           if (alias) {
             alias = this.templateSrv.replace(target.alias, options.scopedVars);
           }
-
           const meta: QueryResultMeta = {
             executedQueryString: data.executedQueryString,
           };
-
           const influxSeries = new InfluxSeries({
             refId: target.refId,
             series: data.results[i].series,
             alias: alias,
             meta,
           });
-
           switch (target.resultFormat) {
             case 'logs':
               meta.preferredVisualisationType = 'logs';
@@ -762,26 +671,22 @@ export default class InfluxDatasource extends DataSourceWithBackend<InfluxQuery,
             }
           }
         }
-
         return { data: seriesList };
       })
     );
   }
-
   async annotationEvents(options: DataQueryRequest, annotation: InfluxQuery): Promise<AnnotationEvent[]> {
     if (this.version === InfluxVersion.Flux) {
       return Promise.reject({
         message: 'Flux requires the standard annotation query',
       });
     }
-
     // InfluxQL puts a query string on the annotation
     if (!annotation.query) {
       return Promise.reject({
         message: 'Query missing in annotation definition',
       });
     }
-
     if (this.isMigrationToggleOnAndIsAccessProxy()) {
       // We want to send our query to the backend as a raw query
       const target: InfluxQuery = {
@@ -795,7 +700,6 @@ export default class InfluxDatasource extends DataSourceWithBackend<InfluxQuery,
         ),
         rawQuery: true,
       };
-
       return lastValueFrom(
         getBackendSrv()
           .fetch<BackendDataSourceResponse>({
@@ -817,13 +721,11 @@ export default class InfluxDatasource extends DataSourceWithBackend<InfluxQuery,
           )
       );
     }
-
     const timeFilter = this.getTimeFilter({ rangeRaw: options.range.raw, timezone: options.timezone });
     let query = annotation.query.replace('$timeFilter', timeFilter);
     query = this.templateSrv.replace(query, undefined, (value: string | string[] = [], variable: QueryVariableModel) =>
       this.interpolateQueryExpr(value, variable, query)
     );
-
     return lastValueFrom(this._seriesQuery(query, options)).then((data) => {
       if (!data || !data.results || !data.results[0]) {
         throw { message: 'No results in response from InfluxDB' };
@@ -835,20 +737,16 @@ export default class InfluxDatasource extends DataSourceWithBackend<InfluxQuery,
     });
   }
 }
-
 // we detect the field type based on the value-array
 function getFieldType(values: unknown[]): FieldType {
   // the values-array may contain a lot of nulls.
   // we need the first not-null item
   const firstNotNull = values.find((v) => v !== null);
-
   if (firstNotNull === undefined) {
     // we could not find any not-null values
     return FieldType.number;
   }
-
   const valueType = typeof firstNotNull;
-
   switch (valueType) {
     case 'string':
       return FieldType.string;
@@ -862,30 +760,25 @@ function getFieldType(values: unknown[]): FieldType {
       throw new Error(`InfluxQL: invalid value type ${valueType}`);
   }
 }
-
 // this conversion function is specialized to work with the timeseries
 // data returned by InfluxDatasource.getTimeSeries()
 function timeSeriesToDataFrame(timeSeries: TimeSeries): DataFrame {
   const times: number[] = [];
   const values: unknown[] = [];
-
   // the data we process here is not correctly typed.
   // the typescript types say every data-point is number|null,
   // but in fact it can be string or boolean too.
-
   const points = timeSeries.datapoints;
   for (const point of points) {
     values.push(point[0]);
     times.push(point[1] as number);
   }
-
   const timeField = {
     name: TIME_SERIES_TIME_FIELD_NAME,
     type: FieldType.time,
     config: {},
     values: times,
   };
-
   const valueField = {
     name: TIME_SERIES_VALUE_FIELD_NAME,
     type: getFieldType(values),
@@ -895,9 +788,7 @@ function timeSeriesToDataFrame(timeSeries: TimeSeries): DataFrame {
     values: values,
     labels: timeSeries.tags,
   };
-
   const fields = [timeField, valueField];
-
   return {
     name: timeSeries.target,
     refId: timeSeries.refId,

--- a/public/app/plugins/datasource/loki/LanguageProvider.ts
+++ b/public/app/plugins/datasource/loki/LanguageProvider.ts
@@ -1,6 +1,6 @@
+import { structLog } from '@grafana/data';
 import { flatten } from 'lodash';
 import { LRUCache } from 'lru-cache';
-
 import {
   type AbstractQuery,
   getDefaultTimeRange,
@@ -10,7 +10,6 @@ import {
   type TimeRange,
 } from '@grafana/data';
 import { type BackendSrvRequest, config } from '@grafana/runtime';
-
 import { LokiQueryType } from './dataquery.gen';
 import { DEFAULT_MAX_LINES_SAMPLE, type LokiDatasource } from './datasource';
 import { abstractQueryToExpr, mapAbstractOperatorsToOp, processLabels } from './languageUtils';
@@ -22,17 +21,14 @@ import {
   extractUnwrapLabelKeysFromDataFrame,
 } from './responseUtils';
 import { type DetectedFieldsResult, LabelType, type LokiQuery, type ParserAndLabelKeysResult } from './types';
-
 const NS_IN_MS = 1000000;
 const EMPTY_SELECTOR = '{}';
 const HIDDEN_LABELS = ['__aggregated_metric__', '__tenant_id__', '__stream_shard__'];
-
 export default class LokiLanguageProvider extends LanguageProvider {
   labelKeys: string[];
   started = false;
   startedTimeRange?: TimeRange;
   datasource: LokiDatasource;
-
   /**
    *  Cache for labels of series. This is bit simplistic in the sense that it just counts responses each as a 1 and does
    *  not account for different size of a response. If that is needed a `length` function can be added in the options.
@@ -43,14 +39,11 @@ export default class LokiLanguageProvider extends LanguageProvider {
   private detectedFieldValuesCache = new LRUCache<string, string[]>({ max: 10 });
   private labelsPromisesCache = new LRUCache<string, Promise<string[]>>({ max: 10 });
   private detectedLabelValuesPromisesCache = new LRUCache<string, Promise<string[]>>({ max: 10 });
-
   constructor(datasource: LokiDatasource) {
     super();
-
     this.datasource = datasource;
     this.labelKeys = [];
   }
-
   request = async (
     url: string,
     params?: Record<string, string | number>,
@@ -63,13 +56,11 @@ export default class LokiLanguageProvider extends LanguageProvider {
       if (throwError) {
         throw error;
       } else {
-        console.error(error);
+        structLog('error', error);
       }
     }
-
     return undefined;
   };
-
   /**
    * Initialize the language provider by fetching set of labels.
    */
@@ -90,10 +81,8 @@ export default class LokiLanguageProvider extends LanguageProvider {
         return [];
       });
     }
-
     return this.startTask;
   };
-
   /**
    * Returns the label keys that have been fetched.
    * If labels have not been fetched yet, it will return an empty array.
@@ -108,7 +97,6 @@ export default class LokiLanguageProvider extends LanguageProvider {
   getLabelKeys(): string[] {
     return this.labelKeys;
   }
-
   importFromAbstractQuery(labelBasedQuery: AbstractQuery): LokiQuery {
     return {
       refId: labelBasedQuery.refId,
@@ -116,13 +104,11 @@ export default class LokiLanguageProvider extends LanguageProvider {
       queryType: LokiQueryType.Range,
     };
   }
-
   exportToAbstractQuery(query: LokiQuery): AbstractQuery {
     if (!query.expr || query.expr.length === 0) {
       return { refId: query.refId, labelMatchers: [] };
     }
     const streamSelectors = getStreamSelectorsFromQuery(query.expr);
-
     const labelMatchers = streamSelectors.map((streamSelector) => {
       const visualQuery = buildVisualQueryFromString(streamSelector).query;
       const matchers = visualQuery.labels.map((label) => {
@@ -134,13 +120,11 @@ export default class LokiLanguageProvider extends LanguageProvider {
       });
       return matchers;
     });
-
     return {
       refId: query.refId,
       labelMatchers: flatten(labelMatchers),
     };
   }
-
   /**
    * Fetch label keys using the best applicable endpoint.
    *
@@ -162,7 +146,6 @@ export default class LokiLanguageProvider extends LanguageProvider {
       return Object.keys(data ?? {});
     }
   }
-
   /**
    * Fetch all label keys
    * This asynchronous function returns all available label keys from the data source.
@@ -194,10 +177,8 @@ export default class LokiLanguageProvider extends LanguageProvider {
       this.labelKeys = labels;
       return this.labelKeys;
     }
-
     return [];
   }
-
   /**
    * Fetch series labels for a selector
    *
@@ -212,13 +193,14 @@ export default class LokiLanguageProvider extends LanguageProvider {
    */
   fetchSeriesLabels = async (
     streamSelector: string,
-    options?: { timeRange?: TimeRange }
+    options?: {
+      timeRange?: TimeRange;
+    }
   ): Promise<Record<string, string[]>> => {
     const interpolatedMatch = this.datasource.interpolateString(streamSelector);
     const url = 'series';
     const range = options?.timeRange ?? this.getDefaultTimeRange();
     const { start, end } = this.datasource.getTimeRangeParams(range);
-
     const cacheKey = this.generateCacheKey(url, start, end, interpolatedMatch);
     let value = this.seriesCache.get(cacheKey);
     if (!value) {
@@ -233,7 +215,6 @@ export default class LokiLanguageProvider extends LanguageProvider {
     }
     return value;
   };
-
   /**
    * Fetch series for a selector. Use this for raw results. Use fetchSeriesLabels() to get labels.
    * @param match
@@ -242,14 +223,18 @@ export default class LokiLanguageProvider extends LanguageProvider {
    * @param options.timeRange - (Optional) The time range for which you want to retrieve label keys. If not provided, the default time range is used.
    * @returns A promise containing array with records of label names and their value.
    */
-  fetchSeries = async (match: string, options?: { timeRange?: TimeRange }): Promise<Array<Record<string, string>>> => {
+  fetchSeries = async (
+    match: string,
+    options?: {
+      timeRange?: TimeRange;
+    }
+  ): Promise<Array<Record<string, string>>> => {
     const url = 'series';
     const range = options?.timeRange ?? this.getDefaultTimeRange();
     const { start, end } = this.datasource.getTimeRangeParams(range);
     const params = { 'match[]': match, start, end };
     return await this.request(url, params);
   };
-
   // Cache key is a bit different here. We round up to a minute the intervals.
   // The rounding may seem strange but makes relative intervals like now-1h less prone to need separate request every
   // millisecond while still actually getting all the keys for the correct interval. This still can create problems
@@ -257,12 +242,10 @@ export default class LokiLanguageProvider extends LanguageProvider {
   private generateCacheKey(url: string, start: number, end: number, param: string): string {
     return [url, this.roundTime(start), this.roundTime(end), param].join();
   }
-
   // Round nanoseconds epoch to nearest 5 minute interval
   private roundTime(nanoseconds: number): number {
     return nanoseconds ? Math.floor(nanoseconds / NS_IN_MS / 1000 / 60 / 5) : 0;
   }
-
   async fetchDetectedFields(
     queryOptions: {
       expr: string;
@@ -276,29 +259,25 @@ export default class LokiLanguageProvider extends LanguageProvider {
       queryOptions.expr && queryOptions.expr !== EMPTY_SELECTOR
         ? this.datasource.interpolateString(queryOptions.expr, queryOptions.scopedVars)
         : undefined;
-
     if (!interpolatedExpr) {
       throw new Error('fetchDetectedFields requires query expression');
     }
-
     const url = `detected_fields`;
     const range = queryOptions?.timeRange ?? this.getDefaultTimeRange();
     const rangeParams = this.datasource.getTimeRangeParams(range);
     const { start, end } = rangeParams;
     const params: KeyValue<string | number> = { start, end, limit: queryOptions?.limit ?? 1000 };
     params.query = interpolatedExpr;
-
     return new Promise(async (resolve, reject) => {
       try {
         const data = await this.request(url, params, true, requestOptions);
         resolve(data);
       } catch (error) {
-        console.error('error', error);
+        structLog('error', 'error', error);
         reject(error);
       }
     });
   }
-
   async fetchDetectedFieldValues(
     labelName: string,
     queryOptions?: {
@@ -313,7 +292,6 @@ export default class LokiLanguageProvider extends LanguageProvider {
     // This function was named poorly, it's not detected label values, it's detected field values! :facepalm
     return this.fetchDetectedLabelValues(labelName, queryOptions, requestOptions);
   }
-
   /**
    * @deprecated: use fetchDetectedFieldValues instead
    */
@@ -329,38 +307,31 @@ export default class LokiLanguageProvider extends LanguageProvider {
     requestOptions?: Partial<BackendSrvRequest>
   ): Promise<string[] | Error> {
     const label = encodeURIComponent(this.datasource.interpolateString(labelName));
-
     const interpolatedExpr =
       queryOptions?.expr && queryOptions.expr !== EMPTY_SELECTOR
         ? this.datasource.interpolateString(queryOptions.expr, queryOptions.scopedVars)
         : undefined;
-
     const url = `detected_field/${label}/values`;
     const range = queryOptions?.timeRange ?? this.getDefaultTimeRange();
     const rangeParams = this.datasource.getTimeRangeParams(range);
     const { start, end } = rangeParams;
     const params: KeyValue<string | number> = { start, end, limit: queryOptions?.limit ?? 1000 };
     let paramCacheKey = label;
-
     if (interpolatedExpr) {
       params.query = interpolatedExpr;
       paramCacheKey += interpolatedExpr;
     }
-
     const cacheKey = this.generateCacheKey(url, start, end, paramCacheKey);
-
     // Values in cache, return
     const labelValues = this.detectedFieldValuesCache.get(cacheKey);
     if (labelValues) {
       return labelValues;
     }
-
     // Promise in cache, return
     let labelValuesPromise = this.detectedLabelValuesPromisesCache.get(cacheKey);
     if (labelValuesPromise) {
       return labelValuesPromise;
     }
-
     labelValuesPromise = new Promise(async (resolve, reject) => {
       try {
         const data = await this.request(url, params, queryOptions?.throwError, requestOptions);
@@ -374,16 +345,14 @@ export default class LokiLanguageProvider extends LanguageProvider {
         if (queryOptions?.throwError) {
           reject(error);
         } else {
-          console.error(error);
+          structLog('error', error);
           resolve([]);
         }
       }
     });
     this.detectedLabelValuesPromisesCache.set(cacheKey, labelValuesPromise);
-
     return labelValuesPromise;
   }
-
   /**
    * Fetch label values
    *
@@ -399,7 +368,10 @@ export default class LokiLanguageProvider extends LanguageProvider {
    */
   async fetchLabelValues(
     labelName: string,
-    options?: { streamSelector?: string; timeRange?: TimeRange }
+    options?: {
+      streamSelector?: string;
+      timeRange?: TimeRange;
+    }
   ): Promise<string[]> {
     const label = encodeURIComponent(this.datasource.interpolateString(labelName));
     // Loki doesn't allow empty streamSelector {}, so we should not send it.
@@ -407,33 +379,27 @@ export default class LokiLanguageProvider extends LanguageProvider {
       options?.streamSelector && options.streamSelector !== EMPTY_SELECTOR
         ? this.datasource.interpolateString(options.streamSelector)
         : undefined;
-
     const url = `label/${label}/values`;
     const range = options?.timeRange ?? this.getDefaultTimeRange();
     const rangeParams = this.datasource.getTimeRangeParams(range);
     const { start, end } = rangeParams;
     const params: KeyValue<string | number> = { start, end };
     let paramCacheKey = label;
-
     if (streamParam) {
       params.query = streamParam;
       paramCacheKey += streamParam;
     }
-
     const cacheKey = this.generateCacheKey(url, start, end, paramCacheKey);
-
     // Values in cache, return
     const labelValues = this.labelsCache.get(cacheKey);
     if (labelValues) {
       return labelValues;
     }
-
     // Promise in cache, return
     let labelValuesPromise = this.labelsPromisesCache.get(cacheKey);
     if (labelValuesPromise) {
       return labelValuesPromise;
     }
-
     labelValuesPromise = new Promise(async (resolve) => {
       try {
         const data = await this.request(url, params);
@@ -444,14 +410,13 @@ export default class LokiLanguageProvider extends LanguageProvider {
           resolve(labelValues);
         }
       } catch (error) {
-        console.error(error);
+        structLog('error', error);
         resolve([]);
       }
     });
     this.labelsPromisesCache.set(cacheKey, labelValuesPromise);
     return labelValuesPromise;
   }
-
   /**
    * Get parser and label keys for a selector
    *
@@ -474,7 +439,10 @@ export default class LokiLanguageProvider extends LanguageProvider {
    */
   async getParserAndLabelKeys(
     streamSelector: string,
-    options?: { maxLines?: number; timeRange?: TimeRange }
+    options?: {
+      maxLines?: number;
+      timeRange?: TimeRange;
+    }
   ): Promise<ParserAndLabelKeysResult> {
     const empty = {
       extractedLabelKeys: [],
@@ -484,7 +452,6 @@ export default class LokiLanguageProvider extends LanguageProvider {
       hasLogfmt: false,
       hasPack: false,
     };
-
     const series = await this.datasource.getDataSamples(
       {
         expr: streamSelector,
@@ -493,13 +460,10 @@ export default class LokiLanguageProvider extends LanguageProvider {
       },
       options?.timeRange ?? this.getDefaultTimeRange()
     );
-
     if (!series.length) {
       return empty;
     }
-
     const { hasLogfmt, hasJSON, hasPack } = extractLogParserFromDataFrame(series[0]);
-
     return {
       extractedLabelKeys: [
         ...extractLabelKeysFromDataFrame(series[0], LabelType.Indexed),
@@ -512,7 +476,6 @@ export default class LokiLanguageProvider extends LanguageProvider {
       hasLogfmt,
     };
   }
-
   /**
    * Get the default time range
    *

--- a/public/app/plugins/datasource/loki/LiveStreams.ts
+++ b/public/app/plugins/datasource/loki/LiveStreams.ts
@@ -1,12 +1,10 @@
+import { structLog } from '@grafana/data';
 import { type Observable, throwError, timer } from 'rxjs';
 import { finalize, map, retryWhen, mergeMap } from 'rxjs/operators';
 import { webSocket } from 'rxjs/webSocket';
-
 import { type DataFrame, FieldType, type KeyValue, CircularDataFrame } from '@grafana/data';
-
 import { appendResponseToBufferedData } from './liveStreamsResultTransformer';
 import { type LokiTailResponse } from './types';
-
 /**
  * Maps directly to a query in the UI (refId is key)
  */
@@ -16,28 +14,23 @@ export interface LokiLiveTarget {
   refId: string;
   size: number;
 }
-
 /**
  * Cache of websocket streams that can be returned as observable. In case there already is a stream for particular
  * target it is returned and on subscription returns the latest dataFrame.
  */
 export class LiveStreams {
   private streams: KeyValue<Observable<DataFrame[]>> = {};
-
   getStream(target: LokiLiveTarget, retryInterval = 5000): Observable<DataFrame[]> {
     let stream = this.streams[target.url];
-
     if (stream) {
       return stream;
     }
-
     const data = new CircularDataFrame({ capacity: target.size });
     data.addField({ name: 'Time', type: FieldType.time, config: {} });
     data.addField({ name: 'Line', type: FieldType.string });
     data.addField({ name: 'id', type: FieldType.string });
     data.meta = { ...data.meta, preferredVisualisationType: 'logs' };
     data.refId = target.refId;
-
     stream = webSocket<LokiTailResponse>(target.url).pipe(
       map((response: LokiTailResponse) => {
         appendResponseToBufferedData(response, data);
@@ -53,7 +46,8 @@ export class LiveStreams {
             if (error.code === 1006 && retryAttempt < 30) {
               if (retryAttempt > 10) {
                 // If more than 10 times retried, consol.warn, but keep reconnecting
-                console.warn(
+                structLog(
+                  'warn',
                   `Websocket connection is being disrupted. We keep reconnecting but consider starting new live tailing again. Error: ${error.reason}`
                 );
               }
@@ -69,7 +63,6 @@ export class LiveStreams {
       })
     );
     this.streams[target.url] = stream;
-
     return stream;
   }
 }

--- a/public/app/plugins/datasource/loki/components/LokiLabelBrowser.tsx
+++ b/public/app/plugins/datasource/loki/components/LokiLabelBrowser.tsx
@@ -1,9 +1,9 @@
+import { structLog } from '@grafana/data';
 import { css, cx } from '@emotion/css';
 import { sortBy } from 'lodash';
 import { type ChangeEvent } from 'react';
 import * as React from 'react';
 import { FixedSizeList } from 'react-window';
-
 import { type CoreApp, type GrafanaTheme2, type TimeRange } from '@grafana/data';
 import { reportInteraction } from '@grafana/runtime';
 import {
@@ -17,17 +17,14 @@ import {
   fuzzyMatch,
   Stack,
 } from '@grafana/ui';
-
 import type LokiLanguageProvider from '../LanguageProvider';
 import { escapeLabelValueInExactSelector, escapeLabelValueInRegexSelector } from '../languageUtils';
-
 // Hard limit on labels to render
 const MAX_LABEL_COUNT = 1000;
 const MAX_VALUE_COUNT = 10000;
 const MAX_AUTO_SELECT = 4;
 const EMPTY_SELECTOR = '{}';
 const collator = new Intl.Collator('en', { sensitivity: 'accent' });
-
 export interface BrowserProps {
   languageProvider: LokiLanguageProvider;
   onChange: (selector: string) => void;
@@ -40,7 +37,6 @@ export interface BrowserProps {
   storeLastUsedLabels: (labels: string[]) => void;
   deleteLastUsedLabels: () => void;
 }
-
 interface BrowserState {
   labels: SelectableLabel[];
   searchTerm: string;
@@ -48,14 +44,12 @@ interface BrowserState {
   error: string;
   validationStatus: string;
 }
-
 interface FacettableValue {
   name: string;
   selected?: boolean;
   highlightParts?: HighlightPart[];
   order?: number;
 }
-
 export interface SelectableLabel {
   name: string;
   selected?: boolean;
@@ -64,7 +58,6 @@ export interface SelectableLabel {
   hidden?: boolean;
   facets?: number;
 }
-
 export function buildSelector(labels: SelectableLabel[]): string {
   const selectedLabels = [];
   for (const label of labels) {
@@ -82,7 +75,6 @@ export function buildSelector(labels: SelectableLabel[]): string {
   }
   return ['{', selectedLabels.join(','), '}'].join('');
 }
-
 export function facetLabels(
   labels: SelectableLabel[],
   possibleLabels: Record<string, string[]>,
@@ -111,12 +103,10 @@ export function facetLabels(
       }
       return { ...label, loading: false, values: existingValues, facets: existingValues.length };
     }
-
     // Label is facetted out, hide all values
     return { ...label, loading: false, hidden: !possibleValues, values: undefined, facets: 0 };
   });
 }
-
 const getStyles = (theme: GrafanaTheme2) => ({
   wrapper: css({
     backgroundColor: theme.colors.background.secondary,
@@ -136,7 +126,6 @@ const getStyles = (theme: GrafanaTheme2) => ({
     '& + &': {
       margin: theme.spacing(2, 0),
     },
-
     position: 'relative',
   }),
   footerSectionStyles: css({
@@ -197,7 +186,6 @@ const getStyles = (theme: GrafanaTheme2) => ({
     textOverflow: 'ellipsis',
   }),
 });
-
 export class UnthemedLokiLabelBrowser extends React.Component<BrowserProps, BrowserState> {
   state: BrowserState = {
     labels: [],
@@ -206,11 +194,9 @@ export class UnthemedLokiLabelBrowser extends React.Component<BrowserProps, Brow
     error: '',
     validationStatus: '',
   };
-
   onChangeSearch = (event: ChangeEvent<HTMLInputElement>) => {
     this.setState({ searchTerm: event.target.value });
   };
-
   onClickRunLogsQuery = () => {
     reportInteraction('grafana_loki_label_browser_closed', {
       app: this.props.app,
@@ -219,7 +205,6 @@ export class UnthemedLokiLabelBrowser extends React.Component<BrowserProps, Brow
     const selector = buildSelector(this.state.labels);
     this.props.onChange(selector);
   };
-
   onClickRunMetricsQuery = () => {
     reportInteraction('grafana_loki_label_browser_closed', {
       app: this.props.app,
@@ -229,7 +214,6 @@ export class UnthemedLokiLabelBrowser extends React.Component<BrowserProps, Brow
     const query = `rate(${selector}[$__auto])`;
     this.props.onChange(query);
   };
-
   onClickClear = () => {
     this.setState((state) => {
       const labels: SelectableLabel[] = state.labels.map((label) => ({
@@ -244,7 +228,6 @@ export class UnthemedLokiLabelBrowser extends React.Component<BrowserProps, Brow
     });
     this.props.deleteLastUsedLabels();
   };
-
   onClickLabel = (name: string, value: string | undefined, event: React.MouseEvent<HTMLElement>) => {
     const label = this.state.labels.find((l) => l.name === name);
     if (!label) {
@@ -262,7 +245,6 @@ export class UnthemedLokiLabelBrowser extends React.Component<BrowserProps, Brow
     this.setState({ searchTerm: '' });
     this.updateLabelState(name, nextValue, '', () => this.doFacettingForLabel(name));
   };
-
   onClickValue = (name: string, value: string | undefined, event: React.MouseEvent<HTMLElement>) => {
     const label = this.state.labels.find((l) => l.name === name);
     if (!label || !label.values) {
@@ -274,12 +256,10 @@ export class UnthemedLokiLabelBrowser extends React.Component<BrowserProps, Brow
     const values = label.values.map((v) => ({ ...v, selected: v.name === value ? !v.selected : v.selected }));
     this.updateLabelState(name, { values }, '', () => this.doFacetting(name));
   };
-
   onClickValidate = () => {
     const selector = buildSelector(this.state.labels);
     this.validateSelector(selector);
   };
-
   updateLabelState(name: string, updatedFields: Partial<SelectableLabel>, status = '', cb?: () => void) {
     this.setState((state) => {
       const labels: SelectableLabel[] = state.labels.map((label) => {
@@ -293,7 +273,6 @@ export class UnthemedLokiLabelBrowser extends React.Component<BrowserProps, Brow
       return { labels, status, error, validationStatus: '' };
     }, cb);
   }
-
   componentDidMount() {
     const { languageProvider, autoSelect = MAX_AUTO_SELECT, lastUsedLabels, timeRange } = this.props;
     if (languageProvider) {
@@ -322,7 +301,6 @@ export class UnthemedLokiLabelBrowser extends React.Component<BrowserProps, Brow
       });
     }
   }
-
   doFacettingForLabel(name: string) {
     const label = this.state.labels.find((l) => l.name === name);
     if (!label) {
@@ -340,7 +318,6 @@ export class UnthemedLokiLabelBrowser extends React.Component<BrowserProps, Brow
       this.doFacetting();
     }
   }
-
   doFacetting = (lastFacetted?: string) => {
     const selector = buildSelector(this.state.labels);
     if (selector === EMPTY_SELECTOR) {
@@ -357,7 +334,6 @@ export class UnthemedLokiLabelBrowser extends React.Component<BrowserProps, Brow
       this.fetchSeries(selector, lastFacetted);
     }
   };
-
   async fetchValues(name: string, selector: string) {
     const { languageProvider, timeRange } = this.props;
     this.updateLabelState(name, { loading: true }, `Fetching values for ${name}`);
@@ -376,10 +352,9 @@ export class UnthemedLokiLabelBrowser extends React.Component<BrowserProps, Brow
       const values: FacettableValue[] = rawValues.map((value) => ({ name: value }));
       this.updateLabelState(name, { values, loading: false });
     } catch (error) {
-      console.error(error);
+      structLog('error', error);
     }
   }
-
   async fetchSeries(selector: string, lastFacetted?: string) {
     const { languageProvider, timeRange } = this.props;
     if (lastFacetted) {
@@ -404,17 +379,15 @@ export class UnthemedLokiLabelBrowser extends React.Component<BrowserProps, Brow
         this.updateLabelState(lastFacetted, { loading: false });
       }
     } catch (error) {
-      console.error(error);
+      structLog('error', error);
     }
   }
-
   async validateSelector(selector: string) {
     const { languageProvider, timeRange } = this.props;
     this.setState({ validationStatus: `Validating selector ${selector}`, error: '' });
     const streams = await languageProvider.fetchSeries(selector, { timeRange });
     this.setState({ validationStatus: `Selector is valid (${streams.length} streams found)` });
   }
-
   render() {
     const { theme } = this.props;
     const { labels, searchTerm, status, error, validationStatus } = this.state;
@@ -424,7 +397,6 @@ export class UnthemedLokiLabelBrowser extends React.Component<BrowserProps, Brow
     const styles = getStyles(theme);
     const selector = buildSelector(this.state.labels);
     const empty = selector === EMPTY_SELECTOR;
-
     let selectedLabels = labels.filter((label) => label.selected && label.values);
     if (searchTerm) {
       selectedLabels = selectedLabels.map((label) => {
@@ -457,7 +429,6 @@ export class UnthemedLokiLabelBrowser extends React.Component<BrowserProps, Brow
           values: label?.values ? label.values.map((value) => ({ ...value, highlightParts: undefined })) : [],
         }));
     }
-
     return (
       <>
         <div className={styles.wrapper}>
@@ -575,5 +546,4 @@ export class UnthemedLokiLabelBrowser extends React.Component<BrowserProps, Brow
     );
   }
 }
-
 export const LokiLabelBrowser = withTheme2(UnthemedLokiLabelBrowser);

--- a/public/app/plugins/datasource/loki/components/monaco-query-field/getOverrideServices.ts
+++ b/public/app/plugins/datasource/loki/components/monaco-query-field/getOverrideServices.ts
@@ -1,5 +1,5 @@
+import { structLog } from '@grafana/data';
 import { type monacoTypes } from '@grafana/ui';
-
 // this thing here is a workaround in a way.
 // what we want to achieve, is that when the autocomplete-window
 // opens, the "second, extra popup" with the extra help,
@@ -17,27 +17,21 @@ import { type monacoTypes } from '@grafana/ui';
 // i am not 100% how the `scope` and `target` things work,
 // but so far it seems to work ok.
 // i would use an another approach, if there was one available.
-
 function makeStorageService() {
   // we need to return an object that fulfills this interface:
   // https://github.com/microsoft/vscode/blob/ff1e16eebb93af79fd6d7af1356c4003a120c563/src/vs/platform/storage/common/storage.ts#L37
   // unfortunately it is not export from monaco-editor
-
   const strings = new Map<string, string>();
-
   // we want this to be true by default
   strings.set('expandSuggestionDocs', true.toString());
-
   return {
     // we do not implement the on* handlers
     onDidChangeValue: (data: unknown): void => undefined,
     onDidChangeTarget: (data: unknown): void => undefined,
     onWillSaveState: (data: unknown): void => undefined,
-
     get: (key: string, scope: unknown, fallbackValue?: string): string | undefined => {
       return strings.get(key) ?? fallbackValue;
     },
-
     getBoolean: (key: string, scope: unknown, fallbackValue?: boolean): boolean | undefined => {
       const val = strings.get(key);
       if (val !== undefined) {
@@ -48,7 +42,6 @@ function makeStorageService() {
         return fallbackValue;
       }
     },
-
     getNumber: (key: string, scope: unknown, fallbackValue?: number): number | undefined => {
       const val = strings.get(key);
       if (val !== undefined) {
@@ -57,7 +50,6 @@ function makeStorageService() {
         return fallbackValue;
       }
     },
-
     store: (
       key: string,
       value: string | boolean | number | undefined | null,
@@ -71,41 +63,33 @@ function makeStorageService() {
         strings.set(key, value.toString());
       }
     },
-
     remove: (key: string, scope: unknown): void => {
       strings.delete(key);
     },
-
     keys: (scope: unknown, target: unknown): string[] => {
       return Array.from(strings.keys());
     },
-
     logStorage: (): void => {
-      console.log('logStorage: not implemented');
+      structLog('log', 'logStorage: not implemented');
     },
-
     migrate: (): Promise<void> => {
       // we do not implement this
       return Promise.resolve(undefined);
     },
-
     isNew: (scope: unknown): boolean => {
       // we create a new storage for every session, we do not persist it,
       // so we return `true`.
       return true;
     },
-
     flush: (reason?: unknown): Promise<void> => {
       // we do not implement this
       return Promise.resolve(undefined);
     },
   };
 }
-
 let overrideServices: monacoTypes.editor.IEditorOverrideServices = {
   storageService: makeStorageService(),
 };
-
 export function getOverrideServices(): monacoTypes.editor.IEditorOverrideServices {
   // One instance of this for every query editor
   return overrideServices;

--- a/public/app/plugins/datasource/loki/mergeResponses.ts
+++ b/public/app/plugins/datasource/loki/mergeResponses.ts
@@ -1,3 +1,4 @@
+import { structLog } from '@grafana/data';
 import {
   closestIdx,
   type DataFrame,
@@ -11,9 +12,7 @@ import {
   type QueryResultMetaStat,
   shallowCompare,
 } from '@grafana/data';
-
 import { LOADING_FRAME_NAME } from './querySplitting';
-
 function getFrameKey(frame: DataFrame): string | undefined {
   // Metric range query data
   if (frame.meta?.type === DataFrameType.TimeSeriesMulti) {
@@ -35,7 +34,6 @@ function getFrameKey(frame: DataFrame): string | undefined {
   }
   return frame.refId ?? frame.name;
 }
-
 /**
  * @todo test new response is error, current response is not
  * @param currentResponse
@@ -45,7 +43,6 @@ export function combineResponses(currentResponse: DataQueryResponse | null, newR
   if (!currentResponse) {
     return cloneQueryResponse(newResponse);
   }
-
   const currentResponseLabelsMap = new Map<string, DataFrame>();
   currentResponse.data.forEach((frame: DataFrame) => {
     const key = getFrameKey(frame);
@@ -55,7 +52,6 @@ export function combineResponses(currentResponse: DataQueryResponse | null, newR
       currentResponseLabelsMap.set(key, frame);
     }
   });
-
   newResponse.data.forEach((newFrame: DataFrame) => {
     let currentFrame: DataFrame | undefined = undefined;
     const key = getFrameKey(newFrame);
@@ -66,13 +62,11 @@ export function combineResponses(currentResponse: DataQueryResponse | null, newR
       currentResponse.data.push(cloneDataFrame(newFrame));
     }
   });
-
   const mergedErrors = [...(currentResponse.errors ?? []), ...(newResponse.errors ?? [])];
   if (mergedErrors.length > 0) {
     currentResponse.errors = mergedErrors;
     currentResponse.state = LoadingState.Error;
   }
-
   // the `.error` attribute is obsolete now,
   // but we have to maintain it, otherwise
   // some grafana parts do not behave well.
@@ -83,15 +77,12 @@ export function combineResponses(currentResponse: DataQueryResponse | null, newR
     currentResponse.error = mergedError;
     currentResponse.state = LoadingState.Error;
   }
-
   const mergedTraceIds = [...(currentResponse.traceIds ?? []), ...(newResponse.traceIds ?? [])];
   if (mergedTraceIds.length > 0) {
     currentResponse.traceIds = mergedTraceIds;
   }
-
   return currentResponse;
 }
-
 /**
  * Given an existing DataQueryResponse, replace any data frame present in newResponse with those in newResponse
  */
@@ -99,7 +90,6 @@ export function replaceResponses(currentResponse: DataQueryResponse | null, newR
   if (!currentResponse) {
     return cloneQueryResponse(newResponse);
   }
-
   newResponse.data.forEach((newFrame) => {
     const currentFrameIndex = currentResponse.data.findIndex((frame) => shouldCombine(frame, newFrame));
     if (currentFrameIndex < 0) {
@@ -108,30 +98,24 @@ export function replaceResponses(currentResponse: DataQueryResponse | null, newR
     }
     currentResponse.data[currentFrameIndex] = newFrame;
   });
-
   // Clean up loading frame when newResponse contains the final response
   if (newResponse.state === LoadingState.Done) {
     currentResponse.data = currentResponse.data.filter((frame) => frame.name !== LOADING_FRAME_NAME);
   }
-
   const mergedErrors = [...(currentResponse.errors ?? []), ...(newResponse.errors ?? [])];
   if (mergedErrors.length > 0) {
     currentResponse.errors = mergedErrors;
   }
-
   const mergedError = currentResponse.error ?? newResponse.error;
   if (mergedError != null) {
     currentResponse.error = mergedError;
   }
-
   const mergedTraceIds = [...(currentResponse.traceIds ?? []), ...(newResponse.traceIds ?? [])];
   if (mergedTraceIds.length > 0) {
     currentResponse.traceIds = mergedTraceIds;
   }
-
   return currentResponse;
 }
-
 /**
  * Given two data frames, merge their values. Overlapping values will be added together.
  */
@@ -140,20 +124,15 @@ export function mergeFrames(dest: DataFrame, source: DataFrame) {
   const destIdField = dest.fields.find((field) => field.type === FieldType.string && field.name === 'id');
   const sourceTimeField = source.fields.find((field) => field.type === FieldType.time);
   const sourceIdField = source.fields.find((field) => field.type === FieldType.string && field.name === 'id');
-
   if (!destTimeField || !sourceTimeField) {
-    console.error(new Error(`Time fields not found in the data frames`));
+    structLog('error', new Error(`Time fields not found in the data frames`));
     return;
   }
-
   const sourceTimeValues = sourceTimeField?.values.slice(0) ?? [];
   const totalFields = Math.max(dest.fields.length, source.fields.length);
-
   for (let i = 0; i < sourceTimeValues.length; i++) {
     const destIdx = resolveIdx(destTimeField, sourceTimeField, i);
-
     const entryExistsInDest = compareEntries(destTimeField, destIdField, destIdx, sourceTimeField, sourceIdField, i);
-
     for (let f = 0; f < totalFields; f++) {
       // For now, skip undefined fields that exist in the new frame
       if (!dest.fields[f]) {
@@ -199,16 +178,13 @@ export function mergeFrames(dest: DataFrame, source: DataFrame) {
       }
     }
   }
-
   dest.length = dest.fields[0].values.length;
-
   dest.meta = {
     ...dest.meta,
     stats: getCombinedMetadataStats(dest.meta?.stats ?? [], source.meta?.stats ?? []),
     notices: getCombinedNotices(dest.meta?.notices ?? [], source.meta?.notices ?? []),
   };
 }
-
 function resolveIdx(destField: Field, sourceField: Field, index: number) {
   const idx = closestIdx(sourceField.values[index], destField.values);
   if (idx < 0) {
@@ -222,7 +198,6 @@ function resolveIdx(destField: Field, sourceField: Field, index: number) {
   }
   return idx;
 }
-
 function compareEntries(
   destTimeField: Field,
   destIdField: Field | undefined,
@@ -243,7 +218,6 @@ function compareEntries(
     destIdField.values[destIndex] !== undefined && destIdField.values[destIndex] === sourceIdField.values[sourceIndex]
   );
 }
-
 function compareNsTimestamps(destField: Field, destIndex: number, sourceField: Field, sourceIndex: number) {
   if (destField.nanos && sourceField.nanos) {
     return (
@@ -255,21 +229,16 @@ function compareNsTimestamps(destField: Field, destIndex: number, sourceField: F
   }
   return destField.values[destIndex] !== undefined && destField.values[destIndex] === sourceField.values[sourceIndex];
 }
-
 function findSourceField(referenceField: Field, sourceFields: Field[], index: number) {
   const candidates = sourceFields.filter((f) => f.name === referenceField.name);
-
   if (candidates.length === 1) {
     return candidates[0];
   }
-
   if (referenceField.labels) {
     return candidates.find((candidate) => shallowCompare(referenceField.labels ?? {}, candidate.labels ?? {}));
   }
-
   return sourceFields[index];
 }
-
 const TOTAL_BYTES_STAT = 'Summary: total bytes processed';
 const EXEC_TIME_STAT = 'Summary: exec time';
 // This is specific for Loki
@@ -282,12 +251,10 @@ function getCombinedMetadataStats(
   for (const stat of [TOTAL_BYTES_STAT, EXEC_TIME_STAT]) {
     const destStat = destStats.find((s) => s.displayName === stat);
     const sourceStat = sourceStats.find((s) => s.displayName === stat);
-
     if (sourceStat != null && destStat != null) {
       stats.push({ value: sourceStat.value + destStat.value, displayName: stat, unit: destStat.unit });
       continue;
     }
-
     // maybe one of them exist
     const eitherStat = sourceStat ?? destStat;
     if (eitherStat != null) {
@@ -296,7 +263,6 @@ function getCombinedMetadataStats(
   }
   return stats;
 }
-
 function getCombinedNotices(
   destNotices: QueryResultMetaNotice[],
   sourceNotices: QueryResultMetaNotice[]
@@ -305,7 +271,6 @@ function getCombinedNotices(
   const allNotices = [...destNotices, ...sourceNotices].filter(
     (notice): notice is QueryResultMetaNotice => notice != null
   );
-
   // Deduplicate notices based on text to avoid showing the same warning twice
   const uniqueNotices = allNotices.reduce((acc: QueryResultMetaNotice[], notice) => {
     const exists = acc.some((n) => n.severity === notice.severity && n.text === notice.text);
@@ -314,10 +279,8 @@ function getCombinedNotices(
     }
     return acc;
   }, []);
-
   return uniqueNotices;
 }
-
 /**
  * Deep clones a DataQueryResponse
  */
@@ -328,7 +291,6 @@ export function cloneQueryResponse(response: DataQueryResponse): DataQueryRespon
   };
   return newResponse;
 }
-
 function cloneDataFrame(frame: DataQueryResponseData): DataQueryResponseData {
   return {
     ...frame,
@@ -338,20 +300,16 @@ function cloneDataFrame(frame: DataQueryResponseData): DataQueryResponseData {
     })),
   };
 }
-
 function shouldCombine(frame1: DataFrame, frame2: DataFrame): boolean {
   if (frame1.refId !== frame2.refId || frame1.name !== frame2.name) {
     return false;
   }
-
   const frameType1 = frame1.meta?.type;
   const frameType2 = frame2.meta?.type;
-
   if (frameType1 !== frameType2) {
     // we do not join things that have a different type
     return false;
   }
-
   // metric range query data
   if (frameType1 === DataFrameType.TimeSeriesMulti) {
     const field1 = frame1.fields.find((f) => f.type === FieldType.number);
@@ -360,10 +318,8 @@ function shouldCombine(frame1: DataFrame, frame2: DataFrame): boolean {
       // should never happen
       return false;
     }
-
     return shallowCompare(field1.labels ?? {}, field2.labels ?? {});
   }
-
   // logs query data
   // logs use a special attribute in the dataframe's "custom" section
   // because we do not have a good "frametype" value for them yet.
@@ -376,7 +332,6 @@ function shouldCombine(frame1: DataFrame, frame2: DataFrame): boolean {
     // Data plane frames don't
     return true;
   }
-
   // should never reach here
   return false;
 }

--- a/public/app/plugins/datasource/loki/querySplitting.ts
+++ b/public/app/plugins/datasource/loki/querySplitting.ts
@@ -1,7 +1,7 @@
+import { structLog } from '@grafana/data';
 import { groupBy, partition } from 'lodash';
 import { Observable, type Subscriber, type Subscription, tap } from 'rxjs';
 import { v4 as uuidv4 } from 'uuid';
-
 import {
   arrayToDataFrame,
   type DataQueryRequest,
@@ -14,7 +14,6 @@ import {
   type TimeRange,
 } from '@grafana/data';
 import { config } from '@grafana/runtime';
-
 import { LokiQueryType, LokiQueryDirection } from './dataquery.gen';
 import { type LokiDatasource } from './datasource';
 import {
@@ -30,7 +29,6 @@ import { addQueryLimitsContext, isLogsQuery, isQueryWithRangeVariable } from './
 import { isRetriableError } from './responseUtils';
 import { trackGroupedQueries } from './tracking';
 import { type LokiGroupedRequest, type LokiQuery } from './types';
-
 export function partitionTimeRange(
   isLogsQuery: boolean,
   originalTimeRange: TimeRange,
@@ -39,9 +37,7 @@ export function partitionTimeRange(
 ): TimeRange[] {
   const start = originalTimeRange.from.toDate().getTime();
   const end = originalTimeRange.to.toDate().getTime();
-
   let ranges: Array<[number, number]>;
-
   if (config.featureToggles.lokiAlignedQuerySplitting) {
     ranges = isLogsQuery
       ? splitLogsTimeRangeAligned(originalTimeRange)
@@ -51,7 +47,6 @@ export function partitionTimeRange(
       ? splitLogsTimeRange(start, end, duration)
       : splitMetricTimeRange(start, end, stepMs, duration);
   }
-
   return ranges.map(([start, end]) => {
     const from = dateTime(start);
     const to = dateTime(end);
@@ -62,7 +57,6 @@ export function partitionTimeRange(
     };
   });
 }
-
 interface QuerySplittingOptions {
   /**
    * Tells the query splitting code to not emit partial updates. Only emit on error or when it finishes querying.
@@ -77,7 +71,6 @@ interface QuerySplittingOptions {
    */
   shardQueryIndex?: number;
 }
-
 /**
  * Based in the state of the current response, if any, adjust target parameters such as `maxLines`.
  * For `maxLines`, we will update it as `maxLines - current amount of lines`.
@@ -88,7 +81,6 @@ export function adjustTargetsFromResponseState(targets: LokiQuery[], response: D
   if (!response) {
     return targets;
   }
-
   return targets
     .map((target) => {
       if (!target.maxLines || !isLogsQuery(target.expr)) {
@@ -106,7 +98,6 @@ export function adjustTargetsFromResponseState(targets: LokiQuery[], response: D
     })
     .filter((target) => target.maxLines === undefined || target.maxLines > 0);
 }
-
 const addLimitsToSplitRequests = (splitQueryIndex: number, shardQueryIndex: number, requests: LokiGroupedRequest[]) => {
   // requests has already been mutated
   return requests.map((r) => ({
@@ -124,7 +115,6 @@ const addLimitsToSplitRequests = (splitQueryIndex: number, shardQueryIndex: numb
     },
   }));
 };
-
 export function runSplitGroupedQueries(
   datasource: LokiDatasource,
   requests: LokiGroupedRequest[],
@@ -134,41 +124,33 @@ export function runSplitGroupedQueries(
   let mergedResponse: DataQueryResponse = { data: [], state: LoadingState.Streaming, key: responseKey };
   const totalRequests = Math.max(...requests.map(({ partition }) => partition.length));
   const longestPartition = requests.filter(({ partition }) => partition.length === totalRequests)[0].partition;
-
   let shouldStop = false;
   let subquerySubscription: Subscription | null = null;
   let retriesMap = new Map<string, number>();
   let retryTimer: ReturnType<typeof setTimeout> | null = null;
   let splitQueryIndex = 0;
   const shardQueryIndex = options.shardQueryIndex ?? 0;
-
   const runNextRequest = (subscriber: Subscriber<DataQueryResponse>, requestN: number, requestGroup: number) => {
     if (config.featureToggles.lokiQueryLimitsContext) {
       requests = addLimitsToSplitRequests(splitQueryIndex, shardQueryIndex, requests);
     }
-
     splitQueryIndex++;
     let retrying = false;
-
     if (subquerySubscription != null) {
       subquerySubscription.unsubscribe();
       subquerySubscription = null;
     }
-
     if (shouldStop) {
       subscriber.complete();
       return;
     }
-
     const done = () => {
       if (mergedResponse.state !== LoadingState.Error) {
         mergedResponse.state = LoadingState.Done;
       }
-
       subscriber.next(mergedResponse);
       subscriber.complete();
     };
-
     const nextRequest = () => {
       const { nextRequestN, nextRequestGroup } = getNextRequestPointers(requests, requestGroup, requestN);
       if (nextRequestN > 0 && nextRequestGroup >= 0) {
@@ -177,7 +159,6 @@ export function runSplitGroupedQueries(
       }
       done();
     };
-
     const retry = (errorResponse?: DataQueryResponse) => {
       if (options.disableRetry) {
         return false;
@@ -187,46 +168,37 @@ export function runSplitGroupedQueries(
           return false;
         }
       } catch (e) {
-        console.error(e);
+        structLog('error', e);
         shouldStop = true;
         return false;
       }
-
       const key = `${requestN}-${requestGroup}`;
       const retries = retriesMap.get(key) ?? 0;
       if (retries > 0) {
         return false;
       }
-
       retriesMap.set(key, retries + 1);
-
       retryTimer = setTimeout(
         () => {
           runNextRequest(subscriber, requestN, requestGroup);
         },
         1500 * Math.pow(2, retries)
       ); // Exponential backoff
-
       retrying = true;
-
       return true;
     };
-
     const group = requests[requestGroup];
     const range = group.partition[requestN - 1];
     const targets = adjustTargetsFromResponseState(group.request.targets, mergedResponse);
-
     if (!targets.length) {
       nextRequest();
       return;
     }
-
     const subRequest = { ...requests[requestGroup].request, range, targets };
     // request may not have a request id
     if (group.request.requestId) {
       subRequest.requestId = `${group.request.requestId}_${requestN}`;
     }
-
     subquerySubscription = datasource.runQuery(subRequest).subscribe({
       next: (partialResponse) => {
         if ((partialResponse.errors ?? []).length > 0 || partialResponse.error != null) {
@@ -239,7 +211,6 @@ export function runSplitGroupedQueries(
         if (!options.skipPartialUpdates) {
           mergedResponse = updateLoadingFrame(mergedResponse, subRequest, longestPartition, requestN);
         }
-
         if (mergedResponse.state === LoadingState.Error) {
           done();
         }
@@ -261,7 +232,6 @@ export function runSplitGroupedQueries(
       },
     });
   };
-
   const response = new Observable<DataQueryResponse>((subscriber) => {
     runNextRequest(subscriber, totalRequests, 0);
     return () => {
@@ -276,12 +246,9 @@ export function runSplitGroupedQueries(
       }
     };
   });
-
   return response;
 }
-
 export const LOADING_FRAME_NAME = 'loki-splitting-progress';
-
 function updateLoadingFrame(
   response: DataQueryResponse,
   request: DataQueryRequest<LokiQuery>,
@@ -292,11 +259,9 @@ function updateLoadingFrame(
     return response;
   }
   response.data = response.data.filter((frame) => frame.name !== LOADING_FRAME_NAME);
-
   if (requestN <= 1) {
     return response;
   }
-
   const loadingFrame = arrayToDataFrame([
     {
       time: partition[0].from.valueOf(),
@@ -309,12 +274,9 @@ function updateLoadingFrame(
   loadingFrame.meta = {
     dataTopic: DataTopic.Annotations,
   };
-
   response.data.push(loadingFrame);
-
   return response;
 }
-
 function getNextRequestPointers(requests: LokiGroupedRequest[], requestGroup: number, requestN: number) {
   // There's a pending request from the next group:
   for (let i = requestGroup + 1; i < requests.length; i++) {
@@ -332,7 +294,6 @@ function getNextRequestPointers(requests: LokiGroupedRequest[], requestGroup: nu
     nextRequestN: requestN - 1,
   };
 }
-
 function querySupportsSplitting(query: LokiQuery) {
   return (
     query.queryType !== LokiQueryType.Instant &&
@@ -341,7 +302,6 @@ function querySupportsSplitting(query: LokiQuery) {
     !isQueryWithRangeVariable(query.expr)
   );
 }
-
 export function runSplitQuery(
   datasource: LokiDatasource,
   request: DataQueryRequest<LokiQuery>,
@@ -353,7 +313,6 @@ export function runSplitQuery(
     .map((query) => datasource.applyTemplateVariables(query, request.scopedVars, request.filters));
   const [nonSplittingQueries, normalQueries] = partition(queries, (query) => !querySupportsSplitting(query));
   const [logQueries, metricQueries] = partition(normalQueries, (query) => isLogsQuery(query.expr));
-
   request.queryGroupId = uuidv4();
   // Allow custom split durations for debugging, e.g. `localStorage.setItem('grafana.loki.querySplitInterval', 24 * 60 * 1000) // 1 hour`
   const debugSplitDuration = parseInt(store.get('grafana.loki.querySplitInterval'), 10);
@@ -362,7 +321,6 @@ export function runSplitQuery(
     query.direction === LokiQueryDirection.Forward ? LokiQueryDirection.Forward : LokiQueryDirection.Backward
   );
   const requests: LokiGroupedRequest[] = [];
-
   for (const direction in directionPartitionedLogQueries) {
     const queries = directionPartitionedLogQueries[direction];
     const resolutionPartition = groupBy(queries, (query) => query.resolution || 1);
@@ -371,19 +329,15 @@ export function runSplitQuery(
         request: { ...request, targets: resolutionPartition[resolution] },
         partition: partitionTimeRange(true, request.range, request.intervalMs, oneDayMs),
       };
-
       if (direction === LokiQueryDirection.Forward) {
         groupedRequest.partition.reverse();
       }
-
       requests.push(groupedRequest);
     }
   }
-
   const stepMsPartition = groupBy(metricQueries, (query) =>
     calculateStep(request.intervalMs, request.range, query.resolution || 1, query.step)
   );
-
   for (const stepMs in stepMsPartition) {
     const targets = stepMsPartition[stepMs].map((q) => {
       const { maxLines, ...query } = q;
@@ -394,14 +348,12 @@ export function runSplitQuery(
       partition: partitionTimeRange(false, request.range, Number(stepMs), oneDayMs),
     });
   }
-
   if (nonSplittingQueries.length) {
     requests.push({
       request: { ...request, targets: nonSplittingQueries },
       partition: [request.range],
     });
   }
-
   const startTime = new Date();
   return runSplitGroupedQueries(datasource, requests, options).pipe(
     tap((response) => {
@@ -411,7 +363,6 @@ export function runSplitQuery(
     })
   );
 }
-
 // Replicate from backend for split queries for now, until we can move query splitting to the backend
 // https://github.com/grafana/grafana/blob/main/pkg/tsdb/loki/step.go#L23
 function calculateStep(intervalMs: number, range: TimeRange, resolution: number, step: string | undefined) {
@@ -421,7 +372,6 @@ function calculateStep(intervalMs: number, range: TimeRange, resolution: number,
   if (step?.match(interval_regex)) {
     return rangeUtil.intervalToMs(step) * resolution;
   }
-
   const newStep = intervalMs * resolution;
   const safeStep = Math.round((range.to.valueOf() - range.from.valueOf()) / 11000);
   return Math.max(newStep, safeStep);

--- a/public/app/plugins/datasource/loki/querybuilder/LokiQueryModeller.ts
+++ b/public/app/plugins/datasource/loki/querybuilder/LokiQueryModeller.ts
@@ -1,3 +1,4 @@
+import { structLog } from '@grafana/data';
 import {
   QueryModellerBase,
   type QueryBuilderLabelFilter,
@@ -5,7 +6,6 @@ import {
   type QueryBuilderOperation,
   type VisualQueryBinary,
 } from '@grafana/plugin-ui';
-
 import { operationDefinitions } from './operations';
 import {
   LokiOperationId,
@@ -13,11 +13,9 @@ import {
   LokiQueryPatternType,
   LokiVisualQueryOperationCategory,
 } from './types';
-
 export class LokiQueryModeller extends QueryModellerBase {
   constructor() {
     super(operationDefinitions, '<expr>');
-
     this.setOperationCategories([
       LokiVisualQueryOperationCategory.Aggregations,
       LokiVisualQueryOperationCategory.RangeFunctions,
@@ -27,7 +25,6 @@ export class LokiQueryModeller extends QueryModellerBase {
       LokiVisualQueryOperationCategory.LineFilters,
     ]);
   }
-
   renderOperations(queryString: string, operations: QueryBuilderOperation[]): string {
     for (const operation of operations) {
       if (operation.disabled) {
@@ -35,14 +32,13 @@ export class LokiQueryModeller extends QueryModellerBase {
       }
       const def = this.operationsRegistry.getIfExists(operation.id);
       if (!def) {
-        console.error(`Could not find operation ${operation.id} in the registry`);
+        structLog('error', `Could not find operation ${operation.id} in the registry`);
         continue;
       }
       queryString = def.renderer(operation, def, queryString);
     }
     return queryString;
   }
-
   renderBinaryQueries(queryString: string, binaryQueries?: Array<VisualQueryBinary<VisualQuery>>) {
     if (binaryQueries) {
       for (const binQuery of binaryQueries) {
@@ -51,47 +47,35 @@ export class LokiQueryModeller extends QueryModellerBase {
     }
     return queryString;
   }
-
   private renderBinaryQuery(leftOperand: string, binaryQuery: VisualQueryBinary<VisualQuery>) {
     let result = leftOperand + ` ${binaryQuery.operator} `;
-
     if (binaryQuery.vectorMatches) {
       result += `${binaryQuery.vectorMatchesType}(${binaryQuery.vectorMatches}) `;
     }
-
     return result + this.renderQuery(binaryQuery.query, true);
   }
-
   renderLabels(labels: QueryBuilderLabelFilter[]): string {
     if (labels.length === 0) {
       return '{}';
     }
-
     let expr = '{';
     for (const filter of labels) {
       if (expr !== '{') {
         expr += ', ';
       }
-
       expr += `${filter.label}${filter.op}"${filter.value}"`;
     }
-
     return expr + `}`;
   }
-
   renderQuery(query: VisualQuery, nested?: boolean): string {
     let queryString = this.renderLabels(query.labels);
     queryString = this.renderOperations(queryString, query.operations);
-
     if (!nested && this.hasBinaryOp(query) && Boolean(query.binaryQueries?.length)) {
       queryString = `(${queryString})`;
     }
-
     queryString = this.renderBinaryQueries(queryString, query.binaryQueries);
-
     return queryString;
   }
-
   getQueryPatterns(): LokiQueryPattern[] {
     return [
       {
@@ -260,5 +244,4 @@ export class LokiQueryModeller extends QueryModellerBase {
     ];
   }
 }
-
 export const lokiQueryModeller = new LokiQueryModeller();

--- a/public/app/plugins/datasource/loki/querybuilder/components/LokiQueryBuilder.tsx
+++ b/public/app/plugins/datasource/loki/querybuilder/components/LokiQueryBuilder.tsx
@@ -8,6 +8,7 @@ import {
   LoadingState,
   type PanelData,
   type SelectableValue,
+  structLog,
   type TimeRange,
 } from '@grafana/data';
 import {
@@ -134,7 +135,9 @@ export const LokiQueryBuilder = memo<Props>(({ datasource, query, onChange, onRu
         Math.abs(timeRange.from.valueOf() - prevTimeRange.from.valueOf()) > TIME_SPAN_TO_TRIGGER_SAMPLES);
     const updateBasedOnChangedQuery = !isEqual(prevQuery, query);
     if (updateBasedOnChangedTimeRange || updateBasedOnChangedQuery) {
-      onGetSampleData().catch(console.error);
+      onGetSampleData().catch((err) => {
+        structLog('error', err);
+      });
     }
   }, [datasource, query, timeRange, prevQuery, prevTimeRange]);
 

--- a/public/app/plugins/datasource/loki/querybuilder/parsing.ts
+++ b/public/app/plugins/datasource/loki/querybuilder/parsing.ts
@@ -1,5 +1,5 @@
+import { structLog } from '@grafana/data';
 import { type SyntaxNode } from '@lezer/common';
-
 import {
   And,
   BinOpExpr,
@@ -58,7 +58,6 @@ import {
   type QueryBuilderOperation,
   type QueryBuilderOperationParamValue,
 } from '@grafana/plugin-ui';
-
 import { binaryScalarDefs } from './binaryScalarOperations';
 import { checkParamsAreValid, getDefinitionById } from './operations';
 import {
@@ -71,59 +70,50 @@ import {
   replaceVariables,
 } from './parsingUtils';
 import { LokiOperationId, type LokiVisualQuery, type LokiVisualQueryBinary } from './types';
-
 interface Context {
   query: LokiVisualQuery;
   errors: ParsingError[];
 }
-
 interface ParsingError {
   text: string;
   from?: number;
   to?: number;
   parentType?: string;
 }
-
 interface GetOperationResult {
   operation?: QueryBuilderOperation;
   error?: string;
 }
-
 export function buildVisualQueryFromString(expr: string): Context {
   const replacedExpr = replaceVariables(expr);
   const tree = parser.parse(replacedExpr);
   const node = tree.topNode;
-
   // This will be modified in the handleExpression
   const visQuery: LokiVisualQuery = {
     labels: [],
     operations: [],
   };
-
   const context: Context = {
     query: visQuery,
     errors: [],
   };
-
   try {
     handleExpression(replacedExpr, node, context);
   } catch (err) {
     // Not ideal to log it here, but otherwise we would lose the stack trace.
-    console.error(err);
+    structLog('error', err);
     if (err instanceof Error) {
       context.errors.push({
         text: err.message,
       });
     }
   }
-
   // If we have empty query, we want to reset errors
   if (isEmptyQuery(context.query)) {
     context.errors = [];
   }
   return context;
 }
-
 export function handleExpression(expr: string, node: SyntaxNode, context: Context) {
   const visQuery = context.query;
   switch (node.type.id) {
@@ -135,7 +125,6 @@ export function handleExpression(expr: string, node: SyntaxNode, context: Contex
       }
       break;
     }
-
     case LineFilter: {
       const { operation, error } = getLineFilter(expr, node);
       if (operation) {
@@ -147,12 +136,10 @@ export function handleExpression(expr: string, node: SyntaxNode, context: Contex
       }
       break;
     }
-
     case LabelParser: {
       visQuery.operations.push(getLabelParser(expr, node));
       break;
     }
-
     case LabelFilter: {
       const { operation, error } = getLabelFilter(expr, node);
       if (operation) {
@@ -168,7 +155,6 @@ export function handleExpression(expr: string, node: SyntaxNode, context: Contex
       visQuery.operations.push(getJsonExpressionParser(expr, node));
       break;
     }
-
     case LogfmtParser:
     case LogfmtExpressionParser: {
       const { operation, error } = getLogfmtParser(expr, node);
@@ -180,17 +166,14 @@ export function handleExpression(expr: string, node: SyntaxNode, context: Contex
       }
       break;
     }
-
     case LineFormatExpr: {
       visQuery.operations.push(getLineFormat(expr, node));
       break;
     }
-
     case LabelFormatMatcher: {
       visQuery.operations.push(getLabelFormat(expr, node));
       break;
     }
-
     case UnwrapExpr: {
       const { operation, error } = handleUnwrapExpr(expr, node, context);
       if (operation) {
@@ -200,30 +183,24 @@ export function handleExpression(expr: string, node: SyntaxNode, context: Contex
       if (error) {
         context.errors.push(createNotSupportedError(expr, node, error));
       }
-
       break;
     }
-
     case Decolorize: {
       visQuery.operations.push(getDecolorize());
       break;
     }
-
     case RangeAggregationExpr: {
       visQuery.operations.push(handleRangeAggregation(expr, node, context));
       break;
     }
-
     case VectorAggregationExpr: {
       visQuery.operations.push(handleVectorAggregation(expr, node, context));
       break;
     }
-
     case BinOpExpr: {
       handleBinary(expr, node, context);
       break;
     }
-
     case ErrorId: {
       if (isIntervalVariableError(node)) {
         break;
@@ -231,17 +208,14 @@ export function handleExpression(expr: string, node: SyntaxNode, context: Contex
       context.errors.push(makeError(expr, node));
       break;
     }
-
     case DropLabelsExpr: {
       visQuery.operations.push(handleDropFilter(expr, node, context));
       break;
     }
-
     case KeepLabelsExpr: {
       visQuery.operations.push(handleKeepFilter(expr, node, context));
       break;
     }
-
     default: {
       // Any other nodes we just ignore and go to its children. This should be fine as there are lots of wrapper
       // nodes that can be skipped.
@@ -255,7 +229,6 @@ export function handleExpression(expr: string, node: SyntaxNode, context: Contex
     }
   }
 }
-
 function getLabel(expr: string, node: SyntaxNode): QueryBuilderLabelFilter {
   const labelNode = node.getChild(Identifier);
   const label = getString(expr, labelNode);
@@ -263,14 +236,12 @@ function getLabel(expr: string, node: SyntaxNode): QueryBuilderLabelFilter {
   let value = getString(expr, node.getChild(String));
   // `value` is wrapped in double quotes, so we need to remove them. As a value can contain double quotes, we can't use RegEx here.
   value = value.substring(1, value.length - 1);
-
   return {
     label,
     op,
     value,
   };
 }
-
 function getLineFilter(expr: string, node: SyntaxNode): GetOperationResult {
   const filter = getString(expr, node.getChild(Filter));
   const filterExpr = handleQuotes(getString(expr, node.getChild(String)));
@@ -283,21 +254,18 @@ function getLineFilter(expr: string, node: SyntaxNode): GetOperationResult {
       },
     };
   }
-
   const params = [filterExpr];
   let orFilter = node.getChild(OrFilter);
   while (orFilter) {
     params.push(handleQuotes(getString(expr, orFilter.getChild(String))));
     orFilter = orFilter.getChild(OrFilter);
   }
-
   const mapFilter: Record<string, LokiOperationId> = {
     '|=': LokiOperationId.LineContains,
     '!=': LokiOperationId.LineContainsNot,
     '|~': LokiOperationId.LineMatchesRegex,
     '!~': LokiOperationId.LineMatchesRegexNot,
   };
-
   return {
     operation: {
       id: mapFilter[filter],
@@ -305,40 +273,33 @@ function getLineFilter(expr: string, node: SyntaxNode): GetOperationResult {
     },
   };
 }
-
 function getLabelParser(expr: string, node: SyntaxNode): QueryBuilderOperation {
   const parserNode = node.firstChild;
   const parser = getString(expr, parserNode);
-
   const string = handleQuotes(getString(expr, node.getChild(String)));
   let params: QueryBuilderOperationParamValue[] = !!string ? [string] : [];
   const opDef = getDefinitionById(parser);
   if (opDef && !checkParamsAreValid(opDef, params)) {
     params = opDef?.defaultParams || [];
   }
-
   return {
     id: parser,
     params,
   };
 }
-
 function getJsonExpressionParser(expr: string, node: SyntaxNode): QueryBuilderOperation {
   const parserNode = node.getChild(Json);
   const parser = getString(expr, parserNode);
-
   const params = [...getAllByType(expr, node, LabelExtractionExpression)];
   return {
     id: parser,
     params,
   };
 }
-
 function getLogfmtParser(expr: string, node: SyntaxNode): GetOperationResult {
   const flags: string[] = [];
   const labels: string[] = [];
   let error: string | undefined = undefined;
-
   const offset = node.from;
   node.toTree().iterate({
     enter: (subNode) => {
@@ -351,18 +312,15 @@ function getLogfmtParser(expr: string, node: SyntaxNode): GetOperationResult {
       }
     },
   });
-
   const operation = {
     id: LokiOperationId.Logfmt,
     params: [flags.includes('--strict'), flags.includes('--keep-empty'), ...labels],
   };
-
   return {
     operation,
     error,
   };
 }
-
 function getLabelFilter(expr: string, node: SyntaxNode): GetOperationResult {
   // Check for nodes not supported in visual builder and return error
   if (node.getChild(Or) || node.getChild(And) || node.getChild('Comma')) {
@@ -376,7 +334,6 @@ function getLabelFilter(expr: string, node: SyntaxNode): GetOperationResult {
     const op = label?.nextSibling;
     const value = ipLabelFilter?.getChild(String);
     const valueString = handleQuotes(getString(expr, value));
-
     return {
       operation: {
         id: LokiOperationId.LabelFilterIpMatches,
@@ -384,7 +341,6 @@ function getLabelFilter(expr: string, node: SyntaxNode): GetOperationResult {
       },
     };
   }
-
   const id = LokiOperationId.LabelFilter;
   if (node.firstChild!.type.id === UnitFilter) {
     const filter = node.firstChild!.firstChild;
@@ -392,7 +348,6 @@ function getLabelFilter(expr: string, node: SyntaxNode): GetOperationResult {
     const op = label!.nextSibling;
     const value = op!.nextSibling;
     const valueString = handleQuotes(getString(expr, value));
-
     return {
       operation: {
         id,
@@ -406,7 +361,6 @@ function getLabelFilter(expr: string, node: SyntaxNode): GetOperationResult {
   const op = label!.nextSibling;
   const value = op!.nextSibling;
   const params = [getString(expr, label), getString(expr, op), handleQuotes(getString(expr, value))];
-
   // Special case of pipe filtering - no errors
   if (params.join('') === `__error__=`) {
     return {
@@ -416,7 +370,6 @@ function getLabelFilter(expr: string, node: SyntaxNode): GetOperationResult {
       },
     };
   }
-
   return {
     operation: {
       id,
@@ -424,51 +377,41 @@ function getLabelFilter(expr: string, node: SyntaxNode): GetOperationResult {
     },
   };
 }
-
 function getLineFormat(expr: string, node: SyntaxNode): QueryBuilderOperation {
   const id = LokiOperationId.LineFormat;
   const string = handleQuotes(getString(expr, node.getChild(String)));
-
   return {
     id,
     params: [string],
   };
 }
-
 function getLabelFormat(expr: string, node: SyntaxNode): QueryBuilderOperation {
   const id = LokiOperationId.LabelFormat;
   const renameTo = node.getChild(Identifier);
   const op = renameTo!.nextSibling;
   const originalLabel = op!.nextSibling;
-
   return {
     id,
     params: [getString(expr, originalLabel), handleQuotes(getString(expr, renameTo))],
   };
 }
-
 function getDecolorize(): QueryBuilderOperation {
   const id = LokiOperationId.Decolorize;
-
   return {
     id,
     params: [],
   };
 }
-
 function handleUnwrapExpr(expr: string, node: SyntaxNode, context: Context): GetOperationResult {
   const unwrapExprChild = node.getChild(UnwrapExpr);
   const labelFilterChild = node.getChild(LabelFilter);
   const unwrapChild = node.getChild(Unwrap);
-
   if (unwrapExprChild) {
     handleExpression(expr, unwrapExprChild, context);
   }
-
   if (labelFilterChild) {
     handleExpression(expr, labelFilterChild, context);
   }
-
   if (unwrapChild) {
     if (unwrapChild.nextSibling?.type.id === ConvOp) {
       const convOp = unwrapChild.nextSibling;
@@ -480,7 +423,6 @@ function handleUnwrapExpr(expr: string, node: SyntaxNode, context: Context): Get
         },
       };
     }
-
     return {
       operation: {
         id: LokiOperationId.Unwrap,
@@ -488,10 +430,8 @@ function handleUnwrapExpr(expr: string, node: SyntaxNode, context: Context): Get
       },
     };
   }
-
   return {};
 }
-
 function handleRangeAggregation(expr: string, node: SyntaxNode, context: Context) {
   const nameNode = node.getChild(RangeOp);
   const funcName = getString(expr, nameNode);
@@ -501,61 +441,47 @@ function handleRangeAggregation(expr: string, node: SyntaxNode, context: Context
   const range = logExpr?.getChild(Range);
   const rangeValue = range ? getString(expr, range) : null;
   const grouping = node.getChild(Grouping);
-
   if (rangeValue) {
     params.unshift(rangeValue.substring(1, rangeValue.length - 1));
   }
-
   if (grouping) {
     params.push(...getAllByType(expr, grouping, Identifier));
   }
-
   const op = {
     id: funcName,
     params,
   };
-
   if (logExpr) {
     handleExpression(expr, logExpr, context);
   }
-
   return op;
 }
-
 function handleVectorAggregation(expr: string, node: SyntaxNode, context: Context) {
   const nameNode = node.getChild(VectorOp);
   let funcName = getString(expr, nameNode);
-
   const grouping = node.getChild(Grouping);
   const params = [];
-
   const numberNode = node.getChild(NumberLezer);
   const errorNode = node.getChild(ErrorId)?.getChild(Identifier);
-
   if (numberNode) {
     params.push(Number(getString(expr, numberNode)));
   } else if (errorNode) {
     // Variables get parsed as errors, so the value us an identifier within an error node.
     params.push(getString(expr, errorNode));
   }
-
   if (grouping) {
     const byModifier = grouping.getChild(By);
     if (byModifier && funcName) {
       funcName = `__${funcName}_by`;
     }
-
     const withoutModifier = grouping.getChild(Without);
     if (withoutModifier) {
       funcName = `__${funcName}_without`;
     }
-
     params.push(...getAllByType(expr, grouping, Identifier));
   }
-
   const metricExpr = node.getChild(MetricExpr);
   const op: QueryBuilderOperation = { id: funcName, params };
-
   if (metricExpr) {
     // A vector aggregation expression with a child of metric expression with a child of binary expression is ambiguous after being parsed into a visual query
     if (metricExpr.firstChild?.type.id === BinOpExpr) {
@@ -565,21 +491,25 @@ function handleVectorAggregation(expr: string, node: SyntaxNode, context: Contex
         to: metricExpr.firstChild?.to,
       });
     }
-
     handleExpression(expr, metricExpr, context);
   }
-
   return op;
 }
-
-const operatorToOpName = binaryScalarDefs.reduce<Record<string, { id: string; comparison?: boolean }>>((acc, def) => {
+const operatorToOpName = binaryScalarDefs.reduce<
+  Record<
+    string,
+    {
+      id: string;
+      comparison?: boolean;
+    }
+  >
+>((acc, def) => {
   acc[def.sign] = {
     id: def.id,
     comparison: def.comparison,
   };
   return acc;
 }, {});
-
 /**
  * Right now binary expressions can be represented in 2 way in visual query. As additional operation in case it is
  * just operation with scalar or it creates a binaryQuery when it's 2 queries.
@@ -592,16 +522,11 @@ function handleBinary(expr: string, node: SyntaxNode, context: Context) {
   const left = node.firstChild!;
   const op = getString(expr, left.nextSibling);
   const binModifier = getBinaryModifier(expr, node.getChild(BinOpModifier));
-
   const right = node.lastChild!;
-
   const opDef = operatorToOpName[op];
-
   const leftNumber = getLastChildWithSelector(left, 'MetricExpr.LiteralExpr.Number');
   const rightNumber = getLastChildWithSelector(right, 'MetricExpr.LiteralExpr.Number');
-
   const rightBinary = right.getChild(BinOpExpr);
-
   if (leftNumber) {
     // TODO: this should be already handled in case parent is binary expression as it has to be added to parent
     //  if query starts with a number that isn't handled now.
@@ -610,7 +535,6 @@ function handleBinary(expr: string, node: SyntaxNode, context: Context) {
     // we have to traverse a bit deeper to know
     handleExpression(expr, left, context);
   }
-
   if (rightNumber) {
     visQuery.operations.push(makeBinOp(opDef, expr, right, !!binModifier?.isBool));
   } else if (rightBinary) {
@@ -620,7 +544,6 @@ function handleBinary(expr: string, node: SyntaxNode, context: Context) {
     if (leftMostChild?.type.id === NumberLezer) {
       visQuery.operations.push(makeBinOp(opDef, expr, leftMostChild, !!binModifier?.isBool));
     }
-
     // If we added the first number literal as operation here we still can continue and handle the rest as the first
     // number will be just skipped.
     handleExpression(expr, right, context);
@@ -644,20 +567,26 @@ function handleBinary(expr: string, node: SyntaxNode, context: Context) {
     });
   }
 }
-
 function getBinaryModifier(
   expr: string,
   node: SyntaxNode | null
 ):
-  | { isBool: true; isMatcher: false }
-  | { isBool: boolean; isMatcher: true; matches: string; matchType: 'ignoring' | 'on' }
+  | {
+      isBool: true;
+      isMatcher: false;
+    }
+  | {
+      isBool: boolean;
+      isMatcher: true;
+      matches: string;
+      matchType: 'ignoring' | 'on';
+    }
   | undefined {
   if (!node) {
     return undefined;
   }
   const matcher = node.getChild(OnOrIgnoringModifier);
   const boolMatcher = node.getChild(Bool);
-
   if (!matcher && boolMatcher) {
     return { isBool: true, isMatcher: false };
   } else {
@@ -674,11 +603,9 @@ function getBinaryModifier(
     };
   }
 }
-
 function isIntervalVariableError(node: SyntaxNode) {
   return node?.parent?.type.id === Range;
 }
-
 export function handleQuotes(string: string) {
   if (string[0] === `"` && string[string.length - 1] === `"`) {
     return string
@@ -688,7 +615,6 @@ export function handleQuotes(string: string) {
   }
   return string.replace(/`/g, '');
 }
-
 /**
  * Simple helper to traverse the syntax tree. Instead of node.getChild('foo')?.getChild('bar')?.getChild('baz') you
  * can write getChildWithSelector(node, 'foo.bar.baz')
@@ -706,7 +632,6 @@ function getLastChildWithSelector(node: SyntaxNode, selector: string) {
   }
   return child;
 }
-
 /**
  * Helper function to enrich error text with information that visual query builder doesn't support that logQL
  * @param expr
@@ -718,14 +643,12 @@ function createNotSupportedError(expr: string, node: SyntaxNode, error: string) 
   err.text = `${error}: ${err.text}`;
   return err;
 }
-
 function isEmptyQuery(query: LokiVisualQuery) {
   if (query.labels.length === 0 && query.operations.length === 0) {
     return true;
   }
   return false;
 }
-
 function handleDropFilter(expr: string, node: SyntaxNode, context: Context): QueryBuilderOperation {
   const labels: string[] = [];
   let exploringNode = node.getChild(DropLabels);
@@ -742,7 +665,6 @@ function handleDropFilter(expr: string, node: SyntaxNode, context: Context): Que
     params: labels,
   };
 }
-
 function handleKeepFilter(expr: string, node: SyntaxNode, context: Context): QueryBuilderOperation {
   const labels: string[] = [];
   let exploringNode = node.getChild(KeepLabels);

--- a/public/app/plugins/datasource/loki/shardQuerySplitting.ts
+++ b/public/app/plugins/datasource/loki/shardQuerySplitting.ts
@@ -1,10 +1,9 @@
+import { structLog } from '@grafana/data';
 import { groupBy, partition } from 'lodash';
 import { Observable, type Subscriber, type Subscription } from 'rxjs';
 import { v4 as uuidv4 } from 'uuid';
-
 import { type DataQueryRequest, type DataQueryResponse, LoadingState, type QueryResultMetaStat } from '@grafana/data';
 import { config } from '@grafana/runtime';
-
 import { type LokiDatasource } from './datasource';
 import { combineResponses, replaceResponses } from './mergeResponses';
 import { adjustTargetsFromResponseState, runSplitQuery } from './querySplitting';
@@ -49,16 +48,13 @@ import { type LokiQuery } from './types';
  *       . If there are retry attempts, it will retry the current cycle, or else stop querying.
  * - Once all request groups have been executed, it will be done().
  */
-
 export function runShardSplitQuery(datasource: LokiDatasource, request: DataQueryRequest<LokiQuery>) {
   const queries = request.targets
     .filter((query) => query.expr)
     .filter((query) => !query.hide)
     .map((query) => datasource.applyTemplateVariables(query, request.scopedVars, request.filters));
-
   return splitQueriesByStreamShard(datasource, request, queries);
 }
-
 const addLimitsToShardGroups = (
   queryIndex: number,
   groups: ShardedQueryGroup[],
@@ -71,7 +67,6 @@ const addLimitsToShardGroups = (
     }),
   }));
 };
-
 function splitQueriesByStreamShard(
   datasource: LokiDatasource,
   request: DataQueryRequest<LokiQuery>,
@@ -83,7 +78,6 @@ function splitQueriesByStreamShard(
   let retriesMap = new Map<string, number>();
   let retryTimer: ReturnType<typeof setTimeout> | null = null;
   let queryIndex = 0;
-
   const runNextRequest = (subscriber: Subscriber<DataQueryResponse>, group: number, groups: ShardedQueryGroup[]) => {
     if (config.featureToggles.lokiQueryLimitsContext) {
       groups = addLimitsToShardGroups(queryIndex, groups, request);
@@ -92,30 +86,25 @@ function splitQueriesByStreamShard(
     let nextGroupSize = groups[group].groupSize;
     const { shards, groupSize, cycle } = groups[group];
     let retrying = false;
-
     if (subquerySubscription != null) {
       subquerySubscription.unsubscribe();
       subquerySubscription = null;
     }
-
     const done = () => {
       mergedResponse.state = shouldStop ? LoadingState.Error : LoadingState.Done;
       subscriber.next(mergedResponse);
       subscriber.complete();
     };
-
     if (shouldStop) {
       done();
       return;
     }
-
     const nextRequest = () => {
       // Find the next group to execute, which can be queries with pending shards to execute, or the next query with no shards.
       const nextGroup =
         groups[group + 1] && (groups[group + 1].shards === undefined || groupHasPendingRequests(groups[group + 1]))
           ? groups[group + 1]
           : groups.find((shardGroup) => groupHasPendingRequests(shardGroup));
-
       if (nextGroup === undefined) {
         done();
         return;
@@ -123,18 +112,16 @@ function splitQueriesByStreamShard(
       groups[group].groupSize = nextGroupSize;
       runNextRequest(subscriber, groups.indexOf(nextGroup), groups);
     };
-
     const retry = (errorResponse?: DataQueryResponse) => {
       try {
         if (errorResponse && !isRetriableError(errorResponse)) {
           return false;
         }
       } catch (e) {
-        console.error(e);
+        structLog('error', e);
         shouldStop = true;
         return false;
       }
-
       if (groupSize !== undefined && groupSize > 1) {
         groups[group].groupSize = Math.floor(Math.sqrt(groupSize));
         debug(`Possible time out, new group size ${groups[group].groupSize}`);
@@ -142,37 +129,29 @@ function splitQueriesByStreamShard(
         runNextRequest(subscriber, group, groups);
         return true;
       }
-
       const key = `${group}_${cycle}`;
       const retries = retriesMap.get(key) ?? 0;
-
       if (retries > 1) {
         shouldStop = true;
         return false;
       }
-
       retriesMap.set(key, retries + 1);
-
       retryTimer = setTimeout(
         () => {
-          console.warn(`Retrying ${group} ${cycle} (${retries + 1})`);
+          structLog('warn', `Retrying ${group} ${cycle} (${retries + 1})`);
           runNextRequest(subscriber, group, groups);
           retryTimer = null;
         },
         1500 * Math.pow(2, retries)
       ); // Exponential backoff
-
       retrying = true;
-
       return true;
     };
-
     const targets = adjustTargetsFromResponseState(groups[group].targets, mergedResponse);
     if (!targets.length) {
       nextRequest();
       return;
     }
-
     const shardsToQuery =
       shards && cycle !== undefined && groupSize ? groupShardRequests(shards, cycle, groupSize) : [];
     const subRequest = { ...request, targets: interpolateShardingSelector(targets, shardsToQuery) };
@@ -181,9 +160,7 @@ function splitQueriesByStreamShard(
       subRequest.requestId =
         shardsToQuery.length > 0 ? `${request.requestId}_shard_${group}_${cycle}_${groupSize}` : request.requestId;
     }
-
     debug(shardsToQuery.length ? `Querying ${shardsToQuery.join(', ')}` : 'Running regular query');
-
     subquerySubscription = runSplitQuery(datasource, subRequest, {
       skipPartialUpdates: true,
       disableRetry: true,
@@ -209,7 +186,6 @@ function splitQueriesByStreamShard(
           shardsToQuery.length > 0
             ? combineResponses(mergedResponse, partialResponse)
             : replaceResponses(mergedResponse, partialResponse);
-
         // When we delegate query running to runSplitQuery(), we will receive partial updates here, and complete
         // will be called when all the sub-requests were completed, so we need to show partial progress here.
         if (shardsToQuery.length === 0) {
@@ -224,7 +200,7 @@ function splitQueriesByStreamShard(
         nextRequest();
       },
       error: (error: unknown) => {
-        console.error(error, { msg: 'failed to shard' });
+        structLog('error', error, { msg: 'failed to shard' });
         subscriber.next(mergedResponse);
         if (retry()) {
           return;
@@ -233,7 +209,6 @@ function splitQueriesByStreamShard(
       },
     });
   };
-
   const response = new Observable<DataQueryResponse>((subscriber) => {
     groupTargetsByQueryType(splittingTargets, datasource, request).then((groupedRequests) => {
       runNextRequest(subscriber, 0, groupedRequests);
@@ -249,17 +224,14 @@ function splitQueriesByStreamShard(
       }
     };
   });
-
   return response;
 }
-
 interface ShardedQueryGroup {
   targets: LokiQuery[];
   shards?: number[];
   groupSize?: number;
   cycle?: number;
 }
-
 async function groupTargetsByQueryType(
   targets: LokiQuery[],
   datasource: LokiDatasource,
@@ -267,13 +239,11 @@ async function groupTargetsByQueryType(
 ) {
   const [shardedQueries, otherQueries] = partition(targets, (query) => requestSupportsSharding([query]));
   const groups: ShardedQueryGroup[] = [];
-
   if (otherQueries.length) {
     groups.push({
       targets: otherQueries,
     });
   }
-
   const selectorPartition = groupBy(shardedQueries, (query) => getSelectorForShardValues(query.expr));
   for (const selector in selectorPartition) {
     try {
@@ -293,16 +263,14 @@ async function groupTargetsByQueryType(
         cycle: 0,
       });
     } catch (error) {
-      console.error(error, { msg: 'failed to fetch label values for __stream_shard__' });
+      structLog('error', error, { msg: 'failed to fetch label values for __stream_shard__' });
       groups.push({
         targets: selectorPartition[selector],
       });
     }
   }
-
   return groups;
 }
-
 function groupHasPendingRequests(group: ShardedQueryGroup) {
   if (group.cycle === undefined || !group.groupSize || !group.shards) {
     return false;
@@ -312,7 +280,6 @@ function groupHasPendingRequests(group: ShardedQueryGroup) {
   group.cycle = nextCycle;
   return cycle < shards.length && nextCycle <= shards.length;
 }
-
 function updateGroupSizeFromResponse(response: DataQueryResponse, group: ShardedQueryGroup) {
   const { groupSize: currentSize } = group;
   if (!currentSize) {
@@ -322,11 +289,9 @@ function updateGroupSizeFromResponse(response: DataQueryResponse, group: Sharded
     // Empty response, increase group size
     return currentSize + 1;
   }
-
   const metaExecutionTime: QueryResultMetaStat | undefined = response.data[0].meta?.stats?.find(
     (stat: QueryResultMetaStat) => stat.displayName === 'Summary: exec time'
   );
-
   if (metaExecutionTime) {
     const executionTime = Math.round(metaExecutionTime.value);
     debug(`${metaExecutionTime.value}`);
@@ -336,7 +301,6 @@ function updateGroupSizeFromResponse(response: DataQueryResponse, group: Sharded
     } else if (executionTime < 6) {
       return Math.ceil(currentSize * 1.1);
     }
-
     // Negative scenarios
     if (currentSize === 1) {
       return currentSize;
@@ -346,10 +310,8 @@ function updateGroupSizeFromResponse(response: DataQueryResponse, group: Sharded
       return Math.floor(currentSize / 2);
     }
   }
-
   return currentSize;
 }
-
 /**
  * Prevents the group size for ever being more than maxFactor% of the pending shards.
  */
@@ -357,23 +319,20 @@ function constrainGroupSize(cycle: number, groupSize: number, shards: number) {
   const maxFactor = 0.7;
   return Math.min(groupSize, Math.max(Math.floor((shards - cycle) * maxFactor), 1));
 }
-
 function groupShardRequests(shards: number[], start: number, groupSize: number) {
   if (start === shards.length) {
     return [-1];
   }
   return shards.slice(start, start + groupSize);
 }
-
 function getInitialGroupSize(shards: number[]) {
   return Math.floor(Math.sqrt(shards.length));
 }
-
 // Enable to output debugging logs
 const DEBUG_ENABLED = Boolean(localStorage.getItem(`loki.sharding_debug_enabled`));
 function debug(message: string) {
   if (!DEBUG_ENABLED) {
     return;
   }
-  console.log(message);
+  structLog('log', message);
 }

--- a/public/app/plugins/datasource/loki/tracking.ts
+++ b/public/app/plugins/datasource/loki/tracking.ts
@@ -1,7 +1,7 @@
+import { structLog } from '@grafana/data';
 import { CoreApp, type DashboardLoadedEvent, type DataQueryRequest, type DataQueryResponse } from '@grafana/data';
 import { QueryEditorMode } from '@grafana/plugin-ui';
 import { reportInteraction, config } from '@grafana/runtime';
-
 import { LokiQueryType } from './dataquery.gen';
 import {
   REF_ID_STARTER_ANNOTATION,
@@ -14,46 +14,33 @@ import pluginJson from './plugin.json';
 import { getNormalizedLokiQuery, isLogsQuery, obfuscate } from './queryUtils';
 import { variableRegex } from './querybuilder/parsingUtils';
 import { type LokiGroupedRequest, type LokiQuery } from './types';
-
 type LokiOnDashboardLoadedTrackingEvent = {
   grafana_version?: string;
   dashboard_id?: string;
   org_id?: number;
-
   /* The number of Loki queries present in the dashboard*/
   queries_count: number;
-
   /* The number of Loki logs queries present in the dashboard*/
   logs_queries_count: number;
-
   /* The number of Loki metric queries present in the dashboard*/
   metric_queries_count: number;
-
   /* The number of Loki instant queries present in the dashboard*/
   instant_queries_count: number;
-
   /* The number of Loki range queries present in the dashboard*/
   range_queries_count: number;
-
   /* The number of Loki queries created in builder mode present in the dashboard*/
   builder_mode_queries_count: number;
-
   /* The number of Loki queries created in code mode present in the dashboard*/
   code_mode_queries_count: number;
-
   /* The number of Loki queries with used template variables present in the dashboard*/
   queries_with_template_variables_count: number;
-
   /* The number of Loki queries with changed resolution present in the dashboard*/
   queries_with_changed_resolution_count: number;
-
   /* The number of Loki queries with changed line limit present in the dashboard*/
   queries_with_changed_line_limit_count: number;
-
   /* The number of Loki queries with changed legend present in the dashboard*/
   queries_with_changed_legend_count: number;
 };
-
 export const onDashboardLoadedHandler = ({
   payload: { dashboardId, orgId, grafanaVersion, queries },
 }: DashboardLoadedEvent<LokiQuery>) => {
@@ -62,11 +49,9 @@ export const onDashboardLoadedHandler = ({
     const lokiQueries = queries[pluginJson.id]
       ?.filter((query) => !query.hide)
       ?.map((query) => getNormalizedLokiQuery(query));
-
     if (!lokiQueries?.length) {
       return;
     }
-
     const logsQueries = lokiQueries.filter((query) => isLogsQuery(query.expr));
     const metricQueries = lokiQueries.filter((query) => !isLogsQuery(query.expr));
     const instantQueries = lokiQueries.filter((query) => query.queryType === LokiQueryType.Instant);
@@ -77,7 +62,6 @@ export const onDashboardLoadedHandler = ({
     const queriesWithChangedResolution = lokiQueries.filter(isQueryWithChangedResolution);
     const queriesWithChangedLineLimit = lokiQueries.filter(isQueryWithChangedLineLimit);
     const queriesWithChangedLegend = lokiQueries.filter(isQueryWithChangedLegend);
-
     const event: LokiOnDashboardLoadedTrackingEvent = {
       grafana_version: grafanaVersion,
       dashboard_id: dashboardId,
@@ -94,17 +78,14 @@ export const onDashboardLoadedHandler = ({
       queries_with_changed_line_limit_count: queriesWithChangedLineLimit.length,
       queries_with_changed_legend_count: queriesWithChangedLegend.length,
     };
-
     reportInteraction('grafana_loki_dashboard_loaded', event);
   } catch (error) {
-    console.error('error in loki tracking handler', error);
+    structLog('error', 'error in loki tracking handler', error);
   }
 };
-
 const isQueryWithTemplateVariables = (query: LokiQuery): boolean => {
   return variableRegex.test(query.expr);
 };
-
 const isQueryWithChangedResolution = (query: LokiQuery): boolean => {
   if (!query.resolution) {
     return false;
@@ -112,18 +93,15 @@ const isQueryWithChangedResolution = (query: LokiQuery): boolean => {
   // 1 is the default resolution
   return query.resolution !== 1;
 };
-
 const isQueryWithChangedLineLimit = (query: LokiQuery): boolean => {
   return query.maxLines !== null && query.maxLines !== undefined;
 };
-
 const isQueryWithChangedLegend = (query: LokiQuery): boolean => {
   if (!query.legendFormat) {
     return false;
   }
   return query.legendFormat !== '';
 };
-
 const shouldNotReportBasedOnRefId = (refId: string): boolean => {
   const starters = [
     REF_ID_STARTER_ANNOTATION,
@@ -132,13 +110,11 @@ const shouldNotReportBasedOnRefId = (refId: string): boolean => {
     REF_ID_STARTER_LOG_SAMPLE,
     REF_ID_DATA_SAMPLES,
   ];
-
   if (starters.some((starter) => refId.startsWith(starter))) {
     return true;
   }
   return false;
 };
-
 const calculateTotalBytes = (response: DataQueryResponse): number => {
   let totalBytes = 0;
   for (const frame of response.data) {
@@ -150,7 +126,6 @@ const calculateTotalBytes = (response: DataQueryResponse): number => {
   }
   return totalBytes;
 };
-
 export function trackQuery(
   response: DataQueryResponse,
   request: DataQueryRequest<LokiQuery>,
@@ -159,18 +134,14 @@ export function trackQuery(
 ): void {
   // We only want to track usage for these specific apps
   const { app, targets: queries } = request;
-
   if (app !== CoreApp.Explore) {
     return;
   }
-
   let totalBytes = calculateTotalBytes(response);
-
   for (const query of queries) {
     if (shouldNotReportBasedOnRefId(query.refId)) {
       return;
     }
-
     reportInteraction('grafana_explore_loki_query_executed', {
       grafana_version: config.buildInfo.version,
       editor_mode: query.editorMode,
@@ -193,7 +164,6 @@ export function trackQuery(
     });
   }
 }
-
 export function trackGroupedQueries(
   response: DataQueryResponse,
   groupedRequests: LokiGroupedRequest[],
@@ -208,7 +178,6 @@ export function trackGroupedQueries(
     simultaneously_executed_query_count: originalRequest.targets.filter((query) => !query.hide).length,
     simultaneously_hidden_query_count: originalRequest.targets.filter((query) => query.hide).length,
   };
-
   for (const group of groupedRequests) {
     const split_query_partition_size = group.partition.length;
     trackQuery(response, group.request, startTime, {

--- a/public/app/plugins/datasource/tempo/datasource.ts
+++ b/public/app/plugins/datasource/tempo/datasource.ts
@@ -1,7 +1,7 @@
+import { structLog } from '@grafana/data';
 import { groupBy } from 'lodash';
 import { EMPTY, from, merge, type Observable, of } from 'rxjs';
 import { catchError, concatMap, finalize, map, mergeMap, toArray } from 'rxjs/operators';
-
 import {
   CoreApp,
   type DataFrame,
@@ -34,7 +34,6 @@ import {
   type TemplateSrv,
 } from '@grafana/runtime';
 import { BarGaugeDisplayMode, TableCellDisplayMode, VariableFormatID } from '@grafana/schema';
-
 import { interpolateFilters } from './SearchTraceQLEditor/utils';
 import { type TempoVariableQuery, TempoVariableQueryType } from './VariableQueryEditor';
 import { type PrometheusDatasource, type PromQuery } from './_importedDependencies/datasources/prometheus/types';
@@ -63,15 +62,12 @@ import { doTempoMetricsStreaming, doTempoSearchStreaming } from './streaming';
 import { type TempoJsonData, type TempoQuery } from './types';
 import { getErrorMessage, mapErrorMessage, migrateFromSearchToTraceQLSearch } from './utils';
 import { TempoVariableSupport } from './variables';
-
 export const DEFAULT_LIMIT = 20;
 export const DEFAULT_SPSS = 3; // spans per span set
-
 export enum FeatureName {
   searchStreaming = 'searchStreaming',
   metricsStreaming = 'metricsStreaming',
 }
-
 /* Map, for each feature (e.g., streaming), the minimum Tempo version required to have that
  ** feature available. If the running Tempo instance on the user's backend is older than the
  ** target version, the feature is disabled in Grafana (frontend).
@@ -80,18 +76,15 @@ export const featuresToTempoVersion = {
   [FeatureName.searchStreaming]: '2.2.0',
   [FeatureName.metricsStreaming]: '2.7.0',
 };
-
 interface ServiceMapQueryResponse {
   nodes: DataFrame;
   edges: DataFrame;
 }
-
 interface ServiceMapQueryResponseWithRates {
   rates: Array<DataFrame | DataFrameDTO>;
   nodes: DataFrame;
   edges: DataFrame;
 }
-
 interface TempoQueryMetrics {
   success: boolean;
   streaming?: boolean;
@@ -101,7 +94,6 @@ interface TempoQueryMetrics {
   statusCode?: number;
   statusText?: string;
 }
-
 export class TempoDatasource extends DataSourceWithBackend<TempoQuery, TempoJsonData> {
   tracesToLogs?: TraceToLogsOptions;
   serviceMap?: {
@@ -121,20 +113,16 @@ export class TempoDatasource extends DataSourceWithBackend<TempoQuery, TempoJson
   spanBar?: SpanBarOptions;
   tagLimit?: TagLimitOptions;
   languageProvider: TempoLanguageProvider;
-
   streamingEnabled?: {
     search?: boolean;
     metrics?: boolean;
   };
-
   timeRangeForTags?: number;
-
   constructor(
     public instanceSettings: DataSourceInstanceSettings<TempoJsonData>,
     private readonly templateSrv: TemplateSrv = getTemplateSrv()
   ) {
     super(instanceSettings);
-
     this.tracesToLogs = instanceSettings.jsonData.tracesToLogs;
     this.serviceMap = instanceSettings.jsonData.serviceMap;
     this.search = instanceSettings.jsonData.search;
@@ -143,7 +131,6 @@ export class TempoDatasource extends DataSourceWithBackend<TempoQuery, TempoJson
     this.streamingEnabled = instanceSettings.jsonData.streamingEnabled;
     this.timeRangeForTags = instanceSettings.jsonData.timeRangeForTags;
     this.languageProvider = new TempoLanguageProvider(this);
-
     if (!this.search?.filters) {
       this.search = {
         ...this.search,
@@ -158,16 +145,17 @@ export class TempoDatasource extends DataSourceWithBackend<TempoQuery, TempoJson
         ],
       };
     }
-
     this.variables = new TempoVariableSupport(this);
   }
-
   async executeVariableQuery(query: TempoVariableQuery, range?: TimeRange) {
     // Avoid failing if the user did not select the query type (label names, label values, etc.)
     if (query.type === undefined) {
-      return new Promise<Array<{ text: string }>>(() => []);
+      return new Promise<
+        Array<{
+          text: string;
+        }>
+      >(() => []);
     }
-
     switch (query.type) {
       case TempoVariableQueryType.LabelNames: {
         return await this.labelNamesQuery(range);
@@ -180,20 +168,27 @@ export class TempoDatasource extends DataSourceWithBackend<TempoQuery, TempoJson
       }
     }
   }
-
-  async labelNamesQuery(range?: TimeRange): Promise<Array<{ text: string }>> {
+  async labelNamesQuery(range?: TimeRange): Promise<
+    Array<{
+      text: string;
+    }>
+  > {
     await this.languageProvider.start(range, this.timeRangeForTags);
     const tags = this.languageProvider.getAutocompleteTags();
     return tags.filter((tag) => tag !== undefined).map((tag) => ({ text: tag }));
   }
-
-  async labelValuesQuery(labelName?: string, range?: TimeRange): Promise<Array<{ text: string }>> {
+  async labelValuesQuery(
+    labelName?: string,
+    range?: TimeRange
+  ): Promise<
+    Array<{
+      text: string;
+    }>
+  > {
     if (!labelName) {
       return [];
     }
-
     await this.languageProvider.start(range, this.timeRangeForTags);
-
     // Retrieve the scope of the tag
     // Example: given `http.status_code`, we want scope `span`
     // Note that we ignore possible name clashes, e.g., `http.status_code` in both `span` and `resource`
@@ -205,7 +200,6 @@ export class TempoDatasource extends DataSourceWithBackend<TempoQuery, TempoJson
     if (!scope) {
       throw Error(`Scope for tag ${labelName} not found`);
     }
-
     // For V2, we need to send scope and tag name, e.g. `span.http.status_code`,
     // unless the tag has intrinsic scope
     const scopeAndTag = scope === 'intrinsic' ? labelName : `${scope}.${labelName}`;
@@ -214,14 +208,16 @@ export class TempoDatasource extends DataSourceWithBackend<TempoQuery, TempoJson
       timeRangeForTags: this.timeRangeForTags,
       range,
     });
-
     return options.flatMap((option: SelectableValue<string>) =>
       option.value !== undefined ? [{ text: option.value }] : []
     );
   }
-
   // Allows to retrieve the list of tags for ad-hoc filters
-  async getTagKeys(options: DataSourceGetTagKeysOptions<TempoQuery>): Promise<Array<{ text: string }>> {
+  async getTagKeys(options: DataSourceGetTagKeysOptions<TempoQuery>): Promise<
+    Array<{
+      text: string;
+    }>
+  > {
     await this.languageProvider.fetchTags(this.timeRangeForTags, options?.timeRange ?? undefined);
     const tags = this.languageProvider.tagsV2 || [];
     return tags
@@ -231,14 +227,24 @@ export class TempoDatasource extends DataSourceWithBackend<TempoQuery, TempoJson
       .flat()
       .map((tag) => ({ text: tag }));
   }
-
   // Allows to retrieve the list of tag values for ad-hoc filters
-  getTagValues(options: DataSourceGetTagValuesOptions<TempoQuery>): Promise<Array<{ text: string }>> {
+  getTagValues(options: DataSourceGetTagValuesOptions<TempoQuery>): Promise<
+    Array<{
+      text: string;
+    }>
+  > {
     const query = this.languageProvider.generateQueryFromFilters({ adhocFilters: options.filters });
     return this.tagValuesQuery(options.key, query, options?.timeRange ?? undefined);
   }
-
-  async tagValuesQuery(tag: string, query: string, range?: TimeRange): Promise<Array<{ text: string }>> {
+  async tagValuesQuery(
+    tag: string,
+    query: string,
+    range?: TimeRange
+  ): Promise<
+    Array<{
+      text: string;
+    }>
+  > {
     // For V2, we need to send scope and tag name, e.g. `span.http.status_code`,
     // unless the tag has intrinsic scope
     const options = await this.languageProvider.getOptionsV2({
@@ -247,59 +253,49 @@ export class TempoDatasource extends DataSourceWithBackend<TempoQuery, TempoJson
       timeRangeForTags: this.timeRangeForTags,
       range,
     });
-
     return options.flatMap((option: SelectableValue<string>) =>
       option.value !== undefined ? [{ text: option.value }] : []
     );
   }
-
   // TODO: Implement this function in Prometheus datasource https://github.com/grafana/grafana/issues/109706
   async getNativeHistograms(timeRange?: TimeRange): Promise<boolean> {
     if (!this.serviceMap?.datasourceUid) {
       return false;
     }
-
     // remove _bucket from the metric name to get the native histogram metric name
     const metricName = histogramMetric.replace('_bucket', '');
-
     try {
       // Get the Prometheus datasource instance
       const promDs = await getDataSourceSrv().get(this.serviceMap.datasourceUid);
       // Use provided time range or default to last hour
       const from = timeRange?.from || dateTime().subtract(1, 'hour');
       const to = timeRange?.to || dateTime();
-
       // Convert to Unix timestamps (seconds since epoch)
       const start = Math.floor(from.valueOf() / 1000);
       const end = Math.floor(to.valueOf() / 1000);
-
       // Use the series endpoint to check if native histogram metrics exist
       // this has a 90% chance of returning correctly due to sparse data
       if (!('metadataRequest' in promDs) || typeof promDs.metadataRequest !== 'function') {
         return false;
       }
-
       const seriesResult = await promDs.metadataRequest('/api/v1/series', {
         'match[]': metricName,
         limit: 1,
         start: start,
         end: end,
       });
-
       // Check if any native histogram series exist
       const seriesData = seriesResult?.data?.data;
       if (seriesData && Array.isArray(seriesData)) {
         // If the series array has any entries, native histograms exist
         return seriesData.length > 0;
       }
-
       return false;
     } catch (error) {
-      console.warn('Failed to check for native histograms:', error);
+      structLog('warn', 'Failed to check for native histograms:', error);
       return false;
     }
   }
-
   /**
    * Check if streaming for search queries is enabled (and available).
    *
@@ -324,29 +320,26 @@ export class TempoDatasource extends DataSourceWithBackend<TempoQuery, TempoJson
   isStreamingMetricsEnabled() {
     return this.streamingEnabled?.metrics && config.liveEnabled;
   }
-
   isTraceQlMetricsQuery(query: string): boolean {
     // Check whether this is a metrics query by checking if it contains a metrics function
     const metricsFnRegex =
       /\|\s*(rate|count_over_time|avg_over_time|max_over_time|min_over_time|sum_over_time|quantile_over_time|histogram_over_time|compare)\s*\(/;
     return !!query.trim().match(metricsFnRegex);
   }
-
   isTraceIdQuery(query: string): boolean {
     const hexOnlyRegex = /^[0-9A-Fa-f]*$/;
     // Check whether this is a trace ID or traceQL query by checking if it only contains hex characters
     return !!query.trim().match(hexOnlyRegex);
   }
-
   query(options: DataQueryRequest<TempoQuery>): Observable<DataQueryResponse> {
     const subQueries: Array<Observable<DataQueryResponse>> = [];
     const filteredTargets = options.targets.filter((target) => !target.hide);
-    const targets: { [type: string]: TempoQuery[] } = groupBy(filteredTargets, (t) => t.queryType || 'traceql');
-
+    const targets: {
+      [type: string]: TempoQuery[];
+    } = groupBy(filteredTargets, (t) => t.queryType || 'traceql');
     if (targets.clear) {
       return of({ data: [], state: LoadingState.Done });
     }
-
     // Migrate user to new query type if they are using the old search query type
     if (targets.nativeSearch?.length) {
       if (
@@ -365,7 +358,6 @@ export class TempoDatasource extends DataSourceWithBackend<TempoQuery, TempoJson
         }
       }
     }
-
     // TraceQL
     if (targets.traceql?.length) {
       try {
@@ -388,7 +380,6 @@ export class TempoDatasource extends DataSourceWithBackend<TempoQuery, TempoJson
               options.app !== CoreApp.CloudAlerting &&
               options.app !== CoreApp.UnifiedAlerting &&
               options.app !== 'grafana-assistant-app';
-
             reportInteraction('grafana_traces_traceql_metrics_queried', {
               datasourceType: 'tempo',
               app: options.app ?? '',
@@ -403,7 +394,6 @@ export class TempoDatasource extends DataSourceWithBackend<TempoQuery, TempoJson
             }
           } else {
             const useStreaming = this.isStreamingSearchEnabled() && options.app !== 'grafana-assistant-app';
-
             reportInteraction('grafana_traces_traceql_queried', {
               datasourceType: 'tempo',
               app: options.app ?? '',
@@ -411,7 +401,6 @@ export class TempoDatasource extends DataSourceWithBackend<TempoQuery, TempoJson
               query: queryValue ?? '',
               streaming: this.isStreamingSearchEnabled(),
             });
-
             if (useStreaming) {
               return this.handleStreamingQuery(options, targets.traceql, queryValue);
             }
@@ -422,7 +411,6 @@ export class TempoDatasource extends DataSourceWithBackend<TempoQuery, TempoJson
         return of({ error: { message: error instanceof Error ? error.message : 'Unknown error occurred' }, data: [] });
       }
     }
-
     // Search
     if (targets.traceqlSearch?.length) {
       if (targets.traceqlSearch[0].groupBy) {
@@ -434,7 +422,6 @@ export class TempoDatasource extends DataSourceWithBackend<TempoQuery, TempoJson
           data: [],
         });
       }
-
       try {
         const traceqlSearchTargets = targets.traceqlSearch;
         if (traceqlSearchTargets.length > 0) {
@@ -443,7 +430,6 @@ export class TempoDatasource extends DataSourceWithBackend<TempoQuery, TempoJson
             traceqlFilters: appliedQuery.filters,
             adhocFilters: options.filters,
           });
-
           reportInteraction('grafana_traces_traceql_search_queried', {
             datasourceType: 'tempo',
             app: options.app ?? '',
@@ -451,7 +437,6 @@ export class TempoDatasource extends DataSourceWithBackend<TempoQuery, TempoJson
             query: queryFromFilters ?? '',
             streaming: this.isStreamingSearchEnabled(),
           });
-
           if (this.isStreamingSearchEnabled()) {
             subQueries.push(this.handleStreamingQuery(options, traceqlSearchTargets, queryFromFilters));
           } else {
@@ -462,7 +447,6 @@ export class TempoDatasource extends DataSourceWithBackend<TempoQuery, TempoJson
         return of({ error: { message: error instanceof Error ? error.message : 'Unknown error occurred' }, data: [] });
       }
     }
-
     // Upload
     if (targets.upload?.length) {
       if (this.uploadedJson) {
@@ -471,12 +455,10 @@ export class TempoDatasource extends DataSourceWithBackend<TempoQuery, TempoJson
           app: options.app ?? '',
           grafana_version: config.buildInfo.version,
         });
-
         const jsonData = JSON.parse(this.uploadedJson);
         const isTraceData = jsonData.batches;
         const isServiceGraphData =
           Array.isArray(jsonData) && jsonData.some((df) => df?.meta?.preferredVisualisationType === 'nodeGraph');
-
         if (isTraceData) {
           subQueries.push(of(transformFromOTEL(jsonData.batches, this.nodeGraph?.enabled)));
         } else if (isServiceGraphData) {
@@ -488,7 +470,6 @@ export class TempoDatasource extends DataSourceWithBackend<TempoQuery, TempoJson
         subQueries.push(of({ data: [], state: LoadingState.Done }));
       }
     }
-
     // Service Map
     if (this.serviceMap?.datasourceUid && targets.serviceMap?.length > 0) {
       reportInteraction('grafana_traces_service_graph_queried', {
@@ -497,13 +478,10 @@ export class TempoDatasource extends DataSourceWithBackend<TempoQuery, TempoJson
         grafana_version: config.buildInfo.version,
         hasServiceMapQuery: targets.serviceMap[0].serviceMapQuery ? true : false,
       });
-
       const { datasourceUid } = this.serviceMap;
-
       // if the query contains the serviceMapUseNativeHistograms flag,
       // then use the native histograms
       const useNativeHistogram = options.targets[0].serviceMapUseNativeHistograms;
-
       const tempoDsUid = this.uid;
       subQueries.push(
         serviceMapQuery(options, datasourceUid, tempoDsUid, useNativeHistogram).pipe(
@@ -517,7 +495,6 @@ export class TempoDatasource extends DataSourceWithBackend<TempoQuery, TempoJson
         )
       );
     }
-
     return merge(...subQueries).pipe(
       map((response) => {
         if (response.errors?.[0]?.message) {
@@ -527,16 +504,13 @@ export class TempoDatasource extends DataSourceWithBackend<TempoQuery, TempoJson
       })
     );
   }
-
   applyTemplateVariables(query: TempoQuery, scopedVars: ScopedVars) {
     return this.applyVariables(query, scopedVars);
   }
-
   interpolateVariablesInQueries(queries: TempoQuery[], scopedVars: ScopedVars): TempoQuery[] {
     if (!queries || queries.length === 0) {
       return [];
     }
-
     return queries.map((query) => {
       return {
         ...query,
@@ -545,14 +519,11 @@ export class TempoDatasource extends DataSourceWithBackend<TempoQuery, TempoJson
       };
     });
   }
-
   applyVariables(query: TempoQuery, scopedVars: ScopedVars) {
     const expandedQuery = { ...query };
-
     if (query.filters) {
       expandedQuery.filters = interpolateFilters(query.filters, scopedVars);
     }
-
     return {
       ...expandedQuery,
       query: this.templateSrv.replace(query.query ?? '', scopedVars, VariableFormatID.Pipe),
@@ -561,7 +532,6 @@ export class TempoDatasource extends DataSourceWithBackend<TempoQuery, TempoJson
         : this.templateSrv.replace(query.serviceMapQuery ?? '', scopedVars),
     };
   }
-
   /**
    * Handles the simplest of the queries where we have just a trace id and return trace data for it.
    * @param options
@@ -579,7 +549,6 @@ export class TempoDatasource extends DataSourceWithBackend<TempoQuery, TempoJson
     if (!validTargets.length) {
       return EMPTY;
     }
-
     const startTime = performance.now();
     const request = this.makeTraceIdRequest(options, validTargets);
     return super.query(request).pipe(
@@ -618,13 +587,16 @@ export class TempoDatasource extends DataSourceWithBackend<TempoQuery, TempoJson
       })
     );
   }
-
-  handleTraceQlQuery(options: DataQueryRequest<TempoQuery>, targets: { [type: string]: TempoQuery[] }) {
+  handleTraceQlQuery(
+    options: DataQueryRequest<TempoQuery>,
+    targets: {
+      [type: string]: TempoQuery[];
+    }
+  ) {
     const startTime = performance.now();
     const traceqlSearchTargets = targets.traceqlSearch || targets.traceql;
     const appliedQuery = this.applyVariables(traceqlSearchTargets[0], options.scopedVars);
     let queries: TempoQuery[];
-
     if (targets.traceqlSearch) {
       const queryFromFilters = this.languageProvider.generateQueryFromFilters({
         traceqlFilters: appliedQuery.filters,
@@ -634,7 +606,6 @@ export class TempoDatasource extends DataSourceWithBackend<TempoQuery, TempoJson
     } else {
       queries = traceqlSearchTargets.map((t) => ({ ...t, query: appliedQuery?.query }));
     }
-
     return super.query({ ...options, targets: queries }).pipe(
       map((response: DataQueryResponse) => {
         if (queries[0].tableType === SearchTableType.Traces && response.data && response.data.length > 0) {
@@ -645,7 +616,6 @@ export class TempoDatasource extends DataSourceWithBackend<TempoQuery, TempoJson
               latencyMs: Math.round(performance.now() - startTime),
               query: queries[0].query ?? '',
             });
-
             // The backend does not support nested data frames directly, so we return
             // what should be nested as a JSON array in a column: e.g. "[{dataframe}]".
             // Here, we take the frames from that column, and change the type to "nestedFrames"
@@ -653,7 +623,6 @@ export class TempoDatasource extends DataSourceWithBackend<TempoQuery, TempoJson
             const nested = frame.fields[5];
             nested.type = 'nestedFrames';
             nested.typeInfo.frame = 'nestedFrames';
-
             // The returned JSON data frame structure does not fully match what the frontend expects for
             // rendering nested frames. Here, we transform each nested frame array to the correct format:
             //
@@ -666,17 +635,13 @@ export class TempoDatasource extends DataSourceWithBackend<TempoQuery, TempoJson
             // const mestedFrames = nested.values as DataFrameJSON[][];
             // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
             const mestedFrames = nested.values as DataFrameJSON[][];
-
             nested.values = mestedFrames.map((nestedFrameArray) => {
               return nestedFrameArray.map((nestedFrame) => {
                 const newNestedFrame = { fields: nestedFrame.schema?.fields, meta: nestedFrame.schema?.meta };
-
                 newNestedFrame.fields = newNestedFrame.fields?.map((field, fieldIndex: number) => {
                   return { ...field, values: nestedFrame.data?.values[fieldIndex] };
                 });
-
                 const rowCount = Array.isArray(nestedFrame.data?.values?.[0]) ? nestedFrame.data.values?.[0].length : 0;
-
                 return { fields: newNestedFrame.fields, meta: nestedFrame.schema?.meta, length: rowCount };
               });
             });
@@ -698,7 +663,6 @@ export class TempoDatasource extends DataSourceWithBackend<TempoQuery, TempoJson
       })
     );
   }
-
   handleTraceQlMetricsQuery(
     options: DataQueryRequest<TempoQuery>,
     targets: TempoQuery[],
@@ -712,7 +676,6 @@ export class TempoDatasource extends DataSourceWithBackend<TempoQuery, TempoJson
     if (!validTargets.length) {
       return EMPTY;
     }
-
     const startTime = performance.now();
     const request = { ...options, targets: validTargets };
     return super.query(request).pipe(
@@ -739,7 +702,6 @@ export class TempoDatasource extends DataSourceWithBackend<TempoQuery, TempoJson
       })
     );
   }
-
   // This function can probably be simplified by avoiding passing both `targets` and `query`,
   // since `query` is built from `targets`, if you look at how this function is currently called
   handleStreamingQuery(
@@ -750,7 +712,6 @@ export class TempoDatasource extends DataSourceWithBackend<TempoQuery, TempoJson
     if (query === '') {
       return EMPTY;
     }
-
     const startTime = performance.now();
     return merge(
       ...targets.map((target) =>
@@ -785,7 +746,6 @@ export class TempoDatasource extends DataSourceWithBackend<TempoQuery, TempoJson
       })
     );
   }
-
   // This function can probably be simplified by avoiding passing both `targets` and `query`,
   // since `query` is built from `targets`, if you look at how this function is currently called
   handleMetricsStreamingQuery(
@@ -796,7 +756,6 @@ export class TempoDatasource extends DataSourceWithBackend<TempoQuery, TempoJson
     if (query === '') {
       return EMPTY;
     }
-
     const startTime = performance.now();
     return merge(
       ...targets.map((target) =>
@@ -833,13 +792,11 @@ export class TempoDatasource extends DataSourceWithBackend<TempoQuery, TempoJson
       })
     );
   }
-
   makeTraceIdRequest(options: DataQueryRequest<TempoQuery>, targets: TempoQuery[]): DataQueryRequest<TempoQuery> {
     const request = {
       ...options,
       targets,
     };
-
     if (this.traceQuery?.timeShiftEnabled) {
       request.range = options.range && {
         ...options.range,
@@ -855,35 +812,28 @@ export class TempoDatasource extends DataSourceWithBackend<TempoQuery, TempoJson
     } else {
       request.range = { from: dateTime(0), to: dateTime(0), raw: { from: dateTime(0), to: dateTime(0) } };
     }
-
     return request;
   }
-
   async metadataRequest(url: string, params = {}) {
     // url must not start with a `/`, otherwise the AJAX-request
     // going from the browser will contain `//`, which can cause problems.
     if (url.startsWith('/')) {
       throw new Error(`invalid metadata request url: ${url}`);
     }
-
     const res = await this.getResource(url, params, { method: 'GET', hideFromInspector: true });
     return res?.data ?? res;
   }
-
   async testDatasource(): Promise<TestDataSourceResponse> {
     return await super.testDatasource();
   }
-
   getQueryDisplayText(query: TempoQuery) {
     if (query.queryType === 'traceql' || query.queryType === 'traceId') {
       return query.query ?? '';
     }
-
     const appliedQuery = this.applyVariables(query, {});
     return this.languageProvider.generateQueryFromFilters({ traceqlFilters: appliedQuery.filters });
   }
 }
-
 function queryPrometheus(request: DataQueryRequest<PromQuery>, datasourceUid: string) {
   return from(getDataSourceSrv().get(datasourceUid)).pipe(
     mergeMap((ds) => {
@@ -891,7 +841,6 @@ function queryPrometheus(request: DataQueryRequest<PromQuery>, datasourceUid: st
     })
   );
 }
-
 function serviceMapQuery(
   request: DataQueryRequest<TempoQuery>,
   datasourceUid: string,
@@ -899,7 +848,6 @@ function serviceMapQuery(
   useNativeHistogram?: boolean
 ): Observable<ServiceMapQueryResponse> {
   const serviceMapRequest = makePromServiceMapRequest(request, useNativeHistogram);
-
   return queryPrometheus(serviceMapRequest, datasourceUid).pipe(
     // Just collect all the responses first before processing into node graph data
     toArray(),
@@ -908,12 +856,10 @@ function serviceMapQuery(
       if (errorRes) {
         throw new Error(getErrorMessage(errorRes.error?.message));
       }
-
       const { nodes, edges } = mapPromMetricsToServiceMap(responses, request.range);
       if (nodes.fields.length > 0 && edges.fields.length > 0) {
         const nodeLength = nodes.fields[0].values.length;
         const edgeLength = edges.fields[0].values.length;
-
         reportInteraction('grafana_traces_service_graph_size', {
           datasourceType: 'tempo',
           grafana_version: config.buildInfo.version,
@@ -921,13 +867,11 @@ function serviceMapQuery(
           edgeLength,
         });
       }
-
       // No handling of multiple targets assume just one. NodeGraph does not support it anyway, but still should be
       // fixed at some point.
       const { serviceMapIncludeNamespace, refId } = request.targets[0];
       nodes.refId = refId;
       edges.refId = refId;
-
       if (serviceMapIncludeNamespace) {
         nodes.fields[0].config = getFieldConfig(
           datasourceUid, // datasourceUid
@@ -938,7 +882,6 @@ function serviceMapQuery(
           { targetNamespace: '__data.fields.subtitle' },
           useNativeHistogram
         );
-
         edges.fields[0].config = getFieldConfig(
           datasourceUid, // datasourceUid
           tempoDatasourceUid, // tempoDatasourceUid
@@ -968,7 +911,6 @@ function serviceMapQuery(
           useNativeHistogram
         );
       }
-
       return {
         nodes,
         edges,
@@ -977,7 +919,6 @@ function serviceMapQuery(
     })
   );
 }
-
 function rateQuery(
   request: DataQueryRequest<TempoQuery>,
   serviceMapResponse: ServiceMapQueryResponse,
@@ -986,7 +927,6 @@ function rateQuery(
 ): Observable<ServiceMapQueryResponseWithRates> {
   const serviceMapRequest = makePromServiceMapRequest(request, useNativeHistogram);
   serviceMapRequest.targets = makeServiceGraphViewRequest([buildExpr(rateMetric, defaultTableFilter, request)]);
-
   return queryPrometheus(serviceMapRequest, datasourceUid).pipe(
     toArray(),
     map((responses: DataQueryResponse[]) => {
@@ -1002,7 +942,6 @@ function rateQuery(
     })
   );
 }
-
 // we need the response from the rate query to get the rate span_name(s),
 // -> which determine the errorRate/duration span_name(s) we need to query
 function errorAndDurationQuery(
@@ -1015,7 +954,6 @@ function errorAndDurationQuery(
   let serviceGraphViewMetrics = [];
   let errorRateBySpanName = '';
   let durationsBySpanName: string[] = [];
-
   let labels = [];
   if (rateResponse.rates[0] && request.app === CoreApp.Explore) {
     const spanNameField = rateResponse.rates[0].fields.find((field) => field.name === 'span_name');
@@ -1031,7 +969,6 @@ function errorAndDurationQuery(
     });
   }
   const spanNames = getEscapedRegexValues(getEscapedValues(labels));
-
   if (spanNames.length > 0) {
     errorRateBySpanName = buildExpr(errorRateMetric, 'span_name=~"' + spanNames.join('|') + '"', request);
     serviceGraphViewMetrics.push(errorRateBySpanName);
@@ -1042,10 +979,8 @@ function errorAndDurationQuery(
       serviceGraphViewMetrics.push(metric);
     });
   }
-
   const serviceMapRequest = makePromServiceMapRequest(request, useNativeHistogram);
   serviceMapRequest.targets = makeServiceGraphViewRequest(serviceGraphViewMetrics);
-
   return queryPrometheus(serviceMapRequest, datasourceUid).pipe(
     // Just collect all the responses first before processing into node graph data
     toArray(),
@@ -1054,7 +989,6 @@ function errorAndDurationQuery(
       if (errorRes) {
         throw new Error(getErrorMessage(errorRes.error?.message));
       }
-
       const serviceGraphView = getServiceGraphViewDataFrames(
         request,
         rateResponse,
@@ -1065,14 +999,12 @@ function errorAndDurationQuery(
         tempoDatasourceUid,
         useNativeHistogram
       );
-
       if (serviceGraphView.fields.length === 0) {
         return {
           data: [rateResponse.nodes, rateResponse.edges],
           state: LoadingState.Done,
         };
       }
-
       return {
         data: [serviceGraphView, rateResponse.nodes, rateResponse.edges],
         state: LoadingState.Done,
@@ -1080,7 +1012,6 @@ function errorAndDurationQuery(
     })
   );
 }
-
 function makePromLink(title: string, expr: string, datasourceUid: string, instant: boolean) {
   return {
     url: '',
@@ -1097,42 +1028,39 @@ function makePromLink(title: string, expr: string, datasourceUid: string, instan
     },
   };
 }
-
 // TODO: this is basically the same as prometheus/datasource.ts#prometheusSpecialRegexEscape which is used to escape
 //  template variable values. It would be best to move it to some common place.
 export function getEscapedRegexValues(values: string[]) {
   return values.map((value: string) => value.replace(/[$^*{}\[\]\'+?.()|]/g, '\\\\$&'));
 }
-
 export function getEscapedValues(values: string[]) {
   return values.map((value: string) => value.replace(/["\\]/g, '\\$&').replace(/[\n]/g, '\\n'));
 }
-
 export function getFieldConfig(
   datasourceUid: string,
   tempoDatasourceUid: string,
   targetField: string,
   tempoField: string,
   sourceField?: string,
-  namespaceFields?: { targetNamespace: string; sourceNamespace?: string },
+  namespaceFields?: {
+    targetNamespace: string;
+    sourceNamespace?: string;
+  },
   useNativeHistogram?: boolean
 ) {
   let source = sourceField ? `client="\${${sourceField}}",` : '';
   let target = `server="\${${targetField}}"`;
   let serverSumBy = 'server';
-
   if (namespaceFields !== undefined) {
     const { targetNamespace } = namespaceFields;
     target += `,server_service_namespace="\${${targetNamespace}}"`;
     serverSumBy += ', server_service_namespace';
-
     if (source) {
       const { sourceNamespace } = namespaceFields;
       source += `client_service_namespace="\${${sourceNamespace}}",`;
       serverSumBy += ', client_service_namespace';
     }
   }
-
   return {
     links: [
       makePromLink(
@@ -1157,7 +1085,6 @@ export function getFieldConfig(
     ],
   };
 }
-
 export function makeHistogramLink(
   datasourceUid: string,
   source: string,
@@ -1177,7 +1104,6 @@ export function makeHistogramLink(
   }
   return [createHistogramLink(histogramMetric, 'Request classic histogram')];
 }
-
 export function makeTempoLink(
   title: string,
   serviceNamespace: string | undefined,
@@ -1216,7 +1142,6 @@ export function makeTempoLink(
       valueType: 'string',
     });
   }
-
   return {
     url: '',
     title,
@@ -1227,7 +1152,6 @@ export function makeTempoLink(
     },
   };
 }
-
 function makeTempoLinkServiceMap(
   title: string,
   serviceNamespaceVar: string | undefined,
@@ -1247,7 +1171,6 @@ function makeTempoLinkServiceMap(
           replaceVariables?.(`\${__data.fields.${NodeGraphDataFrameFieldNames.isInstrumented}}`, scopedVars) !==
           'false';
         const query: TempoQuery = { refId: 'A', queryType: 'traceqlSearch', filters: [] };
-
         // Only do the peer query if service is actively set as not instrumented
         if (isInstrumented === false) {
           const filters = ['db.name', 'db.system', 'peer.service', 'messaging.system', 'net.peer.name']
@@ -1277,13 +1200,11 @@ function makeTempoLinkServiceMap(
             });
           }
         }
-
         return query;
       },
     },
   };
 }
-
 export function makePromServiceMapRequest(
   options: DataQueryRequest<TempoQuery>,
   useNativeHistogram?: boolean
@@ -1306,7 +1227,6 @@ export function makePromServiceMapRequest(
         const groupSubExprs = queries.map(
           (query) => `group by (client, connection_type, server${extraSumByFields}) (${metric}${query || ''})`
         );
-
         return [
           {
             format: 'table',
@@ -1327,7 +1247,6 @@ export function makePromServiceMapRequest(
       .flat(),
   };
 }
-
 function getServiceGraphViewDataFrames(
   request: DataQueryRequest<TempoQuery>,
   rateResponse: ServiceMapQueryResponseWithRates,
@@ -1339,7 +1258,6 @@ function getServiceGraphViewDataFrames(
   useNativeHistogram?: boolean
 ) {
   let df: any = { fields: [] };
-
   const rate = rateResponse.rates.filter((x) => {
     return x.refId === buildExpr(rateMetric, defaultTableFilter, request);
   });
@@ -1349,7 +1267,6 @@ function getServiceGraphViewDataFrames(
   const duration = secondResponse.data.filter((x) => {
     return durationsBySpanName.includes(x.refId ?? '');
   });
-
   if (rate.length > 0 && rate[0].fields?.length > 2) {
     df.fields.push({
       ...rate[0].fields[1],
@@ -1358,7 +1275,6 @@ function getServiceGraphViewDataFrames(
         filterable: false,
       },
     });
-
     df.fields.push({
       ...rate[0].fields[2],
       name: 'Rate',
@@ -1374,7 +1290,6 @@ function getServiceGraphViewDataFrames(
         decimals: 2,
       },
     });
-
     df.fields.push({
       ...rate[0].fields[2],
       name: '  ',
@@ -1393,7 +1308,6 @@ function getServiceGraphViewDataFrames(
       },
     });
   }
-
   if (errorRate.length > 0 && errorRate[0].fields?.length > 2) {
     const errorRateNames = errorRate[0].fields[1]?.values ?? [];
     const errorRateValues = errorRate[0].fields[2]?.values ?? [];
@@ -1406,9 +1320,7 @@ function getServiceGraphViewDataFrames(
     errorRateNames.map((name: string, index: number) => {
       errorRateObj[name] = { value: errorRateValues[index] };
     });
-
     const values = getRateAlignedValues({ ...rate }, errorRateObj);
-
     df.fields.push({
       ...errorRate[0].fields[2],
       name: 'Error Rate',
@@ -1425,7 +1337,6 @@ function getServiceGraphViewDataFrames(
         decimals: 2,
       },
     });
-
     df.fields.push({
       ...errorRate[0].fields[2],
       name: '   ',
@@ -1445,7 +1356,6 @@ function getServiceGraphViewDataFrames(
       },
     });
   }
-
   if (duration.length > 0) {
     let durationObj: Record<
       string,
@@ -1480,7 +1390,6 @@ function getServiceGraphViewDataFrames(
       });
     }
   }
-
   if (df.fields.length > 0 && df.fields[0].values) {
     df.fields.push({
       name: 'Links',
@@ -1493,10 +1402,8 @@ function getServiceGraphViewDataFrames(
       },
     });
   }
-
   return df;
 }
-
 /**
  * Reports metrics for Tempo query interactions.
  *
@@ -1536,9 +1443,12 @@ function reportTempoQueryMetrics(
     ...metrics,
   });
 }
-
 export function buildExpr(
-  metric: { expr: string; params: string[]; topk?: number },
+  metric: {
+    expr: string;
+    params: string[];
+    topk?: number;
+  },
   extraParams: string,
   request: DataQueryRequest<TempoQuery>
 ): string {
@@ -1571,22 +1481,23 @@ export function buildExpr(
   }
   return expr;
 }
-
 export function buildLinkExpr(expr: string) {
   // don't want top 5 or by span name in links
   expr = expr.replace('topk(5, ', '').replace(' by (span_name))', '');
   return expr.replace('__range', '__rate_interval');
 }
-
 // query result frames can come back in any order
 // here we align the table col values to the same row name (rateName) across the table
 export function getRateAlignedValues(
   rateResp: DataQueryResponseData[],
-  objToAlign: { [x: string]: { value: string } }
+  objToAlign: {
+    [x: string]: {
+      value: string;
+    };
+  }
 ) {
   const rateNames = rateResp[0]?.fields[1]?.values ?? [];
   let values: string[] = [];
-
   for (let i = 0; i < rateNames.length; i++) {
     if (Object.keys(objToAlign).includes(rateNames[i])) {
       values.push(objToAlign[rateNames[i]].value);
@@ -1594,10 +1505,8 @@ export function getRateAlignedValues(
       values.push('0');
     }
   }
-
   return values;
 }
-
 export function makeServiceGraphViewRequest(metrics: string[]): PromQuery[] {
   return metrics.map((metric) => {
     return {

--- a/public/app/plugins/datasource/tempo/resultTransformer.ts
+++ b/public/app/plugins/datasource/tempo/resultTransformer.ts
@@ -1,8 +1,8 @@
+import { structLog } from '@grafana/data';
 import { type SpanStatus } from '@opentelemetry/api';
 import { type collectorTypes } from '@opentelemetry/exporter-collector';
 import { SemanticResourceAttributes } from '@opentelemetry/semantic-conventions';
 import { isEqual } from 'lodash';
-
 import {
   createDataFrame,
   createTheme,
@@ -25,27 +25,21 @@ import {
 } from '@grafana/data';
 import { createNodeGraphFrames, type TraceToProfilesData } from '@grafana/o11y-ds-frontend';
 import { getDataSourceSrv } from '@grafana/runtime';
-
 import { SearchTableType } from './dataquery.gen';
 import { type Span, type SpanAttributes, type Spanset, type TempoJsonData, type TraceSearchMetadata } from './types';
-
 function getAttributeValue(value: collectorTypes.opentelemetryProto.common.v1.AnyValue): any {
   if (value.stringValue) {
     return value.stringValue;
   }
-
   if (value.boolValue !== undefined) {
     return Boolean(value.boolValue);
   }
-
   if (value.intValue !== undefined) {
     return Number.parseInt(String(value.intValue), 10);
   }
-
   if (value.doubleValue) {
     return Number.parseFloat(String(value.doubleValue));
   }
-
   if (value.arrayValue) {
     const arrayValue = [];
     for (const arValue of value.arrayValue.values) {
@@ -53,10 +47,8 @@ function getAttributeValue(value: collectorTypes.opentelemetryProto.common.v1.An
     }
     return arrayValue;
   }
-
   return '';
 }
-
 function resourceToProcess(resource: collectorTypes.opentelemetryProto.resource.v1.Resource | undefined) {
   const serviceTags: TraceKeyValuePair[] = [];
   let serviceName = 'OTLPResourceNoServiceName';
@@ -64,7 +56,6 @@ function resourceToProcess(resource: collectorTypes.opentelemetryProto.resource.
   if (!resource) {
     return { serviceName, serviceNamespace, serviceTags };
   }
-
   for (const attribute of resource.attributes) {
     if (attribute.key === SemanticResourceAttributes.SERVICE_NAME) {
       serviceName = attribute.value.stringValue || serviceName;
@@ -75,22 +66,17 @@ function resourceToProcess(resource: collectorTypes.opentelemetryProto.resource.
     }
     serviceTags.push({ key: attribute.key, value: getAttributeValue(attribute.value) });
   }
-
   return { serviceName, serviceNamespace, serviceTags };
 }
-
 function getSpanTags(span: collectorTypes.opentelemetryProto.trace.v1.Span): TraceKeyValuePair[] {
   const spanTags: TraceKeyValuePair[] = [];
-
   if (span.attributes) {
     for (const attribute of span.attributes) {
       spanTags.push({ key: attribute.key, value: getAttributeValue(attribute.value) });
     }
   }
-
   return spanTags;
 }
-
 function getSpanKind(span: collectorTypes.opentelemetryProto.trace.v1.Span) {
   let kind = undefined;
   if (span.kind) {
@@ -99,7 +85,6 @@ function getSpanKind(span: collectorTypes.opentelemetryProto.trace.v1.Span) {
   }
   return kind;
 }
-
 function getReferences(span: collectorTypes.opentelemetryProto.trace.v1.Span) {
   const references: TraceSpanReference[] = [];
   if (span.links) {
@@ -114,10 +99,8 @@ function getReferences(span: collectorTypes.opentelemetryProto.trace.v1.Span) {
       references.push({ traceID: traceId, spanID: spanId, tags });
     }
   }
-
   return references;
 }
-
 function getLogs(span: collectorTypes.opentelemetryProto.trace.v1.Span) {
   const logs: TraceLog[] = [];
   if (span.events) {
@@ -131,10 +114,8 @@ function getLogs(span: collectorTypes.opentelemetryProto.trace.v1.Span) {
       logs.push({ fields, timestamp: event.timeUnixNano / 1000000, name: event.name });
     }
   }
-
   return logs;
 }
-
 export function transformFromOTLP(
   traceData: collectorTypes.opentelemetryProto.trace.v1.ResourceSpans[],
   nodeGraph = false
@@ -196,34 +177,32 @@ export function transformFromOTLP(
       }
     }
   } catch (error) {
-    console.error(error);
+    structLog('error', error);
     return { error: { message: 'JSON is not valid OpenTelemetry format: ' + error }, data: [] };
   }
-
   let data = [frame];
   if (nodeGraph) {
     data.push(...(createNodeGraphFrames(frame) as MutableDataFrame[]));
   }
-
   return { data };
 }
-
 /**
  * Transforms trace dataframes to the OpenTelemetry format
  */
 export function transformToOTLP(data: MutableDataFrame): {
   batches: collectorTypes.opentelemetryProto.trace.v1.ResourceSpans[];
 } {
-  let result: { batches: collectorTypes.opentelemetryProto.trace.v1.ResourceSpans[] } = {
+  let result: {
+    batches: collectorTypes.opentelemetryProto.trace.v1.ResourceSpans[];
+  } = {
     batches: [],
   };
-
   // Lookup object to see which batch contains spans for which services
-  let services: { [key: string]: number } = {};
-
+  let services: {
+    [key: string]: number;
+  } = {};
   for (let i = 0; i < data.length; i++) {
     const span = data.get(i);
-
     // Group spans based on service
     if (!services[span.serviceName]) {
       services[span.serviceName] = result.batches.length;
@@ -239,14 +218,11 @@ export function transformToOTLP(data: MutableDataFrame): {
         ],
       });
     }
-
     let batchIndex = services[span.serviceName];
-
     // Populate resource attributes from service tags
     if (result.batches[batchIndex].resource!.attributes.length === 0) {
       result.batches[batchIndex].resource!.attributes = tagsToAttributes(span.serviceTags);
     }
-
     // Populate instrumentation library if it exists
     if (!result.batches[batchIndex].instrumentationLibrarySpans[0].instrumentationLibrary) {
       if (span.instrumentationLibraryName) {
@@ -256,7 +232,6 @@ export function transformToOTLP(data: MutableDataFrame): {
         };
       }
     }
-
     result.batches[batchIndex].instrumentationLibrarySpans[0].spans.push({
       traceId: span.traceID.padStart(32, '0'),
       spanId: span.spanID,
@@ -275,10 +250,8 @@ export function transformToOTLP(data: MutableDataFrame): {
       links: getOTLPReferences(span.references),
     });
   }
-
   return result;
 }
-
 function getOTLPSpanKind(kind: string): string | undefined {
   let spanKind = undefined;
   if (kind) {
@@ -302,7 +275,6 @@ function getOTLPSpanKind(kind: string): string | undefined {
   }
   return spanKind;
 }
-
 /**
  * Converts key-value tags to OTLP attributes and removes tags added by Grafana
  */
@@ -312,7 +284,6 @@ function tagsToAttributes(tags: TraceKeyValuePair[]): collectorTypes.opentelemet
     []
   );
 }
-
 /**
  * Returns the correct OTLP AnyValue based on the value of the tag value
  */
@@ -333,13 +304,11 @@ function toAttributeValue(tag: TraceKeyValuePair): collectorTypes.opentelemetryP
       for (const val of tag.value) {
         values.push(toAttributeValue(val));
       }
-
       return { arrayValue: { values } };
     }
   }
   return { stringValue: tag.value };
 }
-
 function getOTLPStatus(span: TraceSpanRow): SpanStatus | undefined {
   let status = undefined;
   if (span.statusCode !== undefined) {
@@ -350,12 +319,10 @@ function getOTLPStatus(span: TraceSpanRow): SpanStatus | undefined {
   }
   return status;
 }
-
 function getOTLPEvents(logs: TraceLog[]): collectorTypes.opentelemetryProto.trace.v1.Span.Event[] | undefined {
   if (!logs || !logs.length) {
     return undefined;
   }
-
   let events: collectorTypes.opentelemetryProto.trace.v1.Span.Event[] = [];
   for (const log of logs) {
     let event: collectorTypes.opentelemetryProto.trace.v1.Span.Event = {
@@ -374,14 +341,12 @@ function getOTLPEvents(logs: TraceLog[]): collectorTypes.opentelemetryProto.trac
   }
   return events;
 }
-
 function getOTLPReferences(
   references: TraceSpanReference[]
 ): collectorTypes.opentelemetryProto.trace.v1.Span.Link[] | undefined {
   if (!references || !references.length) {
     return undefined;
   }
-
   let links: collectorTypes.opentelemetryProto.trace.v1.Span.Link[] = [];
   for (const ref of references) {
     let link: collectorTypes.opentelemetryProto.trace.v1.Span.Link = {
@@ -402,20 +367,16 @@ function getOTLPReferences(
   }
   return links;
 }
-
 export const RelatedProfilesTitle = 'Related profiles';
-
 export function transformTrace(
   response: DataQueryResponse,
   instanceSettings: DataSourceInstanceSettings<TempoJsonData>,
   nodeGraph = false
 ): DataQueryResponse {
   const frame = response.data[0];
-
   if (!frame) {
     return emptyDataQueryResponse;
   }
-
   // Get profiles links
   const traceToProfilesData: TraceToProfilesData | undefined = instanceSettings?.jsonData;
   const traceToProfilesOptions = traceToProfilesData?.tracesToProfiles;
@@ -423,7 +384,6 @@ export function transformTrace(
   if (traceToProfilesOptions?.datasourceUid) {
     profilesDataSourceSettings = getDataSourceSrv().getInstanceSettings(traceToProfilesOptions.datasourceUid);
   }
-
   if (traceToProfilesOptions && profilesDataSourceSettings) {
     const customQuery = traceToProfilesOptions.customQuery ? traceToProfilesOptions.query : undefined;
     const dataLink: DataLink = {
@@ -443,25 +403,21 @@ export function transformTrace(
       },
       origin: DataLinkConfigOrigin.Datasource,
     };
-
     frame.fields.forEach((field: Field) => {
       if (field.name === 'tags') {
         field.config.links = [dataLink];
       }
     });
   }
-
   let data = [...response.data];
   if (nodeGraph) {
     data.push(...createNodeGraphFrames(toDataFrame(frame)));
   }
-
   return {
     ...response,
     data,
   };
 }
-
 function transformToTraceData(data: TraceSearchMetadata) {
   return {
     traceID: data.traceID,
@@ -471,7 +427,6 @@ function transformToTraceData(data: TraceSearchMetadata) {
     traceName: data.rootTraceName || '',
   };
 }
-
 export function enhanceTraceQlMetricsResponse(
   data: DataQueryResponse,
   instanceSettings: DataSourceInstanceSettings
@@ -483,7 +438,6 @@ export function enhanceTraceQlMetricsResponse(
       if (traceIDField) {
         const links = getDataLinks(instanceSettings);
         const existingLinks = traceIDField.config.links || [];
-
         // Filter out links that already exist
         const newLinks = links.filter(
           (link) =>
@@ -494,17 +448,14 @@ export function enhanceTraceQlMetricsResponse(
                 isEqual(existing.internal?.query, link.internal?.query)
             )
         );
-
         traceIDField.config.links = existingLinks.length ? [...existingLinks, ...newLinks] : newLinks;
       }
       return frame;
     });
   return data;
 }
-
 function getDataLinks(instanceSettings: DataSourceInstanceSettings): DataLink[] {
   const dataLinks: DataLink[] = [];
-
   if (instanceSettings.uid) {
     dataLinks.push({
       title: 'View trace',
@@ -518,7 +469,6 @@ function getDataLinks(instanceSettings: DataSourceInstanceSettings): DataLink[] 
   }
   return dataLinks;
 }
-
 export function formatTraceQLResponse(
   data: TraceSearchMetadata[],
   instanceSettings: DataSourceInstanceSettings,
@@ -533,7 +483,6 @@ export function formatTraceQLResponse(
       return createTableFrameFromTraceQlQuery(data, instanceSettings);
   }
 }
-
 function createDataFrameFromTraceQlQuery(data: TraceSearchMetadata[]) {
   return [
     createDataFrame({
@@ -543,7 +492,6 @@ function createDataFrameFromTraceQlQuery(data: TraceSearchMetadata[]) {
     }),
   ];
 }
-
 /**
  * Create data frame while adding spans for each trace into a subtable.
  * @param data
@@ -615,12 +563,10 @@ export function createTableFrameFromTraceQlQuery(
       uniqueRowIdFields: [0],
     },
   });
-
   if (!data?.length) {
     return [frame];
   }
   frame.length = data.length;
-
   data
     // Show the most recent traces
     .sort((a, b) => parseInt(b?.startTimeUnixNano!, 10) / 1000000 - parseInt(a?.startTimeUnixNano!, 10) / 1000000)
@@ -630,11 +576,9 @@ export function createTableFrameFromTraceQlQuery(
       frame.fields[1].values.push(traceData.startTime);
       frame.fields[2].values.push(traceData.traceService);
       frame.fields[3].values.push(traceData.traceName);
-
       // Note: this is a workaround to display the duration in the table when it is <1ms
       // and the duration is not available in the trace data response.
       frame.fields[4].values.push(traceData.traceDuration ? traceData.traceDuration : '<1ms');
-
       if (trace.spanSets) {
         frame.fields[5].values.push(
           trace.spanSets.map((spanSet: Spanset) => {
@@ -645,17 +589,14 @@ export function createTableFrameFromTraceQlQuery(
         frame.fields[5].values.push([traceSubFrame(trace, trace.spanSet, instanceSettings)]);
       }
     });
-
   return [frame];
 }
-
 export function createTableFrameFromTraceQlQueryAsSpans(
   data: TraceSearchMetadata[] | undefined,
   instanceSettings: DataSourceInstanceSettings
 ): DataFrame[] {
   const spanDynamicAttrs: Record<string, FieldDTO> = {};
   let hasNameAttribute = false;
-
   data?.forEach((trace) =>
     getSpanSets(trace).forEach((ss) => {
       ss.attributes?.forEach((attr) => {
@@ -679,7 +620,6 @@ export function createTableFrameFromTraceQlQueryAsSpans(
       });
     })
   );
-
   const frame = new MutableDataFrame({
     name: 'Spans',
     refId: 'traces',
@@ -770,11 +710,9 @@ export function createTableFrameFromTraceQlQueryAsSpans(
       preferredVisualisationType: 'table',
     },
   });
-
   if (!data || !data.length) {
     return [frame];
   }
-
   data
     // Show the most recent traces
     .sort((a, b) => parseInt(b?.startTimeUnixNano!, 10) / 1000000 - parseInt(a?.startTimeUnixNano!, 10) / 1000000)
@@ -785,10 +723,8 @@ export function createTableFrameFromTraceQlQueryAsSpans(
         });
       });
     });
-
   return [frame];
 }
-
 /**
  * Get the spansets of a trace.
  *
@@ -801,7 +737,6 @@ export function createTableFrameFromTraceQlQueryAsSpans(
 const getSpanSets = (trace: TraceSearchMetadata): Spanset[] => {
   return trace.spanSets || (trace.spanSet ? [trace.spanSet] : []);
 };
-
 const traceSubFrame = (
   trace: TraceSearchMetadata,
   spanSet: Spanset,
@@ -809,7 +744,6 @@ const traceSubFrame = (
 ): DataFrame => {
   const spanDynamicAttrs: Record<string, FieldDTO> = {};
   let hasNameAttribute = false;
-
   spanSet.attributes?.map((attr) => {
     spanDynamicAttrs[attr.key] = {
       name: attr.key,
@@ -831,7 +765,6 @@ const traceSubFrame = (
       };
     });
   });
-
   const subFrame = new MutableDataFrame({
     fields: [
       {
@@ -907,20 +840,16 @@ const traceSubFrame = (
       preferredVisualisationType: 'table',
     },
   });
-
   // TODO: this should be done in `applyFieldOverrides` instead recursively for the nested `DataFrames`
   const theme = createTheme();
   for (const field of subFrame.fields) {
     field.display = getDisplayProcessor({ field, theme });
   }
-
   spanSet.spans.forEach((span) => {
     subFrame.add(transformSpanToTraceData(span, spanSet, trace));
   });
-
   return toDataFrame(subFrame);
 };
-
 interface TraceTableData {
   [key: string]: string | number | boolean | undefined; // dynamic attribute name
   traceID?: string;
@@ -929,10 +858,8 @@ interface TraceTableData {
   name?: string;
   traceDuration?: number;
 }
-
 function transformSpanToTraceData(span: Span, spanSet: Spanset, trace: TraceSearchMetadata): TraceTableData {
   const spanStartTimeUnixMs = parseInt(span.startTimeUnixNano, 10) / 1000000;
-
   const data: TraceTableData = {
     traceIdHidden: trace.traceID,
     traceService: trace.rootServiceName || '',
@@ -942,7 +869,6 @@ function transformSpanToTraceData(span: Span, spanSet: Spanset, trace: TraceSear
     duration: parseInt(span.durationNanos, 10),
     name: span.name,
   };
-
   let attrs: SpanAttributes[] = [];
   if (spanSet.attributes) {
     attrs = attrs.concat(spanSet.attributes);
@@ -950,7 +876,6 @@ function transformSpanToTraceData(span: Span, spanSet: Spanset, trace: TraceSear
   if (span.attributes) {
     attrs = attrs.concat(span.attributes);
   }
-
   attrs.forEach((attr) => {
     if (attr.value.boolValue || attr.value.Value?.bool_value) {
       data[attr.key] = attr.value.boolValue || attr.value.Value?.bool_value;
@@ -965,10 +890,8 @@ function transformSpanToTraceData(span: Span, spanSet: Spanset, trace: TraceSear
       data[attr.key] = attr.value.stringValue || attr.value.Value?.string_value;
     }
   });
-
   return data;
 }
-
 const emptyDataQueryResponse = {
   data: [
     new MutableDataFrame({

--- a/public/app/plugins/datasource/tempo/traceql/TraceQLEditor.tsx
+++ b/public/app/plugins/datasource/tempo/traceql/TraceQLEditor.tsx
@@ -1,19 +1,16 @@
+import { structLog } from '@grafana/data';
 import { css } from '@emotion/css';
 import { useEffect, useRef, useState } from 'react';
-
 import { type GrafanaTheme2, type TimeRange } from '@grafana/data';
 import { TemporaryAlert } from '@grafana/o11y-ds-frontend';
 import { reportInteraction } from '@grafana/runtime';
 import { CodeEditor, type Monaco, type monacoTypes, useTheme2 } from '@grafana/ui';
-
 import { DEFAULT_TIME_RANGE_FOR_TAGS } from '../configuration/TagsTimeRangeSettings';
 import { type TempoDatasource } from '../datasource';
 import { type TempoQuery } from '../types';
-
 import { CompletionProvider, type CompletionItemType } from './autocomplete';
 import { getErrorNodes, setMarkers } from './highlighting';
 import { languageDefinition } from './traceql';
-
 interface Props {
   placeholder: string;
   query: TempoQuery;
@@ -23,10 +20,8 @@ interface Props {
   readOnly?: boolean;
   range?: TimeRange;
 }
-
 export function TraceQLEditor(props: Props) {
   const [alertText, setAlertText] = useState<string>();
-
   const { query, onChange, onRunQuery, placeholder } = props;
   const setupAutocompleteFn = useAutocomplete(
     props.datasource,
@@ -36,7 +31,6 @@ export function TraceQLEditor(props: Props) {
   );
   const theme = useTheme2();
   const styles = getStyles(theme, placeholder);
-
   // The Monaco Editor uses the first version of props.onChange in handleOnMount i.e. always has the initial
   // value of query because underlying Monaco editor is passed `query` below in the onEditorChange callback.
   // handleOnMount is called only once when the editor is mounted and does not get updates to query.
@@ -46,14 +40,11 @@ export function TraceQLEditor(props: Props) {
   const onEditorChange = (value: string) => {
     onChange({ ...queryRef.current, query: value });
   };
-
   // work around the problem that `onEditorDidMount` is called once
   // and wouldn't get new version of onRunQuery
   const onRunQueryRef = useRef(onRunQuery);
   onRunQueryRef.current = onRunQuery;
-
   const errorTimeoutId = useRef<number | undefined>(undefined);
-
   return (
     <>
       <CodeEditor
@@ -86,7 +77,6 @@ export function TraceQLEditor(props: Props) {
             setupPlaceholder(editor, monaco, styles);
           }
           setupAutoSize(editor);
-
           // Parse query that might already exist (e.g., after a page refresh)
           const model = editor.getModel();
           if (model) {
@@ -94,27 +84,22 @@ export function TraceQLEditor(props: Props) {
               const errorNodes = getErrorNodes(model.getValue());
               setMarkers(monaco, model, errorNodes);
             } catch (err) {
-              console.warn('TraceQL editor: failed to update syntax error markers', err);
+              structLog('warn', 'TraceQL editor: failed to update syntax error markers', err);
             }
           }
-
           // Register callback for query changes
           editor.onDidChangeModelContent((changeEvent) => {
             const model = editor.getModel();
-
             if (!model) {
               return;
             }
-
             // Remove previous callback if existing, to prevent squiggles from been shown while the user is still typing
             if (errorTimeoutId.current) {
               window.clearTimeout(errorTimeoutId.current);
             }
-
             try {
               const errorNodes = getErrorNodes(model.getValue());
               const cursorPosition = changeEvent.changes[0].rangeOffset;
-
               // Immediately updates the squiggles, in case the user fixed an error,
               // excluding the error around the cursor position
               setMarkers(
@@ -122,16 +107,15 @@ export function TraceQLEditor(props: Props) {
                 model,
                 errorNodes.filter((errorNode) => !(errorNode.from <= cursorPosition && cursorPosition <= errorNode.to))
               );
-
               errorTimeoutId.current = window.setTimeout(() => {
                 try {
                   setMarkers(monaco, model, errorNodes);
                 } catch (err) {
-                  console.warn('TraceQL editor: failed to update syntax error markers', err);
+                  structLog('warn', 'TraceQL editor: failed to update syntax error markers', err);
                 }
               }, 500);
             } catch (err) {
-              console.warn('TraceQL editor: failed to parse query for error highlighting', err);
+              structLog('warn', 'TraceQL editor: failed to parse query for error highlighting', err);
             }
           });
         }}
@@ -140,7 +124,6 @@ export function TraceQLEditor(props: Props) {
     </>
   );
 }
-
 function setupPlaceholder(editor: monacoTypes.editor.IStandaloneCodeEditor, monaco: Monaco, styles: EditorStyles) {
   const placeholderDecorators = [
     {
@@ -151,24 +134,18 @@ function setupPlaceholder(editor: monacoTypes.editor.IStandaloneCodeEditor, mona
       },
     },
   ];
-
   let decorators: string[] = [];
-
   const checkDecorators = (): void => {
     const model = editor.getModel();
-
     if (!model) {
       return;
     }
-
     const newDecorators = model.getValueLength() === 0 ? placeholderDecorators : [];
     decorators = model.deltaDecorations(decorators, newDecorators);
   };
-
   checkDecorators();
   editor.onDidChangeModelContent(checkDecorators);
 }
-
 function setupActions(editor: monacoTypes.editor.IStandaloneCodeEditor, monaco: Monaco, onRunQuery: () => void) {
   editor.addAction({
     id: 'run-query',
@@ -181,7 +158,6 @@ function setupActions(editor: monacoTypes.editor.IStandaloneCodeEditor, monaco: 
     },
   });
 }
-
 function setupRegisterInteractionCommand(editor: monacoTypes.editor.IStandaloneCodeEditor): string | null {
   return editor.addCommand(0, function (_, label, type: CompletionItemType) {
     const properties: Record<string, unknown> = { datasourceType: 'tempo', type };
@@ -192,7 +168,6 @@ function setupRegisterInteractionCommand(editor: monacoTypes.editor.IStandaloneC
     reportInteraction('grafana_traces_traceql_completion', properties);
   });
 }
-
 function setupAutoSize(editor: monacoTypes.editor.IStandaloneCodeEditor) {
   const container = editor.getDomNode();
   const updateHeight = () => {
@@ -207,7 +182,6 @@ function setupAutoSize(editor: monacoTypes.editor.IStandaloneCodeEditor) {
   editor.onDidContentSizeChange(updateHeight);
   updateHeight();
 }
-
 /**
  * Hook that returns function that will set up monaco autocomplete for the label selector
  * @param datasource the Tempo datasource instance
@@ -233,9 +207,7 @@ function useAutocomplete(
       range,
     })
   );
-
   const previousRangeRef = useRef<TimeRange | undefined>(range);
-
   useEffect(() => {
     const fetchTags = async () => {
       try {
@@ -249,20 +221,16 @@ function useAutocomplete(
     };
     fetchTags();
   }, [datasource, setAlertText, range, timeRangeForTags]);
-
   useEffect(() => {
     const rangeChanged = datasource.languageProvider.shouldRefreshLabels(range, previousRangeRef.current);
-
     if (rangeChanged) {
       providerRef.current.range = range;
       previousRangeRef.current = range;
     }
   }, [range, datasource.languageProvider]);
-
   useEffect(() => {
     providerRef.current.timeRangeForTags = timeRangeForTags;
   }, [timeRangeForTags]);
-
   const autocompleteDisposeFun = useRef<(() => void) | null>(null);
   useEffect(() => {
     // when we unmount, we unregister the autocomplete-function, if it was registered
@@ -270,7 +238,6 @@ function useAutocomplete(
       autocompleteDisposeFun.current?.();
     };
   }, []);
-
   // This should be run in monaco onEditorDidMount
   return (
     editor: monacoTypes.editor.IStandaloneCodeEditor,
@@ -280,16 +247,13 @@ function useAutocomplete(
     providerRef.current.editor = editor;
     providerRef.current.monaco = monaco;
     providerRef.current.setRegisterInteractionCommandId(registerInteractionCommandId);
-
     const { dispose } = monaco.languages.registerCompletionItemProvider(langId, providerRef.current);
     autocompleteDisposeFun.current = dispose;
   };
 }
-
 // we must only run the setup code once
 let traceqlSetupDone = false;
 const langId = 'traceql';
-
 function ensureTraceQL(monaco: Monaco) {
   if (!traceqlSetupDone) {
     traceqlSetupDone = true;
@@ -299,12 +263,10 @@ function ensureTraceQL(monaco: Monaco) {
     monaco.languages.setLanguageConfiguration(langId, def.languageConfiguration);
   }
 }
-
 interface EditorStyles {
   placeholder: string;
   queryField: string;
 }
-
 const getStyles = (theme: GrafanaTheme2, placeholder: string): EditorStyles => {
   return {
     queryField: css({

--- a/public/app/plugins/datasource/tempo/traceql/situation.ts
+++ b/public/app/plugins/datasource/tempo/traceql/situation.ts
@@ -1,5 +1,5 @@
+import { structLog } from '@grafana/data';
 import { type SyntaxNode, type Tree } from '@lezer/common';
-
 import {
   Aggregate,
   And,
@@ -22,12 +22,11 @@ import {
   String as StringNode,
   TraceQL,
 } from '@grafana/lezer-traceql';
-
 type Direction = 'parent' | 'firstChild' | 'lastChild' | 'nextSibling' | 'prevSibling';
 type NodeType = number;
-
-export type Situation = { query: string } & SituationType;
-
+export type Situation = {
+  query: string;
+} & SituationType;
 export type SituationType =
   | {
       type: 'UNKNOWN';
@@ -89,14 +88,11 @@ export type SituationType =
   | {
       type: 'QUERY_HINT_VALUE';
     };
-
 type Path = Array<[Direction, NodeType[]]>;
-
 type Resolver = {
   path: NodeType[];
   fun: (node: SyntaxNode, text: string, pos: number, originalPos: number) => SituationType | void;
 };
-
 function getErrorNode(tree: Tree, cursorPos: number): SyntaxNode | null {
   const cur = tree.cursorAt(cursorPos);
   do {
@@ -109,11 +105,9 @@ function getErrorNode(tree: Tree, cursorPos: number): SyntaxNode | null {
   } while (cur.next());
   return null;
 }
-
 function move(node: SyntaxNode, direction: Direction): SyntaxNode | null {
   return node[direction];
 }
-
 function walk(node: SyntaxNode, path: Path): SyntaxNode | null {
   let current: SyntaxNode | null = node;
   for (const [direction, expectedNodeIDs] of path) {
@@ -122,7 +116,6 @@ function walk(node: SyntaxNode, path: Path): SyntaxNode | null {
       // we could not move in the direction, we stop
       return null;
     }
-
     // note that the found value can be 0, which is acceptable
     if (expectedNodeIDs.find((id) => id === current?.type.id) === undefined) {
       // the reached node has wrong type, we stop
@@ -131,16 +124,13 @@ function walk(node: SyntaxNode, path: Path): SyntaxNode | null {
   }
   return current;
 }
-
 function getNodeText(node: SyntaxNode, text: string): string {
   // if the from and to are them same (e.g. for an error node) we can subtract 1 from the start/from index
   return text.slice(node.from === node.to ? node.from - 1 : node.from, node.to);
 }
-
 function isPathMatch(resolverPath: NodeType[], cursorPath: number[]): boolean {
   return resolverPath.every((item, index) => item === cursorPath[index]);
 }
-
 /**
  * Figure out where is the cursor and what kind of suggestions are appropriate.
  * @param text the user input
@@ -155,10 +145,8 @@ export function getSituation(text: string, offset: number): Situation | null {
       type: 'EMPTY',
     };
   }
-
   // Check for with clause hint situations first
   const textUpToOffset = text.substring(0, offset);
-
   // Check if we're inside with(...) waiting for parameter names
   if (/\bwith\s*\(\s*$/.test(textUpToOffset)) {
     return {
@@ -166,7 +154,6 @@ export function getSituation(text: string, offset: number): Situation | null {
       type: 'QUERY_HINT_NAME',
     };
   }
-
   // Check if we're after parameter= waiting for values
   if (/\bwith\s*\(\s*\w+\s*=\s*[\w]*$/.test(textUpToOffset)) {
     return {
@@ -174,9 +161,7 @@ export function getSituation(text: string, offset: number): Situation | null {
       type: 'QUERY_HINT_VALUE',
     };
   }
-
   const tree = parser.parse(text);
-
   // Whitespaces (especially when multiple) on the left of the text cursor can trick the Lezer parser,
   // causing a wrong tree cursor to be picked.
   // Example: `{ span.foo =    ↓ }`, with `↓` being the cursor, tricks the parser.
@@ -185,7 +170,6 @@ export function getSituation(text: string, offset: number): Situation | null {
   while (shiftedOffset - 1 >= 0 && text[shiftedOffset - 1] === ' ') {
     shiftedOffset -= 1;
   }
-
   // If the tree contains error, it's probable that our node is one of those error nodes.
   // If there are errors, the node lezer finds us might not be the best node.
   // So, first we check if there is an error node at the cursor position.
@@ -198,27 +182,21 @@ export function getSituation(text: string, offset: number): Situation | null {
     // Try again with the next character
     errorNode = getErrorNode(tree, shiftedOffset + 1);
   }
-
   const cur = errorNode != null ? errorNode.cursor() : tree.cursorAt(shiftedOffset);
-
   const currentNode = cur.node;
   const ids = [cur.type.id];
   while (cur.parent()) {
     ids.push(cur.type.id);
   }
-
   let situationType: SituationType | void = undefined;
   for (let resolver of RESOLVERS) {
     if (isPathMatch(resolver.path, ids)) {
       situationType = resolver.fun(currentNode, text, shiftedOffset, offset);
     }
   }
-
   return { query: text, ...(situationType ?? { type: 'UNKNOWN' }) };
 }
-
 const ERROR_NODE_ID = 0;
-
 const RESOLVERS: Resolver[] = [
   // Curson on error node cases
   {
@@ -279,7 +257,6 @@ const RESOLVERS: Resolver[] = [
     fun: resolveExpression,
   },
 ];
-
 const resolveAttributeCompletion = (node: SyntaxNode, text: string, pos: number): SituationType | void => {
   // The user is completing an expression. We can take advantage of the fact that the Monaco editor is smart
   // enough to automatically detect that there are some characters before the cursor and to take them into
@@ -290,12 +267,10 @@ const resolveAttributeCompletion = (node: SyntaxNode, text: string, pos: number)
     const indexOfDot = attributeFieldParentText.indexOf('.');
     return attributeFieldParentText.slice(0, indexOfDot);
   };
-
   // If there is a space, for sure the attribute is completed and no suggestions to complete it should be provided
   if (text[pos - 1] === ' ') {
     return;
   }
-
   const endOfPathNode = walk(node, [['firstChild', [FieldExpression]]]);
   if (endOfPathNode) {
     return {
@@ -303,7 +278,6 @@ const resolveAttributeCompletion = (node: SyntaxNode, text: string, pos: number)
       scope: getAttributeFieldUpToDot(endOfPathNode),
     };
   }
-
   const endOfPathNode2 = walk(node, [
     ['parent', [SpansetFilter]],
     ['firstChild', [FieldExpression]],
@@ -316,13 +290,11 @@ const resolveAttributeCompletion = (node: SyntaxNode, text: string, pos: number)
     };
   }
 };
-
 function resolveSpanset(node: SyntaxNode, text: string, _: number, originalPos: number): SituationType {
   const situation = resolveAttributeCompletion(node, text, originalPos);
   if (situation) {
     return situation;
   }
-
   let endOfPathNode = walk(node, [
     ['firstChild', [FieldExpression]],
     ['firstChild', [AttributeField]],
@@ -332,7 +304,6 @@ function resolveSpanset(node: SyntaxNode, text: string, _: number, originalPos: 
       type: 'SPANSET_EXPRESSION_OPERATORS',
     };
   }
-
   endOfPathNode = walk(node, [
     ['lastChild', [FieldExpression]],
     ['lastChild', [FieldExpression]],
@@ -343,32 +314,26 @@ function resolveSpanset(node: SyntaxNode, text: string, _: number, originalPos: 
       type: 'SPANFIELD_COMBINING_OPERATORS',
     };
   }
-
   endOfPathNode = walk(node, [['lastChild', [FieldExpression]]]);
   if (endOfPathNode) {
     return {
       type: 'SPANSET_EXPRESSION_OPERATORS',
     };
   }
-
   return {
     type: 'SPANSET_EMPTY',
   };
 }
-
 function resolveAttribute(node: SyntaxNode, text: string): SituationType {
   const attributeFieldParent = walk(node, [['parent', [AttributeField]]]);
   const attributeFieldParentText = attributeFieldParent ? getNodeText(attributeFieldParent, text) : '';
-
   if (attributeFieldParentText === '.') {
     return {
       type: 'SPANSET_ONLY_DOT',
     };
   }
-
   const indexOfDot = attributeFieldParentText.indexOf('.');
   const attributeFieldUpToDot = attributeFieldParentText.slice(0, indexOfDot);
-
   if (
     ['event', 'instrumentation', 'link', 'resource', 'span', 'parent'].find((item) => item === attributeFieldUpToDot)
   ) {
@@ -381,13 +346,11 @@ function resolveAttribute(node: SyntaxNode, text: string): SituationType {
     type: 'SPANSET_IN_NAME',
   };
 }
-
 function resolveExpression(node: SyntaxNode, text: string, _: number, originalPos: number): SituationType {
   const situation = resolveAttributeCompletion(node, text, originalPos);
   if (situation) {
     return situation;
   }
-
   if (
     walk(node, [
       ['parent', [Static]],
@@ -404,7 +367,6 @@ function resolveExpression(node: SyntaxNode, text: string, _: number, originalPo
       };
     }
   }
-
   if (node.prevSibling?.type.id === FieldOp) {
     let attributeField = node.prevSibling?.prevSibling;
     if (attributeField) {
@@ -415,18 +377,15 @@ function resolveExpression(node: SyntaxNode, text: string, _: number, originalPo
       };
     }
   }
-
   if (node.prevSibling?.type.name === 'And' || node.prevSibling?.type.name === 'Or') {
     return {
       type: 'SPANSET_EMPTY',
     };
   }
-
   return {
     type: 'SPANSET_IN_THE_MIDDLE',
   };
 }
-
 function resolveArithmeticOperator(node: SyntaxNode, _0: string, _1: number): SituationType | void {
   if (node.prevSibling?.type.id !== ComparisonOp) {
     return {
@@ -434,7 +393,6 @@ function resolveArithmeticOperator(node: SyntaxNode, _0: string, _1: number): Si
     };
   }
 }
-
 function resolveNewSpansetExpression(node: SyntaxNode, text: string, offset: number): SituationType {
   // Select the node immediately before the one pointed by the cursor
   let previousNode = node.firstChild;
@@ -444,20 +402,17 @@ function resolveNewSpansetExpression(node: SyntaxNode, text: string, offset: num
       previousNode = previousNode!.nextSibling;
     }
   } catch (error) {
-    console.error('Unexpected error while searching for previous node', error);
+    structLog('error', 'Unexpected error while searching for previous node', error);
   }
-
   if (previousNode?.type.id === And || previousNode?.type.id === Or) {
     return {
       type: 'NEW_SPANSET',
     };
   }
-
   return {
     type: 'SPANSET_COMBINING_OPERATORS',
   };
 }
-
 function resolveAttributeForFunction(node: SyntaxNode, _0: string, _1: number): SituationType | void {
   const parent = node?.parent;
   if (!!parent && [IntrinsicField, Aggregate, GroupOperation, SelectOperation, SelectArgs].includes(parent.type.id)) {
@@ -466,7 +421,6 @@ function resolveAttributeForFunction(node: SyntaxNode, _0: string, _1: number): 
     };
   }
 }
-
 function resolveSpansetPipeline(node: SyntaxNode, _1: string, _2: number): SituationType {
   if (node.prevSibling?.type.id === Pipe) {
     return {
@@ -477,13 +431,11 @@ function resolveSpansetPipeline(node: SyntaxNode, _1: string, _2: number): Situa
     type: 'NEW_SPANSET',
   };
 }
-
 function resolveSpansetWithNoClosedBrace(node: SyntaxNode, text: string, originalPos: number): SituationType {
   const situation = resolveAttributeCompletion(node, text, originalPos);
   if (situation) {
     return situation;
   }
-
   return {
     type: 'SPANSET_EXPRESSION_OPERATORS_WITH_MISSING_CLOSED_BRACE',
   };

--- a/public/app/plugins/datasource/tempo/tracking.ts
+++ b/public/app/plugins/datasource/tempo/tracking.ts
@@ -1,9 +1,8 @@
+import { structLog } from '@grafana/data';
 import { type DashboardLoadedEvent } from '@grafana/data';
 import { getTemplateSrv, reportInteraction } from '@grafana/runtime';
-
 import pluginJson from './plugin.json';
 import { type TempoQuery } from './types';
-
 type TempoOnDashboardLoadedTrackingEvent = {
   grafana_version?: string;
   dashboard_id?: string;
@@ -14,17 +13,14 @@ type TempoOnDashboardLoadedTrackingEvent = {
   service_map_queries_with_template_variables_count: number;
   traceql_queries_with_template_variables_count: number;
 };
-
 export const onDashboardLoadedHandler = ({
   payload: { dashboardId, orgId, grafanaVersion, queries },
 }: DashboardLoadedEvent<TempoQuery>) => {
   try {
     const tempoQueries = queries[pluginJson.id];
-
     if (!tempoQueries?.length) {
       return;
     }
-
     let stats: TempoOnDashboardLoadedTrackingEvent = {
       grafana_version: grafanaVersion,
       dashboard_id: dashboardId,
@@ -35,12 +31,10 @@ export const onDashboardLoadedHandler = ({
       service_map_queries_with_template_variables_count: 0,
       traceql_queries_with_template_variables_count: 0,
     };
-
     for (const query of tempoQueries) {
       if (query.hide) {
         continue;
       }
-
       if (query.queryType === 'serviceMap') {
         stats.service_map_query_count++;
         if (query.serviceMapQuery && hasTemplateVariables(query.serviceMapQuery)) {
@@ -55,13 +49,11 @@ export const onDashboardLoadedHandler = ({
         stats.upload_query_count++;
       }
     }
-
     reportInteraction('grafana_tempo_dashboard_loaded', stats);
   } catch (error) {
-    console.error('error in tempo tracking handler', error);
+    structLog('error', 'error in tempo tracking handler', error);
   }
 };
-
 const hasTemplateVariables = (val?: string | string[]): boolean => {
   return (Array.isArray(val) ? val : [val]).some((v) => getTemplateSrv().containsTemplate(v));
 };

--- a/public/app/plugins/datasource/tempo/utils.ts
+++ b/public/app/plugins/datasource/tempo/utils.ts
@@ -1,13 +1,11 @@
+import { structLog } from '@grafana/data';
 import { type DataSourceApi, parseDuration } from '@grafana/data';
 import { getDataSourceSrv } from '@grafana/runtime';
-
 import { generateId } from './SearchTraceQLEditor/TagsInput';
 import { type TraceqlFilter, TraceqlSearchScope } from './dataquery.gen';
 import { type TempoQuery } from './types';
-
 const LIMIT_MESSAGE = /.*range specified by start and end.*exceeds.*/;
 const LIMIT_MESSAGE_METRICS = /.*metrics query time range exceeds the maximum allowed duration of.*/;
-
 export function mapErrorMessage(errorMessage: string) {
   if (errorMessage && (LIMIT_MESSAGE.test(errorMessage) || LIMIT_MESSAGE_METRICS.test(errorMessage))) {
     return 'The selected time range exceeds the maximum allowed duration. Please select a shorter time range.';
@@ -15,28 +13,24 @@ export function mapErrorMessage(errorMessage: string) {
     return errorMessage;
   }
 }
-
 export const getErrorMessage = (message: string | undefined, prefix?: string) => {
   const err = message ? ` (${message})` : '';
   let errPrefix = prefix ? prefix : 'Error';
   const msg = `${errPrefix}${err}. Please check the server logs for more details.`;
   return mapErrorMessage(msg);
 };
-
 export async function getDS(uid?: string): Promise<DataSourceApi | undefined> {
   if (!uid) {
     return undefined;
   }
-
   const dsSrv = getDataSourceSrv();
   try {
     return await dsSrv.get(uid);
   } catch (error) {
-    console.error('Failed to load data source', error);
+    structLog('error', 'Failed to load data source', error);
     return undefined;
   }
 }
-
 export const migrateFromSearchToTraceQLSearch = (query: TempoQuery) => {
   let filters: TraceqlFilter[] = [];
   if (query.spanName) {
@@ -99,7 +93,6 @@ export const migrateFromSearchToTraceQLSearch = (query: TempoQuery) => {
       }
     }
   }
-
   const migratedQuery: TempoQuery = {
     datasource: query.datasource,
     filters,
@@ -110,17 +103,13 @@ export const migrateFromSearchToTraceQLSearch = (query: TempoQuery) => {
   };
   return migratedQuery;
 };
-
 export const stepToNanos = (step?: string) => {
   if (!step) {
     return 0;
   }
-
   const match = step.match(/(\d+)(.+)/);
-
   const rawLength = match?.[1];
   const unit = match?.[2];
-
   if (rawLength) {
     if (unit === 'ns') {
       return parseInt(rawLength, 10);
@@ -138,6 +127,5 @@ export const stepToNanos = (step?: string) => {
       (duration.hours || 0) * 3600000000000
     );
   }
-
   return 0;
 };

--- a/public/app/plugins/panel/canvas/components/connections/Connections.tsx
+++ b/public/app/plugins/panel/canvas/components/connections/Connections.tsx
@@ -1,12 +1,11 @@
+import { structLog } from '@grafana/data';
 import * as React from 'react';
 import { BehaviorSubject } from 'rxjs';
-
 import { config } from '@grafana/runtime';
 import { type CanvasConnection, type ConnectionCoordinates, ConnectionPath } from 'app/features/canvas/element';
 import { type ElementState } from 'app/features/canvas/runtime/element';
 import { type Scene } from 'app/features/canvas/runtime/scene';
 import { findElementByTarget } from 'app/features/canvas/runtime/sceneElementManagement';
-
 import { type ConnectionState } from '../../types';
 import {
   calculateAngle,
@@ -16,7 +15,6 @@ import {
   isConnectionSource,
   isConnectionTarget,
 } from '../../utils';
-
 import {
   CONNECTION_ANCHOR_ALT,
   ConnectionAnchors,
@@ -26,12 +24,10 @@ import {
   HALF_SIZE,
 } from './ConnectionAnchors';
 import { ConnectionSVG } from './ConnectionSVG';
-
 export const CONNECTION_VERTEX_ID = 'vertex';
 export const CONNECTION_VERTEX_ADD_ID = 'vertexAdd';
 const CONNECTION_VERTEX_ORTHO_TOLERANCE = 0.05; // Cartesian ratio against vertical or horizontal tolerance
 const CONNECTION_VERTEX_SNAP_TOLERANCE = (5 / 180) * Math.PI; // Multi-segment snapping angle in radians to trigger vertex removal
-
 export class Connections {
   scene: Scene;
   connectionAnchorDiv?: HTMLDivElement;
@@ -50,23 +46,19 @@ export class Connections {
   didConnectionLeaveHighlight?: boolean;
   state: ConnectionState[] = [];
   readonly selection = new BehaviorSubject<ConnectionState | undefined>(undefined);
-
   constructor(scene: Scene) {
     this.scene = scene;
     this.updateState();
   }
-
   select = (connection: ConnectionState | undefined) => {
     if (connection === this.selection.value) {
       return;
     }
     this.selection.next(connection);
   };
-
   updateState = () => {
     const s = this.selection.value;
     this.state = getConnections(this.scene.byName);
-
     if (s) {
       for (let c of this.state) {
         if (c.source === s.source && c.index === s.index) {
@@ -76,81 +68,63 @@ export class Connections {
       }
     }
   };
-
   setConnectionAnchorRef = (anchorElement: HTMLDivElement) => {
     this.connectionAnchorDiv = anchorElement;
   };
-
   setAnchorsRef = (anchorsElement: HTMLDivElement) => {
     this.anchorsDiv = anchorsElement;
   };
-
   setConnectionSVGRef = (connectionSVG: SVGSVGElement) => {
     this.connectionSVG = connectionSVG;
   };
-
   setConnectionLineRef = (connectionLine: SVGLineElement) => {
     this.connectionLine = connectionLine;
   };
-
   setConnectionSVGVertexRef = (connectionSVG: SVGSVGElement) => {
     this.connectionSVGVertex = connectionSVG;
   };
-
   setConnectionVertexRef = (connectionVertex: SVGCircleElement) => {
     this.connectionVertex = connectionVertex;
   };
-
   setConnectionVertexPathRef = (connectionVertexPath: SVGPathElement) => {
     this.connectionVertexPath = connectionVertexPath;
   };
-
   // Recursively find the first parent that is a canvas element
   findElementTarget = (element: Element): ElementState | undefined => {
     let elementTarget = undefined;
-
     // Cap recursion at the scene level
     if (element === this.scene.div) {
       return undefined;
     }
-
     elementTarget = findElementByTarget(element, this.scene.root.elements);
-
     if (!elementTarget && element.parentElement) {
       elementTarget = this.findElementTarget(element.parentElement);
     }
-
     return elementTarget;
   };
-
   handleMouseEnter = (event: React.MouseEvent) => {
     if (!(event.target instanceof Element) || !this.scene.isEditingEnabled) {
       return;
     }
-
     let element: ElementState | undefined = this.findElementTarget(event.target);
-
     if (!element) {
-      console.log('no element');
+      structLog('log', 'no element');
       return;
     }
-
     if (this.isDrawingConnection) {
       this.connectionTarget = element;
     } else {
       this.connectionSource = element;
       if (!this.connectionSource) {
-        console.log('no connection source');
+        structLog('log', 'no connection source');
         return;
       }
     }
-
     const customElementAnchors = element?.item.customConnectionAnchors || ANCHORS;
     // This type cast is necessary as TS doesn't understand that `Element` is an `HTMLElement`
     // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
     const anchors = Array.from(this.anchorsDiv?.children as HTMLCollectionOf<HTMLElement>);
     const anchorsAmount = customElementAnchors.length;
-
     // re-calculate the position of the existing anchors on hover
     // and hide the rest of the anchors if there are more than the custom ones
     anchors.forEach((anchor, index) => {
@@ -163,14 +137,11 @@ export class Connections {
         anchor.style.display = 'block';
       }
     });
-
     const elementBoundingRect = element.div!.getBoundingClientRect();
     const transformScale = this.scene.scale;
     const parentBoundingRect = getParentBoundingClientRect(this.scene);
-
     const relativeTop = elementBoundingRect.top - (parentBoundingRect?.top ?? 0);
     const relativeLeft = elementBoundingRect.left - (parentBoundingRect?.left ?? 0);
-
     if (this.connectionAnchorDiv) {
       this.connectionAnchorDiv.style.display = 'none';
       this.connectionAnchorDiv.style.display = 'block';
@@ -180,7 +151,6 @@ export class Connections {
       this.connectionAnchorDiv.style.width = `${elementBoundingRect.width / transformScale}px`;
     }
   };
-
   // Return boolean indicates if connection anchors were hidden or not
   handleMouseLeave = (event: React.MouseEvent | React.FocusEvent): boolean => {
     // If mouse is leaving INTO the anchor image, don't remove div
@@ -190,32 +160,24 @@ export class Connections {
     ) {
       return false;
     }
-
     this.connectionTarget = undefined;
     this.connectionAnchorDiv!.style.display = 'none';
     return true;
   };
-
   connectionListener = (event: MouseEvent) => {
     event.preventDefault();
-
     if (!(this.connectionLine && this.scene.div && this.scene.div.parentElement)) {
       return;
     }
-
     const transformScale = this.scene.scale;
     const parentBoundingRect = getParentBoundingClientRect(this.scene);
-
     if (!parentBoundingRect) {
       return;
     }
-
     const x = event.pageX - (parentBoundingRect.x ?? 0);
     const y = event.pageY - (parentBoundingRect.y ?? 0);
-
     this.connectionLine.setAttribute('x2', `${x / transformScale}`);
     this.connectionLine.setAttribute('y2', `${y / transformScale}`);
-
     const connectionLineX1 = this.connectionLine.x1.baseVal.value;
     const connectionLineY1 = this.connectionLine.y1.baseVal.value;
     if (!this.didConnectionLeaveHighlight) {
@@ -226,47 +188,36 @@ export class Connections {
         this.isDrawingConnection = true;
       }
     }
-
     if (!event.buttons) {
       if (this.connectionSource && this.connectionSource.div && this.connectionSource.div.parentElement) {
         const sourceRect = this.connectionSource.div.getBoundingClientRect();
-
         const transformScale = this.scene.scale;
         const parentRect = getParentBoundingClientRect(this.scene);
-
         if (!parentRect) {
           return;
         }
-
         const sourceVerticalCenter = (sourceRect.top - parentRect.top + sourceRect.height / 2) / transformScale;
         const sourceHorizontalCenter = (sourceRect.left - parentRect.left + sourceRect.width / 2) / transformScale;
-
         // Convert from DOM coords to connection coords
         // TODO: Break this out into util function and add tests
         const sourceX = (connectionLineX1 - sourceHorizontalCenter) / (sourceRect.width / 2 / transformScale);
         const sourceY = (sourceVerticalCenter - connectionLineY1) / (sourceRect.height / 2 / transformScale);
-
         let targetX;
         let targetY;
         let targetName;
-
         if (this.connectionTarget && this.connectionTarget.div) {
           const targetRect = this.connectionTarget.div.getBoundingClientRect();
-
           const targetVerticalCenter = targetRect.top - parentRect.top + targetRect.height / 2;
           const targetHorizontalCenter = targetRect.left - parentRect.left + targetRect.width / 2;
-
           targetX = (x - targetHorizontalCenter) / (targetRect.width / 2);
           targetY = (targetVerticalCenter - y) / (targetRect.height / 2);
           targetName = this.connectionTarget.options.name;
         } else {
           const parentVerticalCenter = parentRect.height / 2;
           const parentHorizontalCenter = parentRect.width / 2;
-
           targetX = (x - parentHorizontalCenter) / (parentRect.width / 2);
           targetY = (parentVerticalCenter - y) / (parentRect.height / 2);
         }
-
         const connection = {
           source: {
             x: sourceX,
@@ -287,7 +238,6 @@ export class Connections {
           },
           path: ConnectionPath.Straight,
         };
-
         const { options } = this.connectionSource;
         if (!options.connections) {
           options.connections = [];
@@ -297,48 +247,36 @@ export class Connections {
           this.connectionSource.onChange(this.connectionSource.options);
         }
       }
-
       if (this.connectionSVG) {
         this.connectionSVG.style.display = 'none';
       }
-
       if (this.scene.selecto && this.scene.selecto.rootContainer) {
         this.scene.selecto.rootContainer.style.cursor = 'default';
         this.scene.selecto.rootContainer.removeEventListener('mousemove', this.connectionListener);
       }
-
       this.isDrawingConnection = false;
       this.updateState();
       this.scene.save();
     }
   };
-
   // Handles mousemove and mouseup events when dragging an existing vertex
   vertexListener = (event: MouseEvent) => {
     this.scene.selecto!.rootContainer!.style.cursor = 'crosshair';
-
     event.preventDefault();
-
     if (!(this.connectionVertex && this.scene.div && this.scene.div.parentElement)) {
       return;
     }
-
     const transformScale = this.scene.scale;
     const parentBoundingRect = getParentBoundingClientRect(this.scene);
-
     if (!parentBoundingRect) {
       return;
     }
-
     const x = (event.pageX - parentBoundingRect.x) / transformScale;
     const y = (event.pageY - parentBoundingRect.y) / transformScale;
-
     this.connectionVertex?.setAttribute('cx', `${x}`);
     this.connectionVertex?.setAttribute('cy', `${y}`);
-
     const selectedValue = this.selection.value;
     const sourceRect = selectedValue!.source.div!.getBoundingClientRect();
-
     // calculate relative coordinates based on source and target coorindates of connection
     const { x1, y1, x2, y2 } = calculateCoordinates(
       sourceRect,
@@ -347,7 +285,6 @@ export class Connections {
       selectedValue!.target,
       transformScale
     );
-
     let { xStart, yStart, xEnd, yEnd } = { xStart: x1, yStart: y1, xEnd: x2, yEnd: y2 };
     if (selectedValue?.sourceOriginal && selectedValue.targetOriginal) {
       xStart = selectedValue.sourceOriginal.x;
@@ -355,10 +292,8 @@ export class Connections {
       xEnd = selectedValue.targetOriginal.x;
       yEnd = selectedValue.targetOriginal.y;
     }
-
     const xDist = xEnd - xStart;
     const yDist = yEnd - yStart;
-
     let vx1 = x1;
     let vy1 = y1;
     let vx2 = x2;
@@ -373,7 +308,6 @@ export class Connections {
         vy2 = selectedValue.vertices[this.selectedVertexIndex + 1].y * yDist + yStart;
       }
     }
-
     // Check if slope before vertex and after vertex is within snapping tolerance
     let xSnap = x;
     let ySnap = y;
@@ -385,7 +319,6 @@ export class Connections {
       const verticalAfter = Math.abs((x - vx2) / (y - vy2)) < CONNECTION_VERTEX_ORTHO_TOLERANCE;
       const horizontalBefore = Math.abs((y - vy1) / (x - vx1)) < CONNECTION_VERTEX_ORTHO_TOLERANCE;
       const horizontalAfter = Math.abs((y - vy2) / (x - vx2)) < CONNECTION_VERTEX_ORTHO_TOLERANCE;
-
       if (verticalBefore) {
         xSnap = vx1;
       } else if (verticalAfter) {
@@ -396,7 +329,6 @@ export class Connections {
       } else if (horizontalAfter) {
         ySnap = vy2;
       }
-
       if ((verticalBefore || verticalAfter) && (horizontalBefore || horizontalAfter)) {
         this.scene.selecto!.rootContainer!.style.cursor = 'move';
       } else if (verticalBefore || verticalAfter) {
@@ -404,12 +336,10 @@ export class Connections {
       } else if (horizontalBefore || horizontalAfter) {
         this.scene.selecto!.rootContainer!.style.cursor = 'row-resize';
       }
-
       const angleOverall = calculateAngle(vx1, vy1, vx2, vy2);
       const angleBefore = calculateAngle(vx1, vy1, x, y);
       deleteVertex = Math.abs(angleBefore - angleOverall) < CONNECTION_VERTEX_SNAP_TOLERANCE;
     }
-
     if (deleteVertex) {
       // Display temporary vertex removal
       this.connectionVertexPath?.setAttribute('d', `M${vx1} ${vy1} L${vx2} ${vy2}`);
@@ -421,7 +351,6 @@ export class Connections {
       this.connectionSVGVertex!.style.display = 'block';
       this.connectionVertex.style.display = 'block';
     }
-
     // Handle mouseup
     if (!event.buttons) {
       // Remove existing event listener
@@ -429,35 +358,28 @@ export class Connections {
       this.scene.selecto?.rootContainer?.removeEventListener('mouseup', this.vertexListener);
       this.scene.selecto!.rootContainer!.style.cursor = 'auto';
       this.connectionSVGVertex!.style.display = 'none';
-
       // call onChange here and update appropriate index of connection vertices array
       const connectionIndex = selectedValue?.index;
       const vertexIndex = this.selectedVertexIndex;
-
       if (connectionIndex !== undefined && vertexIndex !== undefined) {
         const currentSource = selectedValue!.source;
         if (currentSource.options.connections) {
           const currentConnections = [...currentSource.options.connections];
           if (currentConnections[connectionIndex].vertices) {
             const currentVertices = [...currentConnections[connectionIndex].vertices!];
-
             // TODO for vertex removal, clear out originals?
             if (deleteVertex) {
               currentVertices.splice(vertexIndex, 1);
             } else {
               const currentVertex = { ...currentVertices[vertexIndex] };
-
               currentVertex.x = (xSnap - xStart) / xDist;
               currentVertex.y = (ySnap - yStart) / yDist;
-
               currentVertices[vertexIndex] = currentVertex;
             }
-
             currentConnections[connectionIndex] = {
               ...currentConnections[connectionIndex],
               vertices: currentVertices,
             };
-
             // Update save model
             currentSource.onChange({ ...currentSource.options, connections: currentConnections });
             this.updateState();
@@ -467,33 +389,24 @@ export class Connections {
       }
     }
   };
-
   // Handles mousemove and mouseup events when dragging a new vertex
   vertexAddListener = (event: MouseEvent) => {
     this.scene.selecto!.rootContainer!.style.cursor = 'crosshair';
-
     event.preventDefault();
-
     if (!(this.connectionVertex && this.scene.div && this.scene.div.parentElement)) {
       return;
     }
-
     const transformScale = this.scene.scale;
     const parentBoundingRect = getParentBoundingClientRect(this.scene);
-
     if (!parentBoundingRect) {
       return;
     }
-
     const x = (event.pageX - parentBoundingRect.x) / transformScale;
     const y = (event.pageY - parentBoundingRect.y) / transformScale;
-
     this.connectionVertex?.setAttribute('cx', `${x}`);
     this.connectionVertex?.setAttribute('cy', `${y}`);
-
     const selectedValue = this.selection.value;
     const sourceRect = selectedValue!.source.div!.getBoundingClientRect();
-
     // calculate relative coordinates based on source and target coorindates of connection
     const { x1, y1, x2, y2 } = calculateCoordinates(
       sourceRect,
@@ -502,7 +415,6 @@ export class Connections {
       selectedValue!.target,
       transformScale
     );
-
     let { xStart, yStart, xEnd, yEnd } = { xStart: x1, yStart: y1, xEnd: x2, yEnd: y2 };
     if (selectedValue?.sourceOriginal && selectedValue.targetOriginal) {
       xStart = selectedValue.sourceOriginal.x;
@@ -510,10 +422,8 @@ export class Connections {
       xEnd = selectedValue.targetOriginal.x;
       yEnd = selectedValue.targetOriginal.y;
     }
-
     const xDist = xEnd - xStart;
     const yDist = yEnd - yStart;
-
     let vx1 = x1;
     let vy1 = y1;
     let vx2 = x2;
@@ -528,7 +438,6 @@ export class Connections {
         vy2 = selectedValue.vertices[this.selectedVertexIndex].y * yDist + yStart;
       }
     }
-
     // Check if slope before vertex and after vertex is within snapping tolerance
     let xSnap = x;
     let ySnap = y;
@@ -539,7 +448,6 @@ export class Connections {
       const verticalAfter = Math.abs((x - vx2) / (y - vy2)) < CONNECTION_VERTEX_ORTHO_TOLERANCE;
       const horizontalBefore = Math.abs((y - vy1) / (x - vx1)) < CONNECTION_VERTEX_ORTHO_TOLERANCE;
       const horizontalAfter = Math.abs((y - vy2) / (x - vx2)) < CONNECTION_VERTEX_ORTHO_TOLERANCE;
-
       if (verticalBefore) {
         xSnap = vx1;
       } else if (verticalAfter) {
@@ -550,7 +458,6 @@ export class Connections {
       } else if (horizontalAfter) {
         ySnap = vy2;
       }
-
       if ((verticalBefore || verticalAfter) && (horizontalBefore || horizontalAfter)) {
         this.scene.selecto!.rootContainer!.style.cursor = 'move';
       } else if (verticalBefore || verticalAfter) {
@@ -559,11 +466,9 @@ export class Connections {
         this.scene.selecto!.rootContainer!.style.cursor = 'row-resize';
       }
     }
-
     this.connectionVertexPath?.setAttribute('d', `M${vx1} ${vy1} L${xSnap} ${ySnap} L${vx2} ${vy2}`);
     this.connectionSVGVertex!.style.display = 'block';
     this.connectionVertex.style.display = 'block';
-
     // Handle mouseup
     if (!event.buttons) {
       // Remove existing event listener
@@ -571,11 +476,9 @@ export class Connections {
       this.scene.selecto?.rootContainer?.removeEventListener('mouseup', this.vertexAddListener);
       this.scene.selecto!.rootContainer!.style.cursor = 'auto';
       this.connectionSVGVertex!.style.display = 'none';
-
       // call onChange here and insert new vertex at appropriate index of connection vertices array
       const connectionIndex = selectedValue?.index;
       const vertexIndex = this.selectedVertexIndex;
-
       if (connectionIndex !== undefined && vertexIndex !== undefined) {
         const currentSource = selectedValue!.source;
         if (currentSource.options.connections) {
@@ -596,7 +499,6 @@ export class Connections {
               vertices: currentVertices,
             };
           }
-
           // Check for original state
           if (
             !currentConnections[connectionIndex].sourceOriginal ||
@@ -616,69 +518,54 @@ export class Connections {
       }
     }
   };
-
   handleConnectionDragStart = (selectedTarget: HTMLElement, clientX: number, clientY: number) => {
     this.scene.selecto!.rootContainer!.style.cursor = 'crosshair';
     if (this.connectionSVG && this.connectionLine && this.scene.div && this.scene.div.parentElement) {
       const connectionStartTargetBox = selectedTarget.getBoundingClientRect();
-
       const transformScale = this.scene.scale;
       const parentBoundingRect = getParentBoundingClientRect(this.scene);
-
       if (!parentBoundingRect) {
         return;
       }
-
       // Multiply by transform scale to calculate the correct scaled offset
       const connectionAnchorOffsetX = CONNECTION_ANCHOR_HIGHLIGHT_OFFSET * transformScale;
       const connectionAnchorOffsetY = CONNECTION_ANCHOR_HIGHLIGHT_OFFSET * transformScale;
-
       const x = (connectionStartTargetBox.x - parentBoundingRect.x + connectionAnchorOffsetX) / transformScale;
       const y = (connectionStartTargetBox.y - parentBoundingRect.y + connectionAnchorOffsetY) / transformScale;
-
       const mouseX = clientX - parentBoundingRect.x;
       const mouseY = clientY - parentBoundingRect.y;
-
       this.connectionLine.setAttribute('x1', `${x}`);
       this.connectionLine.setAttribute('y1', `${y}`);
       this.connectionLine.setAttribute('x2', `${mouseX}`);
       this.connectionLine.setAttribute('y2', `${mouseY}`);
       this.didConnectionLeaveHighlight = false;
     }
-
     this.scene.selecto?.rootContainer?.addEventListener('mousemove', this.connectionListener);
   };
-
   // Add event listener at root container during existing vertex drag
   handleVertexDragStart = (selectedTarget: HTMLElement) => {
     // Get vertex index from selected target data
     this.selectedVertexIndex = Number(selectedTarget.getAttribute('data-index'));
-
     this.scene.selecto?.rootContainer?.addEventListener('mousemove', this.vertexListener);
     this.scene.selecto?.rootContainer?.addEventListener('mouseup', this.vertexListener);
   };
-
   // Add event listener at root container during creation of new vertex
   handleVertexAddDragStart = (selectedTarget: HTMLElement) => {
     // Get vertex index from selected target data
     this.selectedVertexIndex = Number(selectedTarget.getAttribute('data-index'));
-
     this.scene.selecto?.rootContainer?.addEventListener('mousemove', this.vertexAddListener);
     this.scene.selecto?.rootContainer?.addEventListener('mouseup', this.vertexAddListener);
   };
-
   onChange = (current: ConnectionState, update: CanvasConnection) => {
     const connections = current.source.options.connections?.splice(0) ?? [];
     connections[current.index] = update;
     current.source.onChange({ ...current.source.options, connections });
     this.updateState();
   };
-
   // used for moveable actions
   connectionsNeedUpdate = (element: ElementState): boolean => {
     return isConnectionSource(element) || isConnectionTarget(element, this.scene.byName);
   };
-
   renderElement() {
     return (
       <>

--- a/public/app/plugins/panel/canvas/components/connections/Connections2.tsx
+++ b/public/app/plugins/panel/canvas/components/connections/Connections2.tsx
@@ -1,12 +1,11 @@
+import { structLog } from '@grafana/data';
 import * as React from 'react';
 import { BehaviorSubject } from 'rxjs';
-
 import { config } from '@grafana/runtime';
 import { type CanvasConnection, type ConnectionCoordinates, ConnectionPath } from 'app/features/canvas/element';
 import { type ElementState } from 'app/features/canvas/runtime/element';
 import { type Scene } from 'app/features/canvas/runtime/scene';
 import { findElementByTarget } from 'app/features/canvas/runtime/sceneElementManagement';
-
 import { type ConnectionState } from '../../types';
 import {
   calculateAngle,
@@ -18,7 +17,6 @@ import {
   isConnectionSource,
   isConnectionTarget,
 } from '../../utils';
-
 import {
   CONNECTION_ANCHOR_ALT,
   CONNECTION_ANCHOR_HIGHLIGHT_OFFSET,
@@ -28,12 +26,10 @@ import {
 } from './ConnectionAnchors';
 import { ConnectionAnchors } from './ConnectionAnchors2';
 import { ConnectionSVG } from './ConnectionSVG2';
-
 export const CONNECTION_VERTEX_ID = 'vertex';
 export const CONNECTION_VERTEX_ADD_ID = 'vertexAdd';
 const CONNECTION_VERTEX_ORTHO_TOLERANCE = 0.05; // Cartesian ratio against vertical or horizontal tolerance
 const CONNECTION_VERTEX_SNAP_TOLERANCE = (5 / 180) * Math.PI; // Multi-segment snapping angle in radians to trigger vertex removal
-
 export class Connections2 {
   scene: Scene;
   connectionAnchorDiv?: HTMLDivElement;
@@ -49,22 +45,18 @@ export class Connections2 {
   didConnectionLeaveHighlight?: boolean;
   state: ConnectionState[] = [];
   readonly selection = new BehaviorSubject<ConnectionState | undefined>(undefined);
-
   constructor(scene: Scene) {
     this.scene = scene;
     this.updateState();
   }
-
   select = (connection: ConnectionState | undefined) => {
     if (connection === this.selection.value) {
       return;
     }
     this.selection.next(connection);
   };
-
   updateState = () => {
     this.state = getConnections(this.scene.byName);
-
     const s = this.selection.value;
     if (s) {
       for (let c of this.state) {
@@ -75,77 +67,60 @@ export class Connections2 {
       }
     }
   };
-
   setConnectionAnchorRef = (anchorElement: HTMLDivElement) => {
     this.connectionAnchorDiv = anchorElement;
   };
-
   setAnchorsRef = (anchorsElement: HTMLDivElement) => {
     this.anchorsDiv = anchorsElement;
   };
-
   setConnectionsSVGRef = (connectionsSVG: SVGElement) => {
     this.connectionsSVG = connectionsSVG;
   };
-
   setConnectionLineRef = (connectionLine: SVGLineElement) => {
     this.connectionLine = connectionLine;
   };
-
   setConnectionVertexRef = (connectionVertex: SVGCircleElement) => {
     this.connectionVertex = connectionVertex;
   };
-
   setConnectionVertexPathRef = (connectionVertexPath: SVGPathElement) => {
     this.connectionVertexPath = connectionVertexPath;
   };
-
   // Recursively find the first parent that is a canvas element
   findElementTarget = (element: Element): ElementState | undefined => {
     let elementTarget = undefined;
-
     // Cap recursion at the scene level
     if (element === this.scene.viewportDiv) {
       return undefined;
     }
-
     elementTarget = findElementByTarget(element, this.scene.root.elements);
-
     if (!elementTarget && element.parentElement) {
       elementTarget = this.findElementTarget(element.parentElement);
     }
-
     return elementTarget;
   };
-
   handleMouseEnter = (event: React.MouseEvent) => {
     if (!(event.target instanceof Element) || !this.scene.isEditingEnabled) {
       return;
     }
-
     let element: ElementState | undefined = this.findElementTarget(event.target);
-
     if (!element) {
-      console.log('no element');
+      structLog('log', 'no element');
       return;
     }
-
     if (this.isDrawingConnection) {
       this.connectionTarget = element;
     } else {
       this.connectionSource = element;
       if (!this.connectionSource) {
-        console.log('no connection source');
+        structLog('log', 'no connection source');
         return;
       }
     }
-
     const customElementAnchors = element?.item.customConnectionAnchors || ANCHORS;
     // This type cast is necessary as TS doesn't understand that `Element` is an `HTMLElement`
     // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
     const anchors = Array.from(this.anchorsDiv?.children as HTMLCollectionOf<HTMLElement>);
     const anchorsAmount = customElementAnchors.length;
-
     // re-calculate the position of the existing anchors on hover
     // and hide the rest of the anchors if there are more than the custom ones
     anchors.forEach((anchor, index) => {
@@ -158,9 +133,7 @@ export class Connections2 {
         anchor.style.display = 'block';
       }
     });
-
     const { top, left, width, height, rotation } = getElementTransformAndDimensions(element.div!);
-
     if (this.connectionAnchorDiv) {
       this.connectionAnchorDiv.style.display = 'none';
       this.connectionAnchorDiv.style.display = 'block';
@@ -169,7 +142,6 @@ export class Connections2 {
       this.connectionAnchorDiv.style.width = `${width}px`;
     }
   };
-
   // Return boolean indicates if connection anchors were hidden or not
   handleMouseLeave = (event: React.MouseEvent | React.FocusEvent): boolean => {
     // If mouse is leaving INTO the anchor image, don't remove div
@@ -179,34 +151,26 @@ export class Connections2 {
     ) {
       return false;
     }
-
     this.connectionTarget = undefined;
     this.connectionAnchorDiv!.style.display = 'none';
     return true;
   };
-
   connectionListener = (event: MouseEvent) => {
     event.preventDefault();
-
     if (!(this.connectionLine && this.scene.viewportDiv && this.scene.viewportDiv.parentElement)) {
       return;
     }
     const { scale } = this.scene;
     const parentBoundingRect = getParentBoundingClientRect(this.scene);
-
     if (!parentBoundingRect) {
       return;
     }
-
     const x = (event.pageX - parentBoundingRect.x) / scale;
     const y = (event.pageY - parentBoundingRect.y) / scale;
-
     this.connectionLine.setAttribute('x2', `${x}`);
     this.connectionLine.setAttribute('y2', `${y}`);
-
     const connectionLineX1 = this.connectionLine.x1.baseVal.value;
     const connectionLineY1 = this.connectionLine.y1.baseVal.value;
-
     if (!this.didConnectionLeaveHighlight) {
       const connectionLength = Math.hypot(x - connectionLineX1, y - connectionLineY1);
       if (connectionLength > CONNECTION_ANCHOR_HIGHLIGHT_OFFSET) {
@@ -215,7 +179,6 @@ export class Connections2 {
         this.isDrawingConnection = true;
       }
     }
-
     //
     // SAVING CONNECTION
     //
@@ -226,11 +189,9 @@ export class Connections2 {
           connectionLineX1,
           connectionLineY1
         );
-
         let targetX;
         let targetY;
         let targetName;
-
         if (this.connectionTarget && this.connectionTarget.div) {
           ({ x: targetX, y: targetY } = getNormalizedRotatedOffset(this.connectionTarget.div, x, y));
           targetName = this.connectionTarget.options.name;
@@ -239,7 +200,6 @@ export class Connections2 {
           targetX = x;
           targetY = y;
         }
-
         const connection = {
           source: {
             x: sourceX,
@@ -260,7 +220,6 @@ export class Connections2 {
           },
           path: ConnectionPath.Straight,
         };
-
         const { options } = this.connectionSource;
         if (!options.connections) {
           options.connections = [];
@@ -270,53 +229,40 @@ export class Connections2 {
           this.connectionSource.onChange(this.connectionSource.options);
         }
       }
-
       if (this.connectionLine) {
         this.connectionLine.style.display = 'none';
       }
-
       if (this.scene.selecto && this.scene.selecto.rootContainer) {
         this.scene.selecto.rootContainer.style.cursor = 'default';
         this.scene.selecto.rootContainer.removeEventListener('mousemove', this.connectionListener);
       }
-
       this.isDrawingConnection = false;
       this.updateState();
       this.scene.save();
     }
   };
-
   // Handles mousemove and mouseup events when dragging an existing vertex
   vertexListener = (event: MouseEvent) => {
     this.scene.selecto!.rootContainer!.style.cursor = 'crosshair';
-
     event.preventDefault();
-
     if (!(this.connectionVertex && this.scene.viewportDiv && this.scene.viewportDiv.parentElement)) {
       return;
     }
-
     const parentBoundingRect = getParentBoundingClientRect(this.scene);
-
     if (!parentBoundingRect) {
       return;
     }
-
     const { scale } = this.scene;
     const x = (event.pageX - parentBoundingRect.x) / scale;
     const y = (event.pageY - parentBoundingRect.y) / scale;
-
     this.connectionVertex?.setAttribute('cx', `${x}`);
     this.connectionVertex?.setAttribute('cy', `${y}`);
-
     const selectedValue = this.selection.value;
-
     const { x1, y1, x2, y2 } = calculateCoordinates2(
       selectedValue!.source,
       selectedValue!.target,
       selectedValue?.info!
     );
-
     let { xStart, yStart, xEnd, yEnd } = { xStart: x1, yStart: y1, xEnd: x2, yEnd: y2 };
     if (selectedValue?.sourceOriginal && selectedValue.targetOriginal) {
       xStart = selectedValue.sourceOriginal.x;
@@ -324,10 +270,8 @@ export class Connections2 {
       xEnd = selectedValue.targetOriginal.x;
       yEnd = selectedValue.targetOriginal.y;
     }
-
     const xDist = xEnd - xStart;
     const yDist = yEnd - yStart;
-
     let vx1 = x1;
     let vy1 = y1;
     let vx2 = x2;
@@ -342,7 +286,6 @@ export class Connections2 {
         vy2 = selectedValue.vertices[this.selectedVertexIndex + 1].y * yDist + yStart;
       }
     }
-
     // Check if slope before vertex and after vertex is within snapping tolerance
     let xSnap = x;
     let ySnap = y;
@@ -354,7 +297,6 @@ export class Connections2 {
       const verticalAfter = Math.abs((xSnap - vx2) / (ySnap - vy2)) < CONNECTION_VERTEX_ORTHO_TOLERANCE;
       const horizontalBefore = Math.abs((ySnap - vy1) / (xSnap - vx1)) < CONNECTION_VERTEX_ORTHO_TOLERANCE;
       const horizontalAfter = Math.abs((ySnap - vy2) / (xSnap - vx2)) < CONNECTION_VERTEX_ORTHO_TOLERANCE;
-
       if (verticalBefore) {
         xSnap = vx1;
       } else if (verticalAfter) {
@@ -365,7 +307,6 @@ export class Connections2 {
       } else if (horizontalAfter) {
         ySnap = vy2;
       }
-
       if ((verticalBefore || verticalAfter) && (horizontalBefore || horizontalAfter)) {
         this.scene.selecto!.rootContainer!.style.cursor = 'move';
       } else if (verticalBefore || verticalAfter) {
@@ -373,12 +314,10 @@ export class Connections2 {
       } else if (horizontalBefore || horizontalAfter) {
         this.scene.selecto!.rootContainer!.style.cursor = 'row-resize';
       }
-
       const angleOverall = calculateAngle(vx1, vy1, vx2, vy2);
       const angleBefore = calculateAngle(vx1, vy1, x, y);
       deleteVertex = Math.abs(angleBefore - angleOverall) < CONNECTION_VERTEX_SNAP_TOLERANCE;
     }
-
     if (deleteVertex) {
       // Display temporary vertex removal
       this.connectionVertexPath?.setAttribute('d', `M${vx1} ${vy1} L${vx2} ${vy2}`);
@@ -390,7 +329,6 @@ export class Connections2 {
       this.connectionVertexPath!.style.display = 'block';
       this.connectionVertex.style.display = 'block';
     }
-
     // Handle mouseup
     if (!event.buttons) {
       // Remove existing event listener
@@ -399,35 +337,28 @@ export class Connections2 {
       this.scene.selecto!.rootContainer!.style.cursor = 'auto';
       this.connectionVertexPath!.style.display = 'none';
       this.connectionVertex.style.display = 'none';
-
       // call onChange here and update appropriate index of connection vertices array
       const connectionIndex = selectedValue?.index;
       const vertexIndex = this.selectedVertexIndex;
-
       if (connectionIndex !== undefined && vertexIndex !== undefined) {
         const currentSource = selectedValue!.source;
         if (currentSource.options.connections) {
           const currentConnections = [...currentSource.options.connections];
           if (currentConnections[connectionIndex].vertices) {
             const currentVertices = [...currentConnections[connectionIndex].vertices!];
-
             // TODO for vertex removal, clear out originals?
             if (deleteVertex) {
               currentVertices.splice(vertexIndex, 1);
             } else {
               const currentVertex = { ...currentVertices[vertexIndex] };
-
               currentVertex.x = (xSnap - xStart) / xDist;
               currentVertex.y = (ySnap - yStart) / yDist;
-
               currentVertices[vertexIndex] = currentVertex;
             }
-
             currentConnections[connectionIndex] = {
               ...currentConnections[connectionIndex],
               vertices: currentVertices,
             };
-
             // Update save model
             currentSource.onChange({ ...currentSource.options, connections: currentConnections });
             this.updateState();
@@ -437,38 +368,28 @@ export class Connections2 {
       }
     }
   };
-
   // Handles mousemove and mouseup events when dragging a new vertex
   vertexAddListener = (event: MouseEvent) => {
     this.scene.selecto!.rootContainer!.style.cursor = 'crosshair';
-
     event.preventDefault();
-
     if (!(this.connectionVertex && this.scene.viewportDiv && this.scene.viewportDiv.parentElement)) {
       return;
     }
-
     const parentBoundingRect = getParentBoundingClientRect(this.scene);
-
     if (!parentBoundingRect) {
       return;
     }
-
     const { scale } = this.scene;
     const x = (event.pageX - parentBoundingRect.x) / scale;
     const y = (event.pageY - parentBoundingRect.y) / scale;
-
     this.connectionVertex?.setAttribute('cx', `${x}`);
     this.connectionVertex?.setAttribute('cy', `${y}`);
-
     const selectedValue = this.selection.value;
-
     const { x1, y1, x2, y2 } = calculateCoordinates2(
       selectedValue!.source,
       selectedValue!.target,
       selectedValue?.info!
     );
-
     let { xStart, yStart, xEnd, yEnd } = { xStart: x1, yStart: y1, xEnd: x2, yEnd: y2 };
     if (selectedValue?.sourceOriginal && selectedValue.targetOriginal) {
       xStart = selectedValue.sourceOriginal.x;
@@ -476,10 +397,8 @@ export class Connections2 {
       xEnd = selectedValue.targetOriginal.x;
       yEnd = selectedValue.targetOriginal.y;
     }
-
     const xDist = xEnd - xStart;
     const yDist = yEnd - yStart;
-
     let vx1 = x1;
     let vy1 = y1;
     let vx2 = x2;
@@ -494,7 +413,6 @@ export class Connections2 {
         vy2 = selectedValue.vertices[this.selectedVertexIndex].y * yDist + yStart;
       }
     }
-
     // Check if slope before vertex and after vertex is within snapping tolerance
     let xSnap = x;
     let ySnap = y;
@@ -505,7 +423,6 @@ export class Connections2 {
       const verticalAfter = Math.abs((xSnap - vx2) / (ySnap - vy2)) < CONNECTION_VERTEX_ORTHO_TOLERANCE;
       const horizontalBefore = Math.abs((ySnap - vy1) / (xSnap - vx1)) < CONNECTION_VERTEX_ORTHO_TOLERANCE;
       const horizontalAfter = Math.abs((ySnap - vy2) / (xSnap - vx2)) < CONNECTION_VERTEX_ORTHO_TOLERANCE;
-
       if (verticalBefore) {
         xSnap = vx1;
       } else if (verticalAfter) {
@@ -516,7 +433,6 @@ export class Connections2 {
       } else if (horizontalAfter) {
         ySnap = vy2;
       }
-
       if ((verticalBefore || verticalAfter) && (horizontalBefore || horizontalAfter)) {
         this.scene.selecto!.rootContainer!.style.cursor = 'move';
       } else if (verticalBefore || verticalAfter) {
@@ -525,11 +441,9 @@ export class Connections2 {
         this.scene.selecto!.rootContainer!.style.cursor = 'row-resize';
       }
     }
-
     this.connectionVertexPath?.setAttribute('d', `M${vx1} ${vy1} L${xSnap} ${ySnap} L${vx2} ${vy2}`);
     this.connectionVertexPath!.style.display = 'block';
     this.connectionVertex.style.display = 'block';
-
     // Handle mouseup
     if (!event.buttons) {
       // Remove existing event listener
@@ -538,11 +452,9 @@ export class Connections2 {
       this.scene.selecto!.rootContainer!.style.cursor = 'auto';
       this.connectionVertexPath!.style.display = 'none';
       this.connectionVertex.style.display = 'none';
-
       // call onChange here and insert new vertex at appropriate index of connection vertices array
       const connectionIndex = selectedValue?.index;
       const vertexIndex = this.selectedVertexIndex;
-
       if (connectionIndex !== undefined && vertexIndex !== undefined) {
         const currentSource = selectedValue!.source;
         if (currentSource.options.connections) {
@@ -564,7 +476,6 @@ export class Connections2 {
               vertices: currentVertices,
             };
           }
-
           // Check for original state
           if (
             !currentConnections[connectionIndex].sourceOriginal ||
@@ -584,70 +495,54 @@ export class Connections2 {
       }
     }
   };
-
   handleConnectionDragStart = (selectedTarget: HTMLElement, clientX: number, clientY: number) => {
     this.scene.selecto!.rootContainer!.style.cursor = 'crosshair';
-
     if (this.connectionLine && this.scene.viewportDiv && this.scene.viewportDiv.parentElement) {
       const connectionStartTargetBox = selectedTarget.getBoundingClientRect();
-
       const { scale } = this.scene;
       const parentBoundingRect = getParentBoundingClientRect(this.scene);
-
       if (!parentBoundingRect) {
         return;
       }
-
       // Multiply by transform scale to calculate the correct scaled offset
       const connectionAnchorOffsetX = CONNECTION_ANCHOR_HIGHLIGHT_OFFSET * scale;
       const connectionAnchorOffsetY = CONNECTION_ANCHOR_HIGHLIGHT_OFFSET * scale;
-
       const x = (connectionStartTargetBox.x - parentBoundingRect.x + connectionAnchorOffsetX) / scale;
       const y = (connectionStartTargetBox.y - parentBoundingRect.y + connectionAnchorOffsetY) / scale;
-
       const mouseX = clientX - parentBoundingRect.x;
       const mouseY = clientY - parentBoundingRect.y;
-
       this.connectionLine.setAttribute('x1', `${x}`);
       this.connectionLine.setAttribute('y1', `${y}`);
       this.connectionLine.setAttribute('x2', `${mouseX}`);
       this.connectionLine.setAttribute('y2', `${mouseY}`);
       this.didConnectionLeaveHighlight = false;
     }
-
     this.scene.selecto?.rootContainer?.addEventListener('mousemove', this.connectionListener);
   };
-
   // Add event listener at root container during existing vertex drag
   handleVertexDragStart = (selectedTarget: HTMLElement) => {
     // Get vertex index from selected target data
     this.selectedVertexIndex = Number(selectedTarget.getAttribute('data-index'));
-
     this.scene.selecto?.rootContainer?.addEventListener('mousemove', this.vertexListener);
     this.scene.selecto?.rootContainer?.addEventListener('mouseup', this.vertexListener);
   };
-
   // Add event listener at root container during creation of new vertex
   handleVertexAddDragStart = (selectedTarget: HTMLElement) => {
     // Get vertex index from selected target data
     this.selectedVertexIndex = Number(selectedTarget.getAttribute('data-index'));
-
     this.scene.selecto?.rootContainer?.addEventListener('mousemove', this.vertexAddListener);
     this.scene.selecto?.rootContainer?.addEventListener('mouseup', this.vertexAddListener);
   };
-
   onChange = (current: ConnectionState, update: CanvasConnection) => {
     const connections = current.source.options.connections?.splice(0) ?? [];
     connections[current.index] = update;
     current.source.onChange({ ...current.source.options, connections });
     this.updateState();
   };
-
   // used for moveable actions
   connectionsNeedUpdate = (element: ElementState): boolean => {
     return isConnectionSource(element) || isConnectionTarget(element, this.scene.byName);
   };
-
   renderElement() {
     return (
       <>

--- a/public/app/plugins/panel/canvas/editor/element/elementEditor.tsx
+++ b/public/app/plugins/panel/canvas/editor/element/elementEditor.tsx
@@ -1,5 +1,5 @@
+import { structLog } from '@grafana/data';
 import { get as lodashGet } from 'lodash';
-
 import { type NestedPanelOptions, type NestedValueAccess } from '@grafana/data/internal';
 import { t } from '@grafana/i18n';
 import { type CanvasElementOptions } from 'app/features/canvas/element';
@@ -12,29 +12,23 @@ import { type ElementState } from 'app/features/canvas/runtime/element';
 import { type FrameState } from 'app/features/canvas/runtime/frame';
 import { type Scene } from 'app/features/canvas/runtime/scene';
 import { setOptionImmutably } from 'app/features/dashboard/components/PanelEditor/utils';
-
 import { getElementTypes } from '../../utils';
 import { optionBuilder } from '../options';
-
 import { PlacementEditor } from './PlacementEditor';
-
 export interface CanvasEditorOptions {
   element: ElementState;
   scene: Scene;
   category?: string[];
 }
-
 export interface TreeViewEditorProps {
   scene: Scene;
   layer: FrameState;
   selected: ElementState[];
 }
-
 export function getElementEditor(opts: CanvasEditorOptions): NestedPanelOptions<CanvasElementOptions> {
   return {
     category: opts.category,
     path: '--', // not used!
-
     // Note that canvas editor writes things to the scene!
     values: (parent: NestedValueAccess) => ({
       getValue: (path) => {
@@ -45,7 +39,7 @@ export function getElementEditor(opts: CanvasEditorOptions): NestedPanelOptions<
         if (path === 'type' && value) {
           const layer = canvasElementRegistry.getIfExists(value);
           if (!layer) {
-            console.warn('layer does not exist', value);
+            structLog('warn', 'layer does not exist', value);
             return;
           }
           options = {
@@ -60,16 +54,13 @@ export function getElementEditor(opts: CanvasEditorOptions): NestedPanelOptions<
         opts.element.updateData(opts.scene.context);
       },
     }),
-
     // Dynamically fill the selected element
     build: (builder, context) => {
       const { options } = opts.element;
       const current = options?.type ? options.type : DEFAULT_CANVAS_ELEMENT_CONFIG.type;
       const layerTypes = getElementTypes(opts.scene.shouldShowAdvancedTypes, current).options;
-
       const isUnsupported =
         !opts.scene.shouldShowAdvancedTypes && !defaultElementItems.filter((item) => item.id === options?.type).length;
-
       builder.addSelect({
         path: 'type',
         // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/consistent-type-assertions
@@ -84,7 +75,6 @@ export function getElementEditor(opts: CanvasEditorOptions): NestedPanelOptions<
             )
           : '',
       });
-
       // force clean layer configuration
       const layer = canvasElementRegistry.getIfExists(options?.type ?? DEFAULT_CANVAS_ELEMENT_CONFIG.type)!;
       let currentOptions = options;
@@ -96,11 +86,9 @@ export function getElementEditor(opts: CanvasEditorOptions): NestedPanelOptions<
         };
       }
       const ctx = { ...context, options: currentOptions };
-
       if (layer?.registerOptionsUI) {
         layer.registerOptionsUI(builder, ctx);
       }
-
       const shouldAddLayoutEditor = opts.element.item.standardEditorConfig?.layout ?? true;
       if (shouldAddLayoutEditor) {
         builder.addCustomEditor({
@@ -112,17 +100,14 @@ export function getElementEditor(opts: CanvasEditorOptions): NestedPanelOptions<
           settings: opts,
         });
       }
-
       const shouldAddBackgroundEditor = opts.element.item.standardEditorConfig?.background ?? true;
       if (shouldAddBackgroundEditor) {
         optionBuilder.addBackground(builder, ctx);
       }
-
       const shouldAddBorderEditor = opts.element.item.standardEditorConfig?.border ?? true;
       if (shouldAddBorderEditor) {
         optionBuilder.addBorder(builder, ctx);
       }
-
       optionBuilder.addDataLinks(builder, ctx);
       optionBuilder.addActions(builder, ctx);
     },

--- a/public/app/plugins/panel/canvas/editor/element/utils.ts
+++ b/public/app/plugins/panel/canvas/editor/element/utils.ts
@@ -1,29 +1,24 @@
+import { structLog } from '@grafana/data';
 import { AppEvents, textUtil } from '@grafana/data';
 import { type BackendSrvRequest, getBackendSrv, getTemplateSrv } from '@grafana/runtime';
 import { appEvents } from 'app/core/app_events';
 import { createAbsoluteUrl, type RelativeUrl } from 'app/features/alerting/unified/utils/url';
 import { getDashboardSrv } from 'app/features/dashboard/services/DashboardSrv';
-
 import { HttpRequestMethod } from '../../panelcfg.gen';
-
 import { type APIEditorConfig } from './APIEditor';
-
 type IsLoadingCallback = (loading: boolean) => void;
-
 export const callApi = (api: APIEditorConfig, updateLoadingStateCallback?: IsLoadingCallback) => {
   if (!api.endpoint) {
     appEvents.emit(AppEvents.alertError, ['API endpoint is not defined.']);
     return;
   }
-
   const request = getRequest(api);
-
   getBackendSrv()
     .fetch(request)
     .subscribe({
       error: (error) => {
         appEvents.emit(AppEvents.alertError, ['An error has occurred. Check console output for more details.']);
-        console.error('API call error: ', error);
+        structLog('error', 'API call error: ', error);
         updateLoadingStateCallback && updateLoadingStateCallback(false);
       },
       complete: () => {
@@ -33,58 +28,45 @@ export const callApi = (api: APIEditorConfig, updateLoadingStateCallback?: IsLoa
       },
     });
 };
-
 export const interpolateVariables = (text: string) => {
   const panel = getDashboardSrv().getCurrent()?.panelInEdit;
   return getTemplateSrv().replace(text, panel?.scopedVars);
 };
-
 export const getRequest = (api: APIEditorConfig) => {
   const endpoint = getEndpoint(interpolateVariables(api.endpoint));
   const url = new URL(endpoint);
-
   const requestHeaders: Record<string, string> = {};
-
   let request: BackendSrvRequest = {
     url: url.toString(),
     method: api.method,
     data: getData(api),
     headers: requestHeaders,
   };
-
   if (api.headerParams) {
     api.headerParams.forEach(([name, value]) => {
       requestHeaders[interpolateVariables(name)] = interpolateVariables(value);
     });
   }
-
   if (api.queryParams) {
     api.queryParams?.forEach(([name, value]) => {
       url.searchParams.append(interpolateVariables(name), interpolateVariables(value));
     });
-
     request.url = url.toString();
   }
-
   if (api.method === HttpRequestMethod.POST) {
     requestHeaders['Content-Type'] = api.contentType!;
   }
-
   requestHeaders['X-Grafana-Action'] = '1';
   request.headers = requestHeaders;
-
   return request;
 };
-
 const getData = (api: APIEditorConfig) => {
   let data: string | undefined = api.data ? interpolateVariables(api.data) : '{}';
   if (api.method === HttpRequestMethod.GET) {
     data = undefined;
   }
-
   return data;
 };
-
 const getEndpoint = (endpoint: string) => {
   const isRelativeUrl = endpoint.startsWith('/');
   if (isRelativeUrl) {
@@ -92,6 +74,5 @@ const getEndpoint = (endpoint: string) => {
     const sanitizedRelativeURL = textUtil.sanitizeUrl(endpoint) as RelativeUrl;
     endpoint = createAbsoluteUrl(sanitizedRelativeURL, []);
   }
-
   return endpoint;
 };

--- a/public/app/plugins/panel/canvas/editor/layer/TreeNavigationEditor.tsx
+++ b/public/app/plugins/panel/canvas/editor/layer/TreeNavigationEditor.tsx
@@ -1,8 +1,8 @@
+import { structLog } from '@grafana/data';
 import { css } from '@emotion/css';
 import { Global } from '@emotion/react';
 import Tree, { type TreeNodeProps } from '@rc-component/tree';
 import { type Key, useEffect, useMemo, useState } from 'react';
-
 import { type GrafanaTheme2, type StandardEditorProps } from '@grafana/data';
 import { Trans, t } from '@grafana/i18n';
 import { config } from '@grafana/runtime';
@@ -10,46 +10,37 @@ import { Button, Icon, Stack, useStyles2, useTheme2 } from '@grafana/ui';
 import { AddLayerButton } from 'app/core/components/Layers/AddLayerButton';
 import { type ElementState } from 'app/features/canvas/runtime/element';
 import { frameSelection, reorderElements } from 'app/features/canvas/runtime/sceneElementManagement';
-
 import { getGlobalStyles } from '../../globalStyles';
 import { type Options } from '../../panelcfg.gen';
 import { type DragNode, type DropNode } from '../../types';
 import { doSelect, getElementTypes, onAddItem } from '../../utils';
 import { type TreeViewEditorProps } from '../element/elementEditor';
-
 import { TreeNodeTitle } from './TreeNodeTitle';
 import { getTreeData, onNodeDrop, type TreeElement } from './tree';
-
 let allowSelection = true;
-
 export const TreeNavigationEditor = ({ item }: StandardEditorProps<unknown, TreeViewEditorProps, Options>) => {
   const [treeData, setTreeData] = useState(getTreeData(item?.settings?.scene.root));
   const [autoExpandParent, setAutoExpandParent] = useState(true);
   const [expandedKeys, setExpandedKeys] = useState<Key[]>([]);
   const [selectedKeys, setSelectedKeys] = useState<Key[]>([]);
-
   const theme = useTheme2();
   const globalCSS = getGlobalStyles(theme);
   const styles = useStyles2(getStyles);
-
   const selectedBgColor = theme.colors.primary.border;
   const { settings } = item;
   const selection = useMemo(
     () => (settings?.selected ? settings.selected.map((v) => v?.getName()) : []),
     [settings?.selected]
   );
-
   const selectionByUID = useMemo(
     () => (settings?.selected ? settings.selected.map((v) => v?.UID) : []),
     [settings?.selected]
   );
-
   useEffect(() => {
     setTreeData(getTreeData(item?.settings?.scene.root, selection, selectedBgColor));
     setSelectedKeys(selectionByUID);
     setAllowSelection();
   }, [item?.settings?.scene.root, selectedBgColor, selection, selectionByUID]);
-
   if (!settings) {
     return (
       <div>
@@ -57,7 +48,6 @@ export const TreeNavigationEditor = ({ item }: StandardEditorProps<unknown, Tree
       </div>
     );
   }
-
   const layer = settings.layer;
   if (!layer) {
     return (
@@ -66,41 +56,39 @@ export const TreeNavigationEditor = ({ item }: StandardEditorProps<unknown, Tree
       </div>
     );
   }
-
-  const onSelect = (selectedKeys: Key[], info: { node: { dataRef: ElementState } }) => {
+  const onSelect = (
+    selectedKeys: Key[],
+    info: {
+      node: {
+        dataRef: ElementState;
+      };
+    }
+  ) => {
     if (allowSelection && item.settings?.scene) {
       doSelect(item.settings.scene, info.node.dataRef);
     }
   };
-
   const allowDrop = () => {
     return true;
   };
-
   const onDrop = (info: { node: DropNode; dragNode: DragNode; dropPosition: number; dropToGap: boolean }) => {
     const destPos = info.node.pos.split('-');
     const destPosition = info.dropPosition - Number(destPos[destPos.length - 1]);
-
     const srcEl = info.dragNode.dataRef;
     const destEl = info.node.dataRef;
-
     const data = onNodeDrop(info, treeData);
-
     setTreeData(data);
     reorderElements(srcEl, destEl, info.dropToGap, destPosition);
   };
-
   const onExpand = (expandedKeys: Key[]) => {
     setExpandedKeys(expandedKeys);
     setAutoExpandParent(false);
   };
-
   const switcherIcon = (obj: TreeNodeProps) => {
     if (obj.isLeaf) {
       // TODO: Implement element specific icons
       return <></>;
     }
-
     return (
       <Icon
         name="angle-right"
@@ -112,30 +100,24 @@ export const TreeNavigationEditor = ({ item }: StandardEditorProps<unknown, Tree
       />
     );
   };
-
   const setAllowSelection = (allow = true) => {
     allowSelection = allow;
   };
-
   const onClearSelection = () => {
     layer.scene.clearCurrentSelection();
   };
-
   const onTitleRender = (nodeData: TreeElement) => {
     return <TreeNodeTitle nodeData={nodeData} setAllowSelection={setAllowSelection} settings={settings} />;
   };
-
   // TODO: This functionality is currently kinda broken / no way to decouple / delete created frames at this time
   const onFrameSelection = () => {
     if (layer.scene) {
       frameSelection(layer.scene);
     } else {
-      console.warn('no scene!');
+      structLog('warn', 'no scene!');
     }
   };
-
   const typeOptions = getElementTypes(settings.scene.shouldShowAdvancedTypes).options;
-
   return (
     <>
       <Global styles={globalCSS} />
@@ -179,7 +161,6 @@ export const TreeNavigationEditor = ({ item }: StandardEditorProps<unknown, Tree
     </>
   );
 };
-
 const getStyles = (theme: GrafanaTheme2) => ({
   addLayerButton: css({
     marginLeft: '18px',

--- a/public/app/plugins/panel/canvas/editor/layer/layerEditor.tsx
+++ b/public/app/plugins/panel/canvas/editor/layer/layerEditor.tsx
@@ -1,51 +1,41 @@
+import { structLog } from '@grafana/data';
 import { get as lodashGet } from 'lodash';
-
 import { type NestedPanelOptions, type NestedValueAccess } from '@grafana/data/internal';
 import { t } from '@grafana/i18n';
 import { type ElementState } from 'app/features/canvas/runtime/element';
 import { FrameState } from 'app/features/canvas/runtime/frame';
 import { type Scene } from 'app/features/canvas/runtime/scene';
 import { setOptionImmutably } from 'app/features/dashboard/components/PanelEditor/utils';
-
 import { type InstanceState } from '../../CanvasPanel';
 import { PlacementEditor } from '../element/PlacementEditor';
 import { optionBuilder } from '../options';
-
 import { TreeNavigationEditor } from './TreeNavigationEditor';
-
 export interface LayerEditorProps {
   scene: Scene;
   layer: FrameState;
   selected: ElementState[];
 }
-
 export function getLayerEditor(opts: InstanceState): NestedPanelOptions<LayerEditorProps> {
   const { selected, scene } = opts;
-
   if (!scene.currentLayer) {
     scene.currentLayer = scene.root;
   }
-
   if (selected) {
     for (const element of selected) {
       if (element instanceof FrameState) {
         scene.currentLayer = element;
         break;
       }
-
       if (element && element.parent) {
         scene.currentLayer = element.parent;
         break;
       }
     }
   }
-
   const options = scene.currentLayer.options || { elements: [] };
-
   return {
     category: [t('canvas.layer-editor.category-layer', 'Layer')],
     path: '--', // not used!
-
     // Note that canvas editor writes things to the scene!
     values: (parent: NestedValueAccess) => ({
       getValue: (path) => {
@@ -53,7 +43,7 @@ export function getLayerEditor(opts: InstanceState): NestedPanelOptions<LayerEdi
       },
       onChange: (path, value) => {
         if (path === 'type' && value) {
-          console.warn('unable to change layer type');
+          structLog('warn', 'unable to change layer type');
           return;
         }
         const c = setOptionImmutably(options, path, value);
@@ -61,14 +51,12 @@ export function getLayerEditor(opts: InstanceState): NestedPanelOptions<LayerEdi
         scene.currentLayer?.updateData(scene.context);
       },
     }),
-
     // Dynamically fill the selected element
     build: (builder, context) => {
       const currentLayer = scene.currentLayer;
       if (currentLayer && !currentLayer.isRoot()) {
         // TODO: the non-root nav option
       }
-
       builder.addCustomEditor({
         id: 'content',
         path: 'root',
@@ -76,13 +64,11 @@ export function getLayerEditor(opts: InstanceState): NestedPanelOptions<LayerEdi
         editor: TreeNavigationEditor,
         settings: { scene, layer: scene.currentLayer, selected },
       });
-
       const ctx = { ...context, options };
       // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/consistent-type-assertions
       optionBuilder.addBackground(builder as any, ctx);
       // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/consistent-type-assertions
       optionBuilder.addBorder(builder as any, ctx);
-
       if (currentLayer && !currentLayer.isRoot()) {
         builder.addCustomEditor({
           category: [t('canvas.layer-editor.category-layout', 'Layout')],

--- a/public/app/plugins/panel/dashlist/migrations.ts
+++ b/public/app/plugins/panel/dashlist/migrations.ts
@@ -1,22 +1,18 @@
+import { structLog } from '@grafana/data';
 import { type PanelModel } from '@grafana/data';
 import { getBackendSrv } from '@grafana/runtime';
 import { type FolderDTO } from 'app/types/folders';
-
 import { type Options } from './panelcfg.gen';
-
 async function getFolderUID(folderID: number): Promise<string> {
   // folderID 0 is always the fake General/Dashboards folder, which always has a UID of empty string
   if (folderID === 0) {
     return '';
   }
-
   const folderDTO = await getBackendSrv().get<FolderDTO>(`/api/folders/id/${folderID}`, undefined, undefined, {
     showErrorAlert: false,
   });
-
   return folderDTO.uid;
 }
-
 export interface AngularModel {
   /** @deprecated */
   starred?: boolean;
@@ -35,7 +31,6 @@ export interface AngularModel {
   /** @deprecated */
   tags?: string[];
 }
-
 export async function dashlistMigrationHandler(panel: PanelModel<Options> & AngularModel) {
   // Convert old angular model to new react model
   const newOptions: Options = {
@@ -49,27 +44,23 @@ export async function dashlistMigrationHandler(panel: PanelModel<Options> & Angu
     folderId: panel.options.folderId ?? panel.folderId,
     tags: panel.options.tags ?? panel.tags,
   };
-
   // Delete old angular properties
   const previousVersion = parseFloat(panel.pluginVersion || '6.1');
   if (previousVersion < 6.3) {
     const oldProps = ['starred', 'recent', 'search', 'headings', 'limit', 'query', 'folderId'] as const;
     oldProps.forEach((prop) => delete panel[prop]);
   }
-
   // Convert the folderId to folderUID. Uses the API to do the conversion.
   if (newOptions.folderId !== undefined) {
     const folderId = newOptions.folderId;
-
     // If converting ID to UID fails, the panel will not be migrated and will show incorrectly
     try {
       const folderUID = await getFolderUID(folderId);
       newOptions.folderUID = folderUID;
       delete newOptions.folderId;
     } catch (err) {
-      console.warn('Dashlist: Error migrating folder ID to UID', err);
+      structLog('warn', 'Dashlist: Error migrating folder ID to UID', err);
     }
   }
-
   return newOptions;
 }

--- a/public/app/plugins/panel/geomap/GeomapPanel.tsx
+++ b/public/app/plugins/panel/geomap/GeomapPanel.tsx
@@ -1,3 +1,4 @@
+import { structLog } from '@grafana/data';
 import { css } from '@emotion/css';
 import { Global } from '@emotion/react';
 import type OpenLayersMap from 'ol/Map';
@@ -14,7 +15,6 @@ import { fromLonLat, transformExtent } from 'ol/proj';
 import { Component, type ReactNode } from 'react';
 import * as React from 'react';
 import { Subscription } from 'rxjs';
-
 import { DataHoverEvent, type PanelData, type PanelProps } from '@grafana/data';
 import { t } from '@grafana/i18n';
 import { config, locationService } from '@grafana/runtime';
@@ -22,7 +22,6 @@ import { type PanelContext, PanelContextRoot } from '@grafana/ui';
 import { appEvents } from 'app/core/app_events';
 import { VariablesChanged } from 'app/features/variables/types';
 import { PanelEditExitedEvent } from 'app/types/events';
-
 import { GeomapOverlay, type OverlayProps } from './GeomapOverlay';
 import { GeomapTooltip } from './GeomapTooltip';
 import { DebugOverlay } from './components/DebugOverlay';
@@ -46,10 +45,8 @@ import {
   hasLayerData,
 } from './utils/utils';
 import { centerPointRegistry, MapCenterID } from './view';
-
 // Allows multiple panels to share the same view instance
 let sharedView: View | undefined = undefined;
-
 type Props = PanelProps<Options>;
 interface State extends OverlayProps {
   ttip?: GeomapHoverPayload;
@@ -57,26 +54,20 @@ interface State extends OverlayProps {
   legends: ReactNode[];
   measureMenuActive?: boolean;
 }
-
 export class GeomapPanel extends Component<Props, State> {
   declare context: React.ContextType<typeof PanelContextRoot>;
   static contextType = PanelContextRoot;
   panelContext: PanelContext | undefined = undefined;
   private subs = new Subscription();
-
   globalCSS = getGlobalStyles(config.theme2);
-
   mouseWheelZoom?: MouseWheelZoom;
   hoverPayload: GeomapHoverPayload = { point: {}, pageX: -1, pageY: -1 };
   readonly hoverEvent = new DataHoverEvent(this.hoverPayload);
-
   map?: OpenLayersMap;
   mapDiv?: HTMLDivElement;
   layers: MapLayerState[] = [];
   readonly byName = new Map<string, MapLayerState>();
-
   mapViewData?: string;
-
   constructor(props: Props) {
     super(props);
     this.state = { ttipOpen: false, legends: [] };
@@ -99,7 +90,6 @@ export class GeomapPanel extends Component<Props, State> {
             }
             return hasVariableDependencies(config);
           });
-
           if (hasDependencies) {
             this.initMapAsync(this.mapDiv);
           }
@@ -107,39 +97,32 @@ export class GeomapPanel extends Component<Props, State> {
       })
     );
   }
-
   componentDidMount() {
     this.panelContext = this.context;
   }
-
   componentWillUnmount() {
     this.subs.unsubscribe();
-
     // Clear any pending debounce timeout
     if (this.timeoutId) {
       clearTimeout(this.timeoutId);
       this.timeoutId = null;
     }
-
     // Unregister view listener
     if (this.viewListenerKey && this.map) {
       const view = this.map.getView();
       view.un('change', this.viewListenerKey.listener);
       this.viewListenerKey = null;
     }
-
     for (const lyr of this.layers) {
       lyr.handler.dispose?.();
     }
     // Ensure map is disposed
     this.map?.dispose();
   }
-
   shouldComponentUpdate(nextProps: Props) {
     if (!this.map) {
       return true; // not yet initialized
     }
-
     // Check for resize
     if (this.props.height !== nextProps.height || this.props.width !== nextProps.width) {
       this.map.updateSize();
@@ -150,15 +133,12 @@ export class GeomapPanel extends Component<Props, State> {
         this.updateGeoVariables(view, options);
       }
     }
-
     // External data changed
     if (this.props.data !== nextProps.data) {
       this.dataChanged(nextProps.data);
     }
-
     return true; // always?
   }
-
   componentDidUpdate(prevProps: Props) {
     if (this.map && (this.props.height !== prevProps.height || this.props.width !== prevProps.width)) {
       this.map.updateSize();
@@ -172,7 +152,6 @@ export class GeomapPanel extends Component<Props, State> {
       this.optionsChanged(prevProps.options, this.props.options);
     }
   }
-
   /** This function will actually update the JSON model */
   doOptionsUpdate(selected: number) {
     const { options, onOptionsChange } = this.props;
@@ -188,13 +167,10 @@ export class GeomapPanel extends Component<Props, State> {
       basemap: layers[0].options,
       layers: layers.slice(1).map((v) => v.options),
     });
-
     notifyPanelEditor(this, layers, selected);
     this.setState({ legends: this.getLegends() });
   }
-
   actions = getActions(this);
-
   /**
    * Called when the panel options change
    *
@@ -203,7 +179,6 @@ export class GeomapPanel extends Component<Props, State> {
   optionsChanged(oldOptions: Options, newOptions: Options) {
     // First check if noRepeat changed - requires full map reinitialization
     const noRepeatChanged = oldOptions.view?.noRepeat !== newOptions.view?.noRepeat;
-
     if (noRepeatChanged) {
       if (this.mapDiv) {
         this.initMapAsync(this.mapDiv);
@@ -211,7 +186,6 @@ export class GeomapPanel extends Component<Props, State> {
       // Skip other options processing
       return;
     }
-
     // Handle incremental view changes
     if (oldOptions.view !== newOptions.view) {
       // Unregister existing listener from the current view before replacing it
@@ -220,11 +194,9 @@ export class GeomapPanel extends Component<Props, State> {
         oldView.un('change', this.viewListenerKey.listener);
         this.viewListenerKey = null;
       }
-
       const view = this.initMapView(newOptions.view);
       if (this.map && view) {
         this.map.setView(view);
-
         // Register new listener if dashboard variable sync is enabled
         if (newOptions.view.dashboardVariable) {
           this.viewListenerKey = view.on('change', () => {
@@ -234,13 +206,11 @@ export class GeomapPanel extends Component<Props, State> {
         }
       }
     }
-
     // Handle controls changes
     if (newOptions.controls !== oldOptions.controls) {
       this.initControls(newOptions.controls ?? { showZoom: true, showAttribution: true });
     }
   }
-
   /**
    * Called when PanelData changes (query results etc)
    */
@@ -251,27 +221,21 @@ export class GeomapPanel extends Component<Props, State> {
         applyLayerFilter(state.handler, state.options, this.props.data);
       }
     }
-
     // Because data changed, check map view and change if needed (data fit)
     const v = centerPointRegistry.getIfExists(this.props.options.view.id);
     if (v && v.id === MapCenterID.Fit) {
       const view = this.initMapView(this.props.options.view);
-
       if (this.map && view) {
         this.map.setView(view);
       }
     }
-
     // Update legends when data changes
     this.setState({ legends: this.getLegends() });
   }
-
   // view listerner handler, used to unregister when view changes
   private viewListenerKey: EventsKey | null = null;
-
   // updateGeoVariables debounce timeout
   private timeoutId: NodeJS.Timeout | null = null; // for debounce
-
   // Updates the dashboard variable with the view extent value.
   // Use a debounce strategy to wait for the user to stop dragging or zooming the map.
   updateGeoVariables = (view: View, options: Options) => {
@@ -289,7 +253,6 @@ export class GeomapPanel extends Component<Props, State> {
       locationService.partial({ [`var-${variableName}`]: `${bounds4326}` }, true);
     }, 500);
   };
-
   initMapAsync = async (div: HTMLDivElement | null) => {
     if (!div) {
       // Do not initialize new map or dispose old map
@@ -299,11 +262,8 @@ export class GeomapPanel extends Component<Props, State> {
     if (this.map) {
       this.map.dispose();
     }
-
     const { options } = this.props;
-
     const map = getNewOpenLayersMap(this, options, div);
-
     this.byName.clear();
     const layers: MapLayerState[] = [];
     try {
@@ -313,19 +273,16 @@ export class GeomapPanel extends Component<Props, State> {
         noRepeat: options.view?.noRepeat ?? false,
       };
       layers.push(await initLayer(this, map, basemapOptions, true));
-
       // Default layer values
       if (!options.layers) {
         options.layers = [defaultMarkersConfig];
       }
-
       for (const lyr of options.layers) {
         layers.push(await initLayer(this, map, lyr, false));
       }
     } catch (ex) {
-      console.error('error loading layers', ex);
+      structLog('error', 'error loading layers', ex);
     }
-
     for (const lyr of layers) {
       map.addLayer(lyr.layer);
     }
@@ -334,16 +291,12 @@ export class GeomapPanel extends Component<Props, State> {
     const view = map.getView();
     const viewConfig = options.view;
     this.initViewExtent(view, viewConfig);
-
     this.mouseWheelZoom = new MouseWheelZoom();
     this.map?.addInteraction(this.mouseWheelZoom);
-
     updateMap(this, options);
     setTooltipListeners(this);
     notifyPanelEditor(this, layers, layers.length - 1);
-
     this.setState({ legends: this.getLegends() });
-
     // register view listener to update dashboard variable if enabled
     if (viewConfig.dashboardVariable) {
       if (this.viewListenerKey != null) {
@@ -355,33 +308,26 @@ export class GeomapPanel extends Component<Props, State> {
       this.updateGeoVariables(view, options);
     }
   };
-
   clearTooltip = () => {
     if (this.state.ttip && !this.state.ttipOpen) {
       this.tooltipPopupClosed();
     }
   };
-
   tooltipPopupClosed = () => {
     this.setState({ ttipOpen: false, ttip: undefined });
   };
-
   pointerClickListener = (evt: MapBrowserEvent<PointerEvent>) => {
     pointerClickListener(evt, this);
   };
-
   pointerMoveListener = (evt: MapBrowserEvent<PointerEvent>) => {
     pointerMoveListener(evt, this);
   };
-
   initMapView = (config: MapViewConfig): View | undefined => {
     const noRepeat = config.noRepeat ?? false;
-
     let viewOptions: ViewOptions = {
       center: [0, 0],
       zoom: 1,
     };
-
     // Only apply constraints when no-repeat is enabled
     if (noRepeat) {
       // Define the world extent in EPSG:3857 (Web Mercator)
@@ -391,9 +337,7 @@ export class GeomapPanel extends Component<Props, State> {
       viewOptions.showFullExtent = false;
       viewOptions.constrainOnlyCenter = false;
     }
-
     let view = new View(viewOptions);
-
     // With shared views, all panels use the same view instance
     if (config.shared) {
       if (!sharedView) {
@@ -402,11 +346,9 @@ export class GeomapPanel extends Component<Props, State> {
         view = sharedView;
       }
     }
-
     this.initViewExtent(view, config);
     return view;
   };
-
   initViewExtent(view: View, config: MapViewConfig) {
     const v = centerPointRegistry.getIfExists(config.id);
     if (v) {
@@ -439,7 +381,6 @@ export class GeomapPanel extends Component<Props, State> {
         view.setCenter(fromLonLat(coord));
       }
     }
-
     if (config.maxZoom) {
       view.setMaxZoom(config.maxZoom);
     }
@@ -450,17 +391,14 @@ export class GeomapPanel extends Component<Props, State> {
       view.setZoom(config.zoom);
     }
   }
-
   initControls(options: ControlsOptions) {
     if (!this.map) {
       return;
     }
     this.map.getControls().clear();
-
     if (options.showZoom) {
       this.map.addControl(new Zoom());
     }
-
     if (options.showScale) {
       this.map.addControl(
         new ScaleLine({
@@ -469,13 +407,10 @@ export class GeomapPanel extends Component<Props, State> {
         })
       );
     }
-
     this.mouseWheelZoom?.setActive(Boolean(options.mouseWheelZoom));
-
     if (options.showAttribution) {
       this.map.addControl(new Attribution({ collapsed: true, collapsible: true }));
     }
-
     // Update the react overlays
     let topRight1: ReactNode[] = [];
     if (options.showMeasure) {
@@ -490,15 +425,12 @@ export class GeomapPanel extends Component<Props, State> {
         />,
       ];
     }
-
     let topRight2: ReactNode[] = [];
     if (options.showDebug) {
       topRight2 = [<DebugOverlay key="debug" map={this.map} />];
     }
-
     this.setState({ topRight1, topRight2 });
   }
-
   getLegends() {
     const legends: ReactNode[] = [];
     for (const state of this.layers) {
@@ -509,14 +441,11 @@ export class GeomapPanel extends Component<Props, State> {
         }
       }
     }
-
     return legends;
   }
-
   initMapRef = (div: HTMLDivElement | null) => {
     this.initMapAsync(div);
   };
-
   render() {
     let { ttip, ttipOpen, topRight1, legends, topRight2 } = this.state;
     const { options } = this.props;
@@ -524,7 +453,6 @@ export class GeomapPanel extends Component<Props, State> {
     if (!ttipOpen && options.tooltip?.mode === TooltipMode.None) {
       ttip = undefined;
     }
-
     return (
       <>
         <Global styles={this.globalCSS} />
@@ -549,7 +477,6 @@ export class GeomapPanel extends Component<Props, State> {
     );
   }
 }
-
 const styles = {
   wrap: css({
     position: 'relative',

--- a/public/app/plugins/panel/geomap/layers/basemaps/maplibre.ts
+++ b/public/app/plugins/panel/geomap/layers/basemaps/maplibre.ts
@@ -1,34 +1,27 @@
+import { structLog } from '@grafana/data';
 import type Map from 'ol/Map';
 import LayerGroup from 'ol/layer/Group';
 import { apply } from 'ol-mapbox-style';
-
 import { type MapLayerRegistryItem, type MapLayerOptions, type GrafanaTheme2, type EventBus } from '@grafana/data';
-
 // MapLibre Style Specification constants
 const LAYER_TYPE_BACKGROUND = 'background';
 const PAINT_BACKGROUND_OPACITY = 'background-opacity';
-
 export interface MaplibreConfig {
   url: string;
   accessToken?: string;
 }
-
 const sampleURL = 'https://tiles.stadiamaps.com/styles/alidade_smooth.json';
-
 export const defaultMaplibreConfig: MaplibreConfig = {
   url: sampleURL,
 };
-
 interface ExtendedMapLayerOptions<T> extends MapLayerOptions<T> {
   noRepeat?: boolean;
 }
-
 export const maplibreLayer: MapLayerRegistryItem<MaplibreConfig> = {
   id: 'maplibre',
   name: 'MapLibre layer',
   description: 'Add layer using MapLibre style.json URL',
   isBaseMap: true,
-
   create: async (
     map: Map,
     options: ExtendedMapLayerOptions<MaplibreConfig>,
@@ -45,7 +38,6 @@ export const maplibreLayer: MapLayerRegistryItem<MaplibreConfig> = {
       const layer = new LayerGroup({
         opacity: layerOpacity,
       });
-
       const applyNoRepeat = () => {
         if (noRepeat) {
           // Set wrapX: false on the first layer source to prevent world repetition
@@ -58,25 +50,21 @@ export const maplibreLayer: MapLayerRegistryItem<MaplibreConfig> = {
           }
         }
       };
-
       // Handle async operations in the background
       const loadStyle = async () => {
         try {
           if (!cfg.url) {
-            console.warn('No URL provided for MapLibre style, layer will be empty');
+            structLog('warn', 'No URL provided for MapLibre style, layer will be empty');
             return;
           }
-
           const res = await fetch(cfg.url);
           if (!res.ok) {
-            console.warn(`Failed to load MapLibre style from ${cfg.url}: ${res.status} ${res.statusText}`);
+            structLog('warn', `Failed to load MapLibre style from ${cfg.url}: ${res.status} ${res.statusText}`);
             // Try fallback approach
             await tryFallbackApply();
             return;
           }
-
           const style = await res.json();
-
           // Adjust background opacity - let LayerGroup opacity handle everything else
           if (Array.isArray(style?.layers)) {
             for (const l of style.layers) {
@@ -86,32 +74,28 @@ export const maplibreLayer: MapLayerRegistryItem<MaplibreConfig> = {
               }
             }
           }
-
           await apply(layer, style, { styleUrl: cfg.url, accessToken: cfg.accessToken });
           applyNoRepeat();
         } catch (error) {
-          console.warn('Failed to parse or apply MapLibre style JSON:', error);
+          structLog('warn', 'Failed to parse or apply MapLibre style JSON:', error);
           // Try fallback approach
           await tryFallbackApply();
         }
       };
-
       const tryFallbackApply = async () => {
         try {
           if (!cfg.url) {
-            console.warn('No URL available for MapLibre fallback, layer will be empty');
+            structLog('warn', 'No URL available for MapLibre fallback, layer will be empty');
             return;
           }
           await apply(layer, cfg.url, { accessToken: cfg.accessToken });
           applyNoRepeat();
         } catch (fallbackError) {
-          console.warn('Failed to load MapLibre style from both JSON and direct URL approaches:', fallbackError);
+          structLog('warn', 'Failed to load MapLibre style from both JSON and direct URL approaches:', fallbackError);
         }
       };
-
       // Start loading the style asynchronously
       loadStyle();
-
       return layer;
     },
     registerOptionsUI: (builder) => {
@@ -135,5 +119,4 @@ export const maplibreLayer: MapLayerRegistryItem<MaplibreConfig> = {
     },
   }),
 };
-
 export const maplibreLayers = [maplibreLayer];

--- a/public/app/plugins/panel/geomap/style/markers.ts
+++ b/public/app/plugins/panel/geomap/style/markers.ts
@@ -1,19 +1,16 @@
+import { structLog } from '@grafana/data';
 import { Fill, RegularShape, Stroke, Circle, Style, Icon, Text } from 'ol/style';
 import type { FlatStyle } from 'ol/style/flat';
 import tinycolor from 'tinycolor2';
-
 import { Registry, type RegistryItem, textUtil } from '@grafana/data';
 import { config } from '@grafana/runtime';
 import { getPublicOrAbsoluteUrl } from 'app/features/dimensions/resource';
-
 import { defaultStyleConfig, DEFAULT_SIZE, type StyleConfigValues, type StyleMaker } from './types';
 import { getDisplacement } from './utils';
-
 interface SymbolMaker extends RegistryItem {
   aliasIds: string[];
   make: StyleMaker;
 }
-
 enum RegularShapeId {
   circle = 'circle',
   square = 'square',
@@ -22,7 +19,6 @@ enum RegularShapeId {
   cross = 'cross',
   x = 'x',
 }
-
 const MarkerShapePath = {
   circle: 'img/icons/marker/circle.svg',
   square: 'img/icons/marker/square.svg',
@@ -31,7 +27,6 @@ const MarkerShapePath = {
   cross: 'img/icons/marker/cross.svg',
   x: 'img/icons/marker/x-mark.svg',
 };
-
 export function getFillColor(cfg: StyleConfigValues) {
   const opacity = cfg.opacity == null ? 0.8 : cfg.opacity;
   if (opacity === 1) {
@@ -43,7 +38,6 @@ export function getFillColor(cfg: StyleConfigValues) {
   }
   return undefined;
 }
-
 export function getStrokeStyle(cfg: StyleConfigValues) {
   const opacity = cfg.opacity == null ? 0.8 : cfg.opacity;
   if (opacity === 1) {
@@ -55,12 +49,10 @@ export function getStrokeStyle(cfg: StyleConfigValues) {
   }
   return undefined;
 }
-
 const textLabel = (cfg: StyleConfigValues) => {
   if (!cfg.text) {
     return undefined;
   }
-
   const fontFamily = config.theme2.typography.fontFamily;
   const textConfig = {
     ...defaultStyleConfig.textConfig,
@@ -73,13 +65,11 @@ const textLabel = (cfg: StyleConfigValues) => {
     ...textConfig,
   });
 };
-
 export const textMarker = (cfg: StyleConfigValues) => {
   return new Style({
     text: textLabel(cfg),
   });
 };
-
 export const circleMarker = (cfg: StyleConfigValues) => {
   const stroke = new Stroke({ color: cfg.color, width: cfg.lineWidth ?? 1 });
   const radius = cfg.size ?? DEFAULT_SIZE;
@@ -94,7 +84,6 @@ export const circleMarker = (cfg: StyleConfigValues) => {
     stroke, // in case lines are sent to the markers layer
   });
 };
-
 // Does not have image
 export const polyStyle = (cfg: StyleConfigValues) => {
   return new Style({
@@ -103,7 +92,6 @@ export const polyStyle = (cfg: StyleConfigValues) => {
     text: textLabel(cfg),
   });
 };
-
 export const routeStyle = (cfg: StyleConfigValues) => {
   return new Style({
     fill: getFillColor(cfg),
@@ -111,7 +99,6 @@ export const routeStyle = (cfg: StyleConfigValues) => {
     text: textLabel(cfg),
   });
 };
-
 // Square and cross
 const errorMarker = (cfg: StyleConfigValues) => {
   const radius = cfg.size ?? DEFAULT_SIZE;
@@ -136,7 +123,6 @@ const errorMarker = (cfg: StyleConfigValues) => {
     }),
   ];
 };
-
 const makers: SymbolMaker[] = [
   {
     id: RegularShapeId.circle,
@@ -251,7 +237,6 @@ const makers: SymbolMaker[] = [
     },
   },
 ];
-
 async function prepareSVG(url: string, size?: number, backgroundOpacity?: number): Promise<string> {
   return fetch(url, { method: 'GET' })
     .then((res) => {
@@ -259,23 +244,19 @@ async function prepareSVG(url: string, size?: number, backgroundOpacity?: number
     })
     .then((text) => {
       text = textUtil.sanitizeSVGContent(text);
-
       const parser = new DOMParser();
       const doc = parser.parseFromString(text, 'image/svg+xml');
       const svg = doc.getElementsByTagName('svg')[0];
       if (!svg) {
         return '';
       }
-
       const svgSize = size ?? 100;
       const width = svg.getAttribute('width') ?? svgSize;
       const height = svg.getAttribute('height') ?? svgSize;
-
       // open layers requires a white fill becaues it uses tint to set color
       svg.setAttribute('fill', '#fff');
       svg.setAttribute('width', `${width}px`);
       svg.setAttribute('height', `${height}px`);
-
       // add a mostly transparent circle behind the icon for webGL hit detection
       // TODO open layers discards fully transparent elements for hit detection
       if (backgroundOpacity) {
@@ -291,20 +272,17 @@ async function prepareSVG(url: string, size?: number, backgroundOpacity?: number
         circleElement.setAttribute('stroke-width', viewCenterX.toString());
         svg.prepend(circleElement);
       }
-
       const svgString = new XMLSerializer().serializeToString(svg);
       const svgURI = encodeURIComponent(svgString);
       return `data:image/svg+xml,${svgURI}`;
     })
     .catch((error) => {
-      console.error(error); // eslint-disable-line no-console
+      structLog('error', error); // eslint-disable-line no-console
       return '';
     });
 }
-
 // Really just a cache for the various symbol styles
 const markerMakers = new Registry<SymbolMaker>(() => makers);
-
 export function getMarkerAsPath(shape?: string): string | undefined {
   const marker = markerMakers.getIfExists(shape);
   if (marker?.aliasIds?.length) {
@@ -312,14 +290,12 @@ export function getMarkerAsPath(shape?: string): string | undefined {
   }
   return undefined;
 }
-
 // Common expressions used across different style types
 export const colorExpression = ['color', ['get', 'red'], ['get', 'green'], ['get', 'blue'], ['get', 'opacity']];
 export const sizeExpression = ['get', 'size'];
 export const opacityExpression = ['get', 'opacity'];
 export const rotationExpression = ['get', 'rotation'];
 export const offsetExpression = ['array', ['get', 'offsetX'], ['get', 'offsetY']];
-
 // Base style for regular shapes
 export const baseShapeStyle = {
   'shape-radius': ['/', sizeExpression, 2],
@@ -330,7 +306,6 @@ export const baseShapeStyle = {
   'shape-rotation': rotationExpression,
   'shape-displacement': offsetExpression,
 };
-
 // Base style for circles
 export const baseCircleStyle = {
   'circle-radius': ['/', sizeExpression, 2],
@@ -340,14 +315,12 @@ export const baseCircleStyle = {
   'circle-opacity': opacityExpression,
   'circle-displacement': offsetExpression,
 };
-
 // Returns style configuration for WebGL markers
 export async function getWebGLStyle(symbol?: string, opacity?: number): Promise<FlatStyle> {
   // Handle circle explicitly (before generic SVG check)
   if (symbol === MarkerShapePath.circle) {
     return baseCircleStyle;
   }
-
   // Handle square as WebGL regular shape
   if (symbol === MarkerShapePath.square) {
     return {
@@ -356,7 +329,6 @@ export async function getWebGLStyle(symbol?: string, opacity?: number): Promise<
       'shape-angle': Math.PI / 4,
     };
   }
-
   // Handle triangle as WebGL regular shape
   if (symbol === MarkerShapePath.triangle) {
     return {
@@ -365,7 +337,6 @@ export async function getWebGLStyle(symbol?: string, opacity?: number): Promise<
       'shape-angle': 0,
     };
   }
-
   // Handle custom SVG symbols and other shapes as icons
   if (symbol && symbol.endsWith('.svg')) {
     const backgroundOpacity = opacity === 0 ? 0 : 0.1 / (opacity ?? 1);
@@ -379,22 +350,18 @@ export async function getWebGLStyle(symbol?: string, opacity?: number): Promise<
       'icon-color': colorExpression,
     };
   }
-
   // Default to circle (also handles MarkerShapePath.circle)
   return baseCircleStyle;
 }
-
 // Will prepare symbols as necessary
 export async function getMarkerMaker(symbol?: string, hasTextLabel?: boolean): Promise<StyleMaker> {
   if (!symbol) {
     return hasTextLabel ? textMarker : circleMarker;
   }
-
   let maker = markerMakers.getIfExists(symbol);
   if (maker) {
     return maker.make;
   }
-
   // Prepare svg as icon
   if (symbol.endsWith('.svg')) {
     const src = await prepareSVG(getPublicOrAbsoluteUrl(symbol));
@@ -434,7 +401,6 @@ export async function getMarkerMaker(symbol?: string, hasTextLabel?: boolean): P
     markerMakers.register(maker);
     return maker.make;
   }
-
   // default to showing a circle
   return errorMarker;
 }

--- a/public/app/plugins/panel/geomap/style/utils.ts
+++ b/public/app/plugins/panel/geomap/style/utils.ts
@@ -1,6 +1,6 @@
+import { structLog } from '@grafana/data';
 import { config } from '@grafana/runtime';
 import { TextDimensionMode } from '@grafana/schema';
-
 import { getMarkerMaker } from './markers';
 import {
   HorizontalAlign,
@@ -12,7 +12,6 @@ import {
   type SymbolAlign,
   type ColorValue,
 } from './types';
-
 /** Indicate if the style wants to show text values */
 export function styleUsesText(config: StyleConfig): boolean {
   const text = config?.text;
@@ -27,7 +26,6 @@ export function styleUsesText(config: StyleConfig): boolean {
   }
   return false;
 }
-
 /** Return a distinct list of fields used to dynamically change the style */
 export async function getStyleConfigState(cfg?: StyleConfig): Promise<StyleConfigState> {
   if (!cfg) {
@@ -50,7 +48,6 @@ export async function getStyleConfigState(cfg?: StyleConfig): Promise<StyleConfi
     },
     maker,
   };
-
   if (cfg.color?.field?.length) {
     fields.color = cfg.color.field;
   }
@@ -60,23 +57,19 @@ export async function getStyleConfigState(cfg?: StyleConfig): Promise<StyleConfi
   if (cfg.rotation?.field?.length) {
     fields.rotation = cfg.rotation.field;
   }
-
   if (hasText) {
     state.base.text = cfg.text?.fixed;
     state.base.textConfig = cfg.textConfig ?? defaultStyleConfig.textConfig;
-
     if (cfg.text?.field?.length) {
       fields.text = cfg.text.field;
     }
   }
-
   // Clear the fields if possible
   if (!Object.keys(fields).length) {
     state.fields = undefined;
   }
   return state;
 }
-
 /** Return a displacment array depending on alignment and icon radius */
 export function getDisplacement(symbolAlign: SymbolAlign, radius: number) {
   const displacement = [0, 0];
@@ -92,41 +85,33 @@ export function getDisplacement(symbolAlign: SymbolAlign, radius: number) {
   }
   return displacement;
 }
-
 export function getRGBValues(colorString: string): ColorValue | null {
   // Check if it's a hex color
   if (colorString.startsWith('#')) {
     return getRGBFromHex(colorString);
   }
-
   // Check if it's an RGB color
   else if (colorString.startsWith('rgb')) {
     return getRGBFromRGBString(colorString);
   }
-
   // Handle other color formats if needed
   else {
-    console.warn(`Unsupported color format: ${colorString}`);
+    structLog('warn', `Unsupported color format: ${colorString}`);
   }
   return null;
 }
-
 function getRGBFromHex(hexColor: string): ColorValue {
   // Remove the '#' character
   hexColor = hexColor.slice(1);
-
   // Convert hex to decimal values
   const r = parseInt(hexColor.slice(0, 2), 16);
   const g = parseInt(hexColor.slice(2, 4), 16);
   const b = parseInt(hexColor.slice(4, 6), 16);
-
   return { r, g, b };
 }
-
 function getRGBFromRGBString(rgbString: string): ColorValue | null {
   // Use regex to extract the numbers, supporting both rgb(r,g,b) and rgba(r,g,b,a) formats
   const matches = rgbString.match(/\d+\.?\d*/g);
-
   if (matches) {
     if (matches.length === 3) {
       return {
@@ -142,10 +127,10 @@ function getRGBFromRGBString(rgbString: string): ColorValue | null {
         a: parseFloat(matches[3]), // Using parseFloat for alpha as it can be decimal (0-1)
       };
     } else {
-      console.warn(`Unsupported color format: ${rgbString}`);
+      structLog('warn', `Unsupported color format: ${rgbString}`);
     }
   } else {
-    console.warn(`Unsupported color format: ${rgbString}`);
+    structLog('warn', `Unsupported color format: ${rgbString}`);
   }
   return null;
 }

--- a/public/app/plugins/panel/geomap/utils/layers.ts
+++ b/public/app/plugins/panel/geomap/utils/layers.ts
@@ -1,22 +1,18 @@
+import { structLog } from '@grafana/data';
 import { type FeatureLike } from 'ol/Feature';
 import type OpenLayersMap from 'ol/Map';
 import type BaseLayer from 'ol/layer/Base';
 import LayerGroup from 'ol/layer/Group';
 import WebGLPointsLayer from 'ol/layer/WebGLPoints';
 import { Subject } from 'rxjs';
-
 import { getFrameMatchers, type MapLayerHandler, type MapLayerOptions, type PanelData, textUtil } from '@grafana/data';
 import { config } from '@grafana/runtime';
-
 import { type GeomapPanel } from '../GeomapPanel';
 import { MARKERS_LAYER_ID } from '../layers/data/markersLayer';
 import { DEFAULT_BASEMAP_CONFIG, geomapLayerRegistry } from '../layers/registry';
 import { type MapLayerState } from '../types';
-
 import { getNextLayerName } from './utils';
-
 const layerStateMap = new WeakMap<BaseLayer, MapLayerState>();
-
 export const applyLayerFilter = (
   handler: MapLayerHandler<unknown>,
   options: MapLayerOptions<unknown>,
@@ -26,11 +22,9 @@ export const applyLayerFilter = (
     let panelData = panelDataProps;
     if (options.filterData) {
       const matcherFunc = getFrameMatchers(options.filterData);
-
       const queryExists = panelData.request?.targets.some((target) => {
         return target.refId === options.filterData?.options;
       });
-
       // Only apply filter if the target query exists
       if (queryExists) {
         panelData = {
@@ -42,7 +36,6 @@ export const applyLayerFilter = (
     handler.update(panelData);
   }
 };
-
 export async function updateLayer(panel: GeomapPanel, uid: string, newOptions: MapLayerOptions): Promise<boolean> {
   if (!panel.map) {
     return false;
@@ -51,7 +44,6 @@ export async function updateLayer(panel: GeomapPanel, uid: string, newOptions: M
   if (!current) {
     return false;
   }
-
   let layerIndex = -1;
   const group = panel.map?.getLayers()!;
   for (let i = 0; i < group?.getLength(); i++) {
@@ -60,7 +52,6 @@ export async function updateLayer(panel: GeomapPanel, uid: string, newOptions: M
       break;
     }
   }
-
   // Special handling for rename
   if (newOptions.name !== uid) {
     if (!newOptions.name) {
@@ -69,40 +60,33 @@ export async function updateLayer(panel: GeomapPanel, uid: string, newOptions: M
       return false;
     }
     panel.byName.delete(uid);
-
     uid = newOptions.name;
     panel.byName.set(uid, current);
   }
-
   // Type changed -- requires full re-initalization
   if (current.options.type !== newOptions.type) {
     // full init
   } else {
     // just update options
   }
-
   const layers = panel.layers.slice(0);
   try {
     const info = await initLayer(panel, panel.map, newOptions, current.isBasemap);
     layers[layerIndex]?.handler.dispose?.();
     layers[layerIndex] = info;
     group.setAt(layerIndex, info.layer);
-
     // initialize with new data
     applyLayerFilter(info.handler, newOptions, panel.props.data);
   } catch (err) {
-    console.warn('ERROR', err); // eslint-disable-line no-console
+    structLog('warn', 'ERROR', err); // eslint-disable-line no-console
     return false;
   }
-
   // Just to trigger a state update
   panel.setState({ legends: [] });
-
   panel.layers = layers;
   panel.doOptionsUpdate(layerIndex);
   return true;
 }
-
 export async function initLayer(
   panel: GeomapPanel,
   map: OpenLayersMap,
@@ -112,7 +96,6 @@ export async function initLayer(
   if (isBasemap && (!options?.type || config.geomapDisableCustomBaseLayer)) {
     options = DEFAULT_BASEMAP_CONFIG;
   }
-
   // Use default makers layer
   if (!options?.type) {
     options = {
@@ -121,26 +104,21 @@ export async function initLayer(
       config: {},
     };
   }
-
   const item = geomapLayerRegistry.getIfExists(options.type);
   if (!item) {
     return Promise.reject('unknown layer: ' + options.type);
   }
-
   if (options.config?.attribution) {
     options.config.attribution = textUtil.sanitizeTextPanelContent(options.config.attribution);
   }
-
   const handler = await item.create(map, options, panel.props.eventBus, config.theme2);
   const layer = handler.init(); // eslint-disable-line
   if (options.opacity != null) {
     layer.setOpacity(options.opacity);
   }
-
   if (!options.name) {
     options.name = getNextLayerName(panel);
   }
-
   const UID = options.name;
   const state: MapLayerState<unknown> = {
     // UID, // unique name when added to the map (it may change and will need special handling)
@@ -149,18 +127,14 @@ export async function initLayer(
     layer,
     handler,
     mouseEvents: new Subject<FeatureLike | undefined>(),
-
     getName: () => UID,
-
     // Used by the editors
     onChange: (cfg: MapLayerOptions) => {
       updateLayer(panel, UID, cfg);
     },
   };
-
   panel.byName.set(UID, state);
   layerStateMap.set(state.layer, state);
-
   // Pass state into WebGLPointsLayers contained in a LayerGroup
   if (layer instanceof LayerGroup) {
     layer
@@ -172,12 +146,9 @@ export async function initLayer(
         }
       });
   }
-
   applyLayerFilter(handler, options, panel.props.data);
-
   return state;
 }
-
 export const getMapLayerState = (l: BaseLayer | undefined): MapLayerState | undefined => {
   return l ? layerStateMap.get(l) : undefined;
 };

--- a/public/app/plugins/panel/heatmap/HeatmapPanel.tsx
+++ b/public/app/plugins/panel/heatmap/HeatmapPanel.tsx
@@ -1,6 +1,6 @@
+import { structLog } from '@grafana/data';
 import { css } from '@emotion/css';
 import { useMemo, useRef, useState } from 'react';
-
 import { DashboardCursorSync, type PanelProps, type TimeRange } from '@grafana/data';
 import { PanelDataErrorView } from '@grafana/runtime';
 import { type ScaleDistributionConfig } from '@grafana/schema';
@@ -18,30 +18,22 @@ import {
 import { type FacetedData, type TimeRange2, TooltipHoverMode } from '@grafana/ui/internal';
 import { ColorScale } from 'app/core/components/ColorScale/ColorScale';
 import { readHeatmapRowsCustomMeta } from 'app/features/transformers/calculateHeatmap/heatmap';
-
 import { getXAxisConfig } from '../../../core/components/TimeSeries/utils';
 import { AnnotationsPlugin } from '../timeseries/plugins/AnnotationPlugin';
 import { OutsideRangePlugin } from '../timeseries/plugins/OutsideRangePlugin';
 import { getXAnnotationFrames } from '../timeseries/plugins/utils';
-
 import { HeatmapTooltip } from './HeatmapTooltip';
 import { type HeatmapData, prepareHeatmapData } from './fields';
 import { quantizeScheme } from './palettes';
 import { type Options } from './panelcfg.gen';
 import { calculateYSizeDivisor, prepConfig } from './utils';
-
 interface HeatmapPanelProps extends PanelProps<Options> {}
-
 type HeatmapDataForViz = Required<Pick<HeatmapData, 'heatmap'>> & Omit<HeatmapData, 'warning' | 'heatmap'>;
-
 const shouldRenderViz = (info: HeatmapData): info is HeatmapDataForViz => !(info.warning || !info.heatmap);
-
 export const HeatmapPanel = (props: HeatmapPanelProps) => {
   const { data, id, timeRange, options, fieldConfig, replaceVariables } = props;
   const theme = useTheme2();
-
   const palette = useMemo(() => quantizeScheme(options.color, theme), [options.color, theme]);
-
   const info = useMemo(() => {
     try {
       return prepareHeatmapData({
@@ -54,11 +46,10 @@ export const HeatmapPanel = (props: HeatmapPanelProps) => {
         timeRange,
       });
     } catch (ex) {
-      console.error(ex);
+      structLog('error', ex);
       return { warning: `${ex}` };
     }
   }, [data.series, data.annotations, options, palette, theme, replaceVariables, timeRange]);
-
   if (!shouldRenderViz(info)) {
     return (
       <PanelDataErrorView
@@ -70,10 +61,8 @@ export const HeatmapPanel = (props: HeatmapPanelProps) => {
       />
     );
   }
-
   return <HeatmapPanelViz {...props} info={info} palette={palette} />;
 };
-
 const HeatmapPanelViz = ({
   data,
   timeRange,
@@ -86,35 +75,30 @@ const HeatmapPanelViz = ({
   replaceVariables,
   info,
   palette,
-}: HeatmapPanelProps & { info: HeatmapDataForViz; palette: string[] }) => {
+}: HeatmapPanelProps & {
+  info: HeatmapDataForViz;
+  palette: string[];
+}) => {
   const theme = useTheme2();
   const styles = useStyles2(getStyles);
   const { sync, eventsScope, canAddAnnotations, onSelectRange, canExecuteActions } = usePanelContext();
   const cursorSync = sync?.() ?? DashboardCursorSync.Off;
-
   const userCanExecuteActions = useMemo(() => canExecuteActions?.() ?? false, [canExecuteActions]);
-
   // temp range set for adding new annotation set by TooltipPlugin2, consumed by AnnotationPlugin2
   const [newAnnotationRange, setNewAnnotationRange] = useState<TimeRange2 | null>(null);
-
   // ugh
   let timeRangeRef = useRef<TimeRange>(timeRange);
   timeRangeRef.current = timeRange;
-
   const facets = useMemo((): FacetedData => {
     let exemplarsXFacet: number[] | undefined = []; // "Time" field
     let exemplarsYFacet: Array<number | undefined> = [];
-
     const meta = readHeatmapRowsCustomMeta(info.heatmap);
-
     if (info.exemplars?.length) {
       exemplarsXFacet = info.exemplars?.fields[0].values;
-
       // render by match on ordinal y label
       if (meta.yMatchWithLabel) {
         // ordinal/labeled heatmap-buckets?
         const hasLabeledY = meta.yOrdinalDisplay != null;
-
         if (hasLabeledY) {
           let matchExemplarsBy = info.exemplars?.fields.find((field) => field.name === meta.yMatchWithLabel)!.values;
           exemplarsYFacet = matchExemplarsBy.map((label) => meta.yOrdinalLabel?.indexOf(label));
@@ -127,21 +111,15 @@ const HeatmapPanelViz = ({
         exemplarsYFacet = info.exemplars?.fields[1].values; // "Value" field
       }
     }
-
     return [null, info.heatmap.fields.map((f) => f.values), [exemplarsXFacet, exemplarsYFacet]];
   }, [info.heatmap, info.exemplars]);
-
   // ugh
   const dataRef = useRef(info);
   dataRef.current = info;
-
   const annotationsLength = options.annotations?.multiLane ? getXAnnotationFrames(data.annotations).length : undefined;
-
   const builder = useMemo(() => {
     const scaleConfig: ScaleDistributionConfig = dataRef.current?.heatmap?.fields[1].config?.custom?.scaleDistribution;
-
     const activeScaleConfig = options.rowsFrame?.yBucketScale ?? scaleConfig;
-
     // For log/symlog scales: use 1 for pre-bucketed data with explicit scale, otherwise use split value
     const hasExplicitScale = options.rowsFrame?.yBucketScale !== undefined;
     const ySizeDivisor = calculateYSizeDivisor(
@@ -149,7 +127,6 @@ const HeatmapPanelViz = ({
       hasExplicitScale,
       options.calculation?.yBuckets?.value
     );
-
     return prepConfig({
       dataRef,
       theme,
@@ -165,27 +142,21 @@ const HeatmapPanelViz = ({
       xAxisConfig: getXAxisConfig(annotationsLength),
       rowsFrame: options.rowsFrame,
     });
-
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [options, timeZone, data.structureRev, cursorSync, annotationsLength]);
-
   const renderLegend = () => {
     if (!options.legend.show) {
       return null;
     }
-
     let hoverValue: number | undefined = undefined;
-
     // let heatmapType = dataRef.current?.heatmap?.meta?.type;
     // let isSparseHeatmap = heatmapType === DataFrameType.HeatmapCells && !isHeatmapCellsDense(dataRef.current?.heatmap!);
     // let countFieldIdx = !isSparseHeatmap ? 2 : 3;
     // const countField = info.heatmap.fields[countFieldIdx];
-
     // seriesIdx: 1 is heatmap layer; 2 is exemplar layer
     // if (hover && info.heatmap.fields && hover.seriesIdx === 1) {
     //   hoverValue = countField.values[hover.dataIdx];
     // }
-
     return (
       <VizLayout.Legend placement="bottom" maxHeight="20%">
         <div className={styles.colorScaleWrapper}>
@@ -200,9 +171,7 @@ const HeatmapPanelViz = ({
       </VizLayout.Legend>
     );
   };
-
   const enableAnnotationCreation = Boolean(canAddAnnotations && canAddAnnotations());
-
   return (
     <>
       <VizLayout width={width} height={height} legend={renderLegend()}>
@@ -228,14 +197,11 @@ const HeatmapPanelViz = ({
                     dismiss();
                     return;
                   }
-
                   const annotate = () => {
                     let xVal = u.posToVal(u.cursor.left!, 'x');
-
                     setNewAnnotationRange({ from: xVal, to: xVal });
                     dismiss();
                   };
-
                   return (
                     <HeatmapTooltip
                       mode={viaSync ? TooltipDisplayMode.Multi : options.tooltip.mode}
@@ -275,7 +241,6 @@ const HeatmapPanelViz = ({
     </>
   );
 };
-
 const getStyles = () => ({
   colorScaleWrapper: css({
     marginLeft: '25px',

--- a/public/app/plugins/panel/live/LivePanel.tsx
+++ b/public/app/plugins/panel/live/LivePanel.tsx
@@ -1,8 +1,8 @@
+import { structLog } from '@grafana/data';
 import { css, cx } from '@emotion/css';
 import { isEqual } from 'lodash';
 import { PureComponent } from 'react';
 import { type Unsubscribable, type PartialObserver } from 'rxjs';
-
 import {
   type GrafanaTheme2,
   type PanelProps,
@@ -21,14 +21,10 @@ import {
 import { Trans, t } from '@grafana/i18n';
 import { config, getGrafanaLiveSrv } from '@grafana/runtime';
 import { Alert, stylesFactory, JSONFormatter, CustomScrollbar } from '@grafana/ui';
-
 import { TablePanel } from '../table/TablePanel';
-
 import { LivePublish } from './LivePublish';
 import { type LivePanelOptions, MessageDisplayMode, MessagePublishMode } from './types';
-
 interface Props extends PanelProps<LivePanelOptions> {}
-
 interface State {
   error?: unknown;
   addr?: LiveChannelAddress;
@@ -36,35 +32,28 @@ interface State {
   message?: unknown;
   changed: number;
 }
-
 export class LivePanel extends PureComponent<Props, State> {
   private readonly isValid: boolean;
   subscription?: Unsubscribable;
   styles = getStyles(config.theme2);
-
   constructor(props: Props) {
     super(props);
-
     this.isValid = !!getGrafanaLiveSrv();
     this.state = { changed: 0 };
   }
-
   async componentDidMount() {
     this.loadChannel();
   }
-
   componentWillUnmount() {
     if (this.subscription) {
       this.subscription.unsubscribe();
     }
   }
-
   componentDidUpdate(prevProps: Props): void {
     if (this.props.options?.channel !== prevProps.options?.channel) {
       this.loadChannel();
     }
   }
-
   streamObserver: PartialObserver<LiveChannelEvent> = {
     next: (event: LiveChannelEvent) => {
       if (isLiveChannelStatusEvent(event)) {
@@ -72,37 +61,33 @@ export class LivePanel extends PureComponent<Props, State> {
       } else if (isLiveChannelMessageEvent(event)) {
         this.setState({ message: event.message, changed: Date.now() });
       } else {
-        console.log('ignore', event);
+        structLog('log', 'ignore', event);
       }
     },
   };
-
   unsubscribe = () => {
     if (this.subscription) {
       this.subscription.unsubscribe();
       this.subscription = undefined;
     }
   };
-
   async loadChannel() {
     const addr = this.props.options?.channel;
     if (!isValidLiveChannelAddress(addr)) {
-      console.log('INVALID', addr);
+      structLog('log', 'INVALID', addr);
       this.unsubscribe();
       this.setState({
         addr: undefined,
       });
       return;
     }
-
     if (isEqual(addr, this.state.addr)) {
-      console.log('Same channel', this.state.addr);
+      structLog('log', 'Same channel', this.state.addr);
       return;
     }
-
     const live = getGrafanaLiveSrv();
     if (!live) {
-      console.log('INVALID', addr);
+      structLog('log', 'INVALID', addr);
       this.unsubscribe();
       this.setState({
         addr: undefined,
@@ -110,9 +95,7 @@ export class LivePanel extends PureComponent<Props, State> {
       return;
     }
     this.unsubscribe();
-
-    console.log('LOAD', addr);
-
+    structLog('log', 'LOAD', addr);
     // Subscribe to new events
     try {
       this.subscription = live.getStream(addr).subscribe(this.streamObserver);
@@ -121,7 +104,6 @@ export class LivePanel extends PureComponent<Props, State> {
       this.setState({ addr: undefined, error: err });
     }
   }
-
   renderNotEnabled() {
     const preformatted = `[feature_toggles]
     enable = live`;
@@ -137,11 +119,9 @@ export class LivePanel extends PureComponent<Props, State> {
       </Alert>
     );
   }
-
   renderMessage(height: number) {
     const { options } = this.props;
     const { message } = this.state;
-
     if (!message) {
       return (
         <div>
@@ -152,11 +132,9 @@ export class LivePanel extends PureComponent<Props, State> {
         </div>
       );
     }
-
     if (options.display === MessageDisplayMode.JSON) {
       return <JSONFormatter json={message} open={5} />;
     }
-
     if (options.display === MessageDisplayMode.Auto) {
       if (message instanceof StreamingDataFrame) {
         const data: PanelData = {
@@ -178,10 +156,8 @@ export class LivePanel extends PureComponent<Props, State> {
         return <TablePanel {...props} data={data} height={height} />;
       }
     }
-
     return <pre>{JSON.stringify(message)}</pre>;
   }
-
   renderPublish(height: number) {
     const { options } = this.props;
     return (
@@ -194,30 +170,25 @@ export class LivePanel extends PureComponent<Props, State> {
       />
     );
   }
-
   renderStatus() {
     const { status } = this.state;
     if (status?.state === LiveChannelConnectionState.Connected) {
       return; // nothing
     }
-
     let statusClass = '';
     if (status) {
       statusClass = this.styles.status[status.state];
     }
     return <div className={cx(statusClass, this.styles.statusWrap)}>{status?.state}</div>;
   }
-
   renderBody() {
     const { status } = this.state;
     const { options, height } = this.props;
     const publish = options.publish === MessagePublishMode.JSON || options.publish === MessagePublishMode.Influx;
-
     if (publish) {
       if (options.display === MessageDisplayMode.None) {
         return this.renderPublish(height);
       }
-
       // Both message and publish
       const halfHeight = height / 2;
       return (
@@ -234,7 +205,6 @@ export class LivePanel extends PureComponent<Props, State> {
     if (options.display === MessageDisplayMode.None) {
       return <pre>{JSON.stringify(status)}</pre>;
     }
-
     // Only message
     return (
       <div style={{ overflow: 'hidden', height }}>
@@ -244,7 +214,6 @@ export class LivePanel extends PureComponent<Props, State> {
       </div>
     );
   }
-
   render() {
     if (!this.isValid) {
       return this.renderNotEnabled();
@@ -275,7 +244,6 @@ export class LivePanel extends PureComponent<Props, State> {
     );
   }
 }
-
 const getStyles = stylesFactory((theme: GrafanaTheme2) => ({
   statusWrap: css({
     margin: 'auto',

--- a/public/app/plugins/panel/live/LivePublish.tsx
+++ b/public/app/plugins/panel/live/LivePublish.tsx
@@ -1,12 +1,10 @@
+import { structLog } from '@grafana/data';
 import { useMemo } from 'react';
-
 import { type LiveChannelAddress, isValidLiveChannelAddress } from '@grafana/data';
 import { Trans } from '@grafana/i18n';
 import { getBackendSrv, getGrafanaLiveSrv } from '@grafana/runtime';
 import { CodeEditor, Button } from '@grafana/ui';
-
 import { MessagePublishMode } from './types';
-
 interface Props {
   height: number;
   addr?: LiveChannelAddress;
@@ -14,7 +12,6 @@ interface Props {
   body?: string | object;
   onSave: (v: string | object) => void;
 }
-
 export function LivePublish({ height, mode, body, addr, onSave }: Props) {
   const txt = useMemo(() => {
     if (mode === MessagePublishMode.JSON) {
@@ -22,7 +19,6 @@ export function LivePublish({ height, mode, body, addr, onSave }: Props) {
     }
     return body == null ? '' : `${body}`;
   }, [mode, body]);
-
   const doSave = (v: string) => {
     if (mode === MessagePublishMode.JSON) {
       onSave(JSON.parse(v));
@@ -30,7 +26,6 @@ export function LivePublish({ height, mode, body, addr, onSave }: Props) {
       onSave(v);
     }
   };
-
   const onPublishClicked = async () => {
     if (mode === MessagePublishMode.Influx) {
       if (addr?.scope !== 'stream') {
@@ -39,16 +34,13 @@ export function LivePublish({ height, mode, body, addr, onSave }: Props) {
       }
       return getBackendSrv().post(`api/live/push/${addr.stream}`, body);
     }
-
     if (!isValidLiveChannelAddress(addr)) {
       alert('invalid address');
       return;
     }
-
     const rsp = await getGrafanaLiveSrv().publish(addr, body);
-    console.log('onPublishClicked (response from publish)', rsp);
+    structLog('log', 'onPublishClicked (response from publish)', rsp);
   };
-
   return (
     <>
       <CodeEditor

--- a/public/app/plugins/panel/logs/LogsPanel.tsx
+++ b/public/app/plugins/panel/logs/LogsPanel.tsx
@@ -1,9 +1,9 @@
+import { structLog } from '@grafana/data';
 import { css, cx } from '@emotion/css';
 import { groupBy } from 'lodash';
 import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import * as React from 'react';
 import { isObservable, lastValueFrom } from 'rxjs';
-
 import {
   type AbsoluteTimeRange,
   CoreApp,
@@ -44,12 +44,10 @@ import { LogList } from 'app/features/logs/components/panel/LogList';
 import { getLogsPanelState } from 'app/features/logs/components/panel/panelState/getLogsPanelState';
 import { PanelDataErrorView } from 'app/features/panel/components/PanelDataErrorView';
 import { combineResponses } from 'app/plugins/datasource/loki/mergeResponses';
-
 import { createAndCopyShortLink, getLogsPermalinkRange } from '../../../core/utils/shortLinks';
 import { LogLabels } from '../../../features/logs/components/LogLabels';
 import { LogRows } from '../../../features/logs/components/LogRows';
 import { COMMON_LABELS, dataFrameToLogsModel, dedupLogRows } from '../../../features/logs/logsModel';
-
 import type { Options } from './panelcfg.gen';
 import {
   type GetFieldLinksFn,
@@ -70,80 +68,8 @@ import {
   type onNewLogsReceivedType,
 } from './types';
 import { useDatasourcesFromTargets } from './useDatasourcesFromTargets';
-
-interface LogsPanelProps extends PanelProps<Options> {
-  /**
-   * Adds a key => value filter to the query referenced by the provided DataFrame refId. Used by Log details and Logs table.
-   * onClickFilterLabel?: (key: string, value: string, frame?: DataFrame) => void;
-   *
-   * Adds a negative key => value filter to the query referenced by the provided DataFrame refId. Used by Log details and Logs table.
-   * onClickFilterOutLabel?: (key: string, value: string, frame?: DataFrame) => void;
-   *
-   * Adds a string filter to the query referenced by the provided DataFrame refId. Used by the Logs popover menu.
-   * onClickFilterOutString?: (value: string, refId?: string) => void;
-   *
-   * Removes a string filter to the query referenced by the provided DataFrame refId. Used by the Logs popover menu.
-   * onClickFilterString?: (value: string, refId?: string) => void;
-   *
-   * Determines if a given key => value filter is active in a given query. Used by Log details.
-   * isFilterLabelActive?: (key: string, value: string, refId?: string) => Promise<boolean>;
-   *
-   * Array of field names to display instead of the log line. Pass a list of fields or an empty array to enable hide/show fields in Log Details.
-   * displayedFields?: string[]
-   *
-   * Called from the "eye" icon in Log Details to request showing the displayed field. If ommited, a default implementation is used.
-   * onClickShowField?: (key: string) => void;
-   *
-   * Called from the "eye" icon in Log Details to request hiding the displayed field. If ommited, a default implementation is used.
-   * onClickHideField?: (key: string) => void;
-   *
-   * Called from the new Log Details Panel when fields are reordered. If ommited, a default implementation is used.
-   * setDisplayedFields?: (key: string) => void;
-   *
-   * Passed to the LogRowMenuCell component to be rendered before the default actions in the menu.
-   * logRowMenuIconsBefore?: ReactNode[];
-   *
-   * Passed to the LogRowMenuCell component to be rendered after the default actions in the menu.
-   * logRowMenuIconsAfter?: ReactNode[];
-   *
-   * Callback to be invoked when enableInfiniteScrolling and new logs have been received after an scroll event.
-   * onNewLogsReceived?: (allLogs: DataFrame[], newLogs: DataFrame[]) => void;
-   *
-   * Log Controls props:
-   *
-   * Enables a sidebar with controls for scrolling, sort order, deduplication, filtering, timestamps, wrapping, etc.
-   * showControls?: boolean
-   *
-   * If controls are enabled, the component will use this key to store changes to the aforementioned options.
-   * controlsStorageKey?: string
-   *
-   * If controls are enabled, this function is called when a change is made in one of the options from the controls.
-   * onLogOptionsChange?: (option: LogListOptions, value: string | boolean | string[]) => void;
-   *
-   * When the feature toggle newLogsPanel is enabled, you can pass extra options to the LogLineMenu component.
-   * These options are an array of items with { label, onClick } or { divider: true } for dividers.
-   * logLineMenuCustomItems?: LogLineMenuCustomItem[];
-   *
-   * Use the default, bigger, font size, or a smaller one. Defaults to "default".
-   * fontSize?: 'default' | 'small'
-   *
-   * Set the mode used by the Log Details panel. Displayed as a sidebar, or inline below the log line. Defaults to "inline".
-   * detailsMode?: 'inline' | 'sidebar'
-   *
-   * When showing timestamps, toggle between showing nanoseconds or milliseconds.
-   * timestampResolution?: 'ms' | 'ns'
-   *
-   * Experimental. When OTel logs are displayed, add an extra displayed field with relevant key-value pairs from labels and metadata.
-   * Requires the `otelLogsFormatting`.
-   * @alpha
-   * showLogAttributes?: boolean
-   *
-   * Custom Prism grammar definition for highlighting. When used, the .prism-syntax-highlight CSS class name is applied to the component, to allow standard token colors to be applied.
-   * grammar?: Grammar
-   */
-}
+interface LogsPanelProps extends PanelProps<Options> {}
 const noCommonLabels: Labels = {};
-
 export const LogsPanel = ({ data, timeZone, fieldConfig, options, onOptionsChange, height, id }: LogsPanelProps) => {
   const {
     showControls,
@@ -195,7 +121,6 @@ export const LogsPanel = ({ data, timeZone, fieldConfig, options, onOptionsChang
   const keepScrollPositionRef = useRef<null | 'infinite-scroll' | 'user'>(null);
   const closeCallback = useRef<(() => void) | undefined>(undefined);
   const { app, eventBus, onAddAdHocFilter } = usePanelContext();
-
   useEffect(() => {
     getAppEvents().publish(
       new LogSortOrderChangeEvent({
@@ -203,7 +128,6 @@ export const LogsPanel = ({ data, timeZone, fieldConfig, options, onOptionsChang
       })
     );
   }, [sortOrder]);
-
   const onLogRowHover = useCallback(
     (row?: LogRowModel) => {
       if (row) {
@@ -218,18 +142,15 @@ export const LogsPanel = ({ data, timeZone, fieldConfig, options, onOptionsChang
     },
     [eventBus]
   );
-
   const onLogContainerMouseLeave = useCallback(() => {
     eventBus.publish(new DataHoverClearEvent());
   }, [eventBus]);
-
   const onCloseContext = useCallback(() => {
     setContextRow(null);
     if (closeCallback.current) {
       closeCallback.current();
     }
   }, [closeCallback]);
-
   const onOpenContext = useCallback(
     (row: LogRowModel, onClose: () => void) => {
       setContextRow(row);
@@ -237,7 +158,6 @@ export const LogsPanel = ({ data, timeZone, fieldConfig, options, onOptionsChang
     },
     [closeCallback]
   );
-
   const showContextToggle = useCallback(
     (row: LogRowModel): boolean => {
       if (
@@ -250,13 +170,11 @@ export const LogsPanel = ({ data, timeZone, fieldConfig, options, onOptionsChang
       ) {
         return false;
       }
-
       const dataSource = dataSourcesMap.get(row.dataFrame.refId);
       return hasLogsContextSupport(dataSource);
     },
     [dataSourcesMap, showLogContextToggle, panelData.request?.app]
   );
-
   const showPermaLink = useCallback(() => {
     return !(
       panelData.request?.app !== CoreApp.Dashboard &&
@@ -264,55 +182,44 @@ export const LogsPanel = ({ data, timeZone, fieldConfig, options, onOptionsChang
       panelData.request?.app !== CoreApp.PanelViewer
     );
   }, [panelData.request?.app]);
-
   const getLogRowContext = useCallback(
     async (row: LogRowModel, origRow: LogRowModel, options: LogRowContextOptions): Promise<DataQueryResponse> => {
       if (!origRow.dataFrame.refId || !dataSourcesMap) {
         return Promise.resolve({ data: [] });
       }
-
       const query = panelData.request?.targets[0];
       if (!query) {
         return Promise.resolve({ data: [] });
       }
-
       const dataSource = dataSourcesMap.get(origRow.dataFrame.refId);
       if (!hasLogsContextSupport(dataSource)) {
         return Promise.resolve({ data: [] });
       }
-
       options.scopedVars = panelData.request?.scopedVars;
-
       return dataSource.getLogRowContext(row, options, query);
     },
     [panelData.request?.targets, panelData.request?.scopedVars, dataSourcesMap]
   );
-
   const getLogRowContextUi = useCallback(
     (origRow: LogRowModel, runContextQuery?: () => void): React.ReactNode => {
       if (!origRow.dataFrame.refId || !dataSourcesMap) {
         return <></>;
       }
-
       const query = panelData.request?.targets[0];
       if (!query) {
         return <></>;
       }
-
       const dataSource = dataSourcesMap.get(origRow.dataFrame.refId);
       if (!hasLogsContextUiSupport(dataSource)) {
         return <></>;
       }
-
       if (!dataSource.getLogRowContextUi) {
         return <></>;
       }
-
       return dataSource.getLogRowContextUi(origRow, runContextQuery, query, panelData.request?.scopedVars);
     },
     [panelData.request?.targets, panelData.request?.scopedVars, dataSourcesMap]
   );
-
   // Important to memoize stuff here, as panel rerenders a lot for example when resizing.
   const [logRows, deduplicatedRows, commonLabels] = useMemo(() => {
     const logs = panelData
@@ -329,20 +236,17 @@ export const LogsPanel = ({ data, timeZone, fieldConfig, options, onOptionsChang
     const deduplicatedRows = dedupLogRows(logRows, dedupStrategy);
     return [logRows, deduplicatedRows, commonLabels];
   }, [dedupStrategy, enableInfiniteScrolling, panelData]);
-
   const onPermalinkClick = useCallback(
     async (row: LogRowModel) => {
       return await copyDashboardUrl(row, logRows, panelData.timeRange);
     },
     [panelData.timeRange, logRows]
   );
-
   useEffect(() => {
     if (data.state !== LoadingState.Loading) {
       setPanelData(data);
     }
   }, [data]);
-
   useLayoutEffect(() => {
     if (config.featureToggles.newLogsPanel) {
       return;
@@ -360,7 +264,6 @@ export const LogsPanel = ({ data, timeZone, fieldConfig, options, onOptionsChang
       scrollElement.scrollTo(0, isAscending ? logsContainerRef.current.scrollHeight : 0);
     }
   }, [panelData.request?.app, isAscending, scrollElement, logRows]);
-
   const getFieldLinks: GetFieldLinksFn = useCallback(
     (field, rowIndex, dataFrame, vars) => {
       return getFieldLinksForExplore({
@@ -373,7 +276,6 @@ export const LogsPanel = ({ data, timeZone, fieldConfig, options, onOptionsChang
     },
     [panelData]
   );
-
   /**
    * Scrolls the given row into view.
    */
@@ -386,7 +288,6 @@ export const LogsPanel = ({ data, timeZone, fieldConfig, options, onOptionsChang
     },
     [scrollElement]
   );
-
   const handleOnClickFilterLabel = useCallback(
     (key: string, value: string) => {
       onAddAdHocFilter?.({
@@ -397,7 +298,6 @@ export const LogsPanel = ({ data, timeZone, fieldConfig, options, onOptionsChang
     },
     [onAddAdHocFilter]
   );
-
   const handleOnClickFilterOutLabel = useCallback(
     (key: string, value: string) => {
       onAddAdHocFilter?.({
@@ -408,7 +308,6 @@ export const LogsPanel = ({ data, timeZone, fieldConfig, options, onOptionsChang
     },
     [onAddAdHocFilter]
   );
-
   const showField = useCallback(
     (key: string) => {
       const index = displayedFields?.indexOf(key);
@@ -423,7 +322,6 @@ export const LogsPanel = ({ data, timeZone, fieldConfig, options, onOptionsChang
     },
     [displayedFields, onOptionsChange, options]
   );
-
   const hideField = useCallback(
     (key: string) => {
       const index = displayedFields?.indexOf(key);
@@ -438,13 +336,11 @@ export const LogsPanel = ({ data, timeZone, fieldConfig, options, onOptionsChang
     },
     [displayedFields, onOptionsChange, options]
   );
-
   useEffect(() => {
     if (options.displayedFields) {
       setDisplayedFields(options.displayedFields);
     }
   }, [options.displayedFields]);
-
   // Respect the scroll position when refreshing the panel
   useEffect(() => {
     function handleScroll() {
@@ -468,18 +364,14 @@ export const LogsPanel = ({ data, timeZone, fieldConfig, options, onOptionsChang
       scrollElement?.removeEventListener('wheel', handleScroll);
     };
   }, [isAscending, scrollElement]);
-
   const loadMoreLogs = useCallback(
     async (scrollRange: AbsoluteTimeRange) => {
       if (!data.request || loadingRef.current) {
         return;
       }
-
       loadingRef.current = true;
       setInfiniteScrolling(true);
-
       const onNewLogsReceivedCallback = isOnNewLogsReceivedType(onNewLogsReceived) ? onNewLogsReceived : undefined;
-
       let newSeries: DataFrame[] = [];
       try {
         newSeries = await requestMoreLogs(dataSourcesMap, panelData, scrollRange, timeZone, onNewLogsReceivedCallback);
@@ -488,12 +380,11 @@ export const LogsPanel = ({ data, timeZone, fieldConfig, options, onOptionsChang
           newSeries = await lastValueFrom(transformDataFrame(panel?.transformations, newSeries));
         }
       } catch (e) {
-        console.error(e);
+        structLog('error', e);
       } finally {
         setInfiniteScrolling(false);
         loadingRef.current = false;
       }
-
       keepScrollPositionRef.current = 'infinite-scroll';
       setPanelData({
         ...panelData,
@@ -502,7 +393,6 @@ export const LogsPanel = ({ data, timeZone, fieldConfig, options, onOptionsChang
     },
     [data.request, dataSourcesMap, id, onNewLogsReceived, panelData, timeZone]
   );
-
   const renderCommonLabels = () => (
     <div className={cx(style.labelContainer, isAscending && style.labelContainerAscending)}>
       <span className={style.label}>
@@ -514,7 +404,6 @@ export const LogsPanel = ({ data, timeZone, fieldConfig, options, onOptionsChang
       />
     </div>
   );
-
   const initialScrollPosition = useMemo(() => {
     /**
      * In dashboards, users with newest logs at the bottom have the expectation of keeping the scroll at the bottom
@@ -525,7 +414,6 @@ export const LogsPanel = ({ data, timeZone, fieldConfig, options, onOptionsChang
     }
     return 'top';
   }, [app, sortOrder]);
-
   const storageKey = useMemo(() => {
     if (controlsStorageKey) {
       return controlsStorageKey;
@@ -535,24 +423,19 @@ export const LogsPanel = ({ data, timeZone, fieldConfig, options, onOptionsChang
     }
     return `${data.request?.dashboardUID}.${id}`;
   }, [controlsStorageKey, data.request, id]);
-
   if (!data || logRows.length === 0) {
     return <PanelDataErrorView fieldConfig={fieldConfig} panelId={id} data={data} needsStringField />;
   }
-
   // Passing callbacks control the display of the filtering buttons. We want to pass it only if onAddAdHocFilter is defined.
   const defaultOnClickFilterLabel = onAddAdHocFilter ? handleOnClickFilterLabel : undefined;
   const defaultOnClickFilterOutLabel = onAddAdHocFilter ? handleOnClickFilterOutLabel : undefined;
-
   const onClickShowField = isOnClickShowField(options.onClickShowField) ? options.onClickShowField : showField;
   const onClickHideField = isOnClickHideField(options.onClickHideField) ? options.onClickHideField : hideField;
   const setDisplayedFieldsFn = isSetDisplayedFields(options.setDisplayedFields)
     ? options.setDisplayedFields
     : setDisplayedFields;
-
   // In Dashboards, default to inline. Otherwise, let apps control or have automatic behavior.
   const detailsMode = detailsModeProp ? detailsModeProp : app === CoreApp.Dashboard ? 'inline' : undefined;
-
   return (
     <>
       {(!config.featureToggles.newLogsPanel || !config.featureToggles.newLogContext) && contextRow && (
@@ -767,7 +650,6 @@ export const LogsPanel = ({ data, timeZone, fieldConfig, options, onOptionsChang
     </>
   );
 };
-
 const getStyles = (theme: GrafanaTheme2) => ({
   container: css({
     marginBottom: theme.spacing(1.5),
@@ -797,7 +679,6 @@ const getStyles = (theme: GrafanaTheme2) => ({
     fontWeight: theme.typography.fontWeightMedium,
   }),
 });
-
 async function copyDashboardUrl(row: LogRowModel, rows: LogRowModel[], timeRange: TimeRange) {
   // this is an extra check, to be sure that we are not
   // creating permalinks for logs without an id-field.
@@ -806,15 +687,12 @@ async function copyDashboardUrl(row: LogRowModel, rows: LogRowModel[], timeRange
   if (row.rowId === undefined || !row.dataFrame.refId) {
     return;
   }
-
   // get panel state, add log-row-id
   const panelState = {
     logs: { id: row.uid },
   };
-
   // Grab the current dashboard URL
   const currentURL = new URL(window.location.href);
-
   // Add panel state containing the rowId, and absolute time range from the current query, but leave everything else the same, if the user is in edit mode when grabbing the link, that's what will be linked to, etc.
   currentURL.searchParams.set('panelState', JSON.stringify(panelState));
   const range = getLogsPermalinkRange(row, rows, {
@@ -823,12 +701,9 @@ async function copyDashboardUrl(row: LogRowModel, rows: LogRowModel[], timeRange
   });
   currentURL.searchParams.set('from', range.from.toString());
   currentURL.searchParams.set('to', range.to.toString());
-
   await createAndCopyShortLink(currentURL.toString());
-
   return Promise.resolve();
 }
-
 export async function requestMoreLogs(
   dataSourcesMap: Map<string, DataSourceApi>,
   panelData: PanelData,
@@ -839,19 +714,16 @@ export async function requestMoreLogs(
   if (!panelData.request) {
     return [];
   }
-
   const range: TimeRange = rangeUtil.convertRawToRange({
     from: dateTimeForTimeZone(timeZone, timeRange.from),
     to: dateTimeForTimeZone(timeZone, timeRange.to),
   });
-
   const targetGroups = groupBy(panelData.request.targets, 'datasource.uid');
   const dataRequests = [];
-
   for (const uid in targetGroups) {
     const dataSource = dataSourcesMap.get(panelData.request.targets[0].refId);
     if (!dataSource) {
-      console.warn(`Could not resolve data source for target ${panelData.request.targets[0].refId}`);
+      structLog('warn', `Could not resolve data source for target ${panelData.request.targets[0].refId}`);
       continue;
     }
     dataRequests.push(
@@ -862,23 +734,19 @@ export async function requestMoreLogs(
       })
     );
   }
-
   const responses = await Promise.all(dataRequests);
   let updatedSeries = panelData.series;
   for (const response of responses) {
     const newData = isObservable(response) ? await lastValueFrom(response) : response;
-
     updatedSeries = combineResponses(
       {
         data: updatedSeries,
       },
       { data: newData.data }
     ).data;
-
     if (onNewLogsReceived) {
       onNewLogsReceived(updatedSeries, newData.data);
     }
   }
-
   return updatedSeries;
 }

--- a/public/app/plugins/panel/logstable/fieldSelector/buildColumnsWithMeta.ts
+++ b/public/app/plugins/panel/logstable/fieldSelector/buildColumnsWithMeta.ts
@@ -1,16 +1,14 @@
+import { structLog } from '@grafana/data';
 import { type DataFrame, type FieldWithIndex, getFieldDisplayName } from '@grafana/data';
 import { type FieldNameMeta, type FieldNameMetaStore } from 'app/features/explore/Logs/LogsTableWrap';
 import { LOG_LINE_BODY_FIELD_NAME } from 'app/features/logs/components/fieldSelector/logFields';
-
 type FieldName = string;
-
 export interface LogsFrameFields {
   extraFields: FieldWithIndex[];
   severityField: FieldWithIndex | null;
   bodyField: FieldWithIndex;
   timeField: FieldWithIndex;
 }
-
 export const buildColumnsWithMeta = (
   logsFrameFields: LogsFrameFields,
   dataFrame: DataFrame,
@@ -18,7 +16,6 @@ export const buildColumnsWithMeta = (
 ) => {
   const otherFields = [];
   const numberOfLogLines = logsFrameFields?.timeField.values.length;
-
   if (logsFrameFields.extraFields) {
     otherFields.push(...logsFrameFields.extraFields.filter((field) => !field?.config?.custom?.hidden));
   }
@@ -31,13 +28,10 @@ export const buildColumnsWithMeta = (
   if (logsFrameFields?.timeField) {
     otherFields.push(logsFrameFields?.timeField);
   }
-
   // Use a map to dedupe labels and count their occurrences in the logs
   const labelCardinality = new Map<FieldName, FieldNameMeta>();
-
   // What the label state will look like
   let pendingLabelState: FieldNameMetaStore = {};
-
   // If we have labels and log lines
   if (dataFrame.fields.length && numberOfLogLines) {
     // Iterate through all of fields
@@ -50,17 +44,14 @@ export const buildColumnsWithMeta = (
         }
         return acc;
       }, 0);
-
       labelCardinality.set(fieldName, {
         percentOfLinesWithLabel: countOfValues,
         active: false,
         index: undefined,
       });
     });
-
     // Converting the map to an object
     pendingLabelState = Object.fromEntries(labelCardinality);
-
     // Convert count to percent of log lines
     Object.keys(pendingLabelState).forEach((key) => {
       pendingLabelState[key].percentOfLinesWithLabel = normalize(
@@ -69,7 +60,6 @@ export const buildColumnsWithMeta = (
       );
     });
   }
-
   // Normalize the other fields
   otherFields.forEach((field) => {
     const fieldName = getFieldDisplayName(field);
@@ -95,7 +85,6 @@ export const buildColumnsWithMeta = (
       };
     }
   });
-
   displayedFields.forEach((fieldName, idx) => {
     if (pendingLabelState[fieldName]) {
       pendingLabelState[fieldName].active = true;
@@ -104,10 +93,9 @@ export const buildColumnsWithMeta = (
       pendingLabelState[logsFrameFields.bodyField?.name].active = true;
       pendingLabelState[logsFrameFields.bodyField?.name].index = idx;
     } else {
-      console.error(`Unknown field ${fieldName}`, { pendingLabelState, displayedFields });
+      structLog('error', `Unknown field ${fieldName}`, { pendingLabelState, displayedFields });
     }
   });
-
   // If nothing is selected, then select the default columns
   if (displayedFields.length === 0) {
     if (logsFrameFields?.bodyField?.name) {
@@ -119,15 +107,12 @@ export const buildColumnsWithMeta = (
       pendingLabelState[logsFrameFields.timeField.name].active = true;
     }
   }
-
   if (logsFrameFields?.bodyField?.name && logsFrameFields?.timeField?.name) {
     pendingLabelState[logsFrameFields.bodyField.name].type = 'BODY_FIELD';
     pendingLabelState[logsFrameFields.timeField.name].type = 'TIME_FIELD';
   }
-
   return pendingLabelState;
 };
-
 const normalize = (value: number, total: number): number => {
   return Math.ceil((100 * value) / total);
 };

--- a/public/app/plugins/panel/logstable/hooks/useExtractFields.ts
+++ b/public/app/plugins/panel/logstable/hooks/useExtractFields.ts
@@ -1,7 +1,7 @@
+import { structLog } from '@grafana/data';
 import { useState, useEffect } from 'react';
 import useMountedState from 'react-use/lib/useMountedState';
 import { lastValueFrom } from 'rxjs';
-
 import {
   applyFieldOverrides,
   type DataFrame,
@@ -13,34 +13,28 @@ import {
 import { getTemplateSrv } from '@grafana/runtime';
 import { useTheme2 } from '@grafana/ui';
 import { replaceVariables } from '@grafana-plugins/loki/querybuilder/parsingUtils';
-
 import { extractLogsFieldsTransform } from '../transforms/extractLogsFieldsTransform';
-
 interface Props {
   rawTableFrame: DataFrame | null;
   fieldConfig?: FieldConfigSource;
   timeZone: TimeZone;
 }
-
 export function useExtractFields({ rawTableFrame, fieldConfig, timeZone }: Props) {
   const dataLinksContext = useDataLinksContext();
   const isMounted = useMountedState();
   const dataLinkPostProcessor = dataLinksContext.dataLinkPostProcessor;
   const [extractedFrame, setExtractedFrame] = useState<DataFrame | null>(null);
   const theme = useTheme2();
-
   useEffect(() => {
     if (!fieldConfig) {
       return;
     }
-
     const extractFields = async () => {
       if (!rawTableFrame) {
         return Promise.resolve([]);
       }
       return await lastValueFrom(transformDataFrame(extractLogsFieldsTransform(rawTableFrame), [rawTableFrame]));
     };
-
     extractFields()
       .then((data) => {
         const extractedFrames = applyFieldOverrides({
@@ -56,11 +50,10 @@ export function useExtractFields({ rawTableFrame, fieldConfig, timeZone }: Props
         }
       })
       .catch((err) => {
-        console.error('LogsTable: Extract fields transform error', err);
+        structLog('error', 'LogsTable: Extract fields transform error', err);
       });
     // @todo hook re-renders unexpectedly when data frame isn't changing if we add `rawTableFrame` as dependency, so we check for changes in the timestamps instead
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [dataLinkPostProcessor, fieldConfig, rawTableFrame?.fields[1]?.values, theme, timeZone]);
-
   return { extractedFrame };
 }

--- a/public/app/plugins/panel/logstable/hooks/useOrganizeFields.tsx
+++ b/public/app/plugins/panel/logstable/hooks/useOrganizeFields.tsx
@@ -1,11 +1,10 @@
+import { structLog } from '@grafana/data';
 import { useEffect, useState } from 'react';
 import useMountedState from 'react-use/lib/useMountedState';
 import { lastValueFrom } from 'rxjs';
-
 import { type DataFrame, type FieldConfigSource, transformDataFrame } from '@grafana/data';
 import { type CustomCellRendererProps, TableCellDisplayMode } from '@grafana/ui';
 import { type LogsFrame } from 'app/features/logs/logsFrame';
-
 import { LOG_LINE_BODY_FIELD_NAME } from '../../../../features/logs/components/fieldSelector/logFields';
 import { LogsTableCustomCellRenderer } from '../cells/LogsTableCustomCellRenderer';
 import { getLogLevelColumnEnhancements } from '../fields/defaultLogLevelColumnConfig';
@@ -16,7 +15,6 @@ import { getDisplayedFields } from '../options/getDisplayedFields';
 import type { Options as LogsTableOptions } from '../panelcfg.gen';
 import { organizeLogsFieldsTransform } from '../transforms/organizeLogsFieldsTransform';
 import { type BuildLinkToLogLine, isBuildLinkToLogLine } from '../types';
-
 interface Props {
   extractedFrame: DataFrame | null;
   timeFieldName: string;
@@ -28,7 +26,6 @@ interface Props {
   onPermalinkClick: BuildLinkToLogLine;
   fieldConfig: FieldConfigSource;
 }
-
 export function useOrganizeFields({
   extractedFrame,
   timeFieldName,
@@ -42,7 +39,6 @@ export function useOrganizeFields({
 }: Props) {
   const [organizedFrame, setOrganizedFrame] = useState<DataFrame | null>(null);
   const isMounted = useMountedState();
-
   /**
    * Organize fields transform
    */
@@ -50,7 +46,6 @@ export function useOrganizeFields({
     if (!extractedFrame || !timeFieldName || !bodyFieldName || !logsFrame) {
       return;
     }
-
     organizeFields(
       extractedFrame,
       options,
@@ -68,7 +63,7 @@ export function useOrganizeFields({
         }
       })
       .catch((err) => {
-        console.error('LogsTable: Organize fields transform error', err);
+        structLog('error', 'LogsTable: Organize fields transform error', err);
       });
   }, [
     bodyFieldName,
@@ -82,10 +77,8 @@ export function useOrganizeFields({
     isMounted,
     fieldConfig,
   ]);
-
   return { organizedFrame };
 }
-
 const organizeFields = async (
   extractedFrame: DataFrame,
   options: LogsTableOptions,
@@ -100,9 +93,7 @@ const organizeFields = async (
   if (!extractedFrame) {
     return Promise.resolve(null);
   }
-
   const displayedFields = getDisplayedFields(options, timeFieldName, levelFieldName);
-
   let indexByName: Record<string, number> = {};
   let includeByName: Record<string, boolean> = {};
   for (let [idx, field] of displayedFields.entries()) {
@@ -113,30 +104,24 @@ const organizeFields = async (
     indexByName[field] = idx;
     includeByName[field] = true;
   }
-
   const organizedFrame = await lastValueFrom(
     transformDataFrame(organizeLogsFieldsTransform(indexByName, includeByName), [extractedFrame])
   );
-
   for (let frameIndex = 0; frameIndex < organizedFrame.length; frameIndex++) {
     const frame = organizedFrame[frameIndex];
-
     const levelField = frame.fields.find((f) => f.name === levelFieldName);
     let isLevelFirstField = false;
     if (levelField) {
       normalizeLogLevelFieldInPlace(levelField);
       isLevelFirstField = frame.fields.indexOf(levelField) === 0;
     }
-
     for (const [fieldIndex, field] of frame.fields.entries()) {
       const isFirstField = (!isLevelFirstField && fieldIndex === 0) || (isLevelFirstField && fieldIndex === 1);
       const baseConfig = {
         ...fieldConfig.defaults,
         ...field.config,
       };
-
       const levelEnhancements = getLogLevelColumnEnhancements(field, levelFieldName, baseConfig);
-
       const configAfterLevel = {
         ...baseConfig,
         ...(levelEnhancements?.mappings ? { mappings: levelEnhancements.mappings } : {}),
@@ -146,12 +131,10 @@ const organizeFields = async (
           ...(levelEnhancements?.width !== undefined ? { width: levelEnhancements.width } : {}),
         },
       };
-
       // We are mutating fields. Would it be possible to avoid it?
       if (configAfterLevel.custom?.cellOptions?.cellComponent) {
         configAfterLevel.custom.cellOptions = undefined;
       }
-
       field.config = {
         ...configAfterLevel,
         filterable: field.config?.filterable ?? doesFieldSupportAdHocFiltering(field, timeFieldName, bodyFieldName),
@@ -183,6 +166,5 @@ const organizeFields = async (
       };
     }
   }
-
   return organizedFrame[0];
 };

--- a/public/app/plugins/panel/logstable/rows/LogsTableRowActionButtons.tsx
+++ b/public/app/plugins/panel/logstable/rows/LogsTableRowActionButtons.tsx
@@ -1,6 +1,6 @@
+import { structLog } from '@grafana/data';
 import { css } from '@emotion/css';
 import { useState } from 'react';
-
 import { type GrafanaTheme2 } from '@grafana/data';
 import { t } from '@grafana/i18n';
 import {
@@ -12,15 +12,12 @@ import {
   useTheme2,
 } from '@grafana/ui';
 import { type LogsFrame } from 'app/features/logs/logsFrame';
-
 import { type BuildLinkToLogLine } from '../types';
-
 interface Props extends CustomCellRendererProps {
   buildLinkToLog?: BuildLinkToLogLine;
   showInspectLogLine: boolean;
   logsFrame: LogsFrame;
 }
-
 /**
  * Logs row actions buttons
  * @param props
@@ -31,11 +28,9 @@ export function LogsTableRowActionButtons(props: Props) {
   const theme = useTheme2();
   const [isInspecting, setIsInspecting] = useState(false);
   const styles = getStyles(theme);
-
   const handleViewClick = () => {
     setIsInspecting(true);
   };
-
   return (
     <>
       <div className={styles.container}>
@@ -71,7 +66,7 @@ export function LogsTableRowActionButtons(props: Props) {
                 if (logId) {
                   return buildLinkToLog(logId) ?? '';
                 } else {
-                  console.error('failed to copy log line link!');
+                  structLog('error', 'failed to copy log line link!');
                 }
                 return '';
               }}
@@ -91,12 +86,10 @@ export function LogsTableRowActionButtons(props: Props) {
     </>
   );
 }
-
 const getLineValue = (logsFrame: LogsFrame, rowIndex: number) => {
   const bodyField = logsFrame.bodyField;
   return bodyField?.values[rowIndex];
 };
-
 export const getStyles = (theme: GrafanaTheme2) => ({
   container: css({
     background: theme.colors.background.secondary,

--- a/public/app/plugins/panel/news/utils.ts
+++ b/public/app/plugins/panel/news/utils.ts
@@ -1,32 +1,27 @@
+import { structLog } from '@grafana/data';
 import { FieldType, type DataFrame, dateTime } from '@grafana/data';
-
 import { type Feed } from './types';
-
 export function feedToDataFrame(feed: Feed): DataFrame {
   const date: number[] = [];
   const title: string[] = [];
   const link: string[] = [];
   const content: string[] = [];
   const ogImage: Array<string | undefined | null> = [];
-
   for (const item of feed.items) {
     const val = dateTime(item.pubDate);
-
     try {
       date.push(val.valueOf());
       title.push(item.title);
       link.push(item.link);
       ogImage.push(item.ogImage);
-
       if (item.content) {
         const body = item.content.replace(/<\/?[^>]+(>|$)/g, '');
         content.push(body);
       }
     } catch (err) {
-      console.warn('Error reading news item:', err, item);
+      structLog('warn', 'Error reading news item:', err, item);
     }
   }
-
   return {
     fields: [
       { name: 'date', type: FieldType.time, config: { displayName: 'Date' }, values: date },

--- a/public/app/plugins/panel/table/migrations.ts
+++ b/public/app/plugins/panel/table/migrations.ts
@@ -1,5 +1,5 @@
+import { structLog } from '@grafana/data';
 import { omitBy, isNil, isNumber, defaultTo, groupBy, omit } from 'lodash';
-
 import {
   type PanelModel,
   FieldMatcherID,
@@ -12,9 +12,7 @@ import {
   ByNamesMatcherMode,
 } from '@grafana/data';
 import { type ReduceTransformerOptions } from '@grafana/data/internal';
-
 import { type Options } from './panelcfg.gen';
-
 /**
  * At 7.0, the `table` panel was swapped from an angular implementation to a react one.
  * The models do not match, so this process will delegate to the old implementation when
@@ -23,26 +21,21 @@ import { type Options } from './panelcfg.gen';
 export const tableMigrationHandler = (panel: PanelModel<Options>): Partial<Options> => {
   // Table was saved as an angular table, lets just swap to the 'table-old' panel
   if (!panel.pluginVersion && 'columns' in panel) {
-    console.log('Was angular table', panel);
+    structLog('log', 'Was angular table', panel);
   }
-
   // ensure overrides array exists before applying rest of overrides
   panel.fieldConfig.overrides = panel.fieldConfig.overrides ?? [];
-
   migrateTextWrapToFieldLevel(panel);
   migrateHiddenFields(panel);
   migrateFooterV2(panel);
-
   return panel.options;
 };
-
 const transformsMap = {
   timeseries_to_rows: 'seriesToRows',
   timeseries_to_columns: 'seriesToColumns',
   timeseries_aggregations: 'reduce',
   table: 'merge',
 };
-
 const columnsMap = {
   avg: 'mean',
   min: 'min',
@@ -51,39 +44,34 @@ const columnsMap = {
   current: 'lastNotNull',
   count: 'count',
 };
-
 const colorModeMap = {
   cell: 'color-background',
   row: 'color-background',
   value: 'color-text',
 };
-
 type Transformations = keyof typeof transformsMap;
-
 type Transformation = {
   id: string;
   options: ReduceTransformerOptions;
 };
-
 type Columns = keyof typeof columnsMap;
-
 type Column = {
   value: Columns;
   text: string;
 };
-
 type ColorModes = keyof typeof colorModeMap;
-
 const generateThresholds = (thresholds: string[], colors: string[]) => {
   return [-Infinity, ...thresholds].map((threshold, idx) => ({
     color: colors[idx],
     value: isNumber(threshold) ? threshold : parseInt(threshold, 10),
   }));
 };
-
 const migrateTransformations = (
   panel: PanelModel<Partial<Options>>,
-  oldOpts: { columns: any; transform: Transformations }
+  oldOpts: {
+    columns: any;
+    transform: Transformations;
+  }
 ) => {
   const transformations: Transformation[] = panel.transformations ?? [];
   if (Object.keys(transformsMap).includes(oldOpts.transform)) {
@@ -101,7 +89,6 @@ const migrateTransformations = (
   }
   return transformations;
 };
-
 type Style = {
   unit: string;
   type: string;
@@ -118,7 +105,6 @@ type Style = {
   linkTooltip?: string;
   linkUrl?: string;
 };
-
 const migrateTableStyleToOverride = (style: Style) => {
   const fieldMatcherId = /^\/.*\/$/.test(style.pattern) ? FieldMatcherID.byRegexp : FieldMatcherID.byName;
   const override: ConfigOverrideRule = {
@@ -128,42 +114,36 @@ const migrateTableStyleToOverride = (style: Style) => {
     },
     properties: [],
   };
-
   if (style.alias) {
     override.properties.push({
       id: 'displayName',
       value: style.alias,
     });
   }
-
   if (style.unit) {
     override.properties.push({
       id: 'unit',
       value: style.unit,
     });
   }
-
   if (style.decimals !== undefined) {
     override.properties.push({
       id: 'decimals',
       value: style.decimals,
     });
   }
-
   if (style.type === 'date') {
     override.properties.push({
       id: 'unit',
       value: `time: ${style.dateFormat}`,
     });
   }
-
   if (style.type === 'hidden') {
     override.properties.push({
       id: 'custom.hidden',
       value: true,
     });
   }
-
   if (style.link) {
     override.properties.push({
       id: 'links',
@@ -176,7 +156,6 @@ const migrateTableStyleToOverride = (style: Style) => {
       ],
     });
   }
-
   if (style.colorMode) {
     override.properties.push({
       id: 'custom.cellOptions',
@@ -185,14 +164,12 @@ const migrateTableStyleToOverride = (style: Style) => {
       },
     });
   }
-
   if (style.align) {
     override.properties.push({
       id: 'custom.align',
       value: style.align === 'auto' ? null : style.align,
     });
   }
-
   if (style.thresholds?.length && style.colors?.length) {
     override.properties.push({
       id: 'thresholds',
@@ -202,10 +179,8 @@ const migrateTableStyleToOverride = (style: Style) => {
       },
     });
   }
-
   return override;
 };
-
 const migrateDefaults = (prevDefaults: Style) => {
   let defaults: FieldConfig = {
     custom: {},
@@ -222,7 +197,6 @@ const migrateDefaults = (prevDefaults: Style) => {
       },
       isNil
     );
-
     if (prevDefaults.thresholds && prevDefaults.thresholds.length) {
       const thresholds: ThresholdsConfig = {
         mode: ThresholdsMode.Absolute,
@@ -230,7 +204,6 @@ const migrateDefaults = (prevDefaults: Style) => {
       };
       defaults.thresholds = thresholds;
     }
-
     if (prevDefaults.colorMode) {
       defaults.custom.cellOptions = {
         type: colorModeMap[prevDefaults.colorMode],
@@ -239,7 +212,6 @@ const migrateDefaults = (prevDefaults: Style) => {
   }
   return defaults;
 };
-
 /**
  * This is called when the panel changes from another panel
  */
@@ -255,21 +227,17 @@ export const tablePanelChangedHandler = (
     const prevDefaults = oldOpts.styles.find((style: any) => style.pattern === '/.*/');
     const defaults = migrateDefaults(prevDefaults);
     const overrides = oldOpts.styles.filter((style: any) => style.pattern !== '/.*/').map(migrateTableStyleToOverride);
-
     panel.transformations = transformations;
     panel.fieldConfig = {
       defaults,
       overrides,
     };
   }
-
   return {};
 };
-
 const getMainFrames = (frames: DataFrame[] | null) => {
   return frames?.filter((df) => df.meta?.custom?.parentRowIndex === undefined) || [frames?.[0]];
 };
-
 /**
  * In 9.3 meta.custom.parentRowIndex was introduced to support sub-tables.
  * In 10.2 meta.custom.parentRowIndex was deprecated in favor of FieldType.nestedFrames, which supports multiple nested frames.
@@ -280,13 +248,11 @@ export const migrateFromParentRowIndexToNestedFrames = (frames: DataFrame[] | nu
   const mainFrames = getMainFrames(frames).filter(
     (frame: DataFrame | undefined): frame is DataFrame => !!frame && frame.length !== 0
   );
-
   mainFrames?.forEach((frame) => {
     const subFrames = frames?.filter((df) => frame.refId === df.refId && df.meta?.custom?.parentRowIndex !== undefined);
     const subFramesGrouped = groupBy(subFrames, (frame: DataFrame) => frame.meta?.custom?.parentRowIndex);
     const subFramesByIndex = Object.keys(subFramesGrouped).map((key) => subFramesGrouped[key]);
     const migratedFrame = { ...frame };
-
     if (subFrames && subFrames.length > 0) {
       migratedFrame.fields.push({
         name: 'nested',
@@ -297,22 +263,17 @@ export const migrateFromParentRowIndexToNestedFrames = (frames: DataFrame[] | nu
     }
     migratedFrames.push(migratedFrame);
   });
-
   return migratedFrames;
 };
-
 export const hasDeprecatedParentRowIndex = (frames: DataFrame[] | null) => {
   return frames?.some((df) => df.meta?.custom?.parentRowIndex !== undefined);
 };
-
 export const migrateTextWrapToFieldLevel = (panel: PanelModel<Partial<Options>>) => {
   if (panel.fieldConfig?.defaults.custom?.wrapText !== undefined) {
     // already migrated
     return;
   }
-
   const legacyDefaultWrapText: boolean | undefined = panel.fieldConfig?.defaults.custom?.cellOptions?.wrapText;
-
   panel.fieldConfig.overrides = panel.fieldConfig.overrides.map((override) => {
     if (override.properties) {
       override.properties = override.properties.flatMap((property) => {
@@ -327,14 +288,11 @@ export const migrateTextWrapToFieldLevel = (panel: PanelModel<Partial<Options>>)
     }
     return override;
   });
-
   panel.fieldConfig.defaults.custom = panel.fieldConfig.defaults.custom ?? {};
   panel.fieldConfig.defaults.custom.wrapText = legacyDefaultWrapText;
   delete panel.fieldConfig.defaults.custom.cellOptions?.wrapText;
-
   return panel;
 };
-
 export const migrateHiddenFields = (panel: PanelModel<Partial<Options>>) => {
   panel.fieldConfig.overrides = panel.fieldConfig.overrides.map((override) => {
     if (override.properties) {
@@ -347,10 +305,8 @@ export const migrateHiddenFields = (panel: PanelModel<Partial<Options>>) => {
     }
     return override;
   });
-
   return panel;
 };
-
 interface LegacyTableFooterOptions {
   show: boolean;
   reducer: string[];
@@ -358,28 +314,23 @@ interface LegacyTableFooterOptions {
   countRows?: boolean;
   enablePagination?: boolean;
 }
-
 export const migrateFooterV2 = (panel: PanelModel<Options>) => {
   if (panel.options && 'footer' in panel.options) {
     // we need to cast the footer to the old type to work with it here.
     // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
     const oldFooter = panel.options.footer as LegacyTableFooterOptions;
-
     if (oldFooter.show) {
       const reducers = oldFooter.reducer;
-
       panel.fieldConfig.defaults.custom = {
         ...panel.fieldConfig.defaults.custom,
         footer: {
           reducers: reducers,
         },
       };
-
       if (oldFooter.countRows && reducers[0] === 'count') {
         panel.fieldConfig.defaults.custom.footer.reducers = ['countAll'];
       } else if (oldFooter.fields && oldFooter.fields.length > 1) {
         delete panel.fieldConfig.defaults.custom.footer;
-
         // Fields is an array of field names, so push a byNames matcher
         // on with the matched reducer.
         panel.fieldConfig.overrides.push({
@@ -394,7 +345,6 @@ export const migrateFooterV2 = (panel: PanelModel<Options>) => {
         });
       } else if (oldFooter.fields && oldFooter.fields.length === 1) {
         delete panel.fieldConfig.defaults.custom.footer;
-
         // Single field, so we can use a byName matcher
         panel.fieldConfig.overrides.push({
           matcher: {
@@ -405,11 +355,9 @@ export const migrateFooterV2 = (panel: PanelModel<Options>) => {
         });
       }
     }
-
     if (oldFooter.enablePagination != null) {
       panel.options.enablePagination = oldFooter.enablePagination;
     }
-
     delete panel.options.footer;
   }
 };

--- a/public/app/plugins/panel/timeseries/NullsThresholdInput.tsx
+++ b/public/app/plugins/panel/timeseries/NullsThresholdInput.tsx
@@ -1,21 +1,18 @@
+import { structLog } from '@grafana/data';
 import * as React from 'react';
-
 import { rangeUtil } from '@grafana/data';
 import { t } from '@grafana/i18n';
 import { Input } from '@grafana/ui';
-
 export enum InputPrefix {
   LessThan = 'lessthan',
   GreaterThan = 'greaterthan',
 }
-
 type Props = {
   value: number;
   onChange: (value?: number | boolean | undefined) => void;
   inputPrefix?: InputPrefix;
   isTime: boolean;
 };
-
 export const NullsThresholdInput = ({ value, onChange, inputPrefix, isTime }: Props) => {
   let defaultValue = rangeUtil.secondsToHms(value / 1000);
   if (!isTime) {
@@ -31,30 +28,26 @@ export const NullsThresholdInput = ({ value, onChange, inputPrefix, isTime }: Pr
           val = Number(txt);
         }
       } catch (err) {
-        console.warn('ERROR', err);
+        structLog('warn', 'ERROR', err);
       }
     }
     onChange(val);
   };
-
   const handleEnterKey = (e: React.KeyboardEvent<HTMLInputElement>) => {
     if (e.key !== 'Enter') {
       return;
     }
     checkAndUpdate(e.currentTarget.value);
   };
-
   const handleBlur = (e: React.FocusEvent<HTMLInputElement>) => {
     checkAndUpdate(e.currentTarget.value);
   };
-
   const prefix =
     inputPrefix === InputPrefix.GreaterThan ? (
       <div>&gt;</div>
     ) : inputPrefix === InputPrefix.LessThan ? (
       <div>&lt;</div>
     ) : null;
-
   return (
     <Input
       autoFocus={false}

--- a/public/app/plugins/panel/timeseries/migrations.ts
+++ b/public/app/plugins/panel/timeseries/migrations.ts
@@ -1,5 +1,5 @@
+import { structLog } from '@grafana/data';
 import { omitBy, pickBy, isNil, isNumber, isString } from 'lodash';
-
 import {
   type ConfigOverrideRule,
   type DynamicConfigValue,
@@ -41,12 +41,9 @@ import { DashboardAnnotationsDataLayer } from 'app/features/dashboard-scene/scen
 import { DashboardScene } from 'app/features/dashboard-scene/scene/DashboardScene';
 import { dashboardSceneGraph } from 'app/features/dashboard-scene/utils/dashboardSceneGraph';
 import { type GrafanaQuery, GrafanaQueryType } from 'app/plugins/datasource/grafana/types';
-
 import { defaultGraphConfig } from './config';
 import { type Options } from './panelcfg.gen';
-
 let dashboardRefreshDebouncer: ReturnType<typeof setTimeout> | null = null;
-
 /**
  * This is called when the panel changes from another panel
  */
@@ -63,29 +60,23 @@ export const graphPanelChangedHandler: PanelTypeChangedHandler = (
       fieldConfig: prevFieldConfig,
       panel: panel,
     });
-
     if (annotations?.length > 0) {
       addAnnotationsToDashboard(annotations);
     }
-
     panel.fieldConfig = fieldConfig; // Mutates the incoming panel
     panel.alert = prevOptions.angular.alert;
     return options;
   }
-
   //fixes graph -> viz renaming in custom.hideFrom field config by mutation.
   migrateHideFrom(panel);
-
   return {};
 };
-
 export function graphToTimeseriesOptions(angular: any): {
   fieldConfig: FieldConfigSource;
   options: Options;
   annotations: AnnotationQuery[];
 } {
   let annotations: AnnotationQuery[] = [];
-
   const overrides: ConfigOverrideRule[] = angular.fieldConfig?.overrides ?? [];
   const yaxes = angular.yaxes ?? [];
   let y1 = getFieldConfigFromOldAxis(yaxes[0]);
@@ -95,13 +86,11 @@ export function graphToTimeseriesOptions(angular: any): {
       ...y1, // Keep the y-axis unit and custom
     };
   }
-
   // Dashes
   const dash: LineStyle = {
     fill: angular.dashes ? 'dash' : 'solid',
     dash: [angular.dashLength ?? 10, angular.spaceLength ?? 10],
   };
-
   // "seriesOverrides": [
   //   {
   //     "$$hashKey": "object:183",
@@ -112,7 +101,6 @@ export function graphToTimeseriesOptions(angular: any): {
   //     "linewidth": 2
   //   }
   // ],
-
   if (angular.aliasColors) {
     for (const alias of Object.keys(angular.aliasColors)) {
       const color = angular.aliasColors[alias];
@@ -135,9 +123,7 @@ export function graphToTimeseriesOptions(angular: any): {
       }
     }
   }
-
   let hasFillBelowTo = false;
-
   if (angular.seriesOverrides?.length) {
     for (const seriesOverride of angular.seriesOverrides) {
       if (!seriesOverride.alias) {
@@ -152,7 +138,6 @@ export function graphToTimeseriesOptions(angular: any): {
         properties: [],
       };
       let dashOverride: LineStyle | undefined = undefined;
-
       for (const p of Object.keys(seriesOverride)) {
         const v = seriesOverride[p];
         switch (p) {
@@ -283,7 +268,7 @@ export function graphToTimeseriesOptions(angular: any): {
             });
             break;
           default:
-            console.log('Ignore override migration:', seriesOverride.alias, p, v);
+            structLog('log', 'Ignore override migration:', seriesOverride.alias, p, v);
         }
       }
       if (dashOverride) {
@@ -297,57 +282,45 @@ export function graphToTimeseriesOptions(angular: any): {
       }
     }
   }
-
   const graph: GraphFieldConfig = y1.custom ?? {};
   graph.drawStyle = angular.bars ? GraphDrawStyle.Bars : angular.lines ? GraphDrawStyle.Line : GraphDrawStyle.Points;
-
   if (angular.points) {
     graph.showPoints = VisibilityMode.Always;
-
     if (isNumber(angular.pointradius)) {
       graph.pointSize = 2 + angular.pointradius * 2;
     }
   } else if (graph.drawStyle !== GraphDrawStyle.Points) {
     graph.showPoints = VisibilityMode.Never;
   }
-
   graph.lineWidth = angular.linewidth;
   if (dash.fill !== 'solid') {
     graph.lineStyle = dash;
   }
-
   if (hasFillBelowTo) {
     graph.fillOpacity = 35; // bands are hardcoded in flot
   } else if (isNumber(angular.fill)) {
     graph.fillOpacity = angular.fill * 10; // fill was 0 - 10, new is 0 to 100
   }
-
   if (isNumber(angular.fillGradient) && angular.fillGradient > 0) {
     graph.gradientMode = GraphGradientMode.Opacity;
     graph.fillOpacity = angular.fillGradient * 10; // fill is 0-10
   }
-
   graph.spanNulls = angular.nullPointMode === NullValueMode.Ignore;
-
   if (angular.steppedLine) {
     graph.lineInterpolation = LineInterpolation.StepAfter;
   }
-
   if (graph.drawStyle === GraphDrawStyle.Bars) {
     graph.fillOpacity = 100; // bars were always
   }
-
   if (angular.stack) {
     graph.stacking = {
       mode: angular.percentage ? StackingMode.Percent : StackingMode.Normal,
       group: defaultGraphConfig.stacking!.group,
     };
-
     if (angular.percentage) {
       if (angular.yaxis) {
         delete y1.min;
         delete y1.max;
-
         // TimeSeries currently uses 0-1 for percent, so allowing zero leaves only top and bottom ticks.
         // removing it feels better. probably should fix in TimeSeries, but let's kick it down the road
         if (y1.decimals === 0) {
@@ -356,10 +329,8 @@ export function graphToTimeseriesOptions(angular: any): {
       }
     }
   }
-
   y1.custom = omitBy(graph, isNil);
   y1.nullValueMode = angular.nullPointMode;
-
   const options: Options = {
     legend: {
       displayMode: LegendDisplayMode.List,
@@ -372,7 +343,6 @@ export function graphToTimeseriesOptions(angular: any): {
       sort: SortOrder.None,
     },
   };
-
   // Legend config migration
   const legendConfig = angular.legend;
   if (legendConfig) {
@@ -381,29 +351,23 @@ export function graphToTimeseriesOptions(angular: any): {
     } else {
       options.legend.showLegend = false;
     }
-
     if (legendConfig.rightSide) {
       options.legend.placement = 'right';
     }
-
     if (angular.legend.values) {
       const enabledLegendValues = pickBy(angular.legend);
       options.legend.calcs = getReducersFromLegend(enabledLegendValues);
     }
-
     if (angular.legend.sideWidth) {
       options.legend.width = angular.legend.sideWidth;
     }
-
     if (legendConfig.hideZero) {
       overrides.push(getLegendHideFromOverride(ReducerID.allIsZero));
     }
-
     if (legendConfig.hideEmpty) {
       overrides.push(getLegendHideFromOverride(ReducerID.allIsNull));
     }
   }
-
   // timeRegions migration
   if (angular.timeRegions?.length) {
     let regions = angular.timeRegions.map((old: GraphTimeRegionConfig, idx: number) => ({
@@ -416,7 +380,6 @@ export function graphToTimeseriesOptions(angular: any): {
       from: old.from,
       to: old.to,
     }));
-
     regions.forEach((region: GraphTimeRegionConfig, idx: number) => {
       const anno: AnnotationQuery<GrafanaQuery> = {
         datasource: {
@@ -443,7 +406,6 @@ export function graphToTimeseriesOptions(angular: any): {
           },
         },
       };
-
       if (region.fill) {
         annotations.push(anno);
       } else if (region.line) {
@@ -452,13 +414,11 @@ export function graphToTimeseriesOptions(angular: any): {
       }
     });
   }
-
   const tooltipConfig = angular.tooltip;
   if (tooltipConfig) {
     if (tooltipConfig.shared !== undefined) {
       options.tooltip.mode = tooltipConfig.shared ? TooltipDisplayMode.Multi : TooltipDisplayMode.Single;
     }
-
     if (tooltipConfig.sort !== undefined && tooltipConfig.shared) {
       switch (tooltipConfig.sort) {
         case 1:
@@ -472,33 +432,26 @@ export function graphToTimeseriesOptions(angular: any): {
       }
     }
   }
-
   if (angular.thresholds && angular.thresholds.length > 0) {
     let steps: Threshold[] = [];
     let area = false;
     let line = false;
-
     const sorted = (angular.thresholds as AngularThreshold[]).sort((a, b) => (a.value > b.value ? 1 : -1));
-
     for (let idx = 0; idx < sorted.length; idx++) {
       const threshold = sorted[idx];
       const next = sorted.length > idx + 1 ? sorted[idx + 1] : null;
-
       if (threshold.fill) {
         area = true;
       }
-
       if (threshold.line) {
         line = true;
       }
-
       if (threshold.op === 'gt') {
         steps.push({
           value: threshold.value,
           color: getThresholdColor(threshold),
         });
       }
-
       if (threshold.op === 'lt') {
         if (steps.length === 0) {
           steps.push({
@@ -506,7 +459,6 @@ export function graphToTimeseriesOptions(angular: any): {
             color: getThresholdColor(threshold),
           });
         }
-
         // next op is gt and there is a gap set color to transparent
         if (next && next.op === 'gt' && next.value > threshold.value) {
           steps.push({
@@ -527,7 +479,6 @@ export function graphToTimeseriesOptions(angular: any): {
         }
       }
     }
-
     // if now less then threshold add an -Infinity base that is transparent
     if (steps.length > 0 && steps[0].value !== -Infinity) {
       steps.unshift({
@@ -535,21 +486,17 @@ export function graphToTimeseriesOptions(angular: any): {
         value: -Infinity,
       });
     }
-
     let displayMode = area ? GraphThresholdsStyleMode.Area : GraphThresholdsStyleMode.Line;
     if (line && area) {
       displayMode = GraphThresholdsStyleMode.LineAndArea;
     }
-
     // TODO move into standard ThresholdConfig ?
     y1.custom.thresholdsStyle = { mode: displayMode };
-
     y1.thresholds = {
       mode: ThresholdsMode.Absolute,
       steps,
     };
   }
-
   if (angular.xaxis && angular.xaxis.show === false && angular.xaxis.mode === 'time') {
     overrides.push({
       matcher: {
@@ -573,7 +520,6 @@ export function graphToTimeseriesOptions(angular: any): {
     annotations,
   };
 }
-
 interface GraphTimeRegionConfig extends TimeRegionConfig {
   colorMode: string;
   fill: boolean;
@@ -581,23 +527,18 @@ interface GraphTimeRegionConfig extends TimeRegionConfig {
   line: boolean;
   lineColor: string;
 }
-
 function getThresholdColor(threshold: AngularThreshold): string {
   if (threshold.colorMode === 'critical') {
     return 'red';
   }
-
   if (threshold.colorMode === 'warning') {
     return 'orange';
   }
-
   if (threshold.colorMode === 'custom') {
     return threshold.fillColor || threshold.lineColor;
   }
-
   return 'red';
 }
-
 interface AngularThreshold {
   op: string;
   fill: boolean;
@@ -608,7 +549,6 @@ interface AngularThreshold {
   fillColor: string;
   lineColor: string;
 }
-
 // {
 //   "label": "Y111",
 //   "show": true,
@@ -649,7 +589,6 @@ function getFieldConfigFromOldAxis(obj: any): FieldConfig<GraphFieldConfig> {
     isNil
   );
 }
-
 function fillY2DynamicValues(
   y1: FieldConfig<GraphFieldConfig>,
   y2: FieldConfig<GraphFieldConfig>,
@@ -664,12 +603,10 @@ function fillY2DynamicValues(
       });
     }
   }
-
   props.push({
     id: `custom.axisPlacement`,
     value: AxisPlacement.Right,
   });
-
   // Add any custom property
   const y1G = y1.custom ?? {};
   const y2G = y2.custom ?? {};
@@ -682,7 +619,6 @@ function fillY2DynamicValues(
     }
   }
 }
-
 function validNumber(val: unknown): number | undefined {
   if (isNumber(val)) {
     return val;
@@ -695,7 +631,6 @@ function validNumber(val: unknown): number | undefined {
   }
   return undefined;
 }
-
 function getReducersFromLegend(obj: Record<string, unknown>): string[] {
   const ids: string[] = [];
   for (const key in obj) {
@@ -706,9 +641,15 @@ function getReducersFromLegend(obj: Record<string, unknown>): string[] {
   }
   return ids;
 }
-
 function migrateHideFrom(panel: {
-  fieldConfig?: { defaults?: { custom?: { hideFrom?: any } }; overrides: ConfigOverrideRule[] };
+  fieldConfig?: {
+    defaults?: {
+      custom?: {
+        hideFrom?: any;
+      };
+    };
+    overrides: ConfigOverrideRule[];
+  };
 }) {
   if (panel.fieldConfig?.defaults?.custom?.hideFrom?.graph !== undefined) {
     panel.fieldConfig.defaults.custom.hideFrom.viz = panel.fieldConfig.defaults.custom.hideFrom.graph;
@@ -727,7 +668,6 @@ function migrateHideFrom(panel: {
     });
   }
 }
-
 function getLegendHideFromOverride(reducer: ReducerID.allIsZero | ReducerID.allIsNull) {
   return {
     matcher: {
@@ -750,7 +690,6 @@ function getLegendHideFromOverride(reducer: ReducerID.allIsZero | ReducerID.allI
     ],
   };
 }
-
 function getStackingFromOverrides(value: Boolean | string) {
   const defaultGroupName = defaultGraphConfig.stacking?.group;
   return {
@@ -758,14 +697,11 @@ function getStackingFromOverrides(value: Boolean | string) {
     group: isString(value) ? value : defaultGroupName,
   };
 }
-
 function addAnnotationsToDashboard(annotations: AnnotationQuery[]) {
   const scene = window.__grafanaSceneContext;
-
   if (scene instanceof DashboardScene) {
     const dataLayers = dashboardSceneGraph.getDataLayers(scene);
     const annotationLayers = [...dataLayers.state.annotationLayers];
-
     for (let annotation of annotations) {
       const newAnnotation = new DashboardAnnotationsDataLayer({
         key: `annotations-${annotation.name}`,
@@ -774,18 +710,14 @@ function addAnnotationsToDashboard(annotations: AnnotationQuery[]) {
         isEnabled: annotation.enable,
         isHidden: annotation.hide,
       });
-
       annotationLayers.push(newAnnotation);
     }
-
     dataLayers.setState({ annotationLayers });
     return;
   }
-
   const dashboard = getDashboardSrv().getCurrent();
   if (dashboard) {
     dashboard.annotations.list = [...dashboard.annotations.list, ...annotations];
-
     // Trigger a full dashboard refresh when annotations change
     if (dashboardRefreshDebouncer == null) {
       dashboardRefreshDebouncer = setTimeout(() => {

--- a/public/app/plugins/panel/timeseries/plugins/annotations2-cluster/useAnnotationClustering.tsx
+++ b/public/app/plugins/panel/timeseries/plugins/annotations2-cluster/useAnnotationClustering.tsx
@@ -1,45 +1,36 @@
+import { structLog } from '@grafana/data';
 import { useMemo } from 'react';
 import uPlot from 'uplot';
-
 import { type DataFrame, FieldType } from '@grafana/data';
 import { maybeSortFrame } from '@grafana/data/internal';
 import { type TimeRange2 } from '@grafana/ui/internal';
-
 import { DEFAULT_CLUSTERING_ANNOTATION_SPACING } from './constants';
-
 interface Props {
   annotations: DataFrame[];
   clusteringMode: ClusteringMode | null;
   timeRange: TimeRange2;
   plotWidth: number | undefined;
 }
-
 export enum ClusteringMode {
   Hover = 'hover',
   Render = 'render',
 }
-
 export const useAnnotationClustering = ({ annotations, clusteringMode, plotWidth, timeRange }: Props) => {
   const { outAnnos } = useMemo(() => {
     const clusteredAnnotations: DataFrame[] = [];
-
     // don't return annotations until the plot is ready
     if (!plotWidth) {
       return { outAnnos: [] };
     }
-
     if (clusteringMode === ClusteringMode.Render) {
       // per-frame clustering
       for (let frameIdx = 0; frameIdx < annotations.length; frameIdx++) {
         const frame = annotations[frameIdx];
-
         const timeVals: number[] = frame.fields.find((f) => f.name === 'time')?.values ?? [];
         const timeEndVals: Array<number | null> = frame.fields.find((f) => f.name === 'timeEnd')?.values ?? [];
         const colorVals: string[] = frame.fields.find((f) => f.name === 'color')?.values ?? [];
-
         if (timeVals.length > 1) {
           const { clusterIdx, clusters } = buildAnnotationClusters(frame, timeVals, timeEndVals, plotWidth, timeRange);
-
           // Shallow copy fields and values and append the clusterIdx field
           const clusteredFields = frame.fields.map((field) => ({
             ...field,
@@ -56,9 +47,7 @@ export const useAnnotationClustering = ({ annotations, clusteringMode, plotWidth
             ...frame,
             fields: clusteredFields,
           };
-
           const hasTimeEndField = frameWithCluster.fields.findIndex((field) => field.name === 'timeEnd') !== -1;
-
           // If the annotation frame doesn't already have an end field defined we'll need to add one so we can create valid annotation regions
           if (!hasTimeEndField) {
             frameWithCluster.fields.push({
@@ -68,7 +57,6 @@ export const useAnnotationClustering = ({ annotations, clusteringMode, plotWidth
               config: {},
             });
           }
-
           // add new isCluster field to annotation frame so we can determine which annotations are clustered
           frameWithCluster.fields.push({
             type: FieldType.boolean,
@@ -76,12 +64,10 @@ export const useAnnotationClustering = ({ annotations, clusteringMode, plotWidth
             values: Array(frameWithCluster.fields[0].values.length).fill(false),
             config: {},
           });
-
           // append cluster annotation regions to frame
           for (let ci = 0; ci < clusters.length; ci++) {
             const idxs = clusters[ci];
             let maxTimeEnd = -1;
-
             // If region annotations are in the cluster we need to check if the end time is later then
             for (let i = 0; i < idxs.length; i++) {
               const timeEnd = timeEndVals[idxs[i]];
@@ -89,9 +75,7 @@ export const useAnnotationClustering = ({ annotations, clusteringMode, plotWidth
                 maxTimeEnd = timeEnd;
               }
             }
-
             const lastTimeVal = timeVals[idxs[idxs.length - 1]];
-
             // Annos are sorted by start time
             const valMapping: Record<string, () => number | boolean | string> = {
               // Push the first clustered annotation
@@ -120,9 +104,8 @@ export const useAnnotationClustering = ({ annotations, clusteringMode, plotWidth
       }
     } else if (clusteringMode === ClusteringMode.Hover) {
       // Have the tooltip be clustered, but not the annotations: https://github.com/grafana/grafana/issues/119436
-      console.warn('Hover mode not implemented');
+      structLog('warn', 'Hover mode not implemented');
     }
-
     // Sort clustered frames
     return {
       outAnnos:
@@ -136,10 +119,8 @@ export const useAnnotationClustering = ({ annotations, clusteringMode, plotWidth
           : annotations,
     };
   }, [annotations, clusteringMode, plotWidth, timeRange]);
-
   return { annotations: outAnnos };
 };
-
 const buildAnnotationClusters = (
   frame: DataFrame,
   timeVals: number[],
@@ -151,50 +132,41 @@ const buildAnnotationClusters = (
     frame.fields.find((f) => f.name === 'isRegion')?.values ?? Array(timeVals.length).fill(false);
   const clusterIdx: Array<number | null> = Array(timeVals.length).fill(null);
   const clusters: number[][] = [];
-
   let cluster: number[] = [];
   let prevIdx: null | number = null;
   const mergeThreshold = calculateMergeThreshold(timeRange, plotWidth);
-
   let clusterEndTime = -1;
   let clusterStartTime = Infinity;
-
   for (let j = 0; j < timeVals.length; j++) {
     const startTime = timeVals[j];
     const prevStartTime = prevIdx != null ? timeVals?.[prevIdx] : null;
     const prevEndTime = prevIdx != null ? timeEndVals[prevIdx] : null;
-
     if (prevEndTime && prevEndTime > clusterEndTime) {
       clusterEndTime = prevEndTime;
     }
     if (prevStartTime && prevStartTime < clusterStartTime) {
       clusterStartTime = prevStartTime;
     }
-
     const pushCluster = (prevIdx: number) => {
       // add previous anno if cluster is empty
       if (cluster.length === 0) {
         cluster.push(prevIdx);
         clusterIdx[prevIdx] = clusters.length;
       }
-
       // Add this anno to cluster
       cluster.push(j);
       clusterIdx[j] = clusters.length;
     };
-
     const closeCluster = () => {
       clusters.push(cluster);
       cluster = [];
       clusterEndTime = -1;
       clusterStartTime = Infinity;
     };
-
     const startTimeWithinThreshold = prevStartTime && startTime - prevStartTime <= mergeThreshold;
     const startTimeWithinClusterThreshold = startTime - clusterStartTime <= mergeThreshold;
     const endTimeWithinClusterThreshold = startTime - clusterEndTime <= mergeThreshold;
     const regionsOverlap = clusterEndTime > startTime - mergeThreshold;
-
     if (prevIdx != null) {
       // Point annotation clusters
       if (!isRegionVals[j]) {
@@ -218,24 +190,19 @@ const buildAnnotationClusters = (
         }
       }
     }
-
     prevIdx = j;
   }
-
   // close cluster
   if (cluster.length > 0) {
     clusters.push(cluster);
   }
-
   return { clusterIdx, clusters };
 };
-
 const calculateMergeThreshold = (timeRange: TimeRange2, plotWidth: number) => {
   // If the plot width is zero, something is very wrong! Let's avoid clustering in this case.
   if (!plotWidth || plotWidth < 0 || isNaN(plotWidth)) {
     return -1;
   }
-
   const pixelThreshold = DEFAULT_CLUSTERING_ANNOTATION_SPACING * uPlot.pxRatio;
   const dt = timeRange.to - timeRange.from;
   const thresholdRatio = pixelThreshold / plotWidth;

--- a/public/swagger/K8sNameLookup.tsx
+++ b/public/swagger/K8sNameLookup.tsx
@@ -1,19 +1,15 @@
+import { structLog } from '@grafana/data';
 import { useEffect, useState } from 'react';
-
 import { type SelectableValue } from '@grafana/data';
 import { Select } from '@grafana/ui';
-
 import { NamespaceContext, ResourceContext } from './plugins';
-
 type Props = {
   value?: string;
   onChange: (v?: string) => void;
-
   // The wrapped element
   Original: React.ElementType;
   props: Record<string, unknown>;
 };
-
 export function K8sNameLookup(props: Props) {
   const [focused, setFocus] = useState(false);
   const [group, setGroup] = useState<string>();
@@ -24,7 +20,6 @@ export function K8sNameLookup(props: Props) {
   const [loading, setLoading] = useState(false);
   const [options, setOptions] = useState<Array<SelectableValue<string>>>();
   const [placeholder, setPlaceholder] = useState<string>('Enter kubernetes name');
-
   useEffect(() => {
     if (focused && group && version && resource) {
       setLoading(true);
@@ -33,7 +28,6 @@ export function K8sNameLookup(props: Props) {
         const url = namespaced
           ? `apis/${group}/${version}/namespaces/${namespace}/${resource}`
           : `apis/${group}/${version}/${resource}`;
-
         const response = await fetch(url + '?limit=100', {
           headers: {
             Accept:
@@ -41,12 +35,12 @@ export function K8sNameLookup(props: Props) {
           },
         });
         if (!response.ok) {
-          console.warn('error loading names');
+          structLog('warn', 'error loading names');
           setLoading(false);
           return;
         }
         const table = await response.json();
-        console.log('LIST', url, table);
+        structLog('log', 'LIST', url, table);
         const options: Array<SelectableValue<string>> = [];
         if (table.rows?.length) {
           for (const row of table.rows) {
@@ -64,7 +58,6 @@ export function K8sNameLookup(props: Props) {
       fn();
     }
   }, [focused, namespace, group, version, resource, namespaced]);
-
   return (
     <NamespaceContext.Consumer>
       {(namespace) => {

--- a/public/swagger/SwaggerPage.tsx
+++ b/public/swagger/SwaggerPage.tsx
@@ -1,16 +1,14 @@
+import { structLog } from '@grafana/data';
 import getDefaultMonacoLanguages from 'lib/monaco-languages';
 import { useState } from 'react';
 import { useAsync } from 'react-use';
 import SwaggerUI from 'swagger-ui-react';
-
 import { createTheme, monacoLanguageRegistry, type SelectableValue } from '@grafana/data';
 import { Trans } from '@grafana/i18n';
 import { Icon, Stack, Select, UserIcon, type UserView, Button } from '@grafana/ui';
 import { setMonacoEnv } from 'app/core/monacoEnv';
 import { ThemeProvider } from 'app/core/utils/ConfigProvider';
-
 import { NamespaceContext, WrappedPlugins } from './plugins';
-
 export const Page = () => {
   const theme = createTheme({ colors: { mode: 'light' } });
   const [url, setURL] = useState<SelectableValue<string>>();
@@ -18,7 +16,6 @@ export const Page = () => {
     const v2 = { label: 'Grafana API (OpenAPI v2)', key: 'openapi2', value: 'public/api-merged.json' };
     const v3 = { label: 'Grafana API (OpenAPI v3)', key: 'openapi3', value: 'public/openapi3.json' };
     const urls: Array<SelectableValue<string>> = [v2, v3];
-
     const rsp = await fetch('openapi/v3');
     const apis = await rsp.json();
     for (const [key, val] of Object.entries<any>(apis.paths)) {
@@ -31,7 +28,6 @@ export const Page = () => {
         });
       }
     }
-
     let idx = 0;
     const urlParams = new URLSearchParams(window.location.search);
     const api = urlParams.get('api');
@@ -42,30 +38,25 @@ export const Page = () => {
         }
       });
     }
-
     monacoLanguageRegistry.setInit(getDefaultMonacoLanguages);
     setMonacoEnv();
-
     setURL(urls[idx]); // Remove to start at the generic landing page
     return urls;
   });
-
   const [userView, setUserView] = useState<UserView>();
-
   const namespace = useAsync(async () => {
     const response = await fetch('api/frontend/settings');
     if (!response.ok) {
-      console.warn('No settings found');
+      structLog('warn', 'No settings found');
       return 'default';
     }
     const val = await response.json();
     return val.namespace;
   });
-
   useAsync(async () => {
     const response = await fetch('api/user');
     if (!response.ok) {
-      console.warn('No user found, show login button');
+      structLog('warn', 'No user found, show login button');
       return;
     }
     const val = await response.json();
@@ -77,7 +68,6 @@ export const Page = () => {
       lastActiveAt: new Date(),
     });
   });
-
   return (
     <div>
       <ThemeProvider value={theme}>

--- a/public/swagger/plugins.tsx
+++ b/public/swagger/plugins.tsx
@@ -1,14 +1,11 @@
+import { structLog } from '@grafana/data';
 import { createContext } from 'react';
-
 import { CodeEditor, type Monaco } from '@grafana/ui';
-
 import { K8sNameLookup } from './K8sNameLookup';
-
 // swagger does not have types
 interface UntypedProps {
   [k: string]: any;
 }
-
 export type SchemaType = Record<string, any> | undefined;
 export type ResourceInfo = {
   group: string;
@@ -16,12 +13,10 @@ export type ResourceInfo = {
   resource: string;
   namespaced: boolean;
 };
-
 // Use react contexts to stash settings
 export const SchemaContext = createContext<SchemaType>(undefined);
 export const NamespaceContext = createContext<string | undefined>(undefined);
 export const ResourceContext = createContext<ResourceInfo | undefined>(undefined);
-
 /* eslint-disable react/display-name */
 export const WrappedPlugins = function () {
   return {
@@ -52,7 +47,6 @@ export const WrappedPlugins = function () {
         }
         return <Original {...props} />;
       },
-
       // https://github.com/swagger-api/swagger-ui/blob/v5.17.14/src/core/components/parameters/parameters.jsx#L235
       // https://github.com/swagger-api/swagger-ui/blob/v5.17.14/src/core/plugins/oas3/components/request-body.jsx#L35
       RequestBody: (Original: React.ElementType) => (props: UntypedProps) => {
@@ -63,7 +57,7 @@ export const WrappedPlugins = function () {
           if (mime) {
             v = mime.get('schema').toJS();
           }
-          console.log('RequestBody', v, mime, props);
+          structLog('log', 'RequestBody', v, mime, props);
         }
         // console.log('RequestBody PROPS', props);
         return (
@@ -72,10 +66,9 @@ export const WrappedPlugins = function () {
           </SchemaContext.Provider>
         );
       },
-
       modelExample: (Original: React.ElementType) => (props: UntypedProps) => {
         if (props.isExecute && props.schema) {
-          console.log('modelExample PROPS', props);
+          structLog('log', 'modelExample PROPS', props);
           return (
             <SchemaContext.Provider value={props.schema.toJS()}>
               <Original {...props} />
@@ -84,7 +77,6 @@ export const WrappedPlugins = function () {
         }
         return <Original {...props} />;
       },
-
       JsonSchemaForm: (Original: React.ElementType) => (props: UntypedProps) => {
         const { description, disabled, required, onChange, value } = props;
         if (!disabled && required) {
@@ -111,7 +103,6 @@ export const WrappedPlugins = function () {
         }
         return <Original {...props} />;
       },
-
       // https://github.com/swagger-api/swagger-ui/blob/v5.17.14/src/core/plugins/oas3/components/request-body-editor.jsx
       TextArea: (Original: React.ElementType) => (props: UntypedProps) => {
         return (
@@ -128,8 +119,7 @@ export const WrappedPlugins = function () {
                     },
                   });
                 };
-                console.log('CodeEditor', schema);
-
+                structLog('log', 'CodeEditor', schema);
                 return (
                   <CodeEditor
                     value={val}

--- a/scripts/codemods/replace-console-with-structLog.mjs
+++ b/scripts/codemods/replace-console-with-structLog.mjs
@@ -1,0 +1,159 @@
+/**
+ * Replaces console.log/warn/error/debug/info with structLog from @grafana/data.
+ * Run: node ./scripts/codemods/replace-console-with-structLog.mjs
+ */
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { glob } from 'glob';
+import ts from 'typescript';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const root = path.resolve(__dirname, '../..');
+
+const levelMap = { log: 'log', info: 'info', warn: 'warn', error: 'error', debug: 'debug' };
+
+function shouldProcessFile(relative) {
+  if (relative.includes('node_modules') || relative.includes('dist/')) {
+    return false;
+  }
+  if (relative.includes('public/test/') || relative.includes('e2e/') || relative.includes('e2e-playwright/')) {
+    return false;
+  }
+  const base = path.basename(relative);
+  if (
+    /\.(test|spec|stories|story)\.tsx?$/.test(base) ||
+    /jest\.config/.test(base) ||
+    /webpack\./.test(relative) ||
+    relative.startsWith('scripts/') // keep build scripts on console
+  ) {
+    return false;
+  }
+  if (base === 'replace-console-with-structLog.mjs') {
+    return false;
+  }
+  if (relative.includes('structLog.ts') || relative.includes('packages/grafana-data/src/utils/structLog')) {
+    return false;
+  }
+  return true;
+}
+
+function isEslintNoConsoleDisabled(text, pos) {
+  for (const cr of ts.getLeadingCommentRanges(text, pos) ?? []) {
+    const t = text.substring(cr.pos, cr.end);
+    if (t.includes('eslint') && t.includes('no-console')) {
+      return true;
+    }
+  }
+  return false;
+}
+
+/**
+ * @param {ts.SourceFile} sourceFile
+ */
+function addStructLogImport(sourceFile) {
+  const newImport = ts.factory.createImportDeclaration(
+    undefined,
+    ts.factory.createImportClause(
+      false,
+      undefined,
+      ts.factory.createNamedImports([ts.factory.createImportSpecifier(false, undefined, ts.factory.createIdentifier('structLog'))])
+    ),
+    ts.factory.createStringLiteral('@grafana/data'),
+    undefined
+  );
+  return ts.factory.updateSourceFile(sourceFile, [newImport, ...sourceFile.statements]);
+}
+
+function hasStructLogImport(sourceFile) {
+  for (const s of sourceFile.statements) {
+    if (ts.isImportDeclaration(s) && s.moduleSpecifier && ts.isStringLiteral(s.moduleSpecifier)) {
+      if (s.moduleSpecifier.text !== '@grafana/data') {
+        continue;
+      }
+      const b = s.importClause?.namedBindings;
+      if (b && ts.isNamedImports(b)) {
+        for (const e of b.elements) {
+          if (e.name.text === 'structLog' || (e.propertyName && e.propertyName.text === 'structLog')) {
+            return true;
+          }
+        }
+      }
+    }
+  }
+  return false;
+}
+
+let needsStructLog = false;
+/**
+ * @param {ts.TransformationContext} context
+ * @param {ts.SourceFile} sourceFile
+ */
+function transformSourceFile(context, sourceFile) {
+  needsStructLog = false;
+  const fullText = sourceFile.getFullText();
+  const visitor = (node) => {
+    if (ts.isCallExpression(node) && ts.isPropertyAccessExpression(node.expression)) {
+      const expr = node.expression;
+      if (expr.name && expr.expression && ts.isIdentifier(expr.expression) && expr.expression.text === 'console') {
+        const method = expr.name.text;
+        if (levelMap[method]) {
+          if (isEslintNoConsoleDisabled(fullText, node.getFullStart())) {
+            return ts.visitEachChild(node, visitor, context);
+          }
+          needsStructLog = true;
+          return ts.factory.createCallExpression(
+            ts.factory.createIdentifier('structLog'),
+            undefined,
+            [ts.factory.createStringLiteral(levelMap[method]), ...node.arguments]
+          );
+        }
+      }
+    }
+    return ts.visitEachChild(node, visitor, context);
+  };
+  const result = ts.visitNode(sourceFile, visitor);
+  if (needsStructLog && ts.isSourceFile(result) && !hasStructLogImport(result)) {
+    return addStructLogImport(result);
+  }
+  return result;
+}
+
+const printer = ts.createPrinter({ newLine: ts.NewLineKind.LineFeed });
+
+const patterns = [
+  'public/app/**/*.{ts,tsx}',
+  'packages/**/*.{ts,tsx}',
+  'public/swagger/**/*.{ts,tsx}',
+];
+
+const files = patterns.flatMap((p) => glob.sync(p, { cwd: root, nodir: true, absolute: true }));
+
+let count = 0;
+for (const file of files) {
+  const rel = path.relative(root, file);
+  if (!shouldProcessFile(rel)) {
+    continue;
+  }
+  const text = fs.readFileSync(file, 'utf8');
+  if (!/console\.(log|info|warn|error|debug)\s*\(/.test(text)) {
+    continue;
+  }
+  const sf = ts.createSourceFile(file, text, ts.ScriptTarget.Latest, true, file.endsWith('.tsx') ? ts.ScriptKind.TSX : ts.ScriptKind.TS);
+  const tr = (context) => (s) => transformSourceFile(context, s);
+  const res = ts.transform(sf, [tr]);
+  const out = res.transformed[0];
+  if (!out) {
+    continue;
+  }
+  if (out === sf) {
+    res.dispose();
+    continue;
+  }
+  const outText = printer.printFile(out) + (text.endsWith('\n') ? '' : '\n');
+  fs.writeFileSync(file, outText);
+  count += 1;
+  res.dispose();
+  console.log('updated', rel);
+}
+console.log('Files updated:', count);

--- a/yarn.lock
+++ b/yarn.lock
@@ -3543,6 +3543,7 @@ __metadata:
   resolution: "@grafana/i18n@workspace:packages/grafana-i18n"
   dependencies:
     "@formatjs/intl-durationformat": "npm:^0.7.0"
+    "@grafana/data": "npm:13.0.0-pre"
     "@types/react": "npm:18.3.18"
     "@typescript-eslint/utils": "npm:^8.33.1"
     fast-deep-equal: "npm:^3.1.3"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Adds `structLog` in `@grafana/data` (via `@grafana/data/structLog` to avoid import cycles) as the default replacement for `console.*` in app code, with dev/test behavior and reduced prod noise for verbose levels.
- Wires runtime Faro helpers in `@grafana/runtime` to use the same `structLog` path when the JS agent is off; normalizes Faro log context to `Record<string, string>`.
- Migrates `console` usage across the main app and packages, adds `scripts/codemods/replace-console-with-structLog.mjs` for follow-up, updates tests that asserted on `console` where needed, and documents the approach in `.cursor/docs/structured-logging-migration.md`.

## Intentional leftovers
- Dev-only `console.group*` / `console` in `performanceUtils`, AMD mock string in `pluginLoader.mock`, and commented-out console lines in a few files.
- Storybook, e2e, and build script files are excluded from the codemod.

Target repo: fieldsphere/grafana. Base: `main`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fefc2ef6-d20d-42a3-93b6-ee355fee6c37"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fefc2ef6-d20d-42a3-93b6-ee355fee6c37"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

