### PR TITLE
Replace console logging with structured client logging

### DIFF
--- a/packages/grafana-alerting/src/grafana/notificationPolicies/components/RoutingTreeSelector/RoutingTreeSelector.tsx
+++ b/packages/grafana-alerting/src/grafana/notificationPolicies/components/RoutingTreeSelector/RoutingTreeSelector.tsx
@@ -1,3 +1,4 @@
+import { createClientLog } from '@grafana/data';
 import { type ComponentProps, useMemo } from 'react';
 
 import { type RoutingTree } from '@grafana/api-clients/rtkq/notifications.alerting/v0alpha1';
@@ -7,6 +8,9 @@ import { Alert, Combobox, type ComboboxOption, MultiCombobox } from '@grafana/ui
 import { type CustomComboBoxProps } from '../../../common/ComboBox.types';
 import { USER_DEFINED_TREE_NAME } from '../../consts';
 import { useListRoutingTrees } from '../../hooks/useRoutingTrees';
+const clientLog = createClientLog('packages/grafana-alerting/src/grafana/notificationPolicies/components/RoutingTreeSelector/RoutingTreeSelector');
+
+
 
 const collator = new Intl.Collator('en', { sensitivity: 'accent' });
 
@@ -130,7 +134,7 @@ function RoutingTreeSelector(props: RoutingTreeSelectorProps) {
     if (selectedOption) {
       const tree = treeLookup.get(selectedOption.value);
       if (!tree) {
-        console.warn(`RoutingTreeSelector: could not find routing tree for value "${selectedOption.value}"`);
+        clientLog.warn(`RoutingTreeSelector: could not find routing tree for value "${selectedOption.value}"`);
         return;
       }
 

--- a/packages/grafana-data/src/dataframe/FieldCache.ts
+++ b/packages/grafana-data/src/dataframe/FieldCache.ts
@@ -1,6 +1,10 @@
+import { createClientLog } from '../utils/clientStructuredLog';
 import { type DataFrame, type Field, FieldType } from '../types/dataFrame';
 
 import { guessFieldTypeForField } from './processDataFrame';
+const clientLog = createClientLog('packages/grafana-data/src/dataframe/FieldCache');
+
+
 
 export interface FieldWithIndex extends Field {
   index: number;
@@ -36,7 +40,7 @@ export class FieldCache {
       });
 
       if (this.fieldByName[field.name]) {
-        console.warn('Duplicate field names in DataFrame: ', field.name);
+        clientLog.warn('Duplicate field names in DataFrame: ', field.name);
       } else {
         this.fieldByName[field.name] = { ...field, index: i };
       }

--- a/packages/grafana-data/src/dataframe/processDataFrame.ts
+++ b/packages/grafana-data/src/dataframe/processDataFrame.ts
@@ -1,3 +1,4 @@
+import { createClientLog } from '../utils/clientStructuredLog';
 // Libraries
 import { isArray, isBoolean, isNumber, isString } from 'lodash';
 
@@ -22,6 +23,9 @@ import { type PanelData } from '../types/panel';
 
 import { arrayToDataFrame } from './ArrayDataFrame';
 import { dataFrameFromJSON } from './DataFrameJSON';
+const clientLog = createClientLog('packages/grafana-data/src/dataframe/processDataFrame');
+
+
 
 function convertTableToDataFrame(table: TableData): DataFrame {
   const fields = table.columns.map((c) => {
@@ -340,7 +344,7 @@ export function toDataFrame(data: any): DataFrame {
     return arrayToDataFrame(data);
   }
 
-  console.warn('Can not convert', data);
+  clientLog.warn('Can not convert', data);
   throw new Error('Unsupported data format');
 }
 

--- a/packages/grafana-data/src/events/EventBus.ts
+++ b/packages/grafana-data/src/events/EventBus.ts
@@ -13,6 +13,7 @@ import {
   type EventFilterOptions,
 } from './types';
 
+
 /**
  * @alpha
  */
@@ -56,7 +57,7 @@ export class EventBusSrv implements EventBus, LegacyEmitter {
    * Legacy functions
    */
   emit<T>(event: AppEvent<T> | string, payload?: T): void {
-    // console.log(`Deprecated emitter function used (emit), use $emit`);
+    // clientLog.info(`Deprecated emitter function used (emit), use $emit`);
 
     if (typeof event === 'string') {
       this.emitter.emit(event, { type: event, payload });
@@ -66,7 +67,7 @@ export class EventBusSrv implements EventBus, LegacyEmitter {
   }
 
   on<T>(event: AppEvent<T> | string, handler: LegacyEventHandler<T>) {
-    // console.log(`Deprecated emitter function used (on), use $on`);
+    // clientLog.info(`Deprecated emitter function used (on), use $on`);
 
     // need this wrapper to make old events compatible with old handlers
     handler.wrapper = (emittedEvent: BusEvent) => {

--- a/packages/grafana-data/src/index.ts
+++ b/packages/grafana-data/src/index.ts
@@ -243,6 +243,16 @@ export {
 } from './utils/datasource';
 export { deprecationWarning } from './utils/deprecationWarning';
 export {
+  setClientStructuredLog,
+  createClientLog,
+  clientStructuredInfo,
+  clientStructuredDebug,
+  clientStructuredWarn,
+  clientStructuredError,
+  formatClientLogArgs,
+  type ClientLogContext,
+} from './utils/clientStructuredLog';
+export {
   CSVHeaderStyle,
   type CSVConfig,
   type CSVParseCallbacks,

--- a/packages/grafana-data/src/text/sanitize.ts
+++ b/packages/grafana-data/src/text/sanitize.ts
@@ -1,6 +1,10 @@
+import { createClientLog } from '../utils/clientStructuredLog';
 import { sanitizeUrl as braintreeSanitizeUrl } from '@braintree/sanitize-url';
 import DOMPurify from 'dompurify';
 import * as xss from 'xss';
+const clientLog = createClientLog('packages/grafana-data/src/text/sanitize');
+
+
 
 const XSSWL = Object.keys(xss.whiteList).reduce<xss.IWhiteList>((acc, element) => {
   acc[element] = xss.whiteList[element]?.concat(['class', 'style']);
@@ -68,7 +72,7 @@ export function sanitize(unsanitizedString: string): string {
       ADD_ATTR: ['target'],
     });
   } catch (error) {
-    console.error('String could not be sanitized', unsanitizedString);
+    clientLog.error('String could not be sanitized', unsanitizedString);
     return escapeHtml(unsanitizedString);
   } finally {
     DOMPurify.removeHook('afterSanitizeAttributes');
@@ -99,7 +103,7 @@ export function sanitizeTextPanelContent(unsanitizedString: string): string {
   try {
     return sanitizeTextPanelWhitelist.process(unsanitizedString);
   } catch (error) {
-    console.error('String could not be sanitized', unsanitizedString);
+    clientLog.error('String could not be sanitized', unsanitizedString);
     return 'Text string could not be sanitized';
   }
 }

--- a/packages/grafana-data/src/themes/colorManipulator.ts
+++ b/packages/grafana-data/src/themes/colorManipulator.ts
@@ -1,8 +1,12 @@
+import { createClientLog } from '../utils/clientStructuredLog';
 // Code based on Material-UI
 // https://github.com/mui-org/material-ui/blob/1b096070faf102281f8e3c4f9b2bf50acf91f412/packages/material-ui/src/styles/colorManipulator.js#L97
 // MIT License Copyright (c) 2014 Call-Em-All
 
 import tinycolor from 'tinycolor2';
+const clientLog = createClientLog('packages/grafana-data/src/themes/colorManipulator');
+
+
 
 /**
  * Returns a number whose value is limited to the given range.
@@ -15,7 +19,7 @@ import tinycolor from 'tinycolor2';
 function clamp(value: number, min = 0, max = 1) {
   if (process.env.NODE_ENV !== 'production') {
     if (value < min || value > max) {
-      console.error(`The value provided ${value} is out of range [${min}, ${max}].`);
+      clientLog.error(`The value provided ${value} is out of range [${min}, ${max}].`);
     }
   }
 

--- a/packages/grafana-data/src/themes/createSpacing.ts
+++ b/packages/grafana-data/src/themes/createSpacing.ts
@@ -1,7 +1,11 @@
+import { createClientLog } from '../utils/clientStructuredLog';
 // Code based on Material UI
 // The MIT License (MIT)
 // Copyright (c) 2014 Call-Em-All
 import { z } from 'zod';
+const clientLog = createClientLog('packages/grafana-data/src/themes/createSpacing');
+
+
 
 /** @internal */
 export const ThemeSpacingOptionsSchema = z.object({
@@ -52,7 +56,7 @@ export function createSpacing(options: ThemeSpacingOptions = {}): ThemeSpacing {
 
     if (process.env.NODE_ENV !== 'production') {
       if (typeof value !== 'number') {
-        console.error(`Expected spacing argument to be a number or a string, got ${value}.`);
+        clientLog.error(`Expected spacing argument to be a number or a string, got ${value}.`);
       }
     }
     return value * gridSize;
@@ -61,7 +65,7 @@ export function createSpacing(options: ThemeSpacingOptions = {}): ThemeSpacing {
   const spacing = (...args: Array<number | string>): string => {
     if (process.env.NODE_ENV !== 'production') {
       if (!(args.length <= 4)) {
-        console.error(`Too many arguments provided, expected between 0 and 4, got ${args.length}`);
+        clientLog.error(`Too many arguments provided, expected between 0 and 4, got ${args.length}`);
       }
     }
 

--- a/packages/grafana-data/src/themes/createTypography.ts
+++ b/packages/grafana-data/src/themes/createTypography.ts
@@ -1,9 +1,13 @@
+import { createClientLog } from '../utils/clientStructuredLog';
 // Code based on Material UI
 // The MIT License (MIT)
 // Copyright (c) 2014 Call-Em-All
 import { z } from 'zod';
 
 import { type ThemeColors } from './createColors';
+const clientLog = createClientLog('packages/grafana-data/src/themes/createTypography');
+
+
 
 /** @beta */
 export interface ThemeTypography extends ThemeTypographyVariantTypes {
@@ -76,11 +80,11 @@ export function createTypography(colors: ThemeColors, typographyInput: ThemeTypo
 
   if (process.env.NODE_ENV !== 'production') {
     if (typeof fontSize !== 'number') {
-      console.error('Grafana-UI: `fontSize` is required to be a number.');
+      clientLog.error('Grafana-UI: `fontSize` is required to be a number.');
     }
 
     if (typeof htmlFontSize !== 'number') {
-      console.error('Grafana-UI: `htmlFontSize` is required to be a number.');
+      clientLog.error('Grafana-UI: `htmlFontSize` is required to be a number.');
     }
   }
 

--- a/packages/grafana-data/src/themes/registry.ts
+++ b/packages/grafana-data/src/themes/registry.ts
@@ -1,3 +1,4 @@
+import { createClientLog } from '../utils/clientStructuredLog';
 import { Registry, type RegistryItem } from '../utils/Registry';
 
 import { createTheme, NewThemeOptionsSchema } from './createTheme';
@@ -18,6 +19,9 @@ import tron from './themeDefinitions/tron.json';
 import victorian from './themeDefinitions/victorian.json';
 import zen from './themeDefinitions/zen.json';
 import { type GrafanaTheme2 } from './types';
+const clientLog = createClientLog('packages/grafana-data/src/themes/registry');
+
+
 
 export interface ThemeRegistryItem extends RegistryItem {
   isExtra?: boolean;
@@ -87,7 +91,7 @@ const themeRegistry = new Registry<ThemeRegistryItem>(() => {
 for (const [name, json] of Object.entries(extraThemes)) {
   const result = NewThemeOptionsSchema.safeParse(json);
   if (!result.success) {
-    console.error(`Invalid theme definition for theme ${name}: ${result.error.message}`);
+    clientLog.error(`Invalid theme definition for theme ${name}: ${result.error.message}`);
   } else {
     const theme = result.data;
     themeRegistry.register({

--- a/packages/grafana-data/src/transformations/matchers/nameMatcher.ts
+++ b/packages/grafana-data/src/transformations/matchers/nameMatcher.ts
@@ -1,9 +1,13 @@
+import { createClientLog } from '../../utils/clientStructuredLog';
 import { getFieldDisplayName } from '../../field/fieldState';
 import { stringToJsRegex } from '../../text/string';
 import { type DataFrame, type Field, FieldType, TIME_SERIES_VALUE_FIELD_NAME } from '../../types/dataFrame';
 import { type FieldMatcher, type FieldMatcherInfo, type FrameMatcherInfo } from '../../types/transformations';
 
 import { FieldMatcherID, FrameMatcherID } from './ids';
+const clientLog = createClientLog('packages/grafana-data/src/transformations/matchers/nameMatcher');
+
+
 
 export interface RegexpOrNamesMatcherOptions {
   pattern?: string;
@@ -201,7 +205,7 @@ const patternToRegex = (pattern?: string): RegExp | undefined => {
   try {
     return stringToJsRegex(pattern);
   } catch (error) {
-    console.error(error);
+    clientLog.error(error);
     return undefined;
   }
 };

--- a/packages/grafana-data/src/transformations/matchers/refIdMatcher.ts
+++ b/packages/grafana-data/src/transformations/matchers/refIdMatcher.ts
@@ -1,8 +1,12 @@
+import { createClientLog } from '../../utils/clientStructuredLog';
 import { escapeStringForRegex, stringStartsAsRegEx, stringToJsRegex } from '../../text/string';
 import { type DataFrame } from '../../types/dataFrame';
 import { type FrameMatcherInfo } from '../../types/transformations';
 
 import { FrameMatcherID } from './ids';
+const clientLog = createClientLog('packages/grafana-data/src/transformations/matchers/refIdMatcher');
+
+
 
 // General Field matcher
 const refIdMatcher: FrameMatcherInfo<string> = {
@@ -19,7 +23,7 @@ const refIdMatcher: FrameMatcherInfo<string> = {
         regex = stringToJsRegex(pattern);
       } catch (error) {
         if (error instanceof Error) {
-          console.warn(error.message);
+          clientLog.warn(error.message);
         }
       }
     }

--- a/packages/grafana-data/src/transformations/transformers/filterByValue.ts
+++ b/packages/grafana-data/src/transformations/transformers/filterByValue.ts
@@ -1,3 +1,4 @@
+import { createClientLog } from '../../utils/clientStructuredLog';
 import { map } from 'rxjs/operators';
 
 import { getFieldDisplayName } from '../../field/fieldState';
@@ -7,6 +8,9 @@ import { getValueMatcher } from '../matchers';
 
 import { DataTransformerID } from './ids';
 import { noopTransformer } from './noop';
+const clientLog = createClientLog('packages/grafana-data/src/transformations/transformers/filterByValue');
+
+
 
 export enum FilterByValueType {
   exclude = 'exclude',
@@ -139,7 +143,7 @@ const createFilterValueMatchers = (
     const fieldIndex = fieldIndexByName[filter.fieldName] ?? -1;
 
     if (fieldIndex < 0) {
-      console.warn(`[FilterByValue] Could not find index for field name: ${filter.fieldName}`);
+      clientLog.warn(`[FilterByValue] Could not find index for field name: ${filter.fieldName}`);
       return noop;
     }
 

--- a/packages/grafana-data/src/types/app.ts
+++ b/packages/grafana-data/src/types/app.ts
@@ -1,3 +1,4 @@
+import { createClientLog } from '../utils/clientStructuredLog';
 import { type ComponentType } from 'react';
 
 import { throwIfAngular } from '../utils/throwIfAngular';
@@ -11,6 +12,9 @@ import {
   type PluginExtensionAddedLinkConfig,
   type PluginExtensionAddedFunctionConfig,
 } from './pluginExtensions';
+const clientLog = createClientLog('packages/grafana-data/src/types/app');
+
+
 
 /**
  * @public
@@ -93,7 +97,7 @@ export class AppPlugin<T extends KeyValue = KeyValue> extends GrafanaPlugin<AppP
           const exp = pluginExports[include.component];
 
           if (!exp) {
-            console.warn('App Page uses unknown component: ', include.component, this.meta);
+            clientLog.warn('App Page uses unknown component: ', include.component, this.meta);
             continue;
           }
         }

--- a/packages/grafana-data/src/types/plugin.ts
+++ b/packages/grafana-data/src/types/plugin.ts
@@ -1,7 +1,11 @@
+import { createClientLog } from '../utils/clientStructuredLog';
 import { type ComponentType } from 'react';
 
 import { type KeyValue } from './data';
 import { type IconName } from './icon';
+const clientLog = createClientLog('packages/grafana-data/src/types/plugin');
+
+
 
 /** Describes plugins life cycle status */
 export enum PluginState {
@@ -260,7 +264,7 @@ export class GrafanaPlugin<T extends PluginMeta = PluginMeta> {
    * @deprecated -- this is no longer necessary and will be removed
    */
   setChannelSupport() {
-    console.warn('[deprecation] plugin is using ignored option: setChannelSupport', this.meta);
+    clientLog.warn('[deprecation] plugin is using ignored option: setChannelSupport', this.meta);
     return this;
   }
 

--- a/packages/grafana-data/src/utils/LocalStorageValueProvider.tsx
+++ b/packages/grafana-data/src/utils/LocalStorageValueProvider.tsx
@@ -1,7 +1,11 @@
+import { createClientLog } from './clientStructuredLog';
 import { useEffect, useState } from 'react';
 import * as React from 'react';
 
 import { store } from './store';
+const clientLog = createClientLog('packages/grafana-data/src/utils/LocalStorageValueProvider');
+
+
 
 export interface Props<T> {
   storageKey: string;
@@ -32,7 +36,7 @@ export const LocalStorageValueProvider = <T,>(props: Props<T>) => {
     try {
       store.setObject(storageKey, value);
     } catch (error) {
-      console.error(error);
+      clientLog.error(error);
     }
     setState({ value });
   };
@@ -41,7 +45,7 @@ export const LocalStorageValueProvider = <T,>(props: Props<T>) => {
     try {
       store.delete(storageKey);
     } catch (error) {
-      console.log(error);
+      clientLog.info(error);
     }
     setState({ value: defaultValue });
   };

--- a/packages/grafana-data/src/utils/clientStructuredLog.ts
+++ b/packages/grafana-data/src/utils/clientStructuredLog.ts
@@ -1,0 +1,131 @@
+/**
+ * Browser structured logging: forwards to the Grafana JavaScript agent (Faro) when
+ * @grafana/runtime is loaded; otherwise no-ops. Use instead of console in application code.
+ */
+
+const noop = () => {};
+
+/**
+ * @public
+ * Context passed to Faro log APIs; values are strings per Faro typing.
+ */
+export type ClientLogContext = Record<string, string>;
+
+type StructuredLogImpl = {
+  logInfo: (message: string, context?: ClientLogContext) => void;
+  logWarning: (message: string, context?: ClientLogContext) => void;
+  logDebug: (message: string, context?: ClientLogContext) => void;
+  logError: (error: Error, context?: ClientLogContext) => void;
+};
+
+const noopImpl: StructuredLogImpl = {
+  logInfo: noop,
+  logWarning: noop,
+  logDebug: noop,
+  logError: noop,
+};
+
+let impl: StructuredLogImpl = noopImpl;
+
+/**
+ * Called from @grafana/runtime when the logging module loads.
+ */
+export function setClientStructuredLog(next: StructuredLogImpl) {
+  impl = next;
+}
+
+/**
+ * @public
+ * @internal — exposed for the console-to-structured codemod.
+ */
+export function formatClientLogArgs(args: readonly unknown[]): string {
+  if (args.length === 0) {
+    return '';
+  }
+  return args.map((a) => formatOneArg(a)).join(' ');
+}
+
+function formatOneArg(value: unknown): string {
+  if (typeof value === 'string') {
+    return value;
+  }
+  if (value === null || value === undefined) {
+    return String(value);
+  }
+  if (value instanceof Error) {
+    return value.stack || value.message;
+  }
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return String(value);
+  }
+}
+
+function ctxFor(source: string, extra?: ClientLogContext): ClientLogContext {
+  if (extra) {
+    return { source, ...extra };
+  }
+  return { source: source || 'grafana' };
+}
+
+function withMessageSource(source: string, message: string) {
+  return source ? `${source}: ${message}` : message;
+}
+
+/**
+ * @public
+ * Structured replacement for `console.log` / `console.info` (and similar).
+ */
+export function clientStructuredInfo(source: string, ...args: unknown[]) {
+  const message = formatClientLogArgs(args);
+  impl.logInfo(withMessageSource(source, message), ctxFor(source));
+}
+
+/**
+ * @public
+ * Structured replacement for `console.debug`.
+ */
+export function clientStructuredDebug(source: string, ...args: unknown[]) {
+  const message = formatClientLogArgs(args);
+  impl.logDebug(withMessageSource(source, message), ctxFor(source));
+}
+
+/**
+ * @public
+ * Structured replacement for `console.warn`.
+ */
+export function clientStructuredWarn(source: string, ...args: unknown[]) {
+  const message = formatClientLogArgs(args);
+  impl.logWarning(withMessageSource(source, message), ctxFor(source));
+}
+
+/**
+ * @public
+ * Structured replacement for `console.error`.
+ */
+export function clientStructuredError(source: string, ...args: unknown[]) {
+  if (args.length === 1 && args[0] instanceof Error) {
+    impl.logError(args[0], ctxFor(source));
+    return;
+  }
+  const message = formatClientLogArgs(args);
+  impl.logError(new Error(message), ctxFor(source));
+}
+
+/**
+ * Binds a stable source string (e.g. module or component id) to structured log methods.
+ * Prefer this over `console` in app code.
+ *
+ * @public
+ */
+export function createClientLog(source: string) {
+  return {
+    info: (...args: unknown[]) => clientStructuredInfo(source, ...args),
+    debug: (...args: unknown[]) => clientStructuredDebug(source, ...args),
+    warn: (...args: unknown[]) => clientStructuredWarn(source, ...args),
+    error: (...args: unknown[]) => clientStructuredError(source, ...args),
+  };
+}
+
+export type { StructuredLogImpl };

--- a/packages/grafana-data/src/utils/deprecationWarning.ts
+++ b/packages/grafana-data/src/utils/deprecationWarning.ts
@@ -1,4 +1,8 @@
+import { createClientLog } from './clientStructuredLog';
 import { type KeyValue } from '../types/data';
+const clientLog = createClientLog('packages/grafana-data/src/utils/deprecationWarning');
+
+
 
 // Avoid writing the warning message more than once every 10s
 const history: KeyValue<number> = {};
@@ -11,7 +15,7 @@ export const deprecationWarning = (file: string, oldName: string, newName?: stri
   const now = Date.now();
   const last = history[message];
   if (!last || now - last > 10000) {
-    console.warn(message);
+    clientLog.warn(message);
     history[message] = now;
   }
 };

--- a/packages/grafana-data/src/utils/store.ts
+++ b/packages/grafana-data/src/utils/store.ts
@@ -1,3 +1,7 @@
+import { createClientLog } from './clientStructuredLog';
+const clientLog = createClientLog('packages/grafana-data/src/utils/store');
+
+
 type StoreValue = string | number | boolean | null;
 type StoreSubscriber = () => void;
 
@@ -65,7 +69,7 @@ export class Store {
       try {
         ret = JSON.parse(json);
       } catch (error) {
-        console.error(`Error parsing store object: ${key}. Returning default: ${def}. [${error}]`);
+        clientLog.error(`Error parsing store object: ${key}. Returning default: ${def}. [${error}]`);
       }
     }
     return ret;

--- a/packages/grafana-data/src/utils/url.ts
+++ b/packages/grafana-data/src/utils/url.ts
@@ -1,3 +1,4 @@
+import { createClientLog } from './clientStructuredLog';
 /**
  * @preserve jquery-param (c) 2015 KNOWLEDGECODE | MIT
  */
@@ -5,6 +6,9 @@
 import { isDateTime } from '../datetime/moment_wrapper';
 import { type ExploreUrlState, type URLRange } from '../types/explore';
 import { type RawTimeRange } from '../types/time';
+const clientLog = createClientLog('packages/grafana-data/src/utils/url');
+
+
 
 /**
  * Type to represent the value of a single query variable.
@@ -226,7 +230,7 @@ export const urlUtil = {
  */
 export function serializeStateToUrlParam(urlState: Partial<ExploreUrlState>, compact?: boolean): string {
   if (compact !== undefined) {
-    console.warn('`compact` parameter is deprecated and will be removed in a future release');
+    clientLog.warn('`compact` parameter is deprecated and will be removed in a future release');
   }
   return JSON.stringify(urlState);
 }

--- a/packages/grafana-data/src/vector/ArrayVector.ts
+++ b/packages/grafana-data/src/vector/ArrayVector.ts
@@ -1,3 +1,7 @@
+import { createClientLog } from '../utils/clientStructuredLog';
+const clientLog = createClientLog('packages/grafana-data/src/vector/ArrayVector');
+
+
 const notice = 'ArrayVector is deprecated and will be removed in Grafana 11. Please use plain arrays for field.values.';
 let notified = false;
 
@@ -47,7 +51,7 @@ export class ArrayVector<T = unknown> extends Array<T> {
     this.buffer = buffer ?? [];
 
     if (!notified) {
-      console.warn(notice);
+      clientLog.warn(notice);
       notified = true;
     }
   }

--- a/packages/grafana-i18n/src/i18n.tsx
+++ b/packages/grafana-i18n/src/i18n.tsx
@@ -1,3 +1,4 @@
+import { createClientLog } from '@grafana/data';
 import i18n, { type InitOptions, type ReactOptions, type TFunction as I18NextTFunction } from 'i18next';
 import LanguageDetector, { type DetectorOptions } from 'i18next-browser-languagedetector';
 import React from 'react';
@@ -8,6 +9,9 @@ import { DEFAULT_LANGUAGE, PSEUDO_LOCALE } from './constants';
 import { initRegionalFormat } from './dates';
 import { LANGUAGES } from './languages';
 import { type ResourceLoader, type Resources, type TFunction, type TransProps, type TransType } from './types';
+const clientLog = createClientLog('packages/grafana-i18n/src/i18n');
+
+
 
 let tFunc: I18NextTFunction<string[], undefined> | undefined;
 let transComponent: TransType;
@@ -44,7 +48,7 @@ export async function loadNamespacedResources(namespace: string, language: strin
         const resources = await loader(resolvedLanguage);
         addResourceBundle(resolvedLanguage, namespace, resources);
       } catch (error) {
-        console.error(`Error loading resources for namespace ${namespace} and language: ${resolvedLanguage}`, error);
+        clientLog.error(`Error loading resources for namespace ${namespace} and language: ${resolvedLanguage}`, error);
       }
     })
   );
@@ -202,7 +206,7 @@ export const t: TFunction = (id: string, defaultMessage: string, values?: Record
   initDefaultI18nInstance();
   if (!tFunc) {
     if (process.env.NODE_ENV !== 'test') {
-      console.warn(
+      clientLog.warn(
         't() was called before i18n was initialized. This is probably caused by calling t() in the root module scope, instead of lazily on render'
       );
     }

--- a/packages/grafana-prometheus/src/components/metrics-browser/ValueSelector.tsx
+++ b/packages/grafana-prometheus/src/components/metrics-browser/ValueSelector.tsx
@@ -1,3 +1,4 @@
+import { createClientLog } from '@grafana/data';
 import { useEffect, useState } from 'react';
 import { FixedSizeList } from 'react-window';
 
@@ -9,6 +10,9 @@ import { LIST_ITEM_SIZE } from '../../constants';
 
 import { useMetricsBrowser } from './MetricsBrowserContext';
 import { getStylesMetricsBrowser, getStylesValueSelector } from './styles';
+const clientLog = createClientLog('packages/grafana-prometheus/src/components/metrics-browser/ValueSelector');
+
+
 
 export function ValueSelector() {
   const styles = useStyles2(getStylesValueSelector);
@@ -59,7 +63,7 @@ export function ValueSelector() {
         <div className={styles.valueListArea}>
           {Object.entries(filteredLabelValues).map(([lk, lv]) => {
             if (!lk || !lv) {
-              console.error('label values are empty:', { lk, lv });
+              clientLog.error('label values are empty:', { lk, lv });
               return null;
             }
             return (

--- a/packages/grafana-prometheus/src/components/monaco-query-field/getOverrideServices.ts
+++ b/packages/grafana-prometheus/src/components/monaco-query-field/getOverrideServices.ts
@@ -1,5 +1,9 @@
+import { createClientLog } from '@grafana/data';
 // Core Grafana history https://github.com/grafana/grafana/blob/v11.0.0-preview/public/app/plugins/datasource/prometheus/components/monaco-query-field/getOverrideServices.ts
 import { type monacoTypes } from '@grafana/ui';
+const clientLog = createClientLog('packages/grafana-prometheus/src/components/monaco-query-field/getOverrideServices');
+
+
 
 // this thing here is a workaround in a way.
 // what we want to achieve, is that when the autocomplete-window
@@ -82,7 +86,7 @@ function makeStorageService() {
     },
 
     logStorage: (): void => {
-      console.log('logStorage: not implemented');
+      clientLog.info('logStorage: not implemented');
     },
 
     migrate: (): Promise<void> => {

--- a/packages/grafana-prometheus/src/components/monaco-query-field/monaco-completion-provider/data_provider.ts
+++ b/packages/grafana-prometheus/src/components/monaco-query-field/monaco-completion-provider/data_provider.ts
@@ -1,10 +1,13 @@
-import { type HistoryItem, type TimeRange } from '@grafana/data';
+import {type HistoryItem, type TimeRange, createClientLog} from '@grafana/data';
 
 import { DEFAULT_COMPLETION_LIMIT, METRIC_LABEL } from '../../../constants';
 import { type PrometheusLanguageProviderInterface } from '../../../language_provider';
 import { removeQuotesIfExist } from '../../../language_utils';
 import { type PromQuery } from '../../../types';
 import { escapeForUtf8Support, isValidLegacyName } from '../../../utf8_support';
+const clientLog = createClientLog('packages/grafana-prometheus/src/components/monaco-query-field/monaco-completion-provider/data_provider');
+
+
 
 export const CODE_MODE_SUGGESTIONS_INCOMPLETE_EVENT = 'codeModeSuggestionsIncomplete';
 
@@ -80,7 +83,7 @@ export class DataProvider {
 
       return Array.isArray(result) ? result : [];
     } catch (error) {
-      console.warn('Failed to query metric names:', error);
+      clientLog.warn('Failed to query metric names:', error);
       return [];
     }
   };

--- a/packages/grafana-prometheus/src/datasource.ts
+++ b/packages/grafana-prometheus/src/datasource.ts
@@ -4,8 +4,7 @@ import { lastValueFrom, type Observable, throwError } from 'rxjs';
 import { map, tap } from 'rxjs/operators';
 import { gte } from 'semver';
 
-import {
-  type AbstractQuery,
+import {type AbstractQuery,
   type AdHocVariableFilter,
   CoreApp,
   type CustomVariableModel,
@@ -26,8 +25,7 @@ import {
   type ScopedVars,
   scopeFilterOperatorMap,
   type ScopeSpecFilter,
-  type TimeRange,
-} from '@grafana/data';
+  type TimeRange, createClientLog} from '@grafana/data';
 import {
   type BackendSrvRequest,
   config,
@@ -70,6 +68,9 @@ import {
 } from './types';
 import { utf8Support, wrapUtf8Filters } from './utf8_support';
 import { PrometheusVariableSupport } from './variables';
+const clientLog = createClientLog('packages/grafana-prometheus/src/datasource');
+
+
 
 export class PrometheusDatasource
   extends DataSourceWithBackend<PromQuery, PromOptions>
@@ -172,8 +173,8 @@ export class PrometheusDatasource
         this.ruleMappings = extractRuleMappingFromGroups(ruleGroups);
       }
     } catch (err) {
-      console.log('Rules API is experimental. Ignore next error.');
-      console.error(err);
+      clientLog.info('Rules API is experimental. Ignore next error.');
+      clientLog.error(err);
     }
   }
 
@@ -352,7 +353,7 @@ export class PrometheusDatasource
       } catch (err) {
         // If status code of error is Method Not Allowed (405) and HTTP method is POST, retry with GET
         if (this.httpMethod === 'POST' && isFetchError(err) && (err.status === 405 || err.status === 400)) {
-          console.warn(`Couldn't use configured POST HTTP method for this request. Trying to use GET method instead.`);
+          clientLog.warn(`Couldn't use configured POST HTTP method for this request. Trying to use GET method instead.`);
         } else {
           throw err;
         }

--- a/packages/grafana-prometheus/src/language_provider.ts
+++ b/packages/grafana-prometheus/src/language_provider.ts
@@ -1,8 +1,7 @@
 // Core Grafana history https://github.com/grafana/grafana/blob/v11.0.0-preview/public/app/plugins/datasource/prometheus/language_provider.ts
 import Prism from 'prismjs';
 
-import {
-  type AbstractLabelMatcher,
+import {type AbstractLabelMatcher,
   AbstractLabelOperator,
   type AbstractQuery,
   type AdHocVariableFilter,
@@ -10,8 +9,7 @@ import {
   type Scope,
   scopeFilterOperatorMap,
   type ScopeSpecFilter,
-  type TimeRange,
-} from '@grafana/data';
+  type TimeRange, createClientLog} from '@grafana/data';
 import { type BackendSrvRequest } from '@grafana/runtime';
 
 import { buildCacheHeaders, getDaysToCacheMetadata, getDefaultCacheHeaders } from './caching';
@@ -21,6 +19,9 @@ import { promqlGrammar } from './promql';
 import { buildVisualQueryFromString } from './querybuilder/parsing';
 import { LabelsApiClient, type ResourceApiClient, SeriesApiClient } from './resource_clients';
 import { type PromMetricsMetadata, type PromQuery } from './types';
+const clientLog = createClientLog('packages/grafana-prometheus/src/language_provider');
+
+
 
 interface PrometheusBaseLanguageProvider {
   datasource: PrometheusDatasource;
@@ -132,7 +133,7 @@ export class PrometheusLanguageProvider implements PrometheusLanguageProviderInt
       return res.data.data;
     } catch (error) {
       if (!isCancelledError(error)) {
-        console.error(error);
+        clientLog.error(error);
       }
     }
 

--- a/packages/grafana-prometheus/src/querybuilder/components/metrics-modal/MetricsModalContext.tsx
+++ b/packages/grafana-prometheus/src/querybuilder/components/metrics-modal/MetricsModalContext.tsx
@@ -11,7 +11,7 @@ import {
   useState,
 } from 'react';
 
-import { type SelectableValue, type TimeRange } from '@grafana/data';
+import {type SelectableValue, type TimeRange, createClientLog} from '@grafana/data';
 
 import { METRIC_LABEL, PROMETHEUS_QUERY_BUILDER_MAX_RESULTS } from '../../../constants';
 import { type PrometheusLanguageProviderInterface } from '../../../language_provider';
@@ -22,6 +22,9 @@ import { formatPrometheusLabelFilters } from '../formatter';
 import { generateMetricData } from './helpers';
 import { type MetricData, type MetricsData } from './types';
 import { fuzzySearch } from './uFuzzy';
+const clientLog = createClientLog('packages/grafana-prometheus/src/querybuilder/components/metrics-modal/MetricsModalContext');
+
+
 
 export const DEFAULT_RESULTS_PER_PAGE = 25;
 
@@ -167,7 +170,7 @@ export const MetricsModalContextProvider: FC<PropsWithChildren<MetricsModalConte
         } catch (error) {
           // Only update state if this is still the latest search
           if (searchId === latestSearchIdRef.current) {
-            console.error('Backend search failed:', error);
+            clientLog.error('Backend search failed:', error);
             setMetricsData([]); // Clear results on error
             setIsLoading(false);
           }

--- a/packages/grafana-prometheus/src/querybuilder/parsing.ts
+++ b/packages/grafana-prometheus/src/querybuilder/parsing.ts
@@ -1,3 +1,4 @@
+import { createClientLog } from '@grafana/data';
 // Core Grafana history https://github.com/grafana/grafana/blob/v11.0.0-preview/public/app/plugins/datasource/prometheus/querybuilder/parsing.ts
 import { type SyntaxNode } from '@lezer/common';
 import {
@@ -43,6 +44,9 @@ import {
 } from './parsingUtils';
 import { type QueryBuilderLabelFilter, type QueryBuilderOperation } from './shared/types';
 import { type PromVisualQuery, type PromVisualQueryBinary } from './types';
+const clientLog = createClientLog('packages/grafana-prometheus/src/querybuilder/parsing');
+
+
 
 /**
  * Parses a PromQL query into a visual query model.
@@ -72,7 +76,7 @@ export function buildVisualQueryFromString(expr: string): Omit<Context, 'replace
     handleExpression(replacedExpr, node, context);
   } catch (err) {
     // Not ideal to log it here, but otherwise we would lose the stack trace.
-    console.error(err);
+    clientLog.error(err);
     if (err instanceof Error) {
       context.errors.push({
         text: err.message,

--- a/packages/grafana-prometheus/src/result_transformer.ts
+++ b/packages/grafana-prometheus/src/result_transformer.ts
@@ -1,8 +1,7 @@
 // Core Grafana history https://github.com/grafana/grafana/blob/v11.0.0-preview/public/app/plugins/datasource/prometheus/result_transformer.ts
 import { flatten, forOwn, groupBy, partition } from 'lodash';
 
-import {
-  CoreApp,
+import {CoreApp,
   type DataFrame,
   DataFrameType,
   type DataLink,
@@ -17,11 +16,13 @@ import {
   type Labels,
   sortDataFrame,
   TIME_SERIES_TIME_FIELD_NAME,
-  TIME_SERIES_VALUE_FIELD_NAME,
-} from '@grafana/data';
+  TIME_SERIES_VALUE_FIELD_NAME, createClientLog} from '@grafana/data';
 import { getDataSourceSrv } from '@grafana/runtime';
 
 import { type ExemplarTraceIdDestination, type PromMetric, type PromQuery, type PromValue } from './types';
+const clientLog = createClientLog('packages/grafana-prometheus/src/result_transformer');
+
+
 
 // handles case-insensitive Inf, +Inf, -Inf (with optional "inity" suffix)
 const INFINITY_SAMPLE_REGEX = /^[+-]?inf(?:inity)?$/i;
@@ -437,7 +438,7 @@ export function sortSeriesByLabel(s1: DataFrame, s2: DataFrame): number {
     le2 = parseSampleValue(s2.fields[1].state?.displayName ?? s2.name ?? s2.fields[1].name);
   } catch (err) {
     // fail if not integer. might happen with bad queries
-    console.error(err);
+    clientLog.error(err);
     return 0;
   }
 

--- a/packages/grafana-runtime/src/config.ts
+++ b/packages/grafana-runtime/src/config.ts
@@ -1,7 +1,6 @@
 import { merge } from 'lodash';
 
-import {
-  type AppPluginConfig as AppPluginConfigGrafanaData,
+import {type AppPluginConfig as AppPluginConfigGrafanaData,
   type AuthSettings,
   type AzureSettings as AzureSettingsGrafanaData,
   type BootData,
@@ -25,8 +24,10 @@ import {
   type TimeOption,
   type UnifiedAlertingConfig,
   type GrafanaConfig,
-  type CurrentUserDTO,
-} from '@grafana/data';
+  type CurrentUserDTO, createClientLog} from '@grafana/data';
+const clientLog = createClientLog('packages/grafana-runtime/src/config');
+
+
 
 /**
  * @deprecated Use the type from `@grafana/data`
@@ -313,7 +314,7 @@ function overrideFeatureTogglesFromLocalStorage(config: GrafanaBootConfig) {
       const toggleState = featureValue === 'true' || featureValue === '1';
       // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
       featureToggles[featureName as keyof FeatureToggles] = toggleState;
-      console.log(`Setting feature toggle ${featureName} = ${toggleState} via localstorage`);
+      clientLog.info(`Setting feature toggle ${featureName} = ${toggleState} via localstorage`);
     }
   }
 }
@@ -339,9 +340,9 @@ function overrideFeatureTogglesFromUrl(config: GrafanaBootConfig) {
       if (toggleState !== featureToggles[key]) {
         if (isDevelopment || safeRuntimeFeatureFlags.has(featureName)) {
           featureToggles[featureName] = toggleState;
-          console.log(`Setting feature toggle ${featureName} = ${toggleState} via url`);
+          clientLog.info(`Setting feature toggle ${featureName} = ${toggleState} via url`);
         } else {
-          console.log(`Unable to change feature toggle ${featureName} via url in production.`);
+          clientLog.info(`Unable to change feature toggle ${featureName} via url in production.`);
         }
       }
     }
@@ -352,7 +353,7 @@ let bootData = window.grafanaBootData;
 
 if (!bootData) {
   if (process.env.NODE_ENV !== 'test') {
-    console.error('window.grafanaBootData was not set by the time config was initialized');
+    clientLog.error('window.grafanaBootData was not set by the time config was initialized');
   }
 
   bootData = {

--- a/packages/grafana-runtime/src/internal/openFeature/index.ts
+++ b/packages/grafana-runtime/src/internal/openFeature/index.ts
@@ -1,10 +1,13 @@
 import { OFREPWebProvider } from '@openfeature/ofrep-web-provider';
 import { OpenFeature, ProviderEvents, NOOP_PROVIDER, type EventDetails } from '@openfeature/react-sdk';
 
-import { type FeatureToggles } from '@grafana/data';
+import {type FeatureToggles, createClientLog} from '@grafana/data';
 
 import { config } from '../../config';
 import { logError } from '../../utils/logging';
+const clientLog = createClientLog('packages/grafana-runtime/src/internal/openFeature/index');
+
+
 
 function checkDefaultProvider(event?: EventDetails) {
   if (event?.domain) {
@@ -18,7 +21,7 @@ function checkDefaultProvider(event?: EventDetails) {
       'OpenFeature default domain provider has been unexpectedly changed. This may be caused by a plugin that is incorrectly using the default domain.',
       { cause: OpenFeature.getProvider() }
     );
-    console.error(err);
+    clientLog.error(err);
     logError(err);
   }
 }

--- a/packages/grafana-runtime/src/services/pluginMeta/logging.ts
+++ b/packages/grafana-runtime/src/services/pluginMeta/logging.ts
@@ -1,6 +1,9 @@
-import { type PluginType } from '@grafana/data';
+import {type PluginType, createClientLog} from '@grafana/data';
 
 import { createMonitoringLogger, type MonitoringLogger } from '../../utils/logging';
+const clientLog = createClientLog('packages/grafana-runtime/src/services/pluginMeta/logging');
+
+
 
 let logger: MonitoringLogger;
 
@@ -14,12 +17,12 @@ function getLogger() {
 
 export function logPluginMetaWarning(message: string, type: PluginType): void {
   getLogger().logWarning(message, { type });
-  console.warn(message);
+  clientLog.warn(message);
 }
 
 export function logPluginMetaError(message: string, error: unknown): void {
   getLogger().logError(new Error(message, { cause: error }));
-  console.error(message, error);
+  clientLog.error(message, error);
 }
 
 export function setPluginMetaLogger(override: MonitoringLogger) {

--- a/packages/grafana-runtime/src/utils/chromeHeaderHeight.ts
+++ b/packages/grafana-runtime/src/utils/chromeHeaderHeight.ts
@@ -1,3 +1,7 @@
+import { createClientLog } from '@grafana/data';
+const clientLog = createClientLog('packages/grafana-runtime/src/utils/chromeHeaderHeight');
+
+
 type ChromeHeaderHeightHook = () => number;
 
 let chromeHeaderHeightHook: ChromeHeaderHeightHook | undefined = undefined;
@@ -11,7 +15,7 @@ export const useChromeHeaderHeight = () => {
     if (process.env.NODE_ENV !== 'production') {
       throw new Error('useChromeHeaderHeight hook not found in @grafana/runtime');
     }
-    console.error('useChromeHeaderHeight hook not found');
+    clientLog.error('useChromeHeaderHeight hook not found');
   }
 
   return chromeHeaderHeightHook?.();

--- a/packages/grafana-runtime/src/utils/logging.ts
+++ b/packages/grafana-runtime/src/utils/logging.ts
@@ -1,3 +1,5 @@
+import { setClientStructuredLog } from '@grafana/data';
+
 import { faro, type LogContext, LogLevel } from '@grafana/faro-web-sdk';
 
 import { config } from '../config';
@@ -143,3 +145,5 @@ export function createMonitoringLogger(source: string, defaultContext?: LogConte
       logMeasurement(type, measurement, createFullContext(contexts)),
   };
 }
+
+setClientStructuredLog({ logInfo, logWarning, logDebug, logError });

--- a/packages/grafana-runtime/src/utils/megaMenuOpen.ts
+++ b/packages/grafana-runtime/src/utils/megaMenuOpen.ts
@@ -1,3 +1,7 @@
+import { createClientLog } from '@grafana/data';
+const clientLog = createClientLog('packages/grafana-runtime/src/utils/megaMenuOpen');
+
+
 type MegaMenuOpenHook = () => Readonly<[boolean, (open: boolean, persist?: boolean) => void]>;
 
 let megaMenuOpenHook: MegaMenuOpenHook | undefined = undefined;
@@ -15,7 +19,7 @@ export const useMegaMenuOpen: MegaMenuOpenHook = () => {
     if (process.env.NODE_ENV !== 'production') {
       throw new Error('useMegaMenuOpen hook not found in @grafana/runtime');
     }
-    return [false, () => console.error('MegaMenuOpen hook not found')];
+    return [false, () => clientLog.error('MegaMenuOpen hook not found')];
   }
 
   return megaMenuOpenHook();

--- a/packages/grafana-runtime/src/utils/migrationHandler.ts
+++ b/packages/grafana-runtime/src/utils/migrationHandler.ts
@@ -1,10 +1,13 @@
-import { type DataQueryRequest } from '@grafana/data';
+import {type DataQueryRequest, createClientLog} from '@grafana/data';
 import { type DataQuery } from '@grafana/schema';
 
 import { config } from '../config';
 import { getBackendSrv } from '../services';
 
 import { DataSourceWithBackend } from './DataSourceWithBackend';
+const clientLog = createClientLog('packages/grafana-runtime/src/utils/migrationHandler');
+
+
 
 /**
  * @alpha Experimental: Plugins implementing MigrationHandler interface will automatically have their queries migrated.
@@ -20,7 +23,7 @@ export function isMigrationHandler(object: unknown): object is MigrationHandler 
 
 async function postMigrateRequest<TQuery extends DataQuery>(queries: TQuery[]): Promise<TQuery[]> {
   if (!(config.featureToggles.grafanaAPIServerWithExperimentalAPIs || config.featureToggles.datasourceAPIServers)) {
-    console.warn('migrateQuery is only available with the experimental API server');
+    clientLog.warn('migrateQuery is only available with the experimental API server');
     return queries;
   }
 

--- a/packages/grafana-runtime/src/utils/plugin.ts
+++ b/packages/grafana-runtime/src/utils/plugin.ts
@@ -1,6 +1,9 @@
-import { type PanelPlugin } from '@grafana/data';
+import {type PanelPlugin, createClientLog} from '@grafana/data';
 
 import { config } from '../config';
+const clientLog = createClientLog('packages/grafana-runtime/src/utils/plugin');
+
+
 
 /**
  * Option to specify a plugin css that should be applied for the dark
@@ -25,7 +28,7 @@ export async function loadPluginCss(options: PluginCssOptions): Promise<System.M
     const cssPath = config.bootData.user.theme === 'light' ? options.light : options.dark;
     return window.System.import(cssPath);
   } catch (err) {
-    console.error(err);
+    clientLog.error(err);
   }
 }
 

--- a/packages/grafana-runtime/src/utils/qscheck.ts
+++ b/packages/grafana-runtime/src/utils/qscheck.ts
@@ -1,4 +1,7 @@
-import { type DataSourceInstanceSettings, type DataSourceJsonData } from '@grafana/data';
+import {type DataSourceInstanceSettings, type DataSourceJsonData, createClientLog} from '@grafana/data';
+const clientLog = createClientLog('packages/grafana-runtime/src/utils/qscheck');
+
+
 
 interface JsonData extends DataSourceJsonData {
   oauthPassThru?: unknown; // we do not assume boolean, to be more robust
@@ -48,11 +51,11 @@ function parseAllowedTypes(data: unknown): AllowedTypes {
     if (types.every((x) => typeof x === 'string')) {
       return { types };
     } else {
-      console.error('qscheck.parseFlags: non-string item in allowed');
+      clientLog.error('qscheck.parseFlags: non-string item in allowed');
       return { types: [] };
     }
   } else {
-    console.error('qscheck.parseFlags: invalid data');
+    clientLog.error('qscheck.parseFlags: invalid data');
     return { types: [] };
   }
 }

--- a/packages/grafana-runtime/src/utils/returnToPrevious.ts
+++ b/packages/grafana-runtime/src/utils/returnToPrevious.ts
@@ -1,3 +1,7 @@
+import { createClientLog } from '@grafana/data';
+const clientLog = createClientLog('packages/grafana-runtime/src/utils/returnToPrevious');
+
+
 type ReturnToPreviousHook = () => (title: string, href?: string) => void;
 
 let rtpHook: ReturnToPreviousHook | undefined = undefined;
@@ -16,7 +20,7 @@ export const useReturnToPrevious: ReturnToPreviousHook = () => {
     if (process.env.NODE_ENV !== 'production') {
       throw new Error('useReturnToPrevious hook not found in @grafana/runtime');
     }
-    return () => console.error('ReturnToPrevious hook not found');
+    return () => clientLog.error('ReturnToPrevious hook not found');
   }
 
   return rtpHook();

--- a/packages/grafana-sql/src/datasource/SqlDatasource.ts
+++ b/packages/grafana-sql/src/datasource/SqlDatasource.ts
@@ -1,8 +1,7 @@
 import { lastValueFrom, type Observable, throwError } from 'rxjs';
 import { map } from 'rxjs/operators';
 
-import {
-  getDefaultTimeRange,
+import {getDefaultTimeRange,
   type DataFrame,
   DataFrameView,
   type DataQuery,
@@ -15,8 +14,7 @@ import {
   getSearchFilterScopedVar,
   type LegacyMetricFindQueryOptions,
   type VariableWithMultiSupport,
-  type TimeRange,
-} from '@grafana/data';
+  type TimeRange, createClientLog} from '@grafana/data';
 import { EditorMode } from '@grafana/plugin-ui';
 import {
   type BackendDataSourceResponse,
@@ -34,6 +32,9 @@ import { SqlQueryEditorLazy } from '../components/QueryEditorLazy';
 import { MACRO_NAMES } from '../constants';
 import { type DB, type SQLQuery, type SQLOptions, type SqlQueryModel, QueryFormat, type SQLDialect } from '../types';
 import migrateAnnotation from '../utils/migration';
+const clientLog = createClientLog('packages/grafana-sql/src/datasource/SqlDatasource');
+
+
 
 export abstract class SqlDatasource extends DataSourceWithBackend<SQLQuery, SQLOptions> {
   uid: string;
@@ -215,7 +216,7 @@ export abstract class SqlDatasource extends DataSourceWithBackend<SQLQuery, SQLO
     try {
       response = await this.runMetaQuery(interpolatedQuery, range);
     } catch (error) {
-      console.error(error);
+      clientLog.error(error);
       throw new Error('error when executing the sql query');
     }
     return this.getResponseParser().transformMetricFindResponse(response);

--- a/packages/grafana-ui/src/components/Combobox/storyUtils.ts
+++ b/packages/grafana-ui/src/components/Combobox/storyUtils.ts
@@ -1,4 +1,8 @@
+import { createClientLog } from '@grafana/data';
 import { type ComboboxOption } from './types';
+const clientLog = createClientLog('packages/grafana-ui/src/components/Combobox/storyUtils');
+
+
 
 let fakeApiOptions: Array<ComboboxOption<string>>;
 export async function fakeSearchAPI(urlString: string): Promise<Array<ComboboxOption<string>>> {
@@ -13,7 +17,7 @@ export async function fakeSearchAPI(urlString: string): Promise<Array<ComboboxOp
 
   if (!fakeApiOptions) {
     fakeApiOptions = await generateOptions(1000);
-    console.log('fakeApiOptions', fakeApiOptions);
+    clientLog.info('fakeApiOptions', fakeApiOptions);
   }
 
   if (!searchQuery || searchQuery.length === 0) {

--- a/packages/grafana-ui/src/components/Combobox/useOptions.ts
+++ b/packages/grafana-ui/src/components/Combobox/useOptions.ts
@@ -1,3 +1,4 @@
+import { createClientLog } from '@grafana/data';
 /* Spreading unbound arrays can be very slow or even crash the browser if used for arguments */
 /* eslint no-restricted-syntax: ["error", "SpreadElement"] */
 
@@ -9,6 +10,9 @@ import { t } from '@grafana/i18n';
 import { fuzzyFind, itemToString } from './filter';
 import { type ComboboxOption } from './types';
 import { StaleResultError, useLatestAsyncCall } from './useLatestAsyncCall';
+const clientLog = createClientLog('packages/grafana-ui/src/components/Combobox/useOptions');
+
+
 
 type AsyncOptions<T extends string | number> =
   | Array<ComboboxOption<T>>
@@ -51,7 +55,7 @@ export function useOptions<T extends string | number>(
               setAsyncLoading(false);
 
               if (error) {
-                console.error('Error loading async options for Combobox', error);
+                clientLog.error('Error loading async options for Combobox', error);
               }
             }
           });

--- a/packages/grafana-ui/src/components/Combobox/utils.ts
+++ b/packages/grafana-ui/src/components/Combobox/utils.ts
@@ -1,6 +1,9 @@
-import { isIconName, type SelectableValue } from '@grafana/data';
+import {isIconName, type SelectableValue, createClientLog} from '@grafana/data';
 
 import { type ComboboxOption } from './types';
+const clientLog = createClientLog('packages/grafana-ui/src/components/Combobox/utils');
+
+
 
 export const isNewGroup = <T extends string | number>(option: ComboboxOption<T>, prevOption?: ComboboxOption<T>) => {
   const currentGroup = option.group;
@@ -25,11 +28,11 @@ export const selectableValueToComboboxOption = <T extends string | number>(
   v: SelectableValue<T>
 ): ComboboxOption<T> | undefined => {
   if (v == null || v.value == null) {
-    console.warn('selectableValueToComboboxOption: value is null or undefined', v);
+    clientLog.warn('selectableValueToComboboxOption: value is null or undefined', v);
     return undefined;
   }
   if (v.icon != null && !isIconName(v.icon)) {
-    console.warn('selectableValueToComboboxOption: icon is not a valid icon name', v.icon);
+    clientLog.warn('selectableValueToComboboxOption: icon is not a valid icon name', v.icon);
     return undefined;
   }
   return {

--- a/packages/grafana-ui/src/components/DateTimePickers/TimeRangePicker/CalendarBody.tsx
+++ b/packages/grafana-ui/src/components/DateTimePickers/TimeRangePicker/CalendarBody.tsx
@@ -2,7 +2,7 @@ import { css } from '@emotion/css';
 import { useCallback } from 'react';
 import Calendar, { type CalendarType } from 'react-calendar';
 
-import { type GrafanaTheme2, dateTimeParse, type DateTime, type TimeZone } from '@grafana/data';
+import {type GrafanaTheme2, dateTimeParse, type DateTime, type TimeZone, createClientLog} from '@grafana/data';
 import { t } from '@grafana/i18n';
 
 import { useStyles2 } from '../../../themes/ThemeContext';
@@ -11,6 +11,9 @@ import { getWeekStart, type WeekStart } from '../WeekStartPicker';
 import { adjustDateForReactCalendar } from '../utils/adjustDateForReactCalendar';
 
 import { type TimePickerCalendarProps } from './TimePickerCalendar';
+const clientLog = createClientLog('packages/grafana-ui/src/components/DateTimePickers/TimeRangePicker/CalendarBody');
+
+
 
 const weekStartMap: Record<WeekStart, CalendarType> = {
   saturday: 'islamic',
@@ -70,7 +73,7 @@ function useOnCalendarChange(onChange: (from: DateTime, to: DateTime) => void, t
   return useCallback<NonNullable<React.ComponentProps<typeof Calendar>['onChange']>>(
     (value) => {
       if (!Array.isArray(value)) {
-        return console.error('onCalendarChange: should be run in selectRange={true}');
+        return clientLog.error('onCalendarChange: should be run in selectRange={true}');
       }
 
       if (value[0] && value[1]) {

--- a/packages/grafana-ui/src/components/Icon/Icon.tsx
+++ b/packages/grafana-ui/src/components/Icon/Icon.tsx
@@ -2,13 +2,16 @@ import { css, cx } from '@emotion/css';
 import { useCallback, useState, useRef, memo, forwardRef } from 'react';
 import SVG from 'react-inlinesvg';
 
-import { type GrafanaTheme2, isIconName } from '@grafana/data';
+import {type GrafanaTheme2, isIconName, createClientLog} from '@grafana/data';
 
 import { useStyles2 } from '../../themes/ThemeContext';
 import { type IconName, type IconType, type IconSize } from '../../types/icon';
 import { spin } from '../../utils/keyframes';
 
 import { getIconPath, getSvgSize } from './utils';
+const clientLog = createClientLog('packages/grafana-ui/src/components/Icon/Icon');
+
+
 
 export interface IconProps extends Omit<React.SVGProps<SVGElement>, 'onLoad' | 'onError' | 'ref'> {
   name: IconName;
@@ -96,7 +99,7 @@ export const Icon = memo(
       const { nameToUse: name, handleLoad } = useIconWorkaround(nameProp);
 
       if (!isIconName(name)) {
-        console.warn('Icon component passed an invalid icon name', name);
+        clientLog.warn('Icon component passed an invalid icon name', name);
       }
 
       // handle the deprecated 'fa fa-spinner'

--- a/packages/grafana-ui/src/components/Input/AutoSizeInput.tsx
+++ b/packages/grafana-ui/src/components/Input/AutoSizeInput.tsx
@@ -1,3 +1,4 @@
+import { createClientLog } from '@grafana/data';
 import { useCallback, useEffect, useMemo, useRef } from 'react';
 import * as React from 'react';
 
@@ -5,6 +6,9 @@ import { measureText } from '../../utils/measureText';
 
 import { AutoSizeInputContext } from './AutoSizeInputContext';
 import { Input, type Props as InputProps } from './Input';
+const clientLog = createClientLog('packages/grafana-ui/src/components/Input/AutoSizeInput');
+
+
 
 export interface Props extends InputProps {
   /** Sets the min-width to a multiple of 8px. Default value is 10*/
@@ -119,7 +123,7 @@ function useControlledState<T>(controlledValue: T, onChange: Function | undefine
 
   const hasLoggedControlledWarning = useRef(false);
   if (isControlledNow !== isControlledRef.current && !hasLoggedControlledWarning.current) {
-    console.warn(
+    clientLog.warn(
       'An AutoSizeInput is changing from an uncontrolled to a controlled input. If you want to control the input, the empty value should be an empty string.'
     );
     hasLoggedControlledWarning.current = true;

--- a/packages/grafana-ui/src/components/Monaco/CodeEditor.tsx
+++ b/packages/grafana-ui/src/components/Monaco/CodeEditor.tsx
@@ -2,7 +2,7 @@ import { css, cx } from '@emotion/css';
 import type * as monacoType from 'monaco-editor/esm/vs/editor/editor.api';
 import { PureComponent } from 'react';
 
-import { type GrafanaTheme2, monacoLanguageRegistry } from '@grafana/data';
+import {type GrafanaTheme2, monacoLanguageRegistry, createClientLog} from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';
 
 import { withTheme2 } from '../../themes/ThemeContext';
@@ -11,6 +11,9 @@ import { type Themeable2 } from '../../types/theme';
 import { ReactMonacoEditorLazy } from './ReactMonacoEditorLazy';
 import { registerSuggestions } from './suggestions';
 import { type CodeEditorProps, type Monaco, type MonacoEditor as MonacoEditorType, type MonacoOptions } from './types';
+const clientLog = createClientLog('packages/grafana-ui/src/components/Monaco/CodeEditor');
+
+
 
 type Props = CodeEditorProps & Themeable2;
 
@@ -43,7 +46,7 @@ class UnthemedCodeEditor extends PureComponent<Props> {
       }
 
       if (!this.monaco) {
-        console.warn('Monaco instance not loaded yet');
+        clientLog.warn('Monaco instance not loaded yet');
         return;
       }
 

--- a/packages/grafana-ui/src/components/StatsPicker/StatsPicker.tsx
+++ b/packages/grafana-ui/src/components/StatsPicker/StatsPicker.tsx
@@ -1,7 +1,7 @@
 import { difference } from 'lodash';
 import { memo, useEffect } from 'react';
 
-import { fieldReducers, type FieldReducerInfo } from '@grafana/data';
+import {fieldReducers, type FieldReducerInfo, createClientLog} from '@grafana/data';
 import { t } from '@grafana/i18n';
 
 import { Combobox, type ComboboxProps } from '../Combobox/Combobox';
@@ -10,6 +10,9 @@ import { type ComboboxOption } from '../Combobox/types';
 import { selectableValueToComboboxOption } from '../Combobox/utils';
 
 import { pickComboboxLayout } from './pickComboboxLayout';
+const clientLog = createClientLog('packages/grafana-ui/src/components/StatsPicker/StatsPicker');
+
+
 
 /** Props managed by StatsPicker — forwarded combobox props must not replace these. */
 type ComboboxManagedProps = 'value' | 'options' | 'onChange' | 'isClearable' | 'width' | 'minWidth' | 'maxWidth';
@@ -53,13 +56,13 @@ export const StatsPicker = memo<StatsPickerProps>(
       if (current.length !== stats.length) {
         const found = current.map((v) => v.id);
         const notFound = difference(stats, found);
-        console.warn('Unknown stats', notFound, stats);
+        clientLog.warn('Unknown stats', notFound, stats);
         onChange(current.map((stat) => stat.id));
       }
 
       // Make sure there is only one
       if (!allowMultiple && stats.length > 1) {
-        console.warn('Removing extra stat', stats);
+        clientLog.warn('Removing extra stat', stats);
         onChange([stats[0]]);
       }
 

--- a/packages/grafana-ui/src/components/Table/TableNG/utils.ts
+++ b/packages/grafana-ui/src/components/Table/TableNG/utils.ts
@@ -7,8 +7,7 @@ import { type SortColumn } from 'react-data-grid';
 import tinycolor from 'tinycolor2';
 import { type Count, varPreLine } from 'uwrap';
 
-import {
-  FieldType,
+import {FieldType,
   type Field,
   formattedValueToString,
   type GrafanaTheme2,
@@ -19,8 +18,7 @@ import {
   type DisplayProcessor,
   isDataFrame,
   type FieldSparkline,
-  type DecimalCount,
-} from '@grafana/data';
+  type DecimalCount, createClientLog} from '@grafana/data';
 import {
   BarGaugeDisplayMode,
   type FieldTextAlignment,
@@ -46,6 +44,9 @@ import {
   type MeasureCellHeightEntry,
   type FilterType,
 } from './types';
+const clientLog = createClientLog('packages/grafana-ui/src/components/Table/TableNG/utils');
+
+
 
 /* ---------------------------- Cell calculations --------------------------- */
 export type CellNumLinesCalculator = (text: string, cellWidth: number) => number;
@@ -1184,7 +1185,7 @@ export function parseStyleJson(rawValue: unknown): CSSProperties | void {
       }
     } catch (e) {
       if (!warnedAboutStyleJsonSet.has(rawValue)) {
-        console.error(`encountered invalid cell style JSON: ${rawValue}`, e);
+        clientLog.error(`encountered invalid cell style JSON: ${rawValue}`, e);
         warnedAboutStyleJsonSet.add(rawValue);
       }
     }

--- a/packages/grafana-ui/src/components/ThemeDemos/EmotionPerfTest.tsx
+++ b/packages/grafana-ui/src/components/ThemeDemos/EmotionPerfTest.tsx
@@ -4,14 +4,17 @@ import { css, cx } from '@emotion/css';
 import classnames from 'classnames';
 import React, { Profiler, type ProfilerOnRenderCallback, useState, type FC } from 'react';
 
-import { type GrafanaTheme2 } from '@grafana/data';
+import {type GrafanaTheme2, createClientLog} from '@grafana/data';
 
 import { useStyles2, useTheme2 } from '../../themes/ThemeContext';
 import { Button } from '../Button/Button';
 import { Stack } from '../Layout/Stack/Stack';
+const clientLog = createClientLog('packages/grafana-ui/src/components/ThemeDemos/EmotionPerfTest');
+
+
 
 export function EmotionPerfTest() {
-  console.log('process.env.NODE_ENV', process.env.NODE_ENV);
+  clientLog.info('process.env.NODE_ENV', process.env.NODE_ENV);
 
   return (
     <Stack direction="column">
@@ -126,7 +129,7 @@ function NoStyles({ index }: TestComponentProps) {
 
 function MeasureRender({ children, id }: { children: React.ReactNode; id: string }) {
   const onRender: ProfilerOnRenderCallback = (id, phase, actualDuration, baseDuration, startTime, commitTime) => {
-    console.log('Profile ' + id, actualDuration);
+    clientLog.info('Profile ' + id, actualDuration);
   };
 
   return (

--- a/packages/grafana-ui/src/components/VizTooltip/VizTooltipRow.tsx
+++ b/packages/grafana-ui/src/components/VizTooltip/VizTooltipRow.tsx
@@ -3,7 +3,7 @@ import clsx from 'clsx';
 import { type CSSProperties, type ReactNode, useEffect, useRef, useState } from 'react';
 import * as React from 'react';
 
-import { type GrafanaTheme2 } from '@grafana/data';
+import {type GrafanaTheme2, createClientLog} from '@grafana/data';
 
 import { useStyles2 } from '../../themes/ThemeContext';
 import { InlineToast } from '../InlineToast/InlineToast';
@@ -11,6 +11,9 @@ import { Tooltip } from '../Tooltip/Tooltip';
 
 import { ColorIndicatorPosition, VizTooltipColorIndicator } from './VizTooltipColorIndicator';
 import { ColorPlacement, type VizTooltipItem } from './types';
+const clientLog = createClientLog('packages/grafana-ui/src/components/VizTooltip/VizTooltipRow');
+
+
 
 interface VizTooltipRowProps extends Omit<VizTooltipItem, 'value'> {
   value: string | number | null | ReactNode;
@@ -112,7 +115,7 @@ export const VizTooltipRow = ({
         setShowCopySuccess(true);
       }
     } catch (err) {
-      console.error('Unable to copy to clipboard', err);
+      clientLog.error('Unable to copy to clipboard', err);
     }
 
     textarea.remove();

--- a/packages/grafana-ui/src/utils/logOptions.ts
+++ b/packages/grafana-ui/src/utils/logOptions.ts
@@ -1,3 +1,7 @@
+import { createClientLog } from '@grafana/data';
+const clientLog = createClientLog('packages/grafana-ui/src/utils/logOptions');
+
+
 /**
  * This function logs a warning if the amount of items exceeds the recommended amount.
  *
@@ -13,7 +17,7 @@ export function logOptions(
 ): void {
   if (amount > recommendedAmount) {
     const msg = `[Combobox] Items exceed the recommended amount ${recommendedAmount}.`;
-    console.warn(msg, {
+    clientLog.warn(msg, {
       itemsCount: '' + amount,
       recommendedAmount: '' + recommendedAmount,
       'aria-labelledby': ariaLabelledBy ?? '',

--- a/public/app/AppWrapper.tsx
+++ b/public/app/AppWrapper.tsx
@@ -1,3 +1,4 @@
+import { createClientLog } from '@grafana/data';
 import { OpenFeatureProvider } from '@openfeature/react-sdk';
 import { UNSAFE_PortalProvider } from '@react-aria/overlays';
 import { type Action, KBarProvider } from 'kbar';
@@ -23,6 +24,9 @@ import { getPluginExtensionRegistries } from './features/plugins/extensions/regi
 import { type PluginExtensionRegistries } from './features/plugins/extensions/registry/types';
 import { ScopesContextProvider } from './features/scopes/ScopesContextProvider';
 import { RouterWrapper } from './routes/RoutesWrapper';
+const clientLog = createClientLog('public/app/AppWrapper');
+
+
 
 interface AppWrapperProps {
   context: GrafanaContextType;
@@ -77,7 +81,7 @@ export class AppWrapper extends Component<AppWrapperProps, AppWrapperState> {
     if (preloader) {
       preloader.remove();
     } else {
-      console.warn('Preloader element not found');
+      clientLog.warn('Preloader element not found');
     }
   }
 

--- a/public/app/api/clients/provisioning/utils/createOnCacheEntryAdded.ts
+++ b/public/app/api/clients/provisioning/utils/createOnCacheEntryAdded.ts
@@ -1,8 +1,12 @@
+import { createClientLog } from '@grafana/data';
 import { type ThunkDispatch, type UnknownAction } from '@reduxjs/toolkit';
 import { type Subscription } from 'rxjs';
 
 import { ScopedResourceClient } from 'app/features/apiserver/client';
 import { type ListOptions, type GeneratedResourceList as ResourceList } from 'app/features/apiserver/types';
+const clientLog = createClientLog('public/app/api/clients/provisioning/utils/createOnCacheEntryAdded');
+
+
 
 interface OnCacheEntryAddedOptions<List = unknown> {
   onError?: (
@@ -80,7 +84,7 @@ export function createOnCacheEntryAdded<Spec, Status>(
           },
         });
     } catch (error) {
-      console.error('Error in onCacheEntryAdded:', error);
+      clientLog.error('Error in onCacheEntryAdded:', error);
       return;
     }
 

--- a/public/app/api/clients/provisioning/v0alpha1/index.ts
+++ b/public/app/api/clients/provisioning/v0alpha1/index.ts
@@ -1,3 +1,4 @@
+import { createClientLog } from '@grafana/data';
 import {
   generatedAPI,
   type ConnectionSpec,
@@ -25,6 +26,9 @@ import { PAGE_SIZE } from '../../../../features/browse-dashboards/api/services';
 import { refetchChildren } from '../../../../features/browse-dashboards/state/actions';
 import { handleError } from '../../../utils';
 import { createOnCacheEntryAdded } from '../utils/createOnCacheEntryAdded';
+const clientLog = createClientLog('public/app/api/clients/provisioning/v0alpha1/index');
+
+
 
 const handleProvisioningFormError = (e: unknown, dispatch: ThunkDispatch, title: string) => {
   if (typeof e === 'object' && e && 'error' in e && isFetchError(e.error)) {
@@ -271,7 +275,7 @@ export const provisioningAPIv0alpha1 = generatedAPI.enhanceEndpoints({
             dispatch(clearFolders(childrenKeys));
           }
         } catch (e) {
-          console.error('Error in getRepositoryJobsWithPath:', e);
+          clientLog.error('Error in getRepositoryJobsWithPath:', e);
         }
       },
     },

--- a/public/app/app.ts
+++ b/public/app/app.ts
@@ -8,16 +8,14 @@ import 'jquery';
 import { createElement } from 'react';
 import { createRoot } from 'react-dom/client';
 
-import {
-  locationUtil,
+import {locationUtil,
   monacoLanguageRegistry,
   setLocale,
   setTimeZoneResolver,
   setWeekStart,
   standardEditorsRegistry,
   standardFieldConfigEditorRegistry,
-  standardTransformersRegistry,
-} from '@grafana/data';
+  standardTransformersRegistry, createClientLog} from '@grafana/data';
 import { DEFAULT_LANGUAGE } from '@grafana/i18n';
 import { initializeI18n, loadNamespacedResources } from '@grafana/i18n/internal';
 import {
@@ -121,6 +119,9 @@ import { createSwitchVariableAdapter } from './features/variables/switch/adapter
 import { createSystemVariableAdapter } from './features/variables/system/adapter';
 import { createTextBoxVariableAdapter } from './features/variables/textbox/adapter';
 import { configureStore } from './store/configureStore';
+const clientLog = createClientLog('public/app/app');
+
+
 
 // import symlinked extensions
 const extensionsIndex = require.context('.', true, /extensions\/index.ts/);
@@ -146,7 +147,7 @@ export class GrafanaApp {
         try {
           await initOpenFeature();
         } catch (err) {
-          console.error('Failed to initialize OpenFeature provider', err);
+          clientLog.error('Failed to initialize OpenFeature provider', err);
         }
       }
 
@@ -286,7 +287,7 @@ export class GrafanaApp {
       try {
         cleanupOldExpandedFolders();
       } catch (err) {
-        console.warn('Failed to clean up old expanded folders', err);
+        clientLog.warn('Failed to clean up old expanded folders', err);
       }
 
       this.context = {
@@ -316,7 +317,7 @@ export class GrafanaApp {
 
       await postInitTasks();
     } catch (error) {
-      console.error('Failed to start Grafana', error);
+      clientLog.error('Failed to start Grafana', error);
       window.__grafana_load_failed();
     } finally {
       stopMeasure('frontend_app_init');

--- a/public/app/core/components/AccessControl/Permissions.tsx
+++ b/public/app/core/components/AccessControl/Permissions.tsx
@@ -4,7 +4,7 @@ import { useEffect, useMemo, useState } from 'react';
 import * as React from 'react';
 import useAsyncFn from 'react-use/lib/useAsyncFn';
 
-import { type GrafanaTheme2 } from '@grafana/data';
+import {type GrafanaTheme2, createClientLog} from '@grafana/data';
 import { Trans, t } from '@grafana/i18n';
 import { Text, Box, Button, useStyles2, LoadingPlaceholder } from '@grafana/ui';
 import { SlideDown } from 'app/core/components/Animations/SlideDown';
@@ -14,6 +14,9 @@ import { DescendantCount } from 'app/features/browse-dashboards/components/Brows
 import { AddPermission } from './AddPermission';
 import { PermissionList } from './PermissionList';
 import { PermissionTarget, type ResourcePermission, type SetPermission, type Description } from './types';
+const clientLog = createClientLog('public/app/core/components/AccessControl/Permissions');
+
+
 
 const EMPTY_PERMISSION = '';
 
@@ -248,7 +251,7 @@ const getDescription = async (resource: string, queryParams?: Record<string, str
   try {
     return await getBackendSrv().get(`/api/access-control/${resource}/description`, queryParams);
   } catch (e) {
-    console.error('failed to load resource description: ', e);
+    clientLog.error('failed to load resource description: ', e);
     return INITIAL_DESCRIPTION;
   }
 };

--- a/public/app/core/components/AppChrome/TopBar/InviteUserButton.tsx
+++ b/public/app/core/components/AppChrome/TopBar/InviteUserButton.tsx
@@ -1,3 +1,4 @@
+import { createClientLog } from '@grafana/data';
 import { skipToken } from '@reduxjs/toolkit/query';
 
 import { t } from '@grafana/i18n';
@@ -13,6 +14,9 @@ import {
   shouldRenderInviteUserButton,
   shouldRenderUpgradeUserButton,
 } from './InviteUserButtonUtils';
+const clientLog = createClientLog('public/app/core/components/AppChrome/TopBar/InviteUserButton');
+
+
 
 export function InviteUserButton() {
   const isLargeScreen = useMediaQueryMinWidth('lg');
@@ -42,7 +46,7 @@ export function InviteUserButton() {
         performInviteUserClick('top_bar_right', 'invite-user-top-bar');
       }
     } catch (error) {
-      console.error('Failed to handle invite/upgrade user click:', error);
+      clientLog.error('Failed to handle invite/upgrade user click:', error);
     }
   };
 

--- a/public/app/core/components/Login/LoginCtrl.tsx
+++ b/public/app/core/components/Login/LoginCtrl.tsx
@@ -1,3 +1,4 @@
+import { createClientLog } from '@grafana/data';
 import { memo, useState, useCallback, type JSX } from 'react';
 
 import { t } from '@grafana/i18n';
@@ -5,6 +6,9 @@ import { type FetchError, getBackendSrv, isFetchError } from '@grafana/runtime';
 import config from 'app/core/config';
 
 import { type LoginDTO } from './types';
+const clientLog = createClientLog('public/app/core/components/Login/LoginCtrl');
+
+
 
 const isOauthEnabled = () => {
   return !!config.oauth && Object.keys(config.oauth).length > 0;
@@ -88,7 +92,7 @@ export const LoginCtrl = memo(({ resetCode, children }: Props) => {
           .then(() => {
             toGrafana();
           })
-          .catch((err) => console.error(err));
+          .catch((err) => clientLog.error(err));
       }
     },
     [resetCode, toGrafana]

--- a/public/app/core/components/NavLandingPage/NavLandingPage.tsx
+++ b/public/app/core/components/NavLandingPage/NavLandingPage.tsx
@@ -1,13 +1,16 @@
 import { css } from '@emotion/css';
 import * as React from 'react';
 
-import { type GrafanaTheme2, type NavModelItem } from '@grafana/data';
+import {type GrafanaTheme2, type NavModelItem, createClientLog} from '@grafana/data';
 import { usePluginComponents, usePluginLinks } from '@grafana/runtime';
 import { useStyles2 } from '@grafana/ui';
 import { Page } from 'app/core/components/Page/Page';
 import { useNavModel } from 'app/core/hooks/useNavModel';
 
 import { NavLandingPageCard } from './NavLandingPageCard';
+const clientLog = createClientLog('public/app/core/components/NavLandingPage/NavLandingPage');
+
+
 
 interface Props {
   navId: string;
@@ -36,7 +39,7 @@ export function NavLandingPage({ navId, header }: Props) {
   // Warn if both extension points are being used (they are mutually exclusive)
   React.useEffect(() => {
     if (components && components.length > 0 && additionalCards && additionalCards.length > 0) {
-      console.warn(
+      clientLog.warn(
         `[NavLandingPage] Both NavLandingPage and NavLandingPageCards extensions are registered for "${node.id}". ` +
           `The NavLandingPage extension will take precedence and NavLandingPageCards will be ignored. ` +
           `Please use only one extension point.`

--- a/public/app/core/components/RolePicker/TeamRolePicker.tsx
+++ b/public/app/core/components/RolePicker/TeamRolePicker.tsx
@@ -1,3 +1,4 @@
+import { createClientLog } from '@grafana/data';
 import { skipToken } from '@reduxjs/toolkit/query';
 import { useMemo } from 'react';
 
@@ -6,6 +7,9 @@ import { contextSrv } from 'app/core/services/context_srv';
 import { AccessControlAction, type Role } from 'app/types/accessControl';
 
 import { RolePicker } from './RolePicker';
+const clientLog = createClientLog('public/app/core/components/RolePicker/TeamRolePicker');
+
+
 
 export interface Props {
   teamId: number;
@@ -79,7 +83,7 @@ export const TeamRolePicker = ({
           },
         }).unwrap();
       } catch (error) {
-        console.error('Error updating team roles', error);
+        clientLog.error('Error updating team roles', error);
       }
     } else if (onApplyRoles) {
       onApplyRoles(newRoles);

--- a/public/app/core/components/RolePicker/UserRolePicker.tsx
+++ b/public/app/core/components/RolePicker/UserRolePicker.tsx
@@ -1,12 +1,15 @@
 import { skipToken } from '@reduxjs/toolkit/query';
 import { useMemo } from 'react';
 
-import { type OrgRole } from '@grafana/data';
+import {type OrgRole, createClientLog} from '@grafana/data';
 import { useListUserRolesQuery, useSetUserRolesMutation } from 'app/api/clients/roles';
 import { contextSrv } from 'app/core/services/context_srv';
 import { AccessControlAction, type Role } from 'app/types/accessControl';
 
 import { RolePicker } from './RolePicker';
+const clientLog = createClientLog('public/app/core/components/RolePicker/UserRolePicker');
+
+
 
 export interface Props {
   basicRole: OrgRole;
@@ -90,7 +93,7 @@ export const UserRolePicker = ({
           },
         }).unwrap();
       } catch (error) {
-        console.error('Error updating user roles', error);
+        clientLog.error('Error updating user roles', error);
       }
     } else if (onApplyRoles) {
       onApplyRoles(newRoles, userId, orgId);

--- a/public/app/core/components/SharedPreferences/SharedPreferencesFunctional.tsx
+++ b/public/app/core/components/SharedPreferences/SharedPreferencesFunctional.tsx
@@ -2,7 +2,7 @@ import { useBooleanFlagValue } from '@openfeature/react-sdk';
 import { memo, useMemo, useState, useEffect } from 'react';
 
 import { type PreferencesSpec as UserPreferencesDTO } from '@grafana/api-clients/rtkq/preferences/v1alpha1';
-import { FeatureState } from '@grafana/data';
+import {FeatureState, createClientLog} from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';
 import { t, Trans } from '@grafana/i18n';
 import { config, reportInteraction } from '@grafana/runtime';
@@ -38,6 +38,9 @@ import {
   type Props,
   type State,
 } from './utils';
+const clientLog = createClientLog('public/app/core/components/SharedPreferences/SharedPreferencesFunctional');
+
+
 
 export const SharedPreferencesFunctional = memo((props: Props) => {
   const isAnalyticsFrameworkEnabled = useBooleanFlagValue('analyticsFramework', true);
@@ -89,7 +92,7 @@ export const SharedPreferencesFunctional = memo((props: Props) => {
           navbar: prefs.navbar ?? prev.navbar,
         }));
       } catch (err) {
-        console.error('Failed to load preferences', err);
+        clientLog.error('Failed to load preferences', err);
       } finally {
         setState((prev) => ({ ...prev, isLoading: false }));
       }

--- a/public/app/core/components/TimePicker/TimePickerWithHistory.tsx
+++ b/public/app/core/components/TimePicker/TimePickerWithHistory.tsx
@@ -1,16 +1,17 @@
 import { uniqBy } from 'lodash';
 
-import {
-  AppEvents,
+import {AppEvents,
   type DateTime,
   LocalStorageValueProvider,
   type TimeRange,
   isDateTime,
-  rangeUtil,
-} from '@grafana/data';
+  rangeUtil, createClientLog} from '@grafana/data';
 import { t } from '@grafana/i18n';
 import { type TimeRangePickerProps, TimeRangePicker } from '@grafana/ui';
 import { appEvents } from 'app/core/app_events';
+const clientLog = createClientLog('public/app/core/components/TimePicker/TimePickerWithHistory');
+
+
 
 const LOCAL_STORAGE_KEY = 'grafana.dashboard.timepicker.history';
 const MAX_HISTORY_ITEMS = 4;
@@ -136,7 +137,7 @@ function convertToISOString(value: DateTime | string): string {
   }
 
   if (!value?.toISOString) {
-    throw console.error('Invalid DateTime object passed to convertToISOString');
+    throw clientLog.error('Invalid DateTime object passed to convertToISOString');
   }
 
   return value.toISOString();

--- a/public/app/core/navigation/errorModels.ts
+++ b/public/app/core/navigation/errorModels.ts
@@ -1,7 +1,10 @@
-import { type NavModel, type NavModelItem } from '@grafana/data';
+import {type NavModel, type NavModelItem, createClientLog} from '@grafana/data';
+const clientLog = createClientLog('public/app/core/navigation/errorModels');
+
+
 
 export function getExceptionNav(error: unknown): NavModel {
-  console.error(error);
+  clientLog.error(error);
   return getWarningNav('Exception thrown', 'See console for details');
 }
 

--- a/public/app/core/reducers/appNotification.ts
+++ b/public/app/core/reducers/appNotification.ts
@@ -1,6 +1,10 @@
+import { createClientLog } from '@grafana/data';
 import { createSelector, createSlice, type PayloadAction } from '@reduxjs/toolkit';
 
 import { type AppNotification, AppNotificationSeverity, type AppNotificationsState } from 'app/types/appNotifications';
+const clientLog = createClientLog('public/app/core/reducers/appNotification');
+
+
 
 const MAX_STORED_NOTIFICATIONS = 25;
 export const STORAGE_KEY = 'notifications';
@@ -122,7 +126,7 @@ function serializeNotifications(notifs: Record<string, StoredNotification>) {
   try {
     window.localStorage.setItem(STORAGE_KEY, JSON.stringify(reducedNotifs));
   } catch (err) {
-    console.error('Unable to persist notifications to local storage');
-    console.error(err);
+    clientLog.error('Unable to persist notifications to local storage');
+    clientLog.error(err);
   }
 }

--- a/public/app/core/services/FetchQueue.ts
+++ b/public/app/core/services/FetchQueue.ts
@@ -1,6 +1,10 @@
+import { createClientLog } from '@grafana/data';
 import { type Observable, Subject } from 'rxjs';
 
 import { type BackendSrvRequest } from '@grafana/runtime';
+const clientLog = createClientLog('public/app/core/services/FetchQueue');
+
+
 
 export interface QueueState extends Record<string, { state: FetchStatus; options: BackendSrvRequest }> {}
 
@@ -90,8 +94,8 @@ export class FetchQueue {
       []
     );
 
-    console.log('FetchQueue noOfStarted', update.noOfInProgress);
-    console.log('FetchQueue noOfNotStarted', update.noOfPending);
-    console.log('FetchQueue state', entriesWithoutOptions);
+    clientLog.info('FetchQueue noOfStarted', update.noOfInProgress);
+    clientLog.info('FetchQueue noOfNotStarted', update.noOfPending);
+    clientLog.info('FetchQueue state', entriesWithoutOptions);
   };
 }

--- a/public/app/core/services/backend_srv.ts
+++ b/public/app/core/services/backend_srv.ts
@@ -26,7 +26,7 @@ import {
 } from 'rxjs/operators';
 import { v4 as uuidv4 } from 'uuid';
 
-import { AppEvents, DataQueryErrorType, deprecationWarning } from '@grafana/data';
+import {AppEvents, DataQueryErrorType, deprecationWarning, createClientLog} from '@grafana/data';
 import {
   type BackendSrv as BackendService,
   type BackendSrvRequest,
@@ -52,6 +52,9 @@ import { FetchQueue } from './FetchQueue';
 import { FetchQueueWorker } from './FetchQueueWorker';
 import { ResponseQueue } from './ResponseQueue';
 import { type ContextSrv, contextSrv } from './context_srv';
+const clientLog = createClientLog('public/app/core/services/backend_srv');
+
+
 
 const CANCEL_ALL_REQUESTS_REQUEST_ID = 'cancel_all_requests_request_id';
 
@@ -116,7 +119,7 @@ export class BackendSrv implements BackendService {
       const result = await fp.get();
       this.deviceID = result.visitorId;
     } catch (error) {
-      console.error(error);
+      clientLog.error(error);
     }
   }
 
@@ -241,7 +244,7 @@ export class BackendSrv implements BackendService {
             observer.complete();
           }) // runs in background
           .catch((e) => {
-            console.log(requestId, 'catch', e);
+            clientLog.info(requestId, 'catch', e);
             observer.error(e);
           }); // from abort
       },

--- a/public/app/core/services/context_srv.ts
+++ b/public/app/core/services/context_srv.ts
@@ -1,20 +1,21 @@
 import { extend } from 'lodash';
 
-import {
-  type AnalyticsSettings,
+import {type AnalyticsSettings,
   type OrgRole,
   rangeUtil,
   type WithAccessControlMetadata,
   userHasPermission,
   userHasPermissionInMetadata,
-  userHasAnyPermission,
-} from '@grafana/data';
+  userHasAnyPermission, createClientLog} from '@grafana/data';
 import { featureEnabled, getBackendSrv } from '@grafana/runtime';
 import { getSessionExpiry } from 'app/core/utils/auth';
 import { type UserPermission, AccessControlAction } from 'app/types/accessControl';
 import { type CurrentUserInternal } from 'app/types/config';
 
 import config from '../../core/config';
+const clientLog = createClientLog('public/app/core/services/context_srv');
+
+
 
 // When set to auto, the interval will be based on the query range
 // NOTE: this is defined here rather than TimeSrv so we avoid circular dependencies
@@ -112,7 +113,7 @@ export class ContextSrv {
         reloadcache: true,
       });
     } catch (e) {
-      console.error(e);
+      clientLog.error(e);
     }
   }
 
@@ -262,7 +263,7 @@ export class ContextSrv {
         }
       })
       .catch((e) => {
-        console.error(e);
+        clientLog.error(e);
       });
   }
 }

--- a/public/app/core/services/echo/backends/analytics/BrowseConsoleBackend.ts
+++ b/public/app/core/services/echo/backends/analytics/BrowseConsoleBackend.ts
@@ -1,3 +1,4 @@
+import { createClientLog } from '@grafana/data';
 /* eslint-disable no-console */
 import {
   type EchoBackend,
@@ -7,6 +8,9 @@ import {
   isPageviewEvent,
   type PageviewEchoEvent,
 } from '@grafana/runtime';
+const clientLog = createClientLog('public/app/core/services/echo/backends/analytics/BrowseConsoleBackend');
+
+
 
 export class BrowserConsoleBackend implements EchoBackend<PageviewEchoEvent, unknown> {
   options = {};
@@ -16,12 +20,12 @@ export class BrowserConsoleBackend implements EchoBackend<PageviewEchoEvent, unk
 
   addEvent = (e: PageviewEchoEvent) => {
     if (isPageviewEvent(e)) {
-      console.log('[EchoSrv:pageview]', e.payload.page);
+      clientLog.info('[EchoSrv:pageview]', e.payload.page);
     }
 
     if (isInteractionEvent(e)) {
       const eventName = e.payload.interactionName;
-      console.log('[EchoSrv:event]', eventName, e.payload.properties);
+      clientLog.info('[EchoSrv:event]', eventName, e.payload.properties);
 
       // Warn for non-scalar property values. We're not yet making this a hard a
       const invalidTypeProperties = Object.entries(e.payload.properties ?? {}).filter(([_, value]) => {
@@ -32,7 +36,7 @@ export class BrowserConsoleBackend implements EchoBackend<PageviewEchoEvent, unk
       });
 
       if (invalidTypeProperties.length > 0) {
-        console.warn(
+        clientLog.warn(
           'Event',
           eventName,
           'has invalid property types. Event properties should only be string, number or boolean. Invalid properties:',
@@ -42,7 +46,7 @@ export class BrowserConsoleBackend implements EchoBackend<PageviewEchoEvent, unk
     }
 
     if (isExperimentViewEvent(e)) {
-      console.log('[EchoSrv:experiment]', e.payload);
+      clientLog.info('[EchoSrv:experiment]', e.payload);
     }
   };
 

--- a/public/app/core/services/echo/init.ts
+++ b/public/app/core/services/echo/init.ts
@@ -1,9 +1,13 @@
+import { createClientLog } from '@grafana/data';
 import { config, registerEchoBackend, setEchoSrv } from '@grafana/runtime';
 import { reportMetricPerformanceMark } from 'app/core/utils/metrics';
 
 import { contextSrv } from '../context_srv';
 
 import { Echo } from './Echo';
+const clientLog = createClientLog('public/app/core/services/echo/init');
+
+
 
 // Initialise EchoSrv backends, calls during frontend app startup
 export async function initEchoSrv() {
@@ -28,43 +32,43 @@ export async function initEchoSrv() {
   try {
     await initPerformanceBackend();
   } catch (error) {
-    console.error('Error initializing EchoSrv Performance backend', error);
+    clientLog.error('Error initializing EchoSrv Performance backend', error);
   }
 
   try {
     await initFaroBackend();
   } catch (error) {
-    console.error('Error initializing EchoSrv Faro backend', error);
+    clientLog.error('Error initializing EchoSrv Faro backend', error);
   }
 
   try {
     await initGoogleAnalyticsBackend();
   } catch (error) {
-    console.error('Error initializing EchoSrv GoogleAnalytics backend', error);
+    clientLog.error('Error initializing EchoSrv GoogleAnalytics backend', error);
   }
 
   try {
     await initGoogleAnalaytics4Backend();
   } catch (error) {
-    console.error('Error initializing EchoSrv GoogleAnalaytics4 backend', error);
+    clientLog.error('Error initializing EchoSrv GoogleAnalaytics4 backend', error);
   }
 
   try {
     await initRudderstackBackend();
   } catch (error) {
-    console.error('Error initializing EchoSrv Rudderstack backend', error);
+    clientLog.error('Error initializing EchoSrv Rudderstack backend', error);
   }
 
   try {
     await initAzureAppInsightsBackend();
   } catch (error) {
-    console.error('Error initializing EchoSrv AzureAppInsights backend', error);
+    clientLog.error('Error initializing EchoSrv AzureAppInsights backend', error);
   }
 
   try {
     await initConsoleBackend();
   } catch (error) {
-    console.error('Error initializing EchoSrv Console backend', error);
+    clientLog.error('Error initializing EchoSrv Console backend', error);
   }
 }
 

--- a/public/app/core/trustedTypePolicies.ts
+++ b/public/app/core/trustedTypePolicies.ts
@@ -1,5 +1,8 @@
-import { textUtil } from '@grafana/data';
+import {textUtil, createClientLog} from '@grafana/data';
 import { config } from '@grafana/runtime';
+const clientLog = createClientLog('public/app/core/trustedTypePolicies');
+
+
 
 const CSP_REPORT_ONLY_ENABLED = config.cspReportOnlyEnabled;
 
@@ -8,7 +11,7 @@ export const defaultTrustedTypesPolicy = {
     if (!CSP_REPORT_ONLY_ENABLED) {
       return string.replace(/<script/gi, '&lt;script');
     }
-    console.error('[HTML not sanitized with Trusted Types]', string, source, sink);
+    clientLog.error('[HTML not sanitized with Trusted Types]', string, source, sink);
     return string;
   },
   createScript: (string: string) => string,
@@ -16,7 +19,7 @@ export const defaultTrustedTypesPolicy = {
     if (!CSP_REPORT_ONLY_ENABLED) {
       return textUtil.sanitizeUrl(string);
     }
-    console.error('[ScriptURL not sanitized with Trusted Types]', string, source, sink);
+    clientLog.error('[ScriptURL not sanitized with Trusted Types]', string, source, sink);
     return string;
   },
 };

--- a/public/app/core/utils/dag.ts
+++ b/public/app/core/utils/dag.ts
@@ -1,3 +1,7 @@
+import { createClientLog } from '@grafana/data';
+const clientLog = createClientLog('public/app/core/utils/dag');
+
+
 export class Edge {
   inputNode?: Node;
   outputNode?: Node;
@@ -268,7 +272,7 @@ export const printGraph = (g: Graph) => {
     if (!inputEdges) {
       inputEdges = '<none>';
     }
-    console.log(`${n.name}:\n - links to:   ${outputEdges}\n - links from: ${inputEdges}`);
+    clientLog.info(`${n.name}:\n - links to:   ${outputEdges}\n - links from: ${inputEdges}`);
   });
 };
 

--- a/public/app/core/utils/explore.ts
+++ b/public/app/core/utils/explore.ts
@@ -2,8 +2,7 @@ import { customAlphabet } from 'nanoid';
 import { type Unsubscribable } from 'rxjs';
 import { v4 as uuidv4 } from 'uuid';
 
-import {
-  type AdHocVariableFilter,
+import {type AdHocVariableFilter,
   CoreApp,
   type DataQuery,
   type DataQueryRequest,
@@ -22,12 +21,14 @@ import {
   type TimeRange,
   type TimeZone,
   toURLRange,
-  urlUtil,
-} from '@grafana/data';
+  urlUtil, createClientLog} from '@grafana/data';
 import { getDataSourceSrv } from '@grafana/runtime';
 import { RefreshPicker } from '@grafana/ui';
 import { ExpressionDatasourceUID } from 'app/features/expressions/types';
 import { type QueryOptions, type QueryTransaction } from 'app/types/explore';
+const clientLog = createClientLog('public/app/core/utils/explore');
+
+
 
 export const DEFAULT_UI_STATE = {
   dedupStrategy: LogsDedupStrategy.none,
@@ -159,7 +160,7 @@ export const safeStringifyValue = (value: unknown, space?: number) => {
   try {
     return JSON.stringify(value, null, space);
   } catch (error) {
-    console.error(error);
+    clientLog.error(error);
   }
 
   return '';
@@ -232,7 +233,7 @@ export async function ensureQueries(
         try {
           await getDataSourceSrv().get(query.datasource.uid);
         } catch {
-          console.error(`One of the queries has a datasource that is no longer available and was removed.`);
+          clientLog.error(`One of the queries has a datasource that is no longer available and was removed.`);
           validDS = false;
         }
       }

--- a/public/app/core/utils/fetch.ts
+++ b/public/app/core/utils/fetch.ts
@@ -1,8 +1,11 @@
 import { omitBy } from 'lodash';
 import { type Observable, of, throwError } from 'rxjs';
 
-import { deprecationWarning, validatePath } from '@grafana/data';
+import {deprecationWarning, validatePath, createClientLog} from '@grafana/data';
 import { type BackendSrvRequest } from '@grafana/runtime';
+const clientLog = createClientLog('public/app/core/utils/fetch');
+
+
 
 export const parseInitFromOptions = (options: BackendSrvRequest): RequestInit => {
   const method = options.method;
@@ -139,7 +142,7 @@ export async function parseResponseBody<T>(
         // An empty string is not a valid JSON.
         // Sometimes (unfortunately) our APIs declare their Content-Type as JSON, however they return an empty body.
         if (response.headers.get('Content-Length') === '0') {
-          console.warn(`${response.url} returned an invalid JSON`);
+          clientLog.warn(`${response.url} returned an invalid JSON`);
           return {} as T;
         }
         return await response.json();

--- a/public/app/core/utils/metrics.ts
+++ b/public/app/core/utils/metrics.ts
@@ -1,4 +1,8 @@
+import { createClientLog } from '@grafana/data';
 import { reportPerformance } from '../services/echo/EchoSrv';
+const clientLog = createClientLog('public/app/core/utils/metrics');
+
+
 
 export function startMeasure(eventName: string) {
   if (!performance || !performance.mark) {
@@ -8,7 +12,7 @@ export function startMeasure(eventName: string) {
   try {
     performance.mark(`${eventName}_started`);
   } catch (error) {
-    console.error(`[Metrics] Failed to startMeasure ${eventName}`, error);
+    clientLog.error(`[Metrics] Failed to startMeasure ${eventName}`, error);
   }
 }
 
@@ -31,7 +35,7 @@ export function stopMeasure(eventName: string) {
     performance.clearMeasures(measured);
     return measure;
   } catch (error) {
-    console.error(`[Metrics] Failed to stopMeasure ${eventName}`, error);
+    clientLog.error(`[Metrics] Failed to stopMeasure ${eventName}`, error);
     return;
   }
 }

--- a/public/app/core/utils/shortLinks.ts
+++ b/public/app/core/utils/shortLinks.ts
@@ -1,6 +1,6 @@
 import memoizeOne from 'memoize-one';
 
-import { type AbsoluteTimeRange, type LogRowModel, type UrlQueryMap } from '@grafana/data';
+import {type AbsoluteTimeRange, type LogRowModel, type UrlQueryMap, createClientLog} from '@grafana/data';
 import { t } from '@grafana/i18n';
 import { getBackendSrv, config, locationService } from '@grafana/runtime';
 import { sceneGraph, type SceneTimeRangeLike, type VizPanel } from '@grafana/scenes';
@@ -16,6 +16,9 @@ import { type ShareLinkConfiguration } from '../../features/dashboard-scene/shar
 import { notifyApp } from '../reducers/appNotification';
 
 import { copyStringToClipboard } from './explore';
+const clientLog = createClientLog('public/app/core/utils/shortLinks');
+
+
 
 function buildHostUrl() {
   return `${window.location.protocol}//${window.location.host}${config.appSubUrl}`;
@@ -73,7 +76,7 @@ export const createShortLink = memoizeOne(async (path: string): Promise<string> 
       return await createShortLinkLegacy(path);
     }
   } catch (err) {
-    console.error('Error when creating shortened link: ', err);
+    clientLog.error('Error when creating shortened link: ', err);
     dispatch(notifyApp(createErrorNotification('Error generating shortened link')));
     createShortLink.clear();
     throw err; // Re-throw so callers know it failed
@@ -104,7 +107,7 @@ export const createAndCopyShortLink = async (path: string) => {
     }
   } catch (error) {
     // createShortLink already handles error notifications, just log
-    console.error('Error in createAndCopyShortLink:', error);
+    clientLog.error('Error in createAndCopyShortLink:', error);
   }
 };
 

--- a/public/app/core/utils/timeRegions.ts
+++ b/public/app/core/utils/timeRegions.ts
@@ -1,6 +1,9 @@
 import { Cron } from 'croner';
 
-import { type AbsoluteTimeRange, type TimeRange, durationToMilliseconds, parseDuration } from '@grafana/data';
+import {type AbsoluteTimeRange, type TimeRange, durationToMilliseconds, parseDuration, createClientLog} from '@grafana/data';
+const clientLog = createClientLog('public/app/core/utils/timeRegions');
+
+
 
 export type TimeRegionMode = null | 'cron';
 export interface TimeRegionConfig {
@@ -160,7 +163,7 @@ export function calculateTimesWithin(cfg: TimeRegionConfig, tRange: TimeRange): 
     }
   } catch (e) {
     // invalid expression
-    console.error(e);
+    clientLog.error(e);
   }
 
   return ranges;

--- a/public/app/features/actions/ConnectionPicker.tsx
+++ b/public/app/features/actions/ConnectionPicker.tsx
@@ -1,11 +1,14 @@
 import { useMemo } from 'react';
 
-import { ActionType, type DataSourceInstanceSettings } from '@grafana/data';
+import {ActionType, type DataSourceInstanceSettings, createClientLog} from '@grafana/data';
 import { t } from '@grafana/i18n';
 import { config, getDataSourceSrv } from '@grafana/runtime';
 import { Select } from '@grafana/ui';
 
 import { INFINITY_DATASOURCE_TYPE } from './utils';
+const clientLog = createClientLog('public/app/features/actions/ConnectionPicker');
+
+
 
 interface ConnectionOption {
   label: string;
@@ -78,7 +81,7 @@ export const ConnectionPicker = ({ actionType, datasourceUid, onChange }: Connec
       if (selectedDatasource) {
         onChange(selectedDatasource);
       } else {
-        console.error('ConnectionPicker: Could not find datasource with UID:', selectedValue);
+        clientLog.error('ConnectionPicker: Could not find datasource with UID:', selectedValue);
       }
     }
   };

--- a/public/app/features/actions/utils.ts
+++ b/public/app/features/actions/utils.ts
@@ -1,5 +1,4 @@
-import {
-  type Action,
+import {type Action,
   type ActionModel,
   ActionType,
   type ActionVariableInput,
@@ -14,8 +13,7 @@ import {
   type InfinityOptions,
   type ScopedVars,
   textUtil,
-  type ValueLinkConfig,
-} from '@grafana/data';
+  type ValueLinkConfig, createClientLog} from '@grafana/data';
 import { type BackendSrvRequest, config as grafanaConfig, getBackendSrv } from '@grafana/runtime';
 import { appEvents } from 'app/core/app_events';
 
@@ -25,6 +23,9 @@ import { getTimeSrv } from '../dashboard/services/TimeSrv';
 import { getNextRequestId } from '../query/state/PanelQueryRunner';
 
 import { reportActionTrigger } from './analytics';
+const clientLog = createClientLog('public/app/features/actions/utils');
+
+
 
 /** @internal */
 export const isInfinityActionWithAuth = (action: Action): boolean => {
@@ -120,7 +121,7 @@ export const getActions = (
                   appEvents.emit(AppEvents.alertError, [
                     'An error has occurred. Check console output for more details.',
                   ]);
-                  console.error(error);
+                  clientLog.error(error);
                 },
                 complete: () => {
                   appEvents.emit(AppEvents.alertSuccess, ['API call was successful']);
@@ -128,7 +129,7 @@ export const getActions = (
               });
           } catch (error) {
             appEvents.emit(AppEvents.alertError, ['An error has occurred. Check console output for more details.']);
-            console.error(error);
+            clientLog.error(error);
             return;
           }
         },

--- a/public/app/features/admin/UserOrgs.tsx
+++ b/public/app/features/admin/UserOrgs.tsx
@@ -1,7 +1,7 @@
 import { css, cx } from '@emotion/css';
 import { memo, type ReactElement, useEffect, useRef, useState } from 'react';
 
-import { type GrafanaTheme2, OrgRole } from '@grafana/data';
+import {type GrafanaTheme2, OrgRole, createClientLog} from '@grafana/data';
 import { Trans, t } from '@grafana/i18n';
 import { Button, ConfirmButton, Field, Icon, Modal, Tooltip, useStyles2, Stack, TextLink } from '@grafana/ui';
 import { UserRolePicker } from 'app/core/components/RolePicker/UserRolePicker';
@@ -13,6 +13,9 @@ import { type Organization } from 'app/types/organization';
 import { type UserOrg, type UserDTO } from 'app/types/user';
 
 import { OrgRolePicker } from './OrgRolePicker';
+const clientLog = createClientLog('public/app/features/admin/UserOrgs');
+
+
 
 interface Props {
   orgs: UserOrg[];
@@ -128,7 +131,7 @@ const OrgRow = memo(({ user, org, isExternalUser, onOrgRemove, onOrgRoleChange }
       if (contextSrv.hasPermission(AccessControlAction.ActionRolesList)) {
         fetchRoleOptions(org.orgId)
           .then((roles) => setRoleOptions(roles))
-          .catch((e) => console.error(e));
+          .catch((e) => clientLog.error(e));
       }
     }
   }, [org.orgId]);
@@ -266,7 +269,7 @@ export const AddToOrgModal = memo(({ isOpen, user, userOrgs, onOrgAdd, onDismiss
       if (contextSrv.hasPermission(AccessControlAction.ActionRolesList)) {
         fetchRoleOptions(org.value?.id)
           .then((roles) => setRoleOptions(roles))
-          .catch((e) => console.error(e));
+          .catch((e) => clientLog.error(e));
       }
     }
   };

--- a/public/app/features/admin/Users/OrgUsersTable.tsx
+++ b/public/app/features/admin/Users/OrgUsersTable.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useState } from 'react';
 
-import { type OrgRole } from '@grafana/data';
+import {type OrgRole, createClientLog} from '@grafana/data';
 import { selectors as e2eSelectors } from '@grafana/e2e-selectors';
 import { Trans, t } from '@grafana/i18n';
 import { config } from '@grafana/runtime';
@@ -30,6 +30,9 @@ import { AccessControlAction, type Role } from 'app/types/accessControl';
 import { type OrgUser } from 'app/types/user';
 
 import { OrgRolePicker } from '../OrgRolePicker';
+const clientLog = createClientLog('public/app/features/admin/Users/OrgUsersTable');
+
+
 
 type Cell<T extends keyof OrgUser = keyof OrgUser> = CellProps<OrgUser, OrgUser[T]>;
 
@@ -79,7 +82,7 @@ export const OrgUsersTable = ({
           setRoleOptions(options);
         }
       } catch (e) {
-        console.error('Error loading options');
+        clientLog.error('Error loading options');
       }
     }
     if (contextSrv.licensedAccessControlEnabled()) {

--- a/public/app/features/admin/state/actions.ts
+++ b/public/app/features/admin/state/actions.ts
@@ -1,6 +1,6 @@
 import { debounce } from 'lodash';
 
-import { dateTimeFormatTimeAgo } from '@grafana/data';
+import {dateTimeFormatTimeAgo, createClientLog} from '@grafana/data';
 import { featureEnabled, getBackendSrv, isFetchError, locationService } from '@grafana/runtime';
 import { type FetchDataArgs } from '@grafana/ui';
 import config from 'app/core/config';
@@ -36,6 +36,9 @@ import {
   anonPageChanged,
   anonQueryChanged,
 } from './reducers';
+const clientLog = createClientLog('public/app/features/admin/state/actions');
+
+
 // UserAdminPage
 
 export function loadAdminUserPage(userUid: string): ThunkResult<void> {
@@ -50,7 +53,7 @@ export function loadAdminUserPage(userUid: string): ThunkResult<void> {
       }
       dispatch(userAdminPageLoadedAction(true));
     } catch (error) {
-      console.error(error);
+      clientLog.error(error);
 
       if (isFetchError(error)) {
         const userError = {
@@ -300,7 +303,7 @@ export function fetchUsers(): ThunkResult<void> {
       dispatch(usersFetched(result));
     } catch (error) {
       usersFetchEnd();
-      console.error(error);
+      clientLog.error(error);
     }
   };
 }
@@ -366,7 +369,7 @@ export function fetchUsersAnonymousDevices(): ThunkResult<void> {
       const result = await getBackendSrv().get(url);
       dispatch(usersAnonymousDevicesFetched(result));
     } catch (error) {
-      console.error(error);
+      clientLog.error(error);
     }
   };
 }
@@ -409,7 +412,7 @@ export function changeAnonPage(page: number): ThunkResult<void> {
 //       dispatch(usersAnonymousDevicesFetched({ devices: result }));
 //     } catch (error) {
 //       usersFetchEnd();
-//       console.error(error);
+//       clientLog.error(error);
 //     }
 //   };
 // }

--- a/public/app/features/admin/state/apis.tsx
+++ b/public/app/features/admin/state/apis.tsx
@@ -1,4 +1,8 @@
+import { createClientLog } from '@grafana/data';
 import { getBackendSrv } from '@grafana/runtime';
+const clientLog = createClientLog('public/app/features/admin/state/apis');
+
+
 
 interface AnonServerStat {
   activeDevices?: number;
@@ -28,7 +32,7 @@ export const getServerStats = async (): Promise<ServerStat | null> => {
   return getBackendSrv()
     .get('api/admin/stats')
     .catch((err) => {
-      console.error(err);
+      clientLog.error(err);
       return null;
     });
 };

--- a/public/app/features/alerting/unified/components/receivers/form/fields/OptionField.tsx
+++ b/public/app/features/alerting/unified/components/receivers/form/fields/OptionField.tsx
@@ -2,7 +2,7 @@ import { css } from '@emotion/css';
 import { type FC } from 'react';
 import { Controller, type DeepMap, type FieldError, useFormContext } from 'react-hook-form';
 
-import { type GrafanaTheme2 } from '@grafana/data';
+import {type GrafanaTheme2, createClientLog} from '@grafana/data';
 import { t } from '@grafana/i18n';
 import {
   Checkbox,
@@ -29,6 +29,9 @@ import { StringArrayInput } from './StringArrayInput';
 import { SubformArrayField } from './SubformArrayField';
 import { SubformField } from './SubformField';
 import { WrapWithTemplateSelection } from './TemplateSelector';
+const clientLog = createClientLog('public/app/features/alerting/unified/components/receivers/form/fields/OptionField');
+
+
 
 interface Props {
   defaultValue: any;
@@ -318,7 +321,7 @@ const OptionInput: FC<Props & { id: string }> = ({
       );
 
     default:
-      console.error('Element not supported', option.element);
+      clientLog.error('Element not supported', option.element);
       return null;
   }
 };

--- a/public/app/features/alerting/unified/components/rule-editor/labels/LabelsField.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/labels/LabelsField.tsx
@@ -3,7 +3,7 @@ import { type FC, useCallback, useMemo } from 'react';
 import { Controller, FormProvider, useFieldArray, useForm, useFormContext } from 'react-hook-form';
 
 import { AlertLabels } from '@grafana/alerting/unstable';
-import { type GrafanaTheme2, type SelectableValue } from '@grafana/data';
+import {type GrafanaTheme2, type SelectableValue, createClientLog} from '@grafana/data';
 import { Trans, t } from '@grafana/i18n';
 import { Button, type ComboboxOption, Field, InlineLabel, Input, Space, Stack, Text, useStyles2 } from '@grafana/ui';
 
@@ -19,6 +19,9 @@ import { NeedHelpInfo } from '../NeedHelpInfo';
 import { useGetLabelsFromDataSourceName } from '../useAlertRuleSuggestions';
 
 import { AddButton, RemoveButton } from './LabelsButtons';
+const clientLog = createClientLog('public/app/features/alerting/unified/components/rule-editor/labels/LabelsField');
+
+
 
 const useGetOpsLabelsKeys = (skip: boolean) => {
   const { currentData, isLoading: isloadingLabels } = labelsApi.endpoints.getLabels.useQuery(undefined, {
@@ -183,7 +186,7 @@ export function useCombinedLabels(
               opsValues = result.values.map((value) => value.name);
             }
           } catch (error) {
-            console.error('Failed to fetch label values for key:', key, error);
+            clientLog.error('Failed to fetch label values for key:', key, error);
           }
         }
 

--- a/public/app/features/alerting/unified/components/rule-editor/useDashboardQuery.ts
+++ b/public/app/features/alerting/unified/components/rule-editor/useDashboardQuery.ts
@@ -1,3 +1,4 @@
+import { createClientLog } from '@grafana/data';
 import memoizeOne from 'memoize-one';
 import { useEffect, useState } from 'react';
 
@@ -8,6 +9,9 @@ import { isDashboardV2Resource } from 'app/features/dashboard/api/utils';
 import { type DashboardDTO } from 'app/types/dashboard';
 
 import { DashboardModel } from '../../../../dashboard/state/DashboardModel';
+const clientLog = createClientLog('public/app/features/alerting/unified/components/rule-editor/useDashboardQuery');
+
+
 
 export type DashboardResponse = DashboardDTO | DashboardWithAccessInfo<DashboardV2Spec>;
 
@@ -36,11 +40,11 @@ export function useDashboardQuery(dashboardUid?: string) {
           } else if (isDashboardV2Resource(dashboardDTO)) {
             setDashboard(dashboardDTO);
           } else {
-            console.error('Something went wrong, unexpected dashboard format');
+            clientLog.error('Something went wrong, unexpected dashboard format');
           }
         })
         .catch((error) => {
-          console.error('Failed to fetch dashboard', error);
+          clientLog.error('Failed to fetch dashboard', error);
         })
         .finally(() => {
           setIsFetching(false);

--- a/public/app/features/alerting/unified/components/rule-editor/util.ts
+++ b/public/app/features/alerting/unified/components/rule-editor/util.ts
@@ -1,13 +1,11 @@
 import { xor } from 'lodash';
 
-import {
-  type DataFrame,
+import {type DataFrame,
   LoadingState,
   type PanelData,
   type ThresholdsConfig,
   ThresholdsMode,
-  isTimeSeriesFrames,
-} from '@grafana/data';
+  isTimeSeriesFrames, createClientLog} from '@grafana/data';
 import { config } from '@grafana/runtime';
 import { GraphThresholdsStyleMode } from '@grafana/schema';
 import { EvalFunction } from 'app/features/alerting/state/alertDef';
@@ -16,6 +14,9 @@ import { type ClassicCondition, ExpressionQueryType } from 'app/features/express
 import { type AlertQuery } from 'app/types/unified-alerting-dto';
 
 import { createDagFromQueries, getOriginOfRefId } from './dag';
+const clientLog = createClientLog('public/app/features/alerting/unified/components/rule-editor/util');
+
+
 
 export function queriesWithUpdatedReferences(
   queries: AlertQuery[],
@@ -210,7 +211,7 @@ export function getThresholdsForQueries(queries: AlertQuery[], condition: string
           }
         });
       } catch (err) {
-        console.error('Failed to parse thresholds', err);
+        clientLog.error('Failed to parse thresholds', err);
         return;
       }
     });

--- a/public/app/features/alerting/unified/components/rules/Filter/useRuleFilterAutocomplete.ts
+++ b/public/app/features/alerting/unified/components/rules/Filter/useRuleFilterAutocomplete.ts
@@ -1,7 +1,7 @@
 import { chain } from 'lodash';
 import { useCallback } from 'react';
 
-import { type DataSourceInstanceSettings } from '@grafana/data';
+import {type DataSourceInstanceSettings, createClientLog} from '@grafana/data';
 import { t } from '@grafana/i18n';
 import { getDataSourceSrv } from '@grafana/runtime';
 import { type ComboboxOption } from '@grafana/ui';
@@ -9,6 +9,9 @@ import { type GrafanaPromRuleGroupDTO } from 'app/types/unified-alerting-dto';
 
 import { prometheusApi } from '../../../api/prometheusApi';
 import { getRulesDataSources } from '../../../utils/datasource';
+const clientLog = createClientLog('public/app/features/alerting/unified/components/rules/Filter/useRuleFilterAutocomplete');
+
+
 
 // Module-scope utilities
 const collator = new Intl.Collator();
@@ -161,7 +164,7 @@ export function useNamespaceAndGroupOptions(): {
 
         return options;
       } catch (error) {
-        console.error('Error fetching groups:', error);
+        clientLog.error('Error fetching groups:', error);
         return [createInfoOption(t('alerting.rules-filter.group-search-error', 'Error searching groups'))];
       }
     },

--- a/public/app/features/alerting/unified/rule-list/hooks/grafanaFilter.ts
+++ b/public/app/features/alerting/unified/rule-list/hooks/grafanaFilter.ts
@@ -1,3 +1,4 @@
+import { createClientLog } from '@grafana/data';
 import { attempt, isError } from 'lodash';
 
 import { type PromRuleDTO, type PromRuleGroupDTO } from 'app/types/unified-alerting-dto';
@@ -25,6 +26,9 @@ import {
   ruleNameFilter,
   ruleTypeFilter,
 } from './filterPredicates';
+const clientLog = createClientLog('public/app/features/alerting/unified/rule-list/hooks/grafanaFilter');
+
+
 
 /**
  * Determines if client-side filtering is needed for Grafana-managed rules.
@@ -154,7 +158,7 @@ function labelMatchersToBackendFormat(labels: string[]): string[] {
     const result = attempt(() => JSON.stringify(parseMatcher(label)));
 
     if (isError(result)) {
-      console.warn('Failed to parse label matcher:', label, result);
+      clientLog.warn('Failed to parse label matcher:', label, result);
     } else {
       acc.push(result);
     }

--- a/public/app/features/alerting/unified/settings/extensions.ts
+++ b/public/app/features/alerting/unified/settings/extensions.ts
@@ -1,7 +1,10 @@
 import { useLocation } from 'react-router-dom-v5-compat';
 
-import { type NavModelItem } from '@grafana/data';
+import {type NavModelItem, createClientLog} from '@grafana/data';
 import { useSelector } from 'app/types/store';
+const clientLog = createClientLog('public/app/features/alerting/unified/settings/extensions');
+
+
 
 type SettingsSectionUrl = `/alerting/admin/${string}`;
 type SettingsSectionNav = Pick<NavModelItem, 'id' | 'text' | 'icon'> & {
@@ -16,7 +19,7 @@ const settingsExtensions: Map<SettingsSectionUrl, { nav: SettingsSectionNav }> =
  */
 export function addSettingsSection(pageNav: SettingsSectionNav) {
   if (settingsExtensions.has(pageNav.url)) {
-    console.warn('Unable to add settings page, PageNav must have an unique url');
+    clientLog.warn('Unable to add settings page, PageNav must have an unique url');
     return;
   }
   settingsExtensions.set(pageNav.url, { nav: pageNav });

--- a/public/app/features/alerting/unified/state/AlertingQueryRunner.ts
+++ b/public/app/features/alerting/unified/state/AlertingQueryRunner.ts
@@ -3,8 +3,7 @@ import { type Observable, type OperatorFunction, ReplaySubject, type Unsubscriba
 import { catchError, map, share } from 'rxjs/operators';
 import { v4 as uuidv4 } from 'uuid';
 
-import {
-  type DataFrameJSON,
+import {type DataFrameJSON,
   LoadingState,
   type PanelData,
   type TimeRange,
@@ -12,8 +11,7 @@ import {
   getDefaultTimeRange,
   preProcessPanelData,
   rangeUtil,
-  withLoadingIndicator,
-} from '@grafana/data';
+  withLoadingIndicator, createClientLog} from '@grafana/data';
 import { t } from '@grafana/i18n';
 import { DataSourceWithBackend, type FetchResponse, getDataSourceSrv, toDataQueryError } from '@grafana/runtime';
 import { type BackendSrv, getBackendSrv } from 'app/core/services/backend_srv';
@@ -24,6 +22,9 @@ import { type AlertQuery } from 'app/types/unified-alerting-dto';
 
 import { type LinkError, createDAGFromQueriesSafe, getDescendants } from '../components/rule-editor/dag';
 import { getTimeRangeForExpression } from '../utils/timeRange';
+const clientLog = createClientLog('public/app/features/alerting/unified/state/AlertingQueryRunner');
+
+
 
 export interface AlertingQueryResult {
   error?: string;
@@ -210,7 +211,7 @@ const getTimeRange = (query: AlertQuery, queries: AlertQuery[]): TimeRange => {
   }
 
   if (!query.relativeTimeRange) {
-    console.warn(`Query with refId: ${query.refId} did not have any relative time range, using default.`);
+    clientLog.warn(`Query with refId: ${query.refId} did not have any relative time range, using default.`);
     return getDefaultTimeRange();
   }
 

--- a/public/app/features/annotations/components/StandardAnnotationQueryEditor.tsx
+++ b/public/app/features/annotations/components/StandardAnnotationQueryEditor.tsx
@@ -1,14 +1,12 @@
 import { PureComponent, type ReactElement } from 'react';
 import { lastValueFrom } from 'rxjs';
 
-import {
-  type AnnotationEventMappings,
+import {type AnnotationEventMappings,
   type AnnotationQuery,
   type DataSourceApi,
   type DataSourceInstanceSettings,
   DataSourcePluginContextProvider,
-  LoadingState,
-} from '@grafana/data';
+  LoadingState, createClientLog} from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';
 import { Trans, t } from '@grafana/i18n';
 import { type DataQuery } from '@grafana/schema';
@@ -24,6 +22,9 @@ import { updateAnnotationFromSavedQuery } from '../utils/savedQueryUtils';
 
 import { AnnotationQueryEditorActionsWrapper } from './AnnotationQueryEditorActionsWrapper';
 import { AnnotationFieldMapper } from './AnnotationResultMapper';
+const clientLog = createClientLog('public/app/features/annotations/components/StandardAnnotationQueryEditor');
+
+
 
 export interface Props {
   datasource: DataSourceApi;
@@ -261,7 +262,7 @@ export default class StandardAnnotationQueryEditor extends PureComponent<Props, 
       this.setState({ skipNextVerification: true });
       onChange(preparedAnnotation);
     } catch (error) {
-      console.error('Failed to replace annotation query:', error);
+      clientLog.error('Failed to replace annotation query:', error);
       // On error, reset the replacing state but don't change the annotation
     }
   };

--- a/public/app/features/annotations/standardAnnotationSupport.ts
+++ b/public/app/features/annotations/standardAnnotationSupport.ts
@@ -2,8 +2,7 @@ import { isString } from 'lodash';
 import { type Observable, of, type OperatorFunction } from 'rxjs';
 import { map, mergeMap } from 'rxjs/operators';
 
-import {
-  type AnnotationEvent,
+import {type AnnotationEvent,
   AnnotationEventFieldSource,
   type AnnotationEventMappings,
   type AnnotationQuery,
@@ -15,10 +14,12 @@ import {
   FieldType,
   getFieldDisplayName,
   type KeyValue,
-  standardTransformers,
-} from '@grafana/data';
+  standardTransformers, createClientLog} from '@grafana/data';
 import { t } from '@grafana/i18n';
 import { config } from '@grafana/runtime';
+const clientLog = createClientLog('public/app/features/annotations/standardAnnotationSupport');
+
+
 
 export const standardAnnotationSupport: AnnotationSupport = {
   /**
@@ -227,7 +228,7 @@ export function getAnnotationsFromData(
       }
 
       if (!hasTime || !hasText) {
-        console.error('Cannot process annotation fields. No time or text present.');
+        clientLog.error('Cannot process annotation fields. No time or text present.');
         return [];
       }
 

--- a/public/app/features/annotations/utils/savedQueryUtils.ts
+++ b/public/app/features/annotations/utils/savedQueryUtils.ts
@@ -1,14 +1,15 @@
-import {
-  type AnnotationQuery,
+import {type AnnotationQuery,
   CoreApp,
   type DataSourceApi,
   hasQueryExportSupport,
-  hasQueryImportSupport,
-} from '@grafana/data';
+  hasQueryImportSupport, createClientLog} from '@grafana/data';
 import { getDataSourceSrv } from '@grafana/runtime';
 import { type DataQuery } from '@grafana/schema';
 
 import { standardAnnotationSupport } from '../standardAnnotationSupport';
+const clientLog = createClientLog('public/app/features/annotations/utils/savedQueryUtils');
+
+
 
 /**
  * Converts an AnnotationQuery to DataQuery format for SavedQueryButtons.
@@ -128,7 +129,7 @@ export async function updateAnnotationFromSavedQuery(
 
     return preparedAnnotation;
   } catch (error) {
-    console.warn('Could not prepare annotation with new datasource:', error);
+    clientLog.warn('Could not prepare annotation with new datasource:', error);
     // Return structurally correct annotation even if preparation fails
     const { datasource, ...queryFields } = replacedQuery;
     return { ...cleanAnnotation, target: queryFields };

--- a/public/app/features/apiserver/client.ts
+++ b/public/app/features/apiserver/client.ts
@@ -1,6 +1,6 @@
 import { Observable, from, retry, catchError, filter, map, mergeMap } from 'rxjs';
 
-import { isLiveChannelMessageEvent, isLiveChannelStatusEvent, LiveChannelScope } from '@grafana/data';
+import {isLiveChannelMessageEvent, isLiveChannelStatusEvent, LiveChannelScope, createClientLog} from '@grafana/data';
 import { config, getBackendSrv, getGrafanaLiveSrv } from '@grafana/runtime';
 import { contextSrv } from 'app/core/services/context_srv';
 
@@ -23,6 +23,9 @@ import {
   type ResourceClientWriteParams,
   type GroupVersionResource,
 } from './types';
+const clientLog = createClientLog('public/app/features/apiserver/client');
+
+
 
 export class ScopedResourceClient<T = object, S = object, K = string> implements ResourceClient<T, S, K> {
   readonly url: string;
@@ -69,7 +72,7 @@ export class ScopedResourceClient<T = object, S = object, K = string> implements
           filter((event) => isLiveChannelMessageEvent(event)),
           map((event) => event.message),
           catchError((error) => {
-            console.warn('Live channel watch failed, falling back to polling:', error);
+            clientLog.warn('Live channel watch failed, falling back to polling:', error);
             return this.createPollingFallback(params, error);
           })
         );
@@ -100,14 +103,14 @@ export class ScopedResourceClient<T = object, S = object, K = string> implements
           try {
             return JSON.parse(line);
           } catch (e) {
-            console.warn('Invalid JSON in watch stream:', e, line);
+            clientLog.warn('Invalid JSON in watch stream:', e, line);
             return null;
           }
         }),
         filter((event): event is ResourceEvent<T, S, K> => event !== null),
         retry({ count: 3, delay: 1000 }),
         catchError((error) => {
-          console.error('Watch stream error:', error);
+          clientLog.error('Watch stream error:', error);
           throw error;
         })
       );
@@ -250,7 +253,7 @@ export class ScopedResourceClient<T = object, S = object, K = string> implements
             return;
           }
           // Transient failure: log and retry next cycle.
-          console.warn(
+          clientLog.warn(
             `Polling fallback error (${consecutiveFailures}/${ScopedResourceClient.MAX_CONSECUTIVE_POLL_FAILURES}):`,
             pollError
           );

--- a/public/app/features/auth-config/FieldRenderer.tsx
+++ b/public/app/features/auth-config/FieldRenderer.tsx
@@ -2,12 +2,15 @@ import { css } from '@emotion/css';
 import { useEffect, useState } from 'react';
 import { type UseFormReturn, Controller } from 'react-hook-form';
 
-import { type SelectableValue } from '@grafana/data';
+import {type SelectableValue, createClientLog} from '@grafana/data';
 import { Checkbox, Field, Input, SecretInput, Select, Switch, useTheme2 } from '@grafana/ui';
 
 import { fieldMap } from './fields';
 import { type SSOProviderDTO, type SSOSettingsField } from './types';
 import { isSelectableValueArray } from './utils/guards';
+const clientLog = createClientLog('public/app/features/auth-config/FieldRenderer');
+
+
 
 interface FieldRendererProps
   extends Pick<
@@ -78,7 +81,7 @@ export const FieldRenderer = ({
   }, [isDisabled, disabledWhen?.disabledValue, name, setValue]);
 
   if (!field) {
-    console.log('missing field:', name);
+    clientLog.info('missing field:', name);
     return null;
   }
 
@@ -190,7 +193,7 @@ export const FieldRenderer = ({
         </Field>
       );
     default:
-      console.error(`Unknown field type: ${fieldData.type}`);
+      clientLog.error(`Unknown field type: ${fieldData.type}`);
       return null;
   }
 };

--- a/public/app/features/auth-config/state/actions.ts
+++ b/public/app/features/auth-config/state/actions.ts
@@ -1,3 +1,4 @@
+import { createClientLog } from '@grafana/data';
 import { lastValueFrom } from 'rxjs';
 
 import { getBackendSrv, isFetchError } from '@grafana/runtime';
@@ -18,6 +19,9 @@ import {
   setError,
   settingsUpdated,
 } from './reducers';
+const clientLog = createClientLog('public/app/features/auth-config/state/actions');
+
+
 
 export function loadSettings(showSpinner = true): ThunkResult<Promise<Settings>> {
   return async (dispatch) => {
@@ -78,7 +82,7 @@ export function saveSettings(data: UpdateSettingsQuery): ThunkResult<Promise<boo
         dispatch(resetError());
         return true;
       } catch (error) {
-        console.log(error);
+        clientLog.info(error);
         if (isFetchError(error)) {
           error.isHandled = true;
           const updateErr: SettingsError = {

--- a/public/app/features/browse-dashboards/api/browseDashboardsAPI.ts
+++ b/public/app/features/browse-dashboards/api/browseDashboardsAPI.ts
@@ -4,7 +4,7 @@ import { handleRequestError } from '@grafana/api-clients';
 import { generatedAPI as legacyUserAPI } from '@grafana/api-clients/internal/rtkq/legacy/user';
 import { createBaseQuery } from '@grafana/api-clients/rtkq';
 import { invalidateQuotaUsage } from '@grafana/api-clients/rtkq/quotas/v0alpha1';
-import { AppEvents, locationUtil } from '@grafana/data';
+import {AppEvents, locationUtil, createClientLog} from '@grafana/data';
 import { t } from '@grafana/i18n';
 import { config, getBackendSrv, isFetchError, locationService } from '@grafana/runtime';
 import { type Dashboard } from '@grafana/schema';
@@ -37,6 +37,9 @@ import { refetchChildren, refreshParents } from '../state/actions';
 
 import { isProvisionedDashboard } from './isProvisioned';
 import { PAGE_SIZE } from './services';
+const clientLog = createClientLog('public/app/features/browse-dashboards/api/browseDashboardsAPI');
+
+
 
 export interface DeleteFoldersArgs {
   folderUIDs: string[];
@@ -521,7 +524,7 @@ export const browseDashboardsAPI = createApi({
           } catch (error) {
             if (isFetchError(error)) {
               if (error.status !== 404) {
-                console.error('Error fetching dashboard', error);
+                clientLog.error('Error fetching dashboard', error);
               } else {
                 // Do not show the error alert if the dashboard does not exist
                 // this is expected when importing a new dashboard

--- a/public/app/features/browse-dashboards/api/recentlyViewed.ts
+++ b/public/app/features/browse-dashboards/api/recentlyViewed.ts
@@ -1,6 +1,10 @@
+import { createClientLog } from '@grafana/data';
 import impressionSrv from 'app/core/services/impression_srv';
 import { getGrafanaSearcher } from 'app/features/search/service/searcher';
 import { type DashboardQueryResult } from 'app/features/search/service/types';
+const clientLog = createClientLog('public/app/features/browse-dashboards/api/recentlyViewed');
+
+
 
 /**
  * Returns dashboard search results ordered the same way the user opened them.
@@ -30,7 +34,7 @@ export async function getRecentlyViewedDashboards(maxItems = 5): Promise<Dashboa
     dashboards.sort((a, b) => order(a.uid) - order(b.uid));
     return dashboards;
   } catch (error) {
-    console.error('Failed to load recently viewed dashboards', error);
+    clientLog.error('Failed to load recently viewed dashboards', error);
     return [];
   }
 }

--- a/public/app/features/browse-dashboards/api/services.ts
+++ b/public/app/features/browse-dashboards/api/services.ts
@@ -1,3 +1,4 @@
+import { createClientLog } from '@grafana/data';
 import { t } from '@grafana/i18n';
 import { config, getBackendSrv } from '@grafana/runtime';
 import { dashboardAPIv0alpha1 } from 'app/api/clients/dashboard/v0alpha1';
@@ -19,6 +20,9 @@ import {
   parseOwnerRef,
   teamOwnerRef,
 } from '../utils/dashboards';
+const clientLog = createClientLog('public/app/features/browse-dashboards/api/services');
+
+
 
 export const PAGE_SIZE = 50;
 
@@ -78,7 +82,7 @@ async function searchNewAPI(parentUID?: string, page = 1, pageSize = PAGE_SIZE) 
         });
       }
     } catch (error) {
-      console.error('Failed to load team folders', error);
+      clientLog.error('Failed to load team folders', error);
     }
   }
 

--- a/public/app/features/browse-dashboards/api/useRecentlyDeletedStateManager.ts
+++ b/public/app/features/browse-dashboards/api/useRecentlyDeletedStateManager.ts
@@ -1,4 +1,4 @@
-import { type SelectableValue, store } from '@grafana/data';
+import {type SelectableValue, store, createClientLog} from '@grafana/data';
 import { t } from '@grafana/i18n';
 import { type TermCount } from 'app/core/components/TagFilter/TagFilter';
 import { SEARCH_SELECTED_SORT } from 'app/features/search/constants';
@@ -6,6 +6,9 @@ import { type SearchState } from 'app/features/search/types';
 
 import { deletedDashboardsCache } from '../../search/service/deletedDashboardsCache';
 import { initialState, SearchStateManager } from '../../search/state/SearchStateManager';
+const clientLog = createClientLog('public/app/features/browse-dashboards/api/useRecentlyDeletedStateManager');
+
+
 
 // Subclass SearchStateManager to customize the setStateAndDoSearch behavior.
 // We want to clear the search results when the user clears any search input
@@ -65,7 +68,7 @@ export class TrashStateManager extends SearchStateManager {
 
       return termCounts.sort((a, b) => b.count - a.count);
     } catch (error) {
-      console.error('Failed to get tags from deleted dashboards:', error);
+      clientLog.error('Failed to get tags from deleted dashboards:', error);
       return [];
     }
   };

--- a/public/app/features/browse-dashboards/components/RecentlyDeletedActions.tsx
+++ b/public/app/features/browse-dashboards/components/RecentlyDeletedActions.tsx
@@ -1,3 +1,4 @@
+import { createClientLog } from '@grafana/data';
 import { useMemo, useState } from 'react';
 
 import { Trans } from '@grafana/i18n';
@@ -19,6 +20,9 @@ import { clearFolders, setAllSelection } from '../state/slice';
 import { getRestoreNotificationData } from '../utils/notifications';
 
 import { RestoreModal } from './RestoreModal';
+const clientLog = createClientLog('public/app/features/browse-dashboards/components/RecentlyDeletedActions');
+
+
 
 export function RecentlyDeletedActions() {
   const dispatch = useDispatch();
@@ -81,7 +85,7 @@ export function RecentlyDeletedActions() {
       const deletedDashboards = await deletedDashboardsCache.getAsResourceList();
       const dashboard = deletedDashboards?.items.find((d) => d.metadata.name === uid);
       if (!dashboard) {
-        console.warn(`Dashboard ${uid} not found in deleted items`);
+        clientLog.warn(`Dashboard ${uid} not found in deleted items`);
         return { uid, error: 'not_found' };
       }
       // Clone the dashboard to be able to edit the immutable data from the store

--- a/public/app/features/browse-dashboards/state/actions.ts
+++ b/public/app/features/browse-dashboards/state/actions.ts
@@ -1,3 +1,4 @@
+import { createClientLog } from '@grafana/data';
 import { GENERAL_FOLDER_UID, TEAM_FOLDERS_UID } from 'app/features/search/constants';
 import { type DashboardViewItem, type DashboardViewItemKind } from 'app/features/search/types';
 import { createAsyncThunk } from 'app/types/store';
@@ -7,12 +8,15 @@ import { type DashboardViewItemWithUIItems, type UIDashboardViewItem } from '../
 import { addTeamFolderPrefix, removeTeamFolderPrefix } from '../utils/dashboards';
 
 import { findItem } from './utils';
+const clientLog = createClientLog('public/app/features/browse-dashboards/state/actions');
+
+
 
 async function listTeamFoldersSafe() {
   try {
     return await listTeamFolders();
   } catch (error) {
-    console.error('Failed to load team folders', error);
+    clientLog.error('Failed to load team folders', error);
     return [];
   }
 }
@@ -151,7 +155,7 @@ export const fetchNextChildrenPage = createAsyncThunk(
       fetchKind = 'folder';
     } else if (collection.lastFetchedKind === 'dashboard' && !collection.lastKindHasMoreItems) {
       // There's nothing to load at all
-      console.warn(`fetchNextChildrenPage called for ${uid} but that collection is fully loaded`);
+      clientLog.warn(`fetchNextChildrenPage called for ${uid} but that collection is fully loaded`);
       // return;
     } else if (collection.lastFetchedKind === 'folder' && collection.lastKindHasMoreItems) {
       // Load additional pages of folders

--- a/public/app/features/canvas/runtime/frame.tsx
+++ b/public/app/features/canvas/runtime/frame.tsx
@@ -1,3 +1,4 @@
+import { createClientLog } from '@grafana/data';
 import { cloneDeep } from 'lodash';
 
 import { notFoundItem } from 'app/features/canvas/elements/notFound';
@@ -14,6 +15,9 @@ import { ElementState } from './element';
 import { type RootElement } from './root';
 import { type Scene } from './scene';
 import { initMoveable } from './sceneAbleManagement';
+const clientLog = createClientLog('public/app/features/canvas/runtime/frame');
+
+
 
 const DEFAULT_OFFSET = 10;
 const HORIZONTAL_OFFSET = 50;
@@ -129,7 +133,7 @@ export class FrameState extends ElementState {
         break;
       case LayerActionID.Duplicate:
         if (element.item.id === 'frame') {
-          console.log('Can not duplicate frames (yet)', action, element);
+          clientLog.info('Can not duplicate frames (yet)', action, element);
           return;
         }
         const opts = cloneDeep(element.options);
@@ -239,7 +243,7 @@ export class FrameState extends ElementState {
         break;
 
       default:
-        console.log('DO action', action, element);
+        clientLog.info('DO action', action, element);
         return;
     }
   };

--- a/public/app/features/commandPalette/actions/useActions.tsx
+++ b/public/app/features/commandPalette/actions/useActions.tsx
@@ -1,3 +1,4 @@
+import { createClientLog } from '@grafana/data';
 import { useRegisterActions } from 'kbar';
 import { useEffect, useMemo, useState } from 'react';
 
@@ -6,6 +7,9 @@ import { type CommandPaletteAction } from '../types';
 import { getRecentDashboardActions } from './dashboardActions';
 import { useStaticActions } from './staticActions';
 import useExtensionActions from './useExtensionActions';
+const clientLog = createClientLog('public/app/features/commandPalette/actions/useActions');
+
+
 
 /**
  * Register navigation actions to different parts of grafana or some preferences stuff like themes.
@@ -27,7 +31,7 @@ export function useRegisterRecentDashboardsActions() {
     getRecentDashboardActions()
       .then((recentDashboardActions) => setRecentDashboardActions(recentDashboardActions))
       .catch((err) => {
-        console.error('Error loading recent dashboard actions', err);
+        clientLog.error('Error loading recent dashboard actions', err);
       });
   }, []);
 

--- a/public/app/features/dashboard-scene/behaviors/DashboardAnalyticsInitializerBehavior.ts
+++ b/public/app/features/dashboard-scene/behaviors/DashboardAnalyticsInitializerBehavior.ts
@@ -1,7 +1,11 @@
+import { createClientLog } from '@grafana/data';
 import { writePerformanceLog } from '@grafana/scenes';
 
 import { getDashboardAnalyticsAggregator } from '../../dashboard/services/DashboardAnalyticsAggregator';
 import { type DashboardScene } from '../scene/DashboardScene';
+const clientLog = createClientLog('public/app/features/dashboard-scene/behaviors/DashboardAnalyticsInitializerBehavior');
+
+
 
 /**
  * Scene behavior function that manages the dashboard-specific initialization
@@ -15,7 +19,7 @@ export function dashboardAnalyticsInitializer(dashboard: DashboardScene) {
   const { uid, title } = dashboard.state;
 
   if (!uid) {
-    console.warn('dashboardAnalyticsInitializer: Dashboard UID is missing');
+    clientLog.warn('dashboardAnalyticsInitializer: Dashboard UID is missing');
     return;
   }
 

--- a/public/app/features/dashboard-scene/behaviors/DefaultControlsBehavior.ts
+++ b/public/app/features/dashboard-scene/behaviors/DefaultControlsBehavior.ts
@@ -1,3 +1,4 @@
+import { createClientLog } from '@grafana/data';
 import { type Subscription } from 'rxjs';
 
 import { SceneObjectBase, type SceneObjectState } from '@grafana/scenes';
@@ -5,6 +6,9 @@ import { SceneObjectBase, type SceneObjectState } from '@grafana/scenes';
 import { loadDefaultControlsShared$, loadDefaultLinks$, loadDefaultVariables$ } from '../utils/dashboardControls';
 import { getDsRefsFromScene } from '../utils/dashboardDsRefs';
 import { getDashboardSceneFor } from '../utils/utils';
+const clientLog = createClientLog('public/app/features/dashboard-scene/behaviors/DefaultControlsBehavior');
+
+
 
 export class DefaultControlsBehavior extends SceneObjectBase<SceneObjectState> {
   private _variablesSub?: Subscription;
@@ -32,7 +36,7 @@ export class DefaultControlsBehavior extends SceneObjectBase<SceneObjectState> {
     this._variablesSub = loadDefaultVariables$(shared$).subscribe({
       next: (vars) => dashboard.setDefaultVariables(vars),
       error: (err) => {
-        console.warn('Failed to load default variables', err);
+        clientLog.warn('Failed to load default variables', err);
         dashboard.setState({ defaultVariablesLoading: false });
       },
       complete: () => dashboard.setState({ defaultVariablesLoading: false }),
@@ -41,7 +45,7 @@ export class DefaultControlsBehavior extends SceneObjectBase<SceneObjectState> {
     this._linksSub = loadDefaultLinks$(shared$).subscribe({
       next: (links) => dashboard.setDefaultLinks(links),
       error: (err) => {
-        console.warn('Failed to load default links', err);
+        clientLog.warn('Failed to load default links', err);
         dashboard.setState({ defaultLinksLoading: false });
       },
       complete: () => dashboard.setState({ defaultLinksLoading: false }),

--- a/public/app/features/dashboard-scene/edit-pane/DashboardEditPane.tsx
+++ b/public/app/features/dashboard-scene/edit-pane/DashboardEditPane.tsx
@@ -1,3 +1,4 @@
+import { createClientLog } from '@grafana/data';
 import { type SceneObject, SceneObjectBase, type SceneObjectState, sceneGraph } from '@grafana/scenes';
 import {
   type ElementSelectionContextItem,
@@ -22,6 +23,9 @@ import {
   RepeatsUpdatedEvent,
 } from './shared';
 import { type EditPaneSelectionActions } from './types';
+const clientLog = createClientLog('public/app/features/dashboard-scene/edit-pane/DashboardEditPane');
+
+
 
 export interface DashboardEditPaneState extends SceneObjectState {
   selectionContext: ElementSelectionContextState;
@@ -237,7 +241,7 @@ export class DashboardEditPane extends SceneObjectBase<DashboardEditPaneState> i
   private selectElement(element: ElementSelectionContextItem, options: ElementSelectionOnSelectOptions) {
     let obj = sceneGraph.findByKey(this, element.id);
     if (!obj) {
-      console.warn('Cannot find element by key="%s"!', element.id);
+      clientLog.warn('Cannot find element by key="%s"!', element.id);
       return;
     }
 
@@ -245,7 +249,7 @@ export class DashboardEditPane extends SceneObjectBase<DashboardEditPaneState> i
     if (sourceKey) {
       obj = sceneGraph.findByKey(this, sourceKey);
       if (!obj) {
-        console.warn('Cannot find element by source key="%s"!', sourceKey);
+        clientLog.warn('Cannot find element by source key="%s"!', sourceKey);
         return;
       }
     }

--- a/public/app/features/dashboard-scene/inspect/HelpWizard/SupportSnapshotService.ts
+++ b/public/app/features/dashboard-scene/inspect/HelpWizard/SupportSnapshotService.ts
@@ -1,6 +1,6 @@
 import saveAs from 'file-saver';
 
-import { dateTimeFormat, formattedValueToString, getValueFormat, type SelectableValue } from '@grafana/data';
+import {dateTimeFormat, formattedValueToString, getValueFormat, type SelectableValue, createClientLog} from '@grafana/data';
 import { t } from '@grafana/i18n';
 import { sceneGraph, type SceneObject, type VizPanel } from '@grafana/scenes';
 import { StateManagerBase } from 'app/core/services/StateManagerBase';
@@ -9,6 +9,9 @@ import { transformSaveModelToScene } from '../../serialization/transformSaveMode
 
 import { type Randomize } from './randomizer';
 import { getDebugDashboard, getGithubMarkdown } from './utils';
+const clientLog = createClientLog('public/app/features/dashboard-scene/inspect/HelpWizard/SupportSnapshotService');
+
+
 
 interface SupportSnapshotState {
   currentTab: SnapshotTab;
@@ -84,7 +87,7 @@ export class SupportSnapshotService extends StateManagerBase<SupportSnapshotStat
         const dash = transformSaveModelToScene({ dashboard: snapshot, meta: { isEmbedded: true } });
         scene = dash.state.body; // skip the wrappers
       } catch (ex) {
-        console.log('Error creating scene:', ex);
+        clientLog.info('Error creating scene:', ex);
       }
     }
 

--- a/public/app/features/dashboard-scene/inspect/InspectJsonTab.tsx
+++ b/public/app/features/dashboard-scene/inspect/InspectJsonTab.tsx
@@ -1,7 +1,7 @@
 import { isEqual } from 'lodash';
 import AutoSizer from 'react-virtualized-auto-sizer';
 
-import { type SelectableValue } from '@grafana/data';
+import {type SelectableValue, createClientLog} from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';
 import { Trans, t } from '@grafana/i18n';
 import {
@@ -43,6 +43,9 @@ import {
   isLibraryPanel,
 } from '../utils/utils';
 import { isGridLayoutItemKind, isPanelKindV2 } from '../v2schema/validation';
+const clientLog = createClientLog('public/app/features/dashboard-scene/inspect/InspectJsonTab');
+
+
 
 export type ShowContent = 'panel-json' | 'panel-data' | 'data-frames' | 'panel-layout';
 
@@ -165,7 +168,7 @@ export class InspectJsonTab extends SceneObjectBase<InspectJsonTabState> {
     const gridItem = panel.parent;
 
     if (!(gridItem instanceof DashboardGridItem)) {
-      console.error('Cannot update layout: panel parent is not a DashboardGridItem');
+      clientLog.error('Cannot update layout: panel parent is not a DashboardGridItem');
       return;
     }
 
@@ -259,7 +262,7 @@ export class InspectJsonTab extends SceneObjectBase<InspectJsonTabState> {
     const newState = sceneUtils.cloneSceneObjectState(gridItem.state);
 
     if (!(panel.parent instanceof DashboardGridItem)) {
-      console.error('Cannot update state of panel', panel, gridItem);
+      clientLog.error('Cannot update state of panel', panel, gridItem);
       return;
     }
 

--- a/public/app/features/dashboard-scene/pages/DashboardScenePage.tsx
+++ b/public/app/features/dashboard-scene/pages/DashboardScenePage.tsx
@@ -2,7 +2,7 @@ import { useEffect, useRef } from 'react';
 import { type Params, useParams } from 'react-router-dom-v5-compat';
 import { usePrevious } from 'react-use';
 
-import { PageLayoutType } from '@grafana/data';
+import {PageLayoutType, createClientLog} from '@grafana/data';
 import { locationService } from '@grafana/runtime';
 import { UrlSyncContextProvider } from '@grafana/scenes';
 import { Box } from '@grafana/ui';
@@ -30,6 +30,9 @@ import { preserveDashboardSceneStateInLocalStorage } from '../utils/dashboardSes
 
 import { getDashboardScenePageStateManager } from './DashboardScenePageStateManager';
 import { shouldHideDashboardKioskFooter } from './utils';
+const clientLog = createClientLog('public/app/features/dashboard-scene/pages/DashboardScenePage');
+
+
 
 export interface Props
   extends Omit<GrafanaRouteComponentProps<DashboardPageRouteParams, DashboardPageRouteSearchParams>, 'match'> {}
@@ -126,7 +129,7 @@ export function DashboardScenePage({ route, queryParams, location }: Props) {
   // A bit tricky for transition to or from Home dashboard that does not have a uid in the url (but could have it in the dashboard model)
   // if prevMatch is undefined we are going from normal route to home route or vice versa
   if (type !== 'snapshot' && (!prevMatch || uid !== prevMatch?.params.uid)) {
-    console.log('skipping rendering');
+    clientLog.info('skipping rendering');
     return null;
   }
 

--- a/public/app/features/dashboard-scene/pages/DashboardScenePageStateManager.ts
+++ b/public/app/features/dashboard-scene/pages/DashboardScenePageStateManager.ts
@@ -1,4 +1,4 @@
-import { locationUtil, type UrlQueryMap } from '@grafana/data';
+import {locationUtil, type UrlQueryMap, createClientLog} from '@grafana/data';
 import { t } from '@grafana/i18n';
 import { config, getBackendSrv, getDataSourceSrv, isFetchError, locationService } from '@grafana/runtime';
 import { UserStorage } from '@grafana/runtime/internal';
@@ -58,6 +58,9 @@ import {
 import { restoreDashboardStateFromLocalStorage } from '../utils/dashboardSessionState';
 
 import { processQueryParamsForDashboardLoad, updateNavModel } from './utils';
+const clientLog = createClientLog('public/app/features/dashboard-scene/pages/DashboardScenePageStateManager');
+
+
 
 /**
  * Initialize both performance services to ensure they're ready before profiling starts
@@ -436,7 +439,7 @@ abstract class DashboardScenePageStateManagerBase<T>
       });
 
       if (!isFetchError(err)) {
-        console.error('Error loading dashboard:', err);
+        clientLog.error('Error loading dashboard:', err);
       }
 
       // If the error is a DashboardVersionError, we want to throw it so that the error boundary is triggered
@@ -797,7 +800,7 @@ export class DashboardScenePageStateManager extends DashboardScenePageStateManag
             ...locationService.getLocation(),
             pathname: dashboardUrl,
           });
-          console.log('not correct url correcting', dashboardUrl, currentPath);
+          clientLog.info('not correct url correcting', dashboardUrl, currentPath);
         }
       }
 
@@ -1017,7 +1020,7 @@ export class DashboardScenePageStateManagerV2 extends DashboardScenePageStateMan
             ...locationService.getLocation(),
             pathname: dashboardUrl,
           });
-          console.log('not correct url correcting', dashboardUrl, currentPath);
+          clientLog.info('not correct url correcting', dashboardUrl, currentPath);
         }
       }
       // Populate nav model in global store according to the folder

--- a/public/app/features/dashboard-scene/pages/utils.ts
+++ b/public/app/features/dashboard-scene/pages/utils.ts
@@ -1,16 +1,19 @@
-import { type UrlQueryMap, getTimeZone, getDefaultTimeRange, dateMath } from '@grafana/data';
+import {type UrlQueryMap, getTimeZone, getDefaultTimeRange, dateMath, createClientLog} from '@grafana/data';
 import { locationService } from '@grafana/runtime';
 import { getFolderByUidFacade } from 'app/api/clients/folder/v1beta1/hooks';
 import { updateNavIndex } from 'app/core/reducers/navModel';
 import { buildNavModel } from 'app/features/folders/state/navModel';
 import { store } from 'app/store/store';
+const clientLog = createClientLog('public/app/features/dashboard-scene/pages/utils');
+
+
 
 export async function updateNavModel(folderUid: string) {
   try {
     const folder = await getFolderByUidFacade(folderUid);
     store.dispatch(updateNavIndex(buildNavModel(folder)));
   } catch (err) {
-    console.warn('Error fetching parent folder', folderUid, 'for dashboard', err);
+    clientLog.warn('Error fetching parent folder', folderUid, 'for dashboard', err);
   }
 }
 

--- a/public/app/features/dashboard-scene/panel-edit/PanelDataPane/PanelDataQueriesTab.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelDataPane/PanelDataQueriesTab.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useMemo } from 'react';
 
-import { CoreApp, type DataSourceApi, type DataSourceInstanceSettings, getDataSourceRef } from '@grafana/data';
+import {CoreApp, type DataSourceApi, type DataSourceInstanceSettings, getDataSourceRef, createClientLog} from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';
 import { t, Trans } from '@grafana/i18n';
 import { config, getDataSourceSrv, reportInteraction } from '@grafana/runtime';
@@ -45,6 +45,9 @@ import { getUpdatedHoverHeader } from '../getPanelFrameOptions';
 
 import { type PanelDataPaneTab, type PanelDataTabHeaderProps, TabId } from './types';
 import { hasBackendDatasource } from './utils';
+const clientLog = createClientLog('public/app/features/dashboard-scene/panel-edit/PanelDataPane/PanelDataQueriesTab');
+
+
 
 interface PanelDataQueriesTabState extends SceneObjectState {
   datasource?: DataSourceApi;
@@ -163,7 +166,7 @@ export class PanelDataQueriesTab extends SceneObjectBase<PanelDataQueriesTabStat
         });
       }
 
-      console.error(err);
+      clientLog.error(err);
     }
   }
 

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/PanelDataPaneNext.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/PanelDataPaneNext.tsx
@@ -1,13 +1,11 @@
 import { throttle } from 'lodash';
 
-import {
-  CoreApp,
+import {CoreApp,
   type DataSourceApi,
   type DataSourceInstanceSettings,
   type DataTransformerConfig,
   getDataSourceRef,
-  getNextRefId,
-} from '@grafana/data';
+  getNextRefId, createClientLog} from '@grafana/data';
 import { config, getDataSourceSrv, isExpressionReference, reportInteraction } from '@grafana/runtime';
 import {
   SceneDataTransformer,
@@ -31,6 +29,9 @@ import { getUpdatedHoverHeader } from '../getPanelFrameOptions';
 import { QueryEditorContent } from './QueryEditor/QueryEditorContent';
 import { filterDataTransformerConfigs } from './QueryEditor/utils';
 import { TRANSFORMATION_EDIT_INTERACTION_THROTTLE_TIME } from './constants';
+const clientLog = createClientLog('public/app/features/dashboard-scene/panel-edit/PanelEditNext/PanelDataPaneNext');
+
+
 
 const reportTransformationEditInteraction = throttle((context: string, type: string) => {
   reportInteraction('grafana_panel_transformations_clicked', {
@@ -204,7 +205,7 @@ export class PanelDataPaneNext extends SceneObjectBase<PanelDataPaneNextState> {
       this.setState({ datasource, dsSettings, dsError: undefined });
       storeLastUsedDataSourceInLocalStorage(getDataSourceRef(dsSettings) || { default: true });
     } catch (err) {
-      console.error('Failed to load datasource:', err);
+      clientLog.error('Failed to load datasource:', err);
 
       // Fallback to default datasource (parity with PanelDataQueriesTab)
       try {
@@ -218,7 +219,7 @@ export class PanelDataPaneNext extends SceneObjectBase<PanelDataPaneNextState> {
           // resolveDatasourceRef() handles the stale-ref case on the next activation.
         }
       } catch (fallbackErr) {
-        console.error('Failed to load default datasource:', fallbackErr);
+        clientLog.error('Failed to load default datasource:', fallbackErr);
         this.setState({
           datasource: undefined,
           dsSettings: undefined,

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Header/PluginActions.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Header/PluginActions.tsx
@@ -1,10 +1,8 @@
 import { useMemo } from 'react';
 
-import {
-  type CoreApp,
+import {type CoreApp,
   PluginExtensionPoints,
-  type PluginExtensionQueryEditorRowAdaptiveTelemetryV1Context,
-} from '@grafana/data';
+  type PluginExtensionQueryEditorRowAdaptiveTelemetryV1Context, createClientLog} from '@grafana/data';
 import { renderLimitedComponents, usePluginComponents } from '@grafana/runtime';
 import { type DataQuery } from '@grafana/schema';
 import { Stack } from '@grafana/ui';
@@ -12,6 +10,9 @@ import { type QueryActionComponent, RowActionComponents } from 'app/features/que
 
 import { QueryEditorType } from '../../constants';
 import { useActionsContext, useQueryEditorUIContext, useQueryRunnerContext } from '../QueryEditorContext';
+const clientLog = createClientLog('public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Header/PluginActions');
+
+
 
 interface PluginActionsProps {
   app?: CoreApp;
@@ -94,7 +95,7 @@ function useAdaptiveTelemetryComponents(query: DataQuery | null) {
       pluginId: /grafana-adaptive.*/,
     });
   } catch (error) {
-    console.error('Failed to render adaptive telemetry components:', error);
+    clientLog.error('Failed to render adaptive telemetry components:', error);
     return null;
   }
 }

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/hooks/useSelectedQueryDatasource.ts
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/hooks/useSelectedQueryDatasource.ts
@@ -1,8 +1,11 @@
 import { useAsync } from 'react-use';
 
-import { type DataSourceInstanceSettings, getDataSourceRef } from '@grafana/data';
+import {type DataSourceInstanceSettings, getDataSourceRef, createClientLog} from '@grafana/data';
 import { config, getDataSourceSrv } from '@grafana/runtime';
 import { type DataQuery } from '@grafana/schema';
+const clientLog = createClientLog('public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/hooks/useSelectedQueryDatasource');
+
+
 
 /**
  * Hook to load the datasource for the currently selected query.
@@ -41,14 +44,14 @@ export function useSelectedQueryDatasource(
 
       const queryDsSettings = getDataSourceSrv().getInstanceSettings(dsRef);
       if (!queryDsSettings) {
-        console.error('Datasource settings not found for', dsRef);
+        clientLog.error('Datasource settings not found for', dsRef);
         return undefined;
       }
 
       const queryDatasource = await getDataSourceSrv().get(dsRef);
       return { datasource: queryDatasource, dsSettings: queryDsSettings };
     } catch (err) {
-      console.error('Failed to load datasource for selected query:', err);
+      clientLog.error('Failed to load datasource for selected query:', err);
       return undefined;
     }
   }, [

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/localStorageWithTTL.ts
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/localStorageWithTTL.ts
@@ -1,4 +1,7 @@
-import { store } from '@grafana/data';
+import {store, createClientLog} from '@grafana/data';
+const clientLog = createClientLog('public/app/features/dashboard-scene/panel-edit/PanelEditNext/localStorageWithTTL');
+
+
 
 interface StoredValueWithTTL<T> {
   value: T;
@@ -20,7 +23,7 @@ export const setLocalStorageWithTTL = <T>(key: string, value: T) => {
   try {
     store.setObject(key, item);
   } catch (error) {
-    console.error('Failed to persist value with TTL', error);
+    clientLog.error('Failed to persist value with TTL', error);
   }
 };
 

--- a/public/app/features/dashboard-scene/saving/getDashboardChanges.ts
+++ b/public/app/features/dashboard-scene/saving/getDashboardChanges.ts
@@ -1,3 +1,4 @@
+import { createClientLog } from '@grafana/data';
 import type { AdHocVariableModel, TextBoxVariableModel, TypedVariableModel } from '@grafana/data';
 import { config } from '@grafana/runtime';
 import { type Dashboard, type VariableOption } from '@grafana/schema';
@@ -12,6 +13,9 @@ import { type DashboardDataDTO, type DashboardDTO } from 'app/types/dashboard';
 
 import { validateFiltersOrigin } from '../serialization/sceneVariablesSetToVariables';
 import { jsonDiff } from '../settings/version-history/utils';
+const clientLog = createClientLog('public/app/features/dashboard-scene/saving/getDashboardChanges');
+
+
 
 export function deepEqual(a: string | string[], b: string | string[]) {
   return (
@@ -136,12 +140,12 @@ export function getHasTimeChanged(
 
 export function adHocVariableFiltersEqual(filtersA?: AdHocFilterWithLabels[], filtersB?: AdHocFilterWithLabels[]) {
   if (filtersA === undefined && filtersB === undefined) {
-    console.warn('Adhoc variable filter property is undefined');
+    clientLog.warn('Adhoc variable filter property is undefined');
     return true;
   }
 
   if ((filtersA === undefined && filtersB !== undefined) || (filtersB === undefined && filtersA !== undefined)) {
-    console.warn('Adhoc variable filter property is undefined');
+    clientLog.warn('Adhoc variable filter property is undefined');
     return false;
   }
 

--- a/public/app/features/dashboard-scene/scene/DashboardLayoutOrchestrator.tsx
+++ b/public/app/features/dashboard-scene/scene/DashboardLayoutOrchestrator.tsx
@@ -2,7 +2,7 @@ import { css } from '@emotion/css';
 import { type PointerEvent as ReactPointerEvent } from 'react';
 import { createPortal } from 'react-dom';
 
-import { type GrafanaTheme2 } from '@grafana/data';
+import {type GrafanaTheme2, createClientLog} from '@grafana/data';
 import { logWarning } from '@grafana/runtime';
 import {
   sceneGraph,
@@ -33,6 +33,9 @@ import {
   type DashboardDropTarget,
   isDashboardDropTarget,
 } from './types/DashboardDropTarget';
+const clientLog = createClientLog('public/app/features/dashboard-scene/scene/DashboardLayoutOrchestrator');
+
+
 
 const TAB_ACTIVATION_DELAY_MS = 600;
 
@@ -241,7 +244,7 @@ export class DashboardLayoutOrchestrator extends SceneObjectBase<DashboardLayout
             }
           } else {
             const warningMessage = 'No grid item to drag';
-            console.warn(warningMessage);
+            clientLog.warn(warningMessage);
             logWarning(warningMessage);
           }
         });

--- a/public/app/features/dashboard-scene/scene/DashboardMacro.ts
+++ b/public/app/features/dashboard-scene/scene/DashboardMacro.ts
@@ -1,6 +1,10 @@
+import { createClientLog } from '@grafana/data';
 import { type FormatVariable, type SceneObject, sceneUtils } from '@grafana/scenes';
 
 import { getDashboardSceneFor } from '../utils/utils';
+const clientLog = createClientLog('public/app/features/dashboard-scene/scene/DashboardMacro');
+
+
 
 /**
  * Handles expressions like ${__dashboard.uid}
@@ -39,7 +43,7 @@ export function registerDashboardMacro() {
 
     return () => unregister();
   } catch (e) {
-    console.error('Error registering dashboard macro', e);
+    clientLog.error('Error registering dashboard macro', e);
     return () => {};
   }
 }

--- a/public/app/features/dashboard-scene/scene/DashboardMutationClientSetter.ts
+++ b/public/app/features/dashboard-scene/scene/DashboardMutationClientSetter.ts
@@ -1,3 +1,7 @@
+import { createClientLog } from '@grafana/data';
+const clientLog = createClientLog('public/app/features/dashboard-scene/scene/DashboardMutationClientSetter');
+
+
 /**
  * Bridge between DashboardScene and the mutation-api module.
  *
@@ -19,7 +23,7 @@ export function provideMutationClientFactory(create: CreateMutationClient): void
 
 export function createMutationClient(scene: unknown): () => void {
   if (!_create) {
-    console.warn(
+    clientLog.warn(
       'createMutationClient called before provideMutationClientFactory. Mutation API will not be available.'
     );
     return () => {};

--- a/public/app/features/dashboard-scene/scene/DashboardScene.tsx
+++ b/public/app/features/dashboard-scene/scene/DashboardScene.tsx
@@ -1,7 +1,6 @@
 import type * as H from 'history';
 
-import {
-  CoreApp,
+import {CoreApp,
   type DataQueryRequest,
   type FieldConfig,
   type FieldConfigSource,
@@ -10,8 +9,7 @@ import {
   locationUtil,
   type NavIndex,
   type NavModelItem,
-  store,
-} from '@grafana/data';
+  store, createClientLog} from '@grafana/data';
 import { t } from '@grafana/i18n';
 import { config, locationService, RefreshEvent } from '@grafana/runtime';
 import { getPanelPluginMeta } from '@grafana/runtime/internal';
@@ -115,6 +113,9 @@ import { addNewRowTo } from './layouts-shared/addNew';
 import { clearClipboard } from './layouts-shared/paste';
 import { type DashboardLayoutManager } from './types/DashboardLayoutManager';
 import { type LayoutParent } from './types/LayoutParent';
+const clientLog = createClientLog('public/app/features/dashboard-scene/scene/DashboardScene');
+
+
 
 export const PERSISTED_PROPS = ['title', 'description', 'tags', 'editable', 'graphTooltip', 'links', 'meta', 'preload'];
 export const PANEL_SEARCH_VAR = 'systemPanelFilterVar';
@@ -342,7 +343,7 @@ export class DashboardScene extends SceneObjectBase<DashboardSceneState> impleme
         try {
           return createSceneVariableFromVariableModelV2(v);
         } catch (err) {
-          console.error(err);
+          clientLog.error(err);
           return null;
         }
       })
@@ -409,7 +410,7 @@ export class DashboardScene extends SceneObjectBase<DashboardSceneState> impleme
 
   public exitEditMode({ skipConfirm, restoreInitialState }: { skipConfirm: boolean; restoreInitialState?: boolean }) {
     if (!this.canDiscard()) {
-      console.error('Trying to discard back to a state that does not exist, initialState undefined');
+      clientLog.error('Trying to discard back to a state that does not exist, initialState undefined');
       return;
     }
 
@@ -514,7 +515,7 @@ export class DashboardScene extends SceneObjectBase<DashboardSceneState> impleme
    */
   public discardChangesAndKeepEditing() {
     if (!this.canDiscard()) {
-      console.error('Trying to discard back to a state that does not exist, initialState undefined');
+      clientLog.error('Trying to discard back to a state that does not exist, initialState undefined');
       return;
     }
 
@@ -708,7 +709,7 @@ export class DashboardScene extends SceneObjectBase<DashboardSceneState> impleme
         clearClipboard();
         store.set(LS_PANEL_COPY_KEY, JSON.stringify({ elements, gridItem: gridItemKind }));
       } else {
-        console.error('Trying to copy a panel that is not DashboardGridItem child');
+        clientLog.error('Trying to copy a panel that is not DashboardGridItem child');
         throw new Error('Trying to copy a panel that is not DashboardGridItem child');
       }
       return;
@@ -721,7 +722,7 @@ export class DashboardScene extends SceneObjectBase<DashboardSceneState> impleme
     let gridItem = vizPanel.parent;
 
     if (!(gridItem instanceof DashboardGridItem)) {
-      console.error('Trying to copy a panel that is not DashboardGridItem child');
+      clientLog.error('Trying to copy a panel that is not DashboardGridItem child');
       throw new Error('Trying to copy a panel that is not DashboardGridItem child');
     }
 
@@ -876,7 +877,7 @@ export class DashboardScene extends SceneObjectBase<DashboardSceneState> impleme
 
       appEvents.emit('alert-success', ['Panel styles applied.']);
     } catch (e) {
-      console.error('Error pasting panel styles:', e);
+      clientLog.error('Error pasting panel styles:', e);
       appEvents.emit('alert-error', ['Error pasting panel styles.']);
       DashboardInteractions.panelStylesMenuClicked(
         'paste',
@@ -960,7 +961,7 @@ export class DashboardScene extends SceneObjectBase<DashboardSceneState> impleme
       return;
     }
 
-    console.error('Trying to unlink a lib panel in a layout that is not DashboardGridItem or AutoGridItem');
+    clientLog.error('Trying to unlink a lib panel in a layout that is not DashboardGridItem or AutoGridItem');
   }
 
   public showModal(modal: SceneObject) {

--- a/public/app/features/dashboard-scene/scene/DashboardSceneUrlSync.ts
+++ b/public/app/features/dashboard-scene/scene/DashboardSceneUrlSync.ts
@@ -1,3 +1,4 @@
+import { createClientLog } from '@grafana/data';
 import { type SceneObjectUrlSyncHandler, type SceneObjectUrlValues, type VizPanel } from '@grafana/scenes';
 import { contextSrv } from 'app/core/services/context_srv';
 
@@ -10,6 +11,9 @@ import { type DashboardScene, type DashboardSceneState } from './DashboardScene'
 import { type LibraryPanelBehavior } from './LibraryPanelBehavior';
 import { UNCONFIGURED_PANEL_PLUGIN_ID } from './UnconfiguredPanel';
 import { DefaultGridLayoutManager } from './layout-default/DefaultGridLayoutManager';
+const clientLog = createClientLog('public/app/features/dashboard-scene/scene/DashboardSceneUrlSync');
+
+
 
 export class DashboardSceneUrlSync implements SceneObjectUrlSyncHandler {
   constructor(private _scene: DashboardScene) {}
@@ -72,7 +76,7 @@ export class DashboardSceneUrlSync implements SceneObjectUrlSyncHandler {
       const panel = findEditPanel(this._scene, values.editPanel);
 
       if (!panel) {
-        console.warn(`Panel ${values.editPanel} not found`);
+        clientLog.warn(`Panel ${values.editPanel} not found`);
         return;
       }
 

--- a/public/app/features/dashboard-scene/scene/GoToSnapshotOriginButton.tsx
+++ b/public/app/features/dashboard-scene/scene/GoToSnapshotOriginButton.tsx
@@ -1,12 +1,15 @@
 import { css } from '@emotion/css';
 
-import { textUtil } from '@grafana/data';
+import {textUtil, createClientLog} from '@grafana/data';
 import { t } from '@grafana/i18n';
 import { config, locationService } from '@grafana/runtime';
 import { ConfirmModal, ToolbarButton } from '@grafana/ui';
 
 import { appEvents } from '../../../core/app_events';
 import { ShowModalReactEvent } from '../../../types/events';
+const clientLog = createClientLog('public/app/features/dashboard-scene/scene/GoToSnapshotOriginButton');
+
+
 
 export function GoToSnapshotOriginButton(props: { originalURL: string }) {
   return (
@@ -59,6 +62,6 @@ export const onOpenSnapshotOriginalDashboard = (originalUrl: string) => {
       locationService.push(sanitizedRelativeURL);
     }
   } catch (err) {
-    console.error('Failed to open original dashboard', err);
+    clientLog.error('Failed to open original dashboard', err);
   }
 };

--- a/public/app/features/dashboard-scene/scene/export/exporters.ts
+++ b/public/app/features/dashboard-scene/scene/export/exporters.ts
@@ -1,6 +1,6 @@
 import { defaults, each, sortBy } from 'lodash';
 
-import { type DataSourceRef, type VariableOption, VariableRefresh } from '@grafana/data';
+import {type DataSourceRef, type VariableOption, VariableRefresh, createClientLog} from '@grafana/data';
 import { getDataSourceSrv } from '@grafana/runtime';
 import { getPanelPluginMeta } from '@grafana/runtime/internal';
 import { type Panel } from '@grafana/schema';
@@ -27,6 +27,9 @@ import { isPanelModelLibraryPanel } from '../../../library-panels/guard';
 import { LibraryElementKind } from '../../../library-panels/types';
 import { type DashboardJson } from '../../../manage-dashboards/types';
 import { isConstant } from '../../../variables/guard';
+const clientLog = createClientLog('public/app/features/dashboard-scene/scene/export/exporters');
+
+
 
 // This label is used to store the export label for a datasource when exporting a V2 dashboard for external sharing.
 // E.g. if a dashboard has two datasources with the same type, the export label will be used to distinguish them.
@@ -352,7 +355,7 @@ export async function makeExportableV1(dashboard: DashboardModel) {
 
     return newObj;
   } catch (err) {
-    console.error('Export failed:', err);
+    clientLog.error('Export failed:', err);
     return {
       error: err,
     };
@@ -374,7 +377,7 @@ async function convertLibraryPanelToInlinePanel(libraryPanelElement: LibraryPane
     inlinePanel.spec.id = id;
     return inlinePanel;
   } catch (error) {
-    console.error(`Failed to load library panel ${libraryPanel.uid}:`, error);
+    clientLog.error(`Failed to load library panel ${libraryPanel.uid}:`, error);
 
     const errorMessage = error instanceof Error ? error.message : 'Unknown error';
     dispatch(
@@ -544,7 +547,7 @@ export async function makeExportableV2(dashboard: DashboardV2Spec, isSharingExte
 
     return dashboard;
   } catch (err) {
-    console.error('Export failed:', err);
+    clientLog.error('Export failed:', err);
     return {
       error: err,
     };

--- a/public/app/features/dashboard-scene/scene/layout-auto-grid/AutoGridItem.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-auto-grid/AutoGridItem.tsx
@@ -1,3 +1,4 @@
+import { createClientLog } from '@grafana/data';
 import { isEqual } from 'lodash';
 import React from 'react';
 
@@ -23,6 +24,9 @@ import { type DashboardLayoutItem } from '../types/DashboardLayoutItem';
 import { getOptions } from './AutoGridItemEditor';
 import { AutoGridItemRenderer } from './AutoGridItemRenderer';
 import { AutoGridLayout } from './AutoGridLayout';
+const clientLog = createClientLog('public/app/features/dashboard-scene/scene/layout-auto-grid/AutoGridItem');
+
+
 
 export interface AutoGridItemState extends SceneObjectState {
   body: VizPanel;
@@ -91,7 +95,7 @@ export class AutoGridItem extends SceneObjectBase<AutoGridItemState> implements 
       });
 
     if (!(variable instanceof MultiValueVariable)) {
-      console.error('DashboardGridItem: Variable is not a MultiValueVariable');
+      clientLog.error('DashboardGridItem: Variable is not a MultiValueVariable');
       return;
     }
 

--- a/public/app/features/dashboard-scene/scene/layout-auto-grid/AutoGridLayoutManager.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-auto-grid/AutoGridLayoutManager.tsx
@@ -1,4 +1,4 @@
-import { AppEvents } from '@grafana/data';
+import {AppEvents, createClientLog} from '@grafana/data';
 import { t } from '@grafana/i18n';
 import { config, getAppEvents } from '@grafana/runtime';
 import {
@@ -36,6 +36,9 @@ import { type LayoutRegistryItem } from '../types/LayoutRegistryItem';
 import { AutoGridItem } from './AutoGridItem';
 import { AutoGridLayout } from './AutoGridLayout';
 import { getEditOptions } from './AutoGridLayoutManagerEditor';
+const clientLog = createClientLog('public/app/features/dashboard-scene/scene/layout-auto-grid/AutoGridLayoutManager');
+
+
 
 interface AutoGridLayoutManagerState extends SceneObjectState {
   layout: AutoGridLayout;
@@ -248,7 +251,7 @@ export class AutoGridLayoutManager
   public duplicatePanel(panel: VizPanel) {
     const gridItem = panel.parent;
     if (!(gridItem instanceof AutoGridItem)) {
-      console.error('Trying to duplicate a panel that is not inside a DashboardGridItem');
+      clientLog.error('Trying to duplicate a panel that is not inside a DashboardGridItem');
       return;
     }
 

--- a/public/app/features/dashboard-scene/scene/layout-default/DashboardGridItem.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-default/DashboardGridItem.tsx
@@ -1,3 +1,4 @@
+import { createClientLog } from '@grafana/data';
 import { isEqual } from 'lodash';
 import React from 'react';
 import { type Unsubscribable } from 'rxjs';
@@ -27,6 +28,9 @@ import { getDashboardGridItemOptions } from './DashboardGridItemEditor';
 import { DashboardGridItemRenderer } from './DashboardGridItemRenderer';
 import { DashboardGridItemVariableDependencyHandler } from './DashboardGridItemVariableDependencyHandler';
 import { RowRepeaterBehavior } from './RowRepeaterBehavior';
+const clientLog = createClientLog('public/app/features/dashboard-scene/scene/layout-default/DashboardGridItem');
+
+
 
 export interface DashboardGridItemState extends SceneGridItemStateLike {
   body: VizPanel;
@@ -150,7 +154,7 @@ export class DashboardGridItem
       });
 
     if (!(variable instanceof MultiValueVariable)) {
-      console.error('DashboardGridItem: Variable is not a MultiValueVariable');
+      clientLog.error('DashboardGridItem: Variable is not a MultiValueVariable');
       return;
     }
 

--- a/public/app/features/dashboard-scene/scene/layout-default/DefaultGridLayoutManager.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-default/DefaultGridLayoutManager.tsx
@@ -1,6 +1,6 @@
 import { css, cx } from '@emotion/css';
 
-import { AppEvents, type GrafanaTheme2 } from '@grafana/data';
+import {AppEvents, type GrafanaTheme2, createClientLog} from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';
 import { t } from '@grafana/i18n';
 import { config, getAppEvents } from '@grafana/runtime';
@@ -57,6 +57,9 @@ import { DashboardGridItem } from './DashboardGridItem';
 import { RowRepeaterBehavior } from './RowRepeaterBehavior';
 import { findSpaceForNewPanel } from './findSpaceForNewPanel';
 import { RowActions } from './row-actions/RowActions';
+const clientLog = createClientLog('public/app/features/dashboard-scene/scene/layout-default/DefaultGridLayoutManager');
+
+
 
 interface DefaultGridLayoutManagerState extends SceneObjectState {
   grid: SceneGridLayout;
@@ -260,7 +263,7 @@ export class DefaultGridLayoutManager
   public duplicatePanel(vizPanel: VizPanel) {
     const gridItem = vizPanel.parent;
     if (!(gridItem instanceof DashboardGridItem)) {
-      console.error('Trying to duplicate a panel that is not inside a DashboardGridItem');
+      clientLog.error('Trying to duplicate a panel that is not inside a DashboardGridItem');
       return;
     }
 

--- a/public/app/features/dashboard-scene/scene/layout-default/RowRepeaterBehavior.ts
+++ b/public/app/features/dashboard-scene/scene/layout-default/RowRepeaterBehavior.ts
@@ -1,3 +1,4 @@
+import { createClientLog } from '@grafana/data';
 import { isEqual } from 'lodash';
 
 import {
@@ -14,6 +15,9 @@ import {
 
 import { getCloneKey, getLocalVariableValueSet } from '../../utils/clone';
 import { getMultiVariableValues } from '../../utils/utils';
+const clientLog = createClientLog('public/app/features/dashboard-scene/scene/layout-default/RowRepeaterBehavior');
+
+
 
 interface RowRepeaterBehaviorState extends SceneObjectState {
   variableName: string;
@@ -91,12 +95,12 @@ export class RowRepeaterBehavior extends SceneObjectBase<RowRepeaterBehaviorStat
     const variable = sceneGraph.lookupVariable(this.state.variableName, this.parent?.parent!);
 
     if (!variable) {
-      console.error('RepeatedRowBehavior: Variable not found');
+      clientLog.error('RepeatedRowBehavior: Variable not found');
       return;
     }
 
     if (!(variable instanceof MultiValueVariable)) {
-      console.error('RepeatedRowBehavior: Variable is not a MultiValueVariable');
+      clientLog.error('RepeatedRowBehavior: Variable is not a MultiValueVariable');
       return;
     }
 

--- a/public/app/features/dashboard-scene/scene/layout-rows/RowItem.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-rows/RowItem.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { store } from '@grafana/data';
+import {store, createClientLog} from '@grafana/data';
 import { t } from '@grafana/i18n';
 import { logWarning } from '@grafana/runtime';
 import { getFeatureFlagClient } from '@grafana/runtime/internal';
@@ -45,6 +45,9 @@ import { useEditOptions } from './RowItemEditor';
 import { RowItemRenderer } from './RowItemRenderer';
 import { RowItems } from './RowItems';
 import { RowsLayoutManager } from './RowsLayoutManager';
+const clientLog = createClientLog('public/app/features/dashboard-scene/scene/layout-rows/RowItem');
+
+
 
 export interface RowItemState extends SceneObjectState {
   layout: DashboardLayoutManager;
@@ -227,7 +230,7 @@ export class RowItem
         layout.setState({ children: newChildren });
       } else {
         const warningMessage = 'Grid item has unexpected parent type';
-        console.warn(warningMessage);
+        clientLog.warn(warningMessage);
         logWarning(warningMessage);
       }
     }
@@ -242,7 +245,7 @@ export class RowItem
       layout.addGridItem(gridItem);
     } else {
       const warningMessage = 'Layout manager does not support addGridItem';
-      console.warn(warningMessage);
+      clientLog.warn(warningMessage);
       logWarning(warningMessage);
     }
     this.setIsDropTarget(false);

--- a/public/app/features/dashboard-scene/scene/layout-tabs/TabItem.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-tabs/TabItem.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { store } from '@grafana/data';
+import {store, createClientLog} from '@grafana/data';
 import { t } from '@grafana/i18n';
 import { logWarning } from '@grafana/runtime';
 import { getFeatureFlagClient } from '@grafana/runtime/internal';
@@ -47,6 +47,9 @@ import { useEditOptions } from './TabItemEditor';
 import { TabItemRenderer } from './TabItemRenderer';
 import { TabItems } from './TabItems';
 import { TabsLayoutManager } from './TabsLayoutManager';
+const clientLog = createClientLog('public/app/features/dashboard-scene/scene/layout-tabs/TabItem');
+
+
 
 export interface TabItemState extends SceneObjectState {
   layout: DashboardLayoutManager;
@@ -234,7 +237,7 @@ export class TabItem
         layout.setState({ children: newChildren });
       } else {
         const warningMessage = 'Grid item has unexpected parent type';
-        console.warn(warningMessage);
+        clientLog.warn(warningMessage);
         logWarning(warningMessage);
       }
     }
@@ -256,13 +259,13 @@ export class TabItem
           rowLayout.addGridItem(gridItem);
         } else {
           const warningMessage = 'First row layout does not support addGridItem';
-          console.warn(warningMessage);
+          clientLog.warn(warningMessage);
           logWarning(warningMessage);
         }
       }
     } else {
       const warningMessage = 'Layout manager does not support addGridItem';
-      console.warn(warningMessage);
+      clientLog.warn(warningMessage);
       logWarning(warningMessage);
     }
     this.setIsDropTarget(false);

--- a/public/app/features/dashboard-scene/serialization/DashboardSceneSerializer.ts
+++ b/public/app/features/dashboard-scene/serialization/DashboardSceneSerializer.ts
@@ -1,3 +1,4 @@
+import { createClientLog } from '@grafana/data';
 import { logWarning } from '@grafana/runtime';
 import { type Dashboard } from '@grafana/schema';
 import { type Spec as DashboardV2Spec } from '@grafana/schema/apis/dashboard.grafana.app/v2';
@@ -24,6 +25,9 @@ import { getVizPanelKeyForPanelId } from '../utils/utils';
 
 import { transformSceneToSaveModel } from './transformSceneToSaveModel';
 import { transformSceneToSaveModelSchemaV2 } from './transformSceneToSaveModelSchemaV2';
+const clientLog = createClientLog('public/app/features/dashboard-scene/serialization/DashboardSceneSerializer');
+
+
 
 /**
  * T is the type of the save model
@@ -353,7 +357,7 @@ export class V2DashboardSerializer
           }
         } else {
           const warningMsg = 'Dashboard serializer: Undefined variable found in dashboard save model, ignoring it';
-          console.warn(warningMsg);
+          clientLog.warn(warningMsg);
           logWarning(warningMsg);
         }
       }

--- a/public/app/features/dashboard-scene/serialization/angularMigration.ts
+++ b/public/app/features/dashboard-scene/serialization/angularMigration.ts
@@ -1,7 +1,10 @@
 import { defaults, cloneDeep } from 'lodash';
 
-import { type PanelModel as PanelModelFromData, type PanelPlugin } from '@grafana/data';
+import {type PanelModel as PanelModelFromData, type PanelPlugin, createClientLog} from '@grafana/data';
 import { autoMigrateAngular, type PanelModel } from 'app/features/dashboard/state/PanelModel';
+const clientLog = createClientLog('public/app/features/dashboard-scene/serialization/angularMigration');
+
+
 
 /**
  * Data structure for Angular migration information stored in v2 schema options.
@@ -42,7 +45,7 @@ export function getAngularPanelMigrationHandler(oldModel: PanelModel) {
       const targetClone = cloneDeep(oldModel.targets);
       Object.defineProperty(panel, 'targets', {
         get: function () {
-          console.warn(
+          clientLog.warn(
             'Accessing the targets property when migrating a panel plugin is deprecated. Changes to this property will be ignored.'
           );
           return targetClone;
@@ -108,7 +111,7 @@ export function getV2AngularMigrationHandler(migrationData: AngularMigrationData
     const targetClone = cloneDeep(panel.targets);
     Object.defineProperty(panel, 'targets', {
       get: function () {
-        console.warn(
+        clientLog.warn(
           'Accessing the targets property when migrating a panel plugin is deprecated. Changes to this property will be ignored.'
         );
         return targetClone;

--- a/public/app/features/dashboard-scene/serialization/layoutSerializers/utils.ts
+++ b/public/app/features/dashboard-scene/serialization/layoutSerializers/utils.ts
@@ -1,4 +1,4 @@
-import { getNextRefId } from '@grafana/data';
+import {getNextRefId, createClientLog} from '@grafana/data';
 import { config } from '@grafana/runtime';
 import { getPanelPluginMetasMapSync, type PanelPluginMetas } from '@grafana/runtime/internal';
 import {
@@ -47,6 +47,9 @@ import { createElements, vizPanelToSchemaV2 } from '../transformSceneToSaveModel
 import { transformMappingsToV1 } from '../transformToV1TypesUtils';
 import { transformDataTopic } from '../transformToV2TypesUtils';
 import { normalizeTransformation } from '../transformationCompat';
+const clientLog = createClientLog('public/app/features/dashboard-scene/serialization/layoutSerializers/utils');
+
+
 
 export function buildVizPanel(panel: PanelKind, id?: number): VizPanel {
   const titleItems: SceneObject[] = [];
@@ -372,7 +375,7 @@ export function getDataSourceForQuery(querySpecDS: DataSourceRef | undefined | n
     // In the datasource list from bootData "id" is the type and the uid could be uid or the name
     // in cases like grafana, dashboard or mixed datasource
 
-    console.warn(
+    clientLog.warn(
       `Could not find datasource for query kind ${queryKind}, defaulting to ${dsList[defaultDatasource].meta.id}`
     );
     return {

--- a/public/app/features/dashboard-scene/serialization/transformSaveModelSchemaV2ToScene.ts
+++ b/public/app/features/dashboard-scene/serialization/transformSaveModelSchemaV2ToScene.ts
@@ -1,3 +1,4 @@
+import { createClientLog } from '@grafana/data';
 import { uniqueId } from 'lodash';
 
 import { config, getDataSourceSrv } from '@grafana/runtime';
@@ -92,6 +93,9 @@ import {
   transformVariableRefreshToEnumV1,
 } from './transformToV1TypesUtils';
 import { LEGACY_STRING_VALUE_KEY } from './transformToV2TypesUtils';
+const clientLog = createClientLog('public/app/features/dashboard-scene/serialization/transformSaveModelSchemaV2ToScene');
+
+
 
 const DEFAULT_DATASOURCE = 'default';
 
@@ -309,7 +313,7 @@ function createVariablesForDashboard(dashboard: DashboardV2Spec, defaultVariable
       try {
         return createSceneVariableFromVariableModel(v);
       } catch (err) {
-        console.error(err);
+        clientLog.error(err);
         return null;
       }
     })
@@ -322,7 +326,7 @@ function createVariablesForDashboard(dashboard: DashboardV2Spec, defaultVariable
       try {
         return createSceneVariableFromVariableModel(v);
       } catch (err) {
-        console.error(err);
+        clientLog.error(err);
         return null;
       }
     })
@@ -616,7 +620,7 @@ export function createVariablesForSnapshot(dashboard: DashboardV2Spec): SceneVar
         // for other variable types we are using the SnapshotVariable
         return createSnapshotVariable(v);
       } catch (err) {
-        console.error(err);
+        clientLog.error(err);
         return null;
       }
     })

--- a/public/app/features/dashboard-scene/serialization/transformSceneToSaveModelSchemaV2.ts
+++ b/public/app/features/dashboard-scene/serialization/transformSceneToSaveModelSchemaV2.ts
@@ -1,6 +1,6 @@
 import { omit } from 'lodash';
 
-import { type AnnotationQuery, isEmptyObject, type TimeRange } from '@grafana/data';
+import {type AnnotationQuery, isEmptyObject, type TimeRange, createClientLog} from '@grafana/data';
 import { config } from '@grafana/runtime';
 import { ExpressionDatasourceRef } from '@grafana/runtime/internal';
 import {
@@ -67,6 +67,9 @@ import { type DSReferencesMapping } from './DashboardSceneSerializer';
 import { transformV1ToV2AnnotationQuery } from './annotations';
 import { sceneVariablesSetToSchemaV2Variables } from './sceneVariablesSetToVariables';
 import { colorIdEnumToColorIdV2, transformCursorSynctoEnum } from './transformToV2TypesUtils';
+const clientLog = createClientLog('public/app/features/dashboard-scene/serialization/transformSceneToSaveModelSchemaV2');
+
+
 // FIXME: This is temporary to avoid creating partial types for all the new schema, it has some performance implications, but it's fine for now
 type DeepPartial<T> = T extends object
   ? {
@@ -172,7 +175,7 @@ export function transformSceneToSaveModelSchemaV2(scene: DashboardScene, isSnaps
     // should never reach this point, validation should throw an error
     throw new Error('Error we could transform the dashboard to schema v2: ' + dashboardSchemaV2);
   } catch (reason) {
-    console.error('Error transforming dashboard to schema v2: ' + reason, dashboardSchemaV2);
+    clientLog.error('Error transforming dashboard to schema v2: ' + reason, dashboardSchemaV2);
     throw new Error('Error transforming dashboard to schema v2: ' + reason);
   }
 }
@@ -612,7 +615,7 @@ function getAnnotations(state: DashboardSceneState, dsReferencesMapping?: DSRefe
       // for layers created for v2 schema. See transform transformSaveModelSchemaV2ToScene.ts.
       // In this case we will resolve default data source
       layerDs = getDefaultDataSourceRef();
-      console.error(
+      clientLog.error(
         'Misconfigured AnnotationsDataLayer: Data source is required for annotations. Resolving default data source',
         layer,
         layerDs

--- a/public/app/features/dashboard-scene/serialization/transformToV1TypesUtils.ts
+++ b/public/app/features/dashboard-scene/serialization/transformToV1TypesUtils.ts
@@ -1,4 +1,4 @@
-import { type FieldConfigSource as FieldConfigSourceV1, SpecialValueMatch as SpecialValueMatchV1 } from '@grafana/data';
+import {type FieldConfigSource as FieldConfigSourceV1, SpecialValueMatch as SpecialValueMatchV1, createClientLog} from '@grafana/data';
 import {
   VariableHide as VariableHideV1,
   VariableRefresh as VariableRefreshV1,
@@ -16,6 +16,9 @@ import {
   type SpecialValueMatch,
   type ThresholdsMode,
 } from '@grafana/schema/apis/dashboard.grafana.app/v2';
+const clientLog = createClientLog('public/app/features/dashboard-scene/serialization/transformToV1TypesUtils');
+
+
 
 export function transformVariableRefreshToEnumV1(refresh?: VariableRefresh): VariableRefreshV1 {
   switch (refresh) {
@@ -98,7 +101,7 @@ function transformSpecialValueMatchToV1(match: SpecialValueMatch): SpecialValueM
     case 'empty':
       return SpecialValueMatchV1.Empty;
     default:
-      console.warn(`Skipping special value mapping with unknown match type: "${match}"`);
+      clientLog.warn(`Skipping special value mapping with unknown match type: "${match}"`);
       return undefined;
   }
 }

--- a/public/app/features/dashboard-scene/settings/AnnotationsEditView.tsx
+++ b/public/app/features/dashboard-scene/settings/AnnotationsEditView.tsx
@@ -1,10 +1,8 @@
-import {
-  type AnnotationQuery,
+import {type AnnotationQuery,
   getDataSourceRef,
   type NavModel,
   type NavModelItem,
-  PageLayoutType,
-} from '@grafana/data';
+  PageLayoutType, createClientLog} from '@grafana/data';
 import { getDataSourceSrv } from '@grafana/runtime';
 import { type SceneComponentProps, SceneObjectBase, type VizPanel, dataLayers } from '@grafana/scenes';
 import { Page } from 'app/core/components/Page/Page';
@@ -21,6 +19,9 @@ import { EditListViewSceneUrlSync } from './EditListViewSceneUrlSync';
 import { AnnotationSettingsEdit } from './annotations/AnnotationSettingsEdit';
 import { AnnotationSettingsList } from './annotations/AnnotationSettingsList';
 import { type DashboardEditView, type DashboardEditViewState, useDashboardEditPageNav } from './utils';
+const clientLog = createClientLog('public/app/features/dashboard-scene/settings/AnnotationsEditView');
+
+
 
 export enum MoveDirection {
   UP = -1,
@@ -65,7 +66,7 @@ export class AnnotationsEditView extends SceneObjectBase<AnnotationsEditViewStat
     const defaultInstanceDS = getDataSourceSrv().getInstanceSettings(null);
     // check for an annotation flag in the plugin json to see if it supports annotations
     if (!defaultInstanceDS || !defaultInstanceDS.meta.annotations) {
-      console.error('Default datasource does not support annotations');
+      clientLog.error('Default datasource does not support annotations');
       return undefined;
     }
     return getDataSourceRef(defaultInstanceDS);

--- a/public/app/features/dashboard-scene/settings/GeneralSettingsEditView.tsx
+++ b/public/app/features/dashboard-scene/settings/GeneralSettingsEditView.tsx
@@ -1,6 +1,6 @@
 import { type ChangeEvent } from 'react';
 
-import { PageLayoutType } from '@grafana/data';
+import {PageLayoutType, createClientLog} from '@grafana/data';
 import { Trans, t } from '@grafana/i18n';
 import { config } from '@grafana/runtime';
 import { type SceneComponentProps, SceneObjectBase, behaviors, sceneGraph } from '@grafana/scenes';
@@ -35,6 +35,9 @@ import { getDashboardSceneFor } from '../utils/utils';
 
 import { DeleteDashboardButton } from './DeleteDashboardButton';
 import { type DashboardEditView, type DashboardEditViewState, useDashboardEditPageNav } from './utils';
+const clientLog = createClientLog('public/app/features/dashboard-scene/settings/GeneralSettingsEditView');
+
+
 
 export interface GeneralSettingsEditViewState extends DashboardEditViewState {
   showMoveModal?: boolean;
@@ -159,7 +162,7 @@ export class GeneralSettingsEditView
       const liveNow = this.getLiveNowTimer();
       enable ? liveNow.enable() : liveNow.disable();
     } catch (err) {
-      console.error(err);
+      clientLog.error(err);
     }
   };
 

--- a/public/app/features/dashboard-scene/settings/VariablesEditView.tsx
+++ b/public/app/features/dashboard-scene/settings/VariablesEditView.tsx
@@ -1,7 +1,7 @@
 import { useMemo } from 'react';
 import { v4 as uuidv4 } from 'uuid';
 
-import { type NavModel, type NavModelItem, PageLayoutType } from '@grafana/data';
+import {type NavModel, type NavModelItem, PageLayoutType, createClientLog} from '@grafana/data';
 import {
   type SceneComponentProps,
   SceneObjectBase,
@@ -31,6 +31,9 @@ import {
   getVariableScene,
   isVariableEditable,
 } from './variables/utils';
+const clientLog = createClientLog('public/app/features/dashboard-scene/settings/VariablesEditView');
+
+
 
 export interface VariablesEditViewState extends DashboardEditViewState {
   editIndex?: number | undefined;
@@ -66,7 +69,7 @@ export class VariablesEditView extends SceneObjectBase<VariablesEditViewState> i
 
     if (!variable) {
       // Handle the case where the variable is not found
-      console.error('Variable not found');
+      clientLog.error('Variable not found');
       return;
     }
 
@@ -82,7 +85,7 @@ export class VariablesEditView extends SceneObjectBase<VariablesEditViewState> i
     const { variables } = this.getVariableSet().state;
     if (variableIndex === -1) {
       // Handle the case where the variable is not found
-      console.error('Variable not found');
+      clientLog.error('Variable not found');
       return;
     }
 
@@ -104,7 +107,7 @@ export class VariablesEditView extends SceneObjectBase<VariablesEditViewState> i
     const variables = this.getVariableSet().state.variables;
 
     if (variableIndex === -1) {
-      console.error('Variable not found');
+      clientLog.error('Variable not found');
       return;
     }
 
@@ -137,7 +140,7 @@ export class VariablesEditView extends SceneObjectBase<VariablesEditViewState> i
     }
     // check the index are within the variables array
     if (fromIndex < 0 || fromIndex >= variables.length || toIndex < 0 || toIndex >= variables.length) {
-      console.error('Invalid index');
+      clientLog.error('Invalid index');
       return;
     }
     const updatedVariables = [...variables];
@@ -151,7 +154,7 @@ export class VariablesEditView extends SceneObjectBase<VariablesEditViewState> i
   public onEdit = (identifier: string) => {
     const variableIndex = this.getVariableIndex(identifier);
     if (variableIndex === -1) {
-      console.error('Variable not found');
+      clientLog.error('Variable not found');
       return;
     }
     this.setState({ editIndex: variableIndex });
@@ -175,7 +178,7 @@ export class VariablesEditView extends SceneObjectBase<VariablesEditViewState> i
 
     if (!variable) {
       // Handle the case where the variable is not found
-      console.error('Variable not found');
+      clientLog.error('Variable not found');
       return;
     }
 

--- a/public/app/features/dashboard-scene/settings/VersionsEditView.tsx
+++ b/public/app/features/dashboard-scene/settings/VersionsEditView.tsx
@@ -2,7 +2,7 @@ import { skipToken } from '@reduxjs/toolkit/query/react';
 import * as React from 'react';
 import { useMemo } from 'react';
 
-import { PageLayoutType, dateTimeFormat, dateTimeFormatTimeAgo } from '@grafana/data';
+import {PageLayoutType, dateTimeFormat, dateTimeFormatTimeAgo, createClientLog} from '@grafana/data';
 import { Trans } from '@grafana/i18n';
 import { type SceneComponentProps, SceneObjectBase, sceneGraph } from '@grafana/scenes';
 import { Alert, Spinner, Stack } from '@grafana/ui';
@@ -31,6 +31,9 @@ import { VersionsHistoryButtons } from './version-history/VersionHistoryButtons'
 import { VersionHistoryComparison } from './version-history/VersionHistoryComparison';
 import { VersionHistoryHeader } from './version-history/VersionHistoryHeader';
 import { VersionHistoryTable } from './version-history/VersionHistoryTable';
+const clientLog = createClientLog('public/app/features/dashboard-scene/settings/VersionsEditView');
+
+
 
 export interface VersionsEditViewState extends DashboardEditViewState {
   versions?: DecoratedRevisionModel[];
@@ -118,7 +121,7 @@ export class VersionsEditView extends SceneObjectBase<VersionsEditViewState> imp
         // Update the continueToken for the next request, if available
         this._continueToken = result.metadata.continue ?? '';
       })
-      .catch((err) => console.log(err))
+      .catch((err) => clientLog.info(err))
       .finally(() => this.setState({ isAppending: false }));
   };
 

--- a/public/app/features/dashboard-scene/settings/annotations/AnnotationQueryOptions.tsx
+++ b/public/app/features/dashboard-scene/settings/annotations/AnnotationQueryOptions.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useState } from 'react';
 import { useAsync } from 'react-use';
 
-import { AppEvents, CoreApp, type DataSourceInstanceSettings, getDataSourceRef } from '@grafana/data';
+import {AppEvents, CoreApp, type DataSourceInstanceSettings, getDataSourceRef, createClientLog} from '@grafana/data';
 import { t, Trans } from '@grafana/i18n';
 import { getAppEvents, getDataSourceSrv } from '@grafana/runtime';
 import { type DataQuery } from '@grafana/schema';
@@ -14,6 +14,9 @@ import { useQueryLibraryContext } from 'app/features/explore/QueryLibrary/QueryL
 import { dashboardEditActions } from '../../edit-pane/shared';
 
 import { type AnnotationLayer } from './AnnotationEditableElement';
+const clientLog = createClientLog('public/app/features/dashboard-scene/settings/annotations/AnnotationQueryOptions');
+
+
 
 export function AnnotationQueryEditorButton({ layer }: { layer: AnnotationLayer }) {
   const { queryLibraryEnabled } = useQueryLibraryContext();
@@ -79,7 +82,7 @@ function QueryLibraryButton({ layer, onQuerySelected }: { layer: AnnotationLayer
           layer.setState({ query: updatedQuery });
           layer.runLayer();
         } catch (error) {
-          console.error('Failed to replace annotation query!', error);
+          clientLog.error('Failed to replace annotation query!', error);
           getAppEvents().publish({
             type: AppEvents.alertError.name,
             payload: ['Failed to create annotation query!', error instanceof Error ? error.message : error],

--- a/public/app/features/dashboard-scene/settings/variables/editors/AdHocFiltersVariableEditor.tsx
+++ b/public/app/features/dashboard-scene/settings/variables/editors/AdHocFiltersVariableEditor.tsx
@@ -2,12 +2,10 @@ import { noop } from 'lodash';
 import { type FormEvent, useCallback, useMemo, useState } from 'react';
 import { useAsync } from 'react-use';
 
-import {
-  type DataSourceInstanceSettings,
+import {type DataSourceInstanceSettings,
   type MetricFindValue,
   type SelectableValue,
-  getDataSourceRef,
-} from '@grafana/data';
+  getDataSourceRef, createClientLog} from '@grafana/data';
 import { t } from '@grafana/i18n';
 import { config, getDataSourceSrv } from '@grafana/runtime';
 import { AdHocFiltersVariable, type AdHocFilterWithLabels, type SceneVariable } from '@grafana/scenes';
@@ -15,6 +13,9 @@ import { OptionsPaneItemDescriptor } from 'app/features/dashboard/components/Pan
 
 import { AdHocOriginFiltersController } from '../components/AdHocOriginFiltersController';
 import { AdHocVariableForm } from '../components/AdHocVariableForm';
+const clientLog = createClientLog('public/app/features/dashboard-scene/settings/variables/editors/AdHocFiltersVariableEditor');
+
+
 
 interface AdHocFiltersVariableEditorProps {
   variable: AdHocFiltersVariable;
@@ -169,7 +170,7 @@ export function AdHocFiltersVariableEditor(props: AdHocFiltersVariableEditorProp
 
 export function getAdHocFilterOptions(variable: SceneVariable): OptionsPaneItemDescriptor[] {
   if (!(variable instanceof AdHocFiltersVariable)) {
-    console.warn('getAdHocFilterOptions: variable is not an AdHocFiltersVariable');
+    clientLog.warn('getAdHocFilterOptions: variable is not an AdHocFiltersVariable');
     return [];
   }
 

--- a/public/app/features/dashboard-scene/settings/variables/editors/ConstantVariableEditor.tsx
+++ b/public/app/features/dashboard-scene/settings/variables/editors/ConstantVariableEditor.tsx
@@ -1,3 +1,4 @@
+import { createClientLog } from '@grafana/data';
 import { type FormEvent } from 'react';
 import { lastValueFrom } from 'rxjs';
 
@@ -7,6 +8,9 @@ import { Input } from '@grafana/ui';
 import { OptionsPaneItemDescriptor } from 'app/features/dashboard/components/PanelEditor/OptionsPaneItemDescriptor';
 
 import { ConstantVariableForm } from '../components/ConstantVariableForm';
+const clientLog = createClientLog('public/app/features/dashboard-scene/settings/variables/editors/ConstantVariableEditor');
+
+
 
 interface ConstantVariableEditorProps {
   variable: ConstantVariable;
@@ -24,7 +28,7 @@ export function ConstantVariableEditor({ variable }: ConstantVariableEditorProps
 
 export function getConstantVariableOptions(variable: SceneVariable): OptionsPaneItemDescriptor[] {
   if (!(variable instanceof ConstantVariable)) {
-    console.warn('getConstantVariableOptions: variable is not a ConstantVariable');
+    clientLog.warn('getConstantVariableOptions: variable is not a ConstantVariable');
     return [];
   }
 

--- a/public/app/features/dashboard-scene/settings/variables/editors/GroupByVariableEditor.tsx
+++ b/public/app/features/dashboard-scene/settings/variables/editors/GroupByVariableEditor.tsx
@@ -2,17 +2,18 @@ import { noop } from 'lodash';
 import { type FormEvent } from 'react';
 import { useAsync } from 'react-use';
 
-import {
-  type DataSourceInstanceSettings,
+import {type DataSourceInstanceSettings,
   type MetricFindValue,
   type SelectableValue,
-  getDataSourceRef,
-} from '@grafana/data';
+  getDataSourceRef, createClientLog} from '@grafana/data';
 import { getDataSourceSrv } from '@grafana/runtime';
 import { GroupByVariable, type SceneVariable } from '@grafana/scenes';
 import { OptionsPaneItemDescriptor } from 'app/features/dashboard/components/PanelEditor/OptionsPaneItemDescriptor';
 
 import { GroupByVariableForm } from '../components/GroupByVariableForm';
+const clientLog = createClientLog('public/app/features/dashboard-scene/settings/variables/editors/GroupByVariableEditor');
+
+
 
 interface GroupByVariableEditorProps {
   variable: GroupByVariable;
@@ -106,7 +107,7 @@ export function GroupByVariableEditor(props: GroupByVariableEditorProps) {
 
 export function getGroupByVariableOptions(variable: SceneVariable): OptionsPaneItemDescriptor[] {
   if (!(variable instanceof GroupByVariable)) {
-    console.warn('getAdHocFilterOptions: variable is not an AdHocFiltersVariable');
+    clientLog.warn('getAdHocFilterOptions: variable is not an AdHocFiltersVariable');
     return [];
   }
 

--- a/public/app/features/dashboard-scene/settings/variables/editors/IntervalVariableEditor.tsx
+++ b/public/app/features/dashboard-scene/settings/variables/editors/IntervalVariableEditor.tsx
@@ -1,7 +1,7 @@
 import { noop } from 'lodash';
 import { type ChangeEvent, type FormEvent } from 'react';
 
-import { type SelectableValue } from '@grafana/data';
+import {type SelectableValue, createClientLog} from '@grafana/data';
 import { IntervalVariable, type SceneVariable } from '@grafana/scenes';
 import { OptionsPaneItemDescriptor } from 'app/features/dashboard/components/PanelEditor/OptionsPaneItemDescriptor';
 import {
@@ -10,6 +10,9 @@ import {
 } from 'app/features/dashboard-scene/utils/utils';
 
 import { IntervalVariableForm } from '../components/IntervalVariableForm';
+const clientLog = createClientLog('public/app/features/dashboard-scene/settings/variables/editors/IntervalVariableEditor');
+
+
 
 interface IntervalVariableEditorProps {
   variable: IntervalVariable;
@@ -65,7 +68,7 @@ export function IntervalVariableEditor({ variable, onRunQuery, inline }: Interva
 
 export function getIntervalVariableOptions(variable: SceneVariable): OptionsPaneItemDescriptor[] {
   if (!(variable instanceof IntervalVariable)) {
-    console.warn('getIntervalVariableOptions: variable is not an IntervalVariable');
+    clientLog.warn('getIntervalVariableOptions: variable is not an IntervalVariable');
     return [];
   }
 

--- a/public/app/features/dashboard-scene/settings/variables/editors/QueryVariableEditor.tsx
+++ b/public/app/features/dashboard-scene/settings/variables/editors/QueryVariableEditor.tsx
@@ -1,12 +1,10 @@
 import { type FormEvent, useState } from 'react';
 import { useAsync } from 'react-use';
 
-import {
-  type DataSourceInstanceSettings,
+import {type DataSourceInstanceSettings,
   getDataSourceRef,
   type SelectableValue,
-  type VariableRegexApplyTo,
-} from '@grafana/data';
+  type VariableRegexApplyTo, createClientLog} from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';
 import { t, Trans } from '@grafana/i18n';
 import { getDataSourceSrv } from '@grafana/runtime';
@@ -29,6 +27,9 @@ import {
 import { QueryVariableEditorForm } from '../components/QueryVariableForm';
 import { VariableValuesPreview } from '../components/VariableValuesPreview';
 import { hasVariableOptions } from '../utils';
+const clientLog = createClientLog('public/app/features/dashboard-scene/settings/variables/editors/QueryVariableEditor');
+
+
 
 interface QueryVariableEditorProps {
   variable: QueryVariable;
@@ -138,7 +139,7 @@ export function QueryVariableEditor({ variable, onRunQuery }: QueryVariableEdito
 
 export function getQueryVariableOptions(variable: SceneVariable): OptionsPaneItemDescriptor[] {
   if (!(variable instanceof QueryVariable)) {
-    console.warn('getQueryVariableOptions: variable is not a QueryVariable');
+    clientLog.warn('getQueryVariableOptions: variable is not a QueryVariable');
     return [];
   }
 

--- a/public/app/features/dashboard-scene/settings/variables/editors/SwitchVariableEditor.tsx
+++ b/public/app/features/dashboard-scene/settings/variables/editors/SwitchVariableEditor.tsx
@@ -1,7 +1,11 @@
+import { createClientLog } from '@grafana/data';
 import { type SceneVariable, SwitchVariable } from '@grafana/scenes';
 import { OptionsPaneItemDescriptor } from 'app/features/dashboard/components/PanelEditor/OptionsPaneItemDescriptor';
 
 import { SwitchVariableForm } from '../components/SwitchVariableForm';
+const clientLog = createClientLog('public/app/features/dashboard-scene/settings/variables/editors/SwitchVariableEditor');
+
+
 
 interface SwitchVariableEditorProps {
   variable: SwitchVariable;
@@ -44,7 +48,7 @@ export function SwitchVariableEditor({ variable, inline = false }: SwitchVariabl
 
 export function getSwitchVariableOptions(variable: SceneVariable): OptionsPaneItemDescriptor[] {
   if (!(variable instanceof SwitchVariable)) {
-    console.warn('getSwitchVariableOptions: variable is not a SwitchVariable');
+    clientLog.warn('getSwitchVariableOptions: variable is not a SwitchVariable');
     return [];
   }
 

--- a/public/app/features/dashboard-scene/settings/variables/editors/TextBoxVariableEditor.tsx
+++ b/public/app/features/dashboard-scene/settings/variables/editors/TextBoxVariableEditor.tsx
@@ -1,3 +1,4 @@
+import { createClientLog } from '@grafana/data';
 import { noop } from 'lodash';
 import { type FormEvent } from 'react';
 
@@ -6,6 +7,9 @@ import { type SceneVariable, TextBoxVariable } from '@grafana/scenes';
 import { OptionsPaneItemDescriptor } from 'app/features/dashboard/components/PanelEditor/OptionsPaneItemDescriptor';
 
 import { TextBoxVariableForm } from '../components/TextBoxVariableForm';
+const clientLog = createClientLog('public/app/features/dashboard-scene/settings/variables/editors/TextBoxVariableEditor');
+
+
 
 interface TextBoxVariableEditorProps {
   variable: TextBoxVariable;
@@ -25,7 +29,7 @@ export function TextBoxVariableEditor({ variable, inline }: TextBoxVariableEdito
 
 export function getTextBoxVariableOptions(variable: SceneVariable): OptionsPaneItemDescriptor[] {
   if (!(variable instanceof TextBoxVariable)) {
-    console.warn('getTextBoxVariableOptions: variable is not a TextBoxVariable');
+    clientLog.warn('getTextBoxVariableOptions: variable is not a TextBoxVariable');
     return [];
   }
 

--- a/public/app/features/dashboard-scene/sharing/ExportButton/ExportAsImage.tsx
+++ b/public/app/features/dashboard-scene/sharing/ExportButton/ExportAsImage.tsx
@@ -3,7 +3,7 @@ import { saveAs } from 'file-saver';
 import { useEffect } from 'react';
 import { useAsyncFn } from 'react-use';
 
-import { type GrafanaTheme2 } from '@grafana/data';
+import {type GrafanaTheme2, createClientLog} from '@grafana/data';
 import { Trans, t } from '@grafana/i18n';
 import { config } from '@grafana/runtime';
 import { type SceneComponentProps, SceneObjectBase } from '@grafana/scenes';
@@ -15,6 +15,9 @@ import { ImagePreview } from '../components/ImagePreview';
 import { type SceneShareTabState, type ShareView } from '../types';
 
 import { generateDashboardImage } from './utils';
+const clientLog = createClientLog('public/app/features/dashboard-scene/sharing/ExportButton/ExportAsImage');
+
+
 
 export class ExportAsImage extends SceneObjectBase<SceneShareTabState> implements ShareView {
   static Component = ExportAsImageRenderer;
@@ -48,7 +51,7 @@ function ExportAsImageRenderer({ model }: SceneComponentProps<ExportAsImage>) {
 
       return result.blob;
     } catch (error) {
-      console.error('Error exporting image:', error);
+      clientLog.error('Error exporting image:', error);
       DashboardInteractions.generateDashboardImageClicked({
         scale: config.rendererDefaultImageScale || 1,
         shareResource: 'dashboard',

--- a/public/app/features/dashboard-scene/utils/DashboardModelCompatibilityWrapper.ts
+++ b/public/app/features/dashboard-scene/utils/DashboardModelCompatibilityWrapper.ts
@@ -1,12 +1,10 @@
 import { Subscription } from 'rxjs';
 
-import {
-  type AnnotationQuery,
+import {type AnnotationQuery,
   DashboardCursorSync,
   dateTimeFormat,
   type DateTimeInput,
-  EventBusSrv,
-} from '@grafana/data';
+  EventBusSrv, createClientLog} from '@grafana/data';
 import { TimeRangeUpdatedEvent } from '@grafana/runtime';
 import { behaviors, sceneGraph, type SceneObject, VizPanel } from '@grafana/scenes';
 
@@ -16,6 +14,9 @@ import { dataLayersToAnnotations } from '../serialization/dataLayersToAnnotation
 
 import { PanelModelCompatibilityWrapper } from './PanelModelCompatibilityWrapper';
 import { findVizPanelByKey, getVizPanelKeyForPanelId } from './utils';
+const clientLog = createClientLog('public/app/features/dashboard-scene/utils/DashboardModelCompatibilityWrapper');
+
+
 
 /**
  * Will move this to make it the main way we remain somewhat compatible with getDashboardSrv().getCurrent
@@ -165,7 +166,7 @@ export class DashboardModelCompatibilityWrapper {
   public removePanel(panel: PanelModelCompatibilityWrapper) {
     const vizPanel = findVizPanelByKey(this._scene, getVizPanelKeyForPanelId(panel.id));
     if (!vizPanel) {
-      console.error('Trying to remove a panel that was not found in scene', panel);
+      clientLog.error('Trying to remove a panel that was not found in scene', panel);
       return;
     }
 

--- a/public/app/features/dashboard-scene/utils/PanelModelCompatibilityWrapper.ts
+++ b/public/app/features/dashboard-scene/utils/PanelModelCompatibilityWrapper.ts
@@ -1,8 +1,11 @@
-import { type PanelModel } from '@grafana/data';
+import {type PanelModel, createClientLog} from '@grafana/data';
 import { SceneDataTransformer, type VizPanel } from '@grafana/scenes';
 import { type DataSourceRef, type DataTransformerConfig } from '@grafana/schema';
 
 import { getPanelIdForVizPanel, getQueryRunnerFor } from './utils';
+const clientLog = createClientLog('public/app/features/dashboard-scene/utils/PanelModelCompatibilityWrapper');
+
+
 
 export class PanelModelCompatibilityWrapper implements PanelModel {
   constructor(private _vizPanel: VizPanel) {}
@@ -11,7 +14,7 @@ export class PanelModelCompatibilityWrapper implements PanelModel {
     const id = getPanelIdForVizPanel(this._vizPanel);
 
     if (isNaN(id)) {
-      console.error('VizPanel key could not be translated to a legacy numeric panel id', this._vizPanel);
+      clientLog.error('VizPanel key could not be translated to a legacy numeric panel id', this._vizPanel);
       return 0;
     }
 

--- a/public/app/features/dashboard-scene/utils/dashboardControls.ts
+++ b/public/app/features/dashboard-scene/utils/dashboardControls.ts
@@ -1,11 +1,14 @@
 import { nanoid } from 'nanoid';
 import { filter, Observable, scan, share, type Subscriber } from 'rxjs';
 
-import { type DataSourceApi } from '@grafana/data';
+import {type DataSourceApi, createClientLog} from '@grafana/data';
 import { getDataSourceSrv, reportInteraction } from '@grafana/runtime';
 import { type SceneVariable } from '@grafana/scenes';
 import { type DashboardLink, type DataSourceRef } from '@grafana/schema';
 import { type VariableKind } from '@grafana/schema/apis/dashboard.grafana.app/v2';
+const clientLog = createClientLog('public/app/features/dashboard-scene/utils/dashboardControls');
+
+
 
 type LoadDefaultControlsPhase = 'default_variables' | 'default_links';
 type InvokeAndTrackOptions = { traceId: string; phase: LoadDefaultControlsPhase; datasourceType?: string };
@@ -85,7 +88,7 @@ async function loadControlsFromRef(ref: DataSourceRef, traceId: string, subscrib
   try {
     ds = await getDataSourceSrv().get(ref);
   } catch (e) {
-    console.warn('Failed to load datasource', ref, e);
+    clientLog.warn('Failed to load datasource', ref, e);
     return;
   }
 
@@ -119,7 +122,7 @@ async function emitDefaultVariables(ds: DataSourceApi, traceId: string, subscrib
       subscriber.next({ type: 'variables', data });
     }
   } catch (e) {
-    console.warn('Failed to load default variables from datasource', ds.type, e);
+    clientLog.warn('Failed to load default variables from datasource', ds.type, e);
   }
 }
 
@@ -145,7 +148,7 @@ async function emitDefaultLinks(ds: DataSourceApi, traceId: string, subscriber: 
       });
     }
   } catch (e) {
-    console.warn('Failed to load default links from datasource', ds.type, e);
+    clientLog.warn('Failed to load default links from datasource', ds.type, e);
   }
 }
 

--- a/public/app/features/dashboard-scene/utils/variables.ts
+++ b/public/app/features/dashboard-scene/utils/variables.ts
@@ -1,4 +1,4 @@
-import { type AdHocVariableFilter, type TypedVariableModel } from '@grafana/data';
+import {type AdHocVariableFilter, type TypedVariableModel, createClientLog} from '@grafana/data';
 import { config, getDataSourceSrv } from '@grafana/runtime';
 import {
   AdHocFiltersVariable,
@@ -22,6 +22,9 @@ import { migrateGroupByVariablesV1 } from '../serialization/groupByMigration';
 import { createSceneVariableFromVariableModel as createSceneVariableFromVariableModelV2 } from '../serialization/transformSaveModelSchemaV2ToScene';
 
 import { getCurrentValueForOldIntervalModel, getIntervalsFromQueryString } from './utils';
+const clientLog = createClientLog('public/app/features/dashboard-scene/utils/variables');
+
+
 
 const DEFAULT_DATASOURCE = 'default';
 
@@ -32,7 +35,7 @@ export function createVariablesForDashboard(oldModel: DashboardModel, defaultVar
       try {
         return createSceneVariableFromVariableModel(v);
       } catch (err) {
-        console.error(err);
+        clientLog.error(err);
         return null;
       }
     })
@@ -45,7 +48,7 @@ export function createVariablesForDashboard(oldModel: DashboardModel, defaultVar
       try {
         return createSceneVariableFromVariableModelV2(v);
       } catch (err) {
-        console.error(err);
+        clientLog.error(err);
         return null;
       }
     })
@@ -91,7 +94,7 @@ export function createVariablesForSnapshot(oldModel: DashboardModel) {
         // for other variable types we are using the SnapshotVariable
         return createSnapshotVariable(v);
       } catch (err) {
-        console.error(err);
+        clientLog.error(err);
         return null;
       }
     })

--- a/public/app/features/dashboard/api/ResponseTransformers.ts
+++ b/public/app/features/dashboard/api/ResponseTransformers.ts
@@ -1,4 +1,4 @@
-import { type MetricFindValue, type TypedVariableModel, type AnnotationQuery } from '@grafana/data';
+import {type MetricFindValue, type TypedVariableModel, type AnnotationQuery, createClientLog} from '@grafana/data';
 import { config } from '@grafana/runtime';
 import {
   type DataQuery,
@@ -85,6 +85,9 @@ import { type DashboardDataDTO, type DashboardDTO } from 'app/types/dashboard';
 
 import { type DashboardWithAccessInfo } from './types';
 import { isDashboardResource, isDashboardV0Spec, isDashboardV2Resource, isDashboardV2Spec } from './utils';
+const clientLog = createClientLog('public/app/features/dashboard/api/ResponseTransformers');
+
+
 
 export function ensureV2Response(
   dto: DashboardDTO | DashboardWithAccessInfo<DashboardDataDTO> | DashboardWithAccessInfo<DashboardV2Spec>
@@ -712,7 +715,7 @@ function getVariables(vars: TypedVariableModel[]): DashboardV2Spec['variables'] 
         let query = v.query || {};
 
         if (typeof query === 'string') {
-          console.warn(
+          clientLog.warn(
             'Query variable query is a string which is deprecated in the schema v2. It should extend DataQuery'
           );
           query = {
@@ -925,7 +928,7 @@ function getVariables(vars: TypedVariableModel[]): DashboardV2Spec['variables'] 
         break;
       default:
         // do not throw error, just log it
-        console.error(`Variable transformation not implemented: ${v.type}`);
+        clientLog.error(`Variable transformation not implemented: ${v.type}`);
     }
   }
   return variables;
@@ -1138,7 +1141,7 @@ function getVariablesV1(vars: DashboardV2Spec['variables']): VariableModel[] {
         break;
       default:
         // do not throw error, just log it
-        console.error(`Variable transformation not implemented: ${v}`);
+        clientLog.error(`Variable transformation not implemented: ${v}`);
     }
   }
   return variables;
@@ -1391,7 +1394,7 @@ function transformSpecialValueMatchToV1(match: SpecialValueMatch): SpecialValueM
     case 'empty':
       return SpecialValueMatchV1.Empty;
     default:
-      console.warn(`Skipping special value mapping with unknown match type: "${match}"`);
+      clientLog.warn(`Skipping special value mapping with unknown match type: "${match}"`);
       return undefined;
   }
 }

--- a/public/app/features/dashboard/api/utils.ts
+++ b/public/app/features/dashboard/api/utils.ts
@@ -23,7 +23,7 @@ export function getDashboardsApiVersion(responseFormat?: 'v1' | 'v2') {
 
   const forcingOldDashboardArch = locationService.getSearch().get('scenes') === 'false';
 
-  // console.log(forcingOldDashboardArch);
+  // clientLog.info(forcingOldDashboardArch);
   // Force legacy API when dashboard scene is force disabled
   if (forcingOldDashboardArch) {
     if (responseFormat === 'v2') {

--- a/public/app/features/dashboard/components/DashExportModal/DashboardExporter.ts
+++ b/public/app/features/dashboard/components/DashExportModal/DashboardExporter.ts
@@ -1,6 +1,6 @@
 import { defaults, each, sortBy } from 'lodash';
 
-import { type DataSourceRef, type VariableOption, VariableRefresh } from '@grafana/data';
+import {type DataSourceRef, type VariableOption, VariableRefresh, createClientLog} from '@grafana/data';
 import { getDataSourceSrv } from '@grafana/runtime';
 import { getPanelPluginMeta } from '@grafana/runtime/internal';
 import config from 'app/core/config';
@@ -14,6 +14,9 @@ import { type DashboardJson } from '../../../manage-dashboards/types';
 import { isConstant } from '../../../variables/guard';
 import { type DashboardModel } from '../../state/DashboardModel';
 import { type GridPos } from '../../state/PanelModel';
+const clientLog = createClientLog('public/app/features/dashboard/components/DashExportModal/DashboardExporter');
+
+
 
 export interface InputUsage {
   libraryPanels?: LibraryPanel[];
@@ -318,7 +321,7 @@ export class DashboardExporter {
 
       return newObj;
     } catch (err) {
-      console.error('Export failed:', err);
+      clientLog.error('Export failed:', err);
       return {
         error: err,
       };

--- a/public/app/features/dashboard/components/DashboardSettings/VersionsSettings.tsx
+++ b/public/app/features/dashboard/components/DashboardSettings/VersionsSettings.tsx
@@ -1,3 +1,4 @@
+import { createClientLog } from '@grafana/data';
 import { PureComponent } from 'react';
 import * as React from 'react';
 
@@ -17,6 +18,9 @@ import { VersionHistoryComparison } from '../VersionHistory/VersionHistoryCompar
 import { VersionHistoryTable } from '../VersionHistory/VersionHistoryTable';
 
 import { type SettingsPageProps } from './types';
+const clientLog = createClientLog('public/app/features/dashboard/components/DashboardSettings/VersionsSettings');
+
+
 
 interface Props extends SettingsPageProps {}
 
@@ -69,7 +73,7 @@ export class VersionsSettings extends PureComponent<Props, State> {
         // Update the continueToken for the next request, if available
         this.continueToken = result.metadata.continue ?? '';
       })
-      .catch((err) => console.log(err))
+      .catch((err) => clientLog.info(err))
       .finally(() => this.setState({ isAppending: false }));
   };
 

--- a/public/app/features/dashboard/components/GenAI/hooks.ts
+++ b/public/app/features/dashboard/components/GenAI/hooks.ts
@@ -1,3 +1,4 @@
+import { createClientLog } from '@grafana/data';
 import { type Dispatch, type SetStateAction, useCallback, useEffect, useState } from 'react';
 import { useAsync } from 'react-use';
 import { type Subscription } from 'rxjs';
@@ -7,6 +8,9 @@ import { createMonitoringLogger } from '@grafana/runtime';
 import { useAppNotification } from 'app/core/copy/appNotification';
 
 import { DEFAULT_LLM_MODEL, isLLMPluginEnabled } from './utils';
+const clientLog = createClientLog('public/app/features/dashboard/components/GenAI/hooks');
+
+
 
 // Declared instead of imported from utils to make this hook modular
 // Ideally we will want to move the hook itself to a different scope later.
@@ -71,7 +75,7 @@ export function useLLMStream(options: Options = defaultOptions): UseLLMStreamRes
         'Failed to generate content using LLM',
         'Please try again or if the problem persists, contact your organization admin.'
       );
-      console.error(e);
+      clientLog.error(e);
       genAILogger.logError(e, { messages: JSON.stringify(messages), model, temperature: String(temperature) });
     },
     [messages, model, temperature, notifyError]

--- a/public/app/features/dashboard/components/HelpWizard/SupportSnapshotService.ts
+++ b/public/app/features/dashboard/components/HelpWizard/SupportSnapshotService.ts
@@ -1,6 +1,6 @@
 import saveAs from 'file-saver';
 
-import { dateTimeFormat, formattedValueToString, getValueFormat, type SelectableValue } from '@grafana/data';
+import {dateTimeFormat, formattedValueToString, getValueFormat, type SelectableValue, createClientLog} from '@grafana/data';
 import { t } from '@grafana/i18n';
 import { type SceneObject } from '@grafana/scenes';
 import { StateManagerBase } from 'app/core/services/StateManagerBase';
@@ -12,6 +12,9 @@ import { DashboardModel } from '../../state/DashboardModel';
 import { type PanelModel } from '../../state/PanelModel';
 
 import { getDebugDashboard, getGithubMarkdown } from './utils';
+const clientLog = createClientLog('public/app/features/dashboard/components/HelpWizard/SupportSnapshotService');
+
+
 
 interface SupportSnapshotState {
   currentTab: SnapshotTab;
@@ -88,7 +91,7 @@ export class SupportSnapshotService extends StateManagerBase<SupportSnapshotStat
       const dash = createDashboardSceneFromDashboardModel(oldModel, snapshot);
       scene = dash.state.body; // skip the wrappers
     } catch (ex) {
-      console.log('Error creating scene:', ex);
+      clientLog.info('Error creating scene:', ex);
     }
 
     this.setState({ snapshot, snapshotText, markdownText, snapshotSize, snapshotUpdate: snapshotUpdate + 1, scene });

--- a/public/app/features/dashboard/components/PanelEditor/state/actions.ts
+++ b/public/app/features/dashboard/components/PanelEditor/state/actions.ts
@@ -1,6 +1,6 @@
 import { pick } from 'lodash';
 
-import { store } from '@grafana/data';
+import {store, createClientLog} from '@grafana/data';
 import { removePanel } from 'app/features/dashboard/utils/panel';
 import { cleanUpPanelState } from 'app/features/panel/state/actions';
 import { panelModelAndPluginReady } from 'app/features/panel/state/reducers';
@@ -17,6 +17,9 @@ import {
   setPanelEditorUIState,
   updateEditorInitState,
 } from './reducers';
+const clientLog = createClientLog('public/app/features/dashboard/components/PanelEditor/state/actions');
+
+
 
 export function initPanelEditor(sourcePanel: PanelModel, dashboard: DashboardModel): ThunkResult<void> {
   return async (dispatch) => {
@@ -171,7 +174,7 @@ export function updatePanelEditorUIState(uiState: Partial<PanelEditorUIState>): 
     try {
       store.setObject(PANEL_EDITOR_UI_STATE_STORAGE_KEY, nextState);
     } catch (error) {
-      console.error(error);
+      clientLog.error(error);
     }
   };
 }

--- a/public/app/features/dashboard/dashgrid/DashboardGrid.tsx
+++ b/public/app/features/dashboard/dashgrid/DashboardGrid.tsx
@@ -1,3 +1,4 @@
+import { createClientLog } from '@grafana/data';
 import classNames from 'classnames';
 import { PureComponent, type CSSProperties } from 'react';
 import * as React from 'react';
@@ -18,6 +19,9 @@ import { type GridPos, type PanelModel } from '../state/PanelModel';
 
 import DashboardEmpty from './DashboardEmpty/DashboardEmpty';
 import { DashboardPanel } from './DashboardPanel';
+const clientLog = createClientLog('public/app/features/dashboard/dashgrid/DashboardGrid');
+
+
 
 export const PANEL_FILTER_VARIABLE = 'systemPanelFilterVar';
 
@@ -115,7 +119,7 @@ export class DashboardGrid extends PureComponent<Props, State> {
       this.panelMap[panel.key] = panel;
 
       if (!panel.gridPos) {
-        console.log('panel without gridpos');
+        clientLog.info('panel without gridpos');
         continue;
       }
 

--- a/public/app/features/dashboard/dashgrid/DashboardLibrary/DashboardCard.tsx
+++ b/public/app/features/dashboard/dashgrid/DashboardLibrary/DashboardCard.tsx
@@ -3,7 +3,7 @@ import { useMemo } from 'react';
 import Skeleton from 'react-loading-skeleton';
 
 import { createAssistantContextItem, useAssistant } from '@grafana/assistant';
-import { type GrafanaTheme2 } from '@grafana/data';
+import {type GrafanaTheme2, createClientLog} from '@grafana/data';
 import { t, Trans } from '@grafana/i18n';
 import { config } from '@grafana/runtime';
 import { Badge, Box, Button, Card, IconButton, Text, TextLink, Tooltip, useStyles2 } from '@grafana/ui';
@@ -13,6 +13,9 @@ import { type PluginDashboard } from 'app/types/plugins';
 import { CompatibilityBadge, type CompatibilityState } from './CompatibilityBadge';
 import { type GnetDashboard } from './types';
 import { buildAssistantPrompt, buildTemplateContextData, buildTemplateContextTitle } from './utils/assistantHelpers';
+const clientLog = createClientLog('public/app/features/dashboard/dashgrid/DashboardLibrary/DashboardCard');
+
+
 
 interface Details {
   id: string;
@@ -120,7 +123,7 @@ function DashboardCardComponent({
               kind === 'suggested_dashboard' ? styles.thumbnailCoverImage : styles.thumbnailContainImage
             )}
             onError={(e) => {
-              console.error('Failed to load image for:', title, 'URL:', imageUrl);
+              clientLog.error('Failed to load image for:', title, 'URL:', imageUrl);
               e.currentTarget.style.display = 'none';
             }}
           />

--- a/public/app/features/dashboard/dashgrid/DashboardLibrary/SuggestedDashboardsList/SuggestedDashboardsList.tsx
+++ b/public/app/features/dashboard/dashgrid/DashboardLibrary/SuggestedDashboardsList/SuggestedDashboardsList.tsx
@@ -3,7 +3,7 @@ import { useBooleanFlagValue } from '@openfeature/react-sdk';
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { useAsyncFn, useDebounce } from 'react-use';
 
-import { type GrafanaTheme2 } from '@grafana/data';
+import {type GrafanaTheme2, createClientLog} from '@grafana/data';
 import { t } from '@grafana/i18n';
 import { config, getDataSourceSrv, isFetchError, locationService } from '@grafana/runtime';
 import { FilterInput, Grid, Pagination, Stack, useStyles2 } from '@grafana/ui';
@@ -25,6 +25,9 @@ import { getPageSlice } from '../utils/suggestedDashboardHelpers';
 import { DashboardResultsGrid } from './DashboardResultsGrid';
 import { EmptyResults } from './EmptyResults';
 import { ListHeader } from './ListHeader';
+const clientLog = createClientLog('public/app/features/dashboard/dashgrid/DashboardLibrary/SuggestedDashboardsList/SuggestedDashboardsList');
+
+
 
 const SEARCH_DEBOUNCE_MS = 500;
 const DEFAULT_SORT_ORDER = 'downloads';
@@ -252,7 +255,7 @@ export const SuggestedDashboardsList = ({
           });
         }
       } catch (err) {
-        console.error('Error loading community dashboards', err);
+        clientLog.error('Error loading community dashboards', err);
       } finally {
         setIsCommunityLoading(false);
       }
@@ -422,7 +425,7 @@ export const SuggestedDashboardsList = ({
         sourceEntryPoint,
       });
     } catch (err) {
-      console.error('Error checking dashboard compatibility:', err);
+      clientLog.error('Error checking dashboard compatibility:', err);
 
       const errorMessage = isFetchError(err) ? err.data?.message : 'Failed to check compatibility';
       const errorCode = isFetchError(err) ? err.data?.code : undefined;

--- a/public/app/features/dashboard/dashgrid/DashboardLibrary/TemplateDashboardModal.tsx
+++ b/public/app/features/dashboard/dashgrid/DashboardLibrary/TemplateDashboardModal.tsx
@@ -4,7 +4,7 @@ import { useEffect } from 'react';
 import { useSearchParams } from 'react-router-dom-v5-compat';
 import { useAsync } from 'react-use';
 
-import { type GrafanaTheme2 } from '@grafana/data';
+import {type GrafanaTheme2, createClientLog} from '@grafana/data';
 import { t, Trans } from '@grafana/i18n';
 import { getBackendSrv, getDataSourceSrv, locationService } from '@grafana/runtime';
 import { Box, Grid, Modal, Text, useStyles2 } from '@grafana/ui';
@@ -21,6 +21,9 @@ import {
 import { TemplateDashboardInteractions } from './interactions';
 import { type GnetDashboard, type GnetDashboardsResponse, type Link } from './types';
 import { getTemplateDashboardUrl } from './utils/templateDashboardHelpers';
+const clientLog = createClientLog('public/app/features/dashboard/dashgrid/DashboardLibrary/TemplateDashboardModal');
+
+
 
 const SourceEntryPointMap: Record<string, SourceEntryPoint> = {
   quickAdd: TemplateDashboardSourceEntryPoint.QUICK_ADD_BUTTON,
@@ -97,7 +100,7 @@ export const TemplateDashboardModal = () => {
 
       return response.items;
     } catch (error) {
-      console.error('Error loading template dashboards ', error);
+      clientLog.error('Error loading template dashboards ', error);
       return [];
     }
   }, [isOpen]);

--- a/public/app/features/dashboard/dashgrid/DashboardLibrary/api/compatibilityApi.ts
+++ b/public/app/features/dashboard/dashgrid/DashboardLibrary/api/compatibilityApi.ts
@@ -1,6 +1,10 @@
+import { createClientLog } from '@grafana/data';
 import { getAPINamespace } from '@grafana/api-clients';
 import { getBackendSrv } from '@grafana/runtime';
 import { type DashboardJson } from 'app/features/manage-dashboards/types';
+const clientLog = createClientLog('public/app/features/dashboard/dashgrid/DashboardLibrary/api/compatibilityApi');
+
+
 
 /**
  * Represents a datasource mapping for compatibility checking.
@@ -105,8 +109,8 @@ export interface CompatibilityCheckResult {
  *   [{ uid: "prometheus-uid", type: "prometheus" }]
  * );
  *
- * console.log(`Compatibility: ${result.compatibilityScore}%`);
- * console.log(`Missing metrics: ${result.datasourceResults[0].missingMetrics}`);
+ * clientLog.info(`Compatibility: ${result.compatibilityScore}%`);
+ * clientLog.info(`Missing metrics: ${result.datasourceResults[0].missingMetrics}`);
  * ```
  */
 export async function checkDashboardCompatibility(
@@ -138,7 +142,7 @@ export async function checkDashboardCompatibility(
     return response;
   } catch (error) {
     // Log error for debugging
-    console.error('Dashboard compatibility check failed:', error);
+    clientLog.error('Dashboard compatibility check failed:', error);
 
     // Re-throw original error for caller to handle
     throw error;

--- a/public/app/features/dashboard/dashgrid/DashboardLibrary/api/dashboardLibraryApi.ts
+++ b/public/app/features/dashboard/dashgrid/DashboardLibrary/api/dashboardLibraryApi.ts
@@ -1,8 +1,12 @@
+import { createClientLog } from '@grafana/data';
 import { getBackendSrv, logInfo, logWarning } from '@grafana/runtime';
 import { type DashboardJson } from 'app/features/manage-dashboards/types';
 import { type PluginDashboard } from 'app/types/plugins';
 
 import { type GnetDashboard, type GnetDashboardsResponse, type Link } from '../types';
+const clientLog = createClientLog('public/app/features/dashboard/dashgrid/DashboardLibrary/api/dashboardLibraryApi');
+
+
 
 /**
  * Panel types that are known to allow JavaScript code execution.
@@ -102,7 +106,7 @@ export async function fetchCommunityDashboards(
   }
 
   // Fallback for unexpected response format
-  console.warn('Unexpected API response format from Grafana.com:', result);
+  clientLog.warn('Unexpected API response format from Grafana.com:', result);
   return {
     page: params.page,
     pages: 1,
@@ -127,7 +131,7 @@ export async function fetchProvisionedDashboards(datasourceType: string): Promis
     });
     return Array.isArray(dashboards) ? dashboards.filter((dashboard) => !dashboard.removed) : [];
   } catch (error) {
-    console.error('Error loading provisioned dashboards', error);
+    clientLog.error('Error loading provisioned dashboards', error);
     return [];
   }
 }
@@ -144,7 +148,7 @@ const filterNonSafeDashboards = (dashboards: GnetDashboard[], dataSourceType?: s
     if (unsafePanelTypes.length > 0) {
       unsafeDashboardsCount++;
 
-      console.warn(
+      clientLog.warn(
         `Community dashboard ${item.id} ${item.name} filtered out due to panel types ${item.panelTypeSlugs?.join(', ')} that can embed JavaScript`
       );
 

--- a/public/app/features/dashboard/dashgrid/DashboardLibrary/utils/communityDashboardHelpers.ts
+++ b/public/app/features/dashboard/dashgrid/DashboardLibrary/utils/communityDashboardHelpers.ts
@@ -1,4 +1,4 @@
-import { type PanelModel } from '@grafana/data';
+import {type PanelModel, createClientLog} from '@grafana/data';
 import { t } from '@grafana/i18n';
 import { getBackendSrv, locationService } from '@grafana/runtime';
 import { createErrorNotification } from 'app/core/copy/appNotification';
@@ -20,6 +20,9 @@ import { type GnetDashboard, type Link } from '../types';
 
 import { type InputMapping, tryAutoMapDatasources, parseConstantInputs, isDataSourceInput } from './autoMapDatasources';
 import type { AssistantSource } from './templateDashboardHelpers';
+const clientLog = createClientLog('public/app/features/dashboard/dashgrid/DashboardLibrary/utils/communityDashboardHelpers');
+
+
 
 export const SEARCH_DEBOUNCE_MS = 500;
 export const DEFAULT_SORT_ORDER = 'downloads';
@@ -165,7 +168,7 @@ function canPanelContainJS(panel: PanelModel): boolean {
   try {
     panelJson = JSON.stringify(panelWithoutSanitizedFields);
   } catch (e) {
-    console.warn('Failed to stringify panel', e);
+    clientLog.warn('Failed to stringify panel', e);
     return true;
   }
 
@@ -196,7 +199,7 @@ function canPanelContainJS(panel: PanelModel): boolean {
 
   const hasSuspiciousValue = valuePatterns.some((pattern) => {
     if (pattern.test(panelJson)) {
-      console.warn('Panel contains JavaScript code in value');
+      clientLog.warn('Panel contains JavaScript code in value');
       return true;
     }
     return false;
@@ -204,7 +207,7 @@ function canPanelContainJS(panel: PanelModel): boolean {
 
   const hasSuspiciousKey = keyPatterns.some((pattern) => {
     if (pattern.test(panelJson)) {
-      console.warn('Panel contains JavaScript code in key');
+      clientLog.warn('Panel contains JavaScript code in key');
       return true;
     }
     return false;
@@ -320,7 +323,7 @@ export async function onUseCommunityDashboard({
       }
     }
   } catch (err) {
-    console.error('Error loading community dashboard:', err);
+    clientLog.error('Error loading community dashboard:', err);
     dispatch(
       notifyApp(
         createErrorNotification(t('dashboard-library.community-error-title', 'Error loading community dashboard'))

--- a/public/app/features/dashboard/dashgrid/PanelStateWrapper.tsx
+++ b/public/app/features/dashboard/dashgrid/PanelStateWrapper.tsx
@@ -2,8 +2,7 @@ import { debounce } from 'lodash';
 import { PureComponent } from 'react';
 import { Subscription } from 'rxjs';
 
-import {
-  type AbsoluteTimeRange,
+import {type AbsoluteTimeRange,
   AnnotationChangeEvent,
   type AnnotationEventUIModel,
   CoreApp,
@@ -21,8 +20,7 @@ import {
   SetPanelAttentionEvent,
   type TimeRange,
   toDataFrameDTO,
-  toUtc,
-} from '@grafana/data';
+  toUtc, createClientLog} from '@grafana/data';
 import { RefreshEvent } from '@grafana/runtime';
 import { type VizLegendOptions } from '@grafana/schema';
 import {
@@ -56,6 +54,9 @@ import { PanelLoadTimeMonitor } from './PanelLoadTimeMonitor';
 import { seriesVisibilityConfigFactory } from './SeriesVisibilityConfigFactory';
 import { liveTimer } from './liveTimer';
 import { PanelOptionsLogger } from './panelOptionsLogger';
+const clientLog = createClientLog('public/app/features/dashboard/dashgrid/PanelStateWrapper');
+
+
 
 const DEFAULT_PLUGIN_ERROR = 'Error in plugin';
 
@@ -257,7 +258,7 @@ export class PanelStateWrapper extends PureComponent<Props, State> {
       const delta = liveTime.to.valueOf() - data.timeRange.to.valueOf();
       if (delta < 100) {
         // 10hz
-        console.log('Skip tick render', this.props.panel.title, delta);
+        clientLog.info('Skip tick render', this.props.panel.title, delta);
         return;
       }
     }

--- a/public/app/features/dashboard/services/DashboardAnalyticsAggregator.ts
+++ b/public/app/features/dashboard/services/DashboardAnalyticsAggregator.ts
@@ -1,3 +1,4 @@
+import { createClientLog } from '@grafana/data';
 import { logMeasurement, reportInteraction } from '@grafana/runtime';
 import { type performanceUtils } from '@grafana/scenes';
 
@@ -9,6 +10,9 @@ import {
   writePerformanceGroupLog,
   writePerformanceGroupEnd,
 } from './performanceUtils';
+const clientLog = createClientLog('public/app/features/dashboard/services/DashboardAnalyticsAggregator');
+
+
 
 /**
  * Panel metrics structure for analytics
@@ -108,7 +112,7 @@ export class DashboardAnalyticsAggregator implements performanceUtils.ScenePerfo
     // Aggregate panel metrics without verbose logging (handled by ScenePerformanceLogger)
     const panel = this.panelMetrics.get(data.panelKey);
     if (!panel) {
-      console.warn('Panel not found for operation completion:', data.panelKey);
+      clientLog.warn('Panel not found for operation completion:', data.panelKey);
       return;
     }
 

--- a/public/app/features/dashboard/services/DashboardLoaderSrv.ts
+++ b/public/app/features/dashboard/services/DashboardLoaderSrv.ts
@@ -2,7 +2,7 @@ import $ from 'jquery';
 import _, { isFunction } from 'lodash'; // eslint-disable-line lodash/import-scope
 import moment from 'moment'; // eslint-disable-line no-restricted-imports
 
-import { AppEvents, dateMath, type UrlQueryMap, type UrlQueryValue } from '@grafana/data';
+import {AppEvents, dateMath, type UrlQueryMap, type UrlQueryValue, createClientLog} from '@grafana/data';
 import { getBackendSrv, isFetchError, locationService } from '@grafana/runtime';
 import { type Spec as DashboardV2Spec } from '@grafana/schema/apis/dashboard.grafana.app/v2';
 import { backendSrv } from 'app/core/services/backend_srv';
@@ -19,6 +19,9 @@ import { DashboardVersionError, type DashboardWithAccessInfo } from '../api/type
 
 import { getDashboardSrv } from './DashboardSrv';
 import { getDashboardSnapshotSrv } from './SnapshotSrv';
+const clientLog = createClientLog('public/app/features/dashboard/services/DashboardLoaderSrv');
+
+
 
 interface DashboardLoaderSrvLike<T> {
   loadDashboard(
@@ -58,7 +61,7 @@ abstract class DashboardLoaderSrvBase<T> implements DashboardLoaderSrvLike<T> {
           };
         },
         (err) => {
-          console.error('Script dashboard error ' + err);
+          clientLog.error('Script dashboard error ' + err);
           appEvents.emit(AppEvents.alertError, [
             'Script Error',
             'Please make sure it exists and returns a valid dashboard',
@@ -143,7 +146,7 @@ export class DashboardLoaderSrv extends DashboardLoaderSrvBase<DashboardDTO> {
           return await api.getDashboardDTO(uid, params);
         } catch (e) {
           if (isFetchError(e) && !(e instanceof DashboardVersionError)) {
-            console.error('Failed to load dashboard', e);
+            clientLog.error('Failed to load dashboard', e);
             e.isHandled = true;
             if (e.status === 404) {
               appEvents.emit(AppEvents.alertError, ['Dashboard not found']);
@@ -208,7 +211,7 @@ export class DashboardLoaderSrvV2 extends DashboardLoaderSrvBase<DashboardWithAc
           return await api.getDashboardDTO(uid, params);
         } catch (e) {
           if (isFetchError(e) && !(e instanceof DashboardVersionError)) {
-            console.error('Failed to load dashboard', e);
+            clientLog.error('Failed to load dashboard', e);
             e.isHandled = true;
             if (e.status === 404) {
               appEvents.emit(AppEvents.alertError, ['Dashboard not found']);

--- a/public/app/features/dashboard/services/performanceUtils.ts
+++ b/public/app/features/dashboard/services/performanceUtils.ts
@@ -1,5 +1,8 @@
-import { store } from '@grafana/data';
+import {store, createClientLog} from '@grafana/data';
 import { performanceUtils, writePerformanceLog } from '@grafana/scenes';
+const clientLog = createClientLog('public/app/features/dashboard/services/performanceUtils');
+
+
 
 /**
  * Utility function to register a performance observer with the global tracker
@@ -86,10 +89,10 @@ export function writePerformanceGroupLog(logger: string, message: string, data?:
   if (isPerformanceLoggingEnabled()) {
     if (data) {
       // eslint-disable-next-line no-console
-      console.log(message, data);
+      clientLog.info(message, data);
     } else {
       // eslint-disable-next-line no-console
-      console.log(message);
+      clientLog.info(message);
     }
   }
 }
@@ -117,7 +120,7 @@ export function createPerformanceMark(name: string, timestamp?: number): void {
       }
     }
   } catch (error) {
-    console.error(`❌ Failed to create performance mark: ${name}`, { timestamp, error });
+    clientLog.error(`❌ Failed to create performance mark: ${name}`, { timestamp, error });
   }
 }
 
@@ -134,6 +137,6 @@ export function createPerformanceMeasure(name: string, startMark: string, endMar
       }
     }
   } catch (error) {
-    console.error(`❌ Failed to create performance measure: ${name}`, { startMark, endMark, error });
+    clientLog.error(`❌ Failed to create performance measure: ${name}`, { startMark, endMark, error });
   }
 }

--- a/public/app/features/dashboard/state/DashboardModel.ts
+++ b/public/app/features/dashboard/state/DashboardModel.ts
@@ -1,8 +1,7 @@
 import { cloneDeep, defaults as _defaults, filter, indexOf, isEqual, map, maxBy, pull } from 'lodash';
 import { Subscription } from 'rxjs';
 
-import {
-  type AnnotationQuery,
+import {type AnnotationQuery,
   type AppEvent,
   type DashboardCursorSync,
   dateTime,
@@ -15,8 +14,7 @@ import {
   type TimeRange,
   type TimeZone,
   type TypedVariableModel,
-  type UrlQueryValue,
-} from '@grafana/data';
+  type UrlQueryValue, createClientLog} from '@grafana/data';
 import { type PromQuery } from '@grafana/prometheus';
 import { RefreshEvent, TimeRangeUpdatedEvent } from '@grafana/runtime';
 import { type Dashboard, type DashboardLink, type VariableModel } from '@grafana/schema';
@@ -51,6 +49,9 @@ import { DashboardMigrator } from './DashboardMigrator';
 import { PanelModel } from './PanelModel';
 import { type TimeModel } from './TimeModel';
 import { deleteScopeVars, isOnTheSameGridRow } from './utils';
+const clientLog = createClientLog('public/app/features/dashboard/state/DashboardModel');
+
+
 
 export interface CloneOptions {
   saveVariables?: boolean;
@@ -1115,13 +1116,13 @@ export class DashboardModel implements TimeModel {
 
   /** @deprecated */
   on<T>(event: AppEvent<T>, callback: (payload?: T) => void) {
-    console.log('DashboardModel.on is deprecated use events.subscribe');
+    clientLog.info('DashboardModel.on is deprecated use events.subscribe');
     this.events.on(event, callback);
   }
 
   /** @deprecated */
   off<T>(event: AppEvent<T>, callback: (payload?: T) => void) {
-    console.log('DashboardModel.off is deprecated');
+    clientLog.info('DashboardModel.off is deprecated');
     this.events.off(event, callback);
   }
 

--- a/public/app/features/dashboard/state/initDashboard.ts
+++ b/public/app/features/dashboard/state/initDashboard.ts
@@ -1,4 +1,4 @@
-import { type DataQuery, locationUtil, setWeekStart, DashboardLoadedEvent, store } from '@grafana/data';
+import {type DataQuery, locationUtil, setWeekStart, DashboardLoadedEvent, store, createClientLog} from '@grafana/data';
 import { t } from '@grafana/i18n';
 import { config, isFetchError, locationService } from '@grafana/runtime';
 import { appEvents } from 'app/core/app_events';
@@ -39,6 +39,9 @@ import { DashboardModel } from './DashboardModel';
 import { type PanelModel } from './PanelModel';
 import { emitDashboardViewEvent } from './analyticsProcessor';
 import { dashboardInitCompleted, dashboardInitFailed, dashboardInitFetching, dashboardInitServices } from './reducers';
+const clientLog = createClientLog('public/app/features/dashboard/state/initDashboard');
+
+
 
 const INIT_DASHBOARD_MEASUREMENT = 'initDashboard';
 
@@ -109,7 +112,7 @@ async function fetchDashboard(
               ...locationService.getLocation(),
               pathname: dashboardUrl,
             });
-            console.log('not correct url correcting', dashboardUrl, currentPath);
+            clientLog.info('not correct url correcting', dashboardUrl, currentPath);
           }
         }
         return dashDTO;
@@ -138,7 +141,7 @@ async function fetchDashboard(
         error: err,
       })
     );
-    console.error(err);
+    clientLog.error(err);
     return null;
   }
 }
@@ -206,7 +209,7 @@ export function initDashboard(args: InitDashboardArgs): ThunkResult<void> {
           error: err,
         })
       );
-      console.error(err);
+      clientLog.error(err);
       return;
     }
 
@@ -264,7 +267,7 @@ export function initDashboard(args: InitDashboardArgs): ThunkResult<void> {
       if (err instanceof Error) {
         dispatch(notifyApp(createErrorNotification('Dashboard init failed', err)));
       }
-      console.error(err);
+      clientLog.error(err);
     }
 
     // send open dashboard event

--- a/public/app/features/dimensions/editors/FileUploader.tsx
+++ b/public/app/features/dimensions/editors/FileUploader.tsx
@@ -1,12 +1,15 @@
 import { css } from '@emotion/css';
 import { type Dispatch, type SetStateAction, useState } from 'react';
 
-import { type GrafanaTheme2 } from '@grafana/data';
+import {type GrafanaTheme2, createClientLog} from '@grafana/data';
 import { Trans, t } from '@grafana/i18n';
 import { FileDropzone, useStyles2, Button, type DropzoneFile, Field } from '@grafana/ui';
 import { SanitizedSVG } from 'app/core/components/SVG/SanitizedSVG';
 
 import { MediaType } from '../types';
+const clientLog = createClientLog('public/app/features/dimensions/editors/FileUploader');
+
+
 
 interface Props {
   setFormData: Dispatch<SetStateAction<FormData>>;
@@ -47,7 +50,7 @@ export const FileUploader = ({ mediaType, setFormData, setUpload, error }: Props
   const onFileRemove = (file: DropzoneFile) => {
     fetch(`/api/storage/delete/upload/${file.file.name}`, {
       method: 'DELETE',
-    }).catch((error) => console.error('cannot delete file', error));
+    }).catch((error) => clientLog.error('cannot delete file', error));
   };
 
   const acceptableFiles =

--- a/public/app/features/dimensions/editors/ResourcePickerPopover.tsx
+++ b/public/app/features/dimensions/editors/ResourcePickerPopover.tsx
@@ -4,7 +4,7 @@ import { FocusScope } from '@react-aria/focus';
 import { useOverlay } from '@react-aria/overlays';
 import { useRef, useState } from 'react';
 
-import { type GrafanaTheme2 } from '@grafana/data';
+import {type GrafanaTheme2, createClientLog} from '@grafana/data';
 import { Trans } from '@grafana/i18n';
 import { config, getBackendSrv } from '@grafana/runtime';
 import { Button, useStyles2 } from '@grafana/ui';
@@ -14,6 +14,9 @@ import { type MediaType, PickerTabType, type ResourceFolderName } from '../types
 import { FileUploader } from './FileUploader';
 import { FolderPickerTab } from './FolderPickerTab';
 import { URLPickerTab } from './URLPickerTab';
+const clientLog = createClientLog('public/app/features/dimensions/editors/ResourcePickerPopover');
+
+
 
 interface Props {
   value?: string; //img/icons/unicons/0-plus.svg
@@ -129,7 +132,7 @@ export const ResourcePickerPopover = (props: Props) => {
                           .then(() => onChange(`${config.appUrl}api/storage/read/${data.path}`))
                           .then(() => hidePopper?.());
                       })
-                      .catch((err) => console.error(err));
+                      .catch((err) => clientLog.error(err));
                   } else {
                     onChange(newValue);
                     hidePopper?.();

--- a/public/app/features/explore/Logs/LogsMetaRow.tsx
+++ b/public/app/features/explore/Logs/LogsMetaRow.tsx
@@ -2,16 +2,14 @@ import { css } from '@emotion/css';
 import { useBooleanFlagValue } from '@openfeature/react-sdk';
 import { memo } from 'react';
 
-import {
-  LogsDedupStrategy,
+import {LogsDedupStrategy,
   type LogsMetaItem,
   LogsMetaKind,
   type LogRowModel,
   CoreApp,
   type Labels,
   store,
-  shallowCompare,
-} from '@grafana/data';
+  shallowCompare, createClientLog} from '@grafana/data';
 import { Trans, t } from '@grafana/i18n';
 import { config, reportInteraction } from '@grafana/runtime';
 import { Button, Dropdown, Menu, ToolbarButton, useStyles2 } from '@grafana/ui';
@@ -22,6 +20,9 @@ import { MetaInfoText, type MetaItemProps } from '../MetaInfoText';
 
 import { type LogsVisualisationType } from './constants';
 import { SETTINGS_KEYS } from './utils/logs';
+const clientLog = createClientLog('public/app/features/explore/Logs/LogsMetaRow');
+
+
 
 const getStyles = () => ({
   metaContainer: css({
@@ -162,6 +163,6 @@ function renderMetaItem(value: string | number | Labels, kind: LogsMetaKind, log
   if (kind === LogsMetaKind.Error) {
     return <span className="logs-meta-item__error">{value.toString()}</span>;
   }
-  console.error(`Meta type ${typeof value} ${value} not recognized.`);
+  clientLog.error(`Meta type ${typeof value} ${value} not recognized.`);
   return <></>;
 }

--- a/public/app/features/explore/Logs/LogsTableWrap.tsx
+++ b/public/app/features/explore/Logs/LogsTableWrap.tsx
@@ -2,8 +2,7 @@ import { css } from '@emotion/css';
 import { Resizable, type ResizeCallback } from 're-resizable';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 
-import {
-  type AbsoluteTimeRange,
+import {type AbsoluteTimeRange,
   type DataFrame,
   type ExploreLogsPanelState,
   type GrafanaTheme2,
@@ -13,8 +12,7 @@ import {
   type SelectableValue,
   type SplitOpen,
   store,
-  type TimeRange,
-} from '@grafana/data';
+  type TimeRange, createClientLog} from '@grafana/data';
 import { t } from '@grafana/i18n';
 import { reportInteraction } from '@grafana/runtime';
 import { getDragStyles, InlineField, Select, useStyles2 } from '@grafana/ui';
@@ -27,6 +25,9 @@ import { parseLogsFrame } from 'app/features/logs/logsFrame';
 
 import { LogsTable } from './LogsTable';
 import { SETTING_KEY_ROOT } from './utils/logs';
+const clientLog = createClientLog('public/app/features/explore/Logs/LogsTableWrap');
+
+
 
 interface Props {
   logsFrames: DataFrame[];
@@ -385,7 +386,7 @@ export function LogsTableWrap(props: Props) {
   // Toggle a column on or off when the user interacts with an element in the multi-select sidebar
   const toggleColumn = (columnName: FieldName) => {
     if (!columnsWithMeta || !(columnName in columnsWithMeta)) {
-      console.warn('failed to get column', columnsWithMeta);
+      clientLog.warn('failed to get column', columnsWithMeta);
       return;
     }
 

--- a/public/app/features/explore/Logs/utils/table/logsTable.ts
+++ b/public/app/features/explore/Logs/utils/table/logsTable.ts
@@ -1,6 +1,9 @@
-import { type DataFrame, FieldType, getFieldDisplayName, LogsSortOrder } from '@grafana/data';
+import {type DataFrame, FieldType, getFieldDisplayName, LogsSortOrder, createClientLog} from '@grafana/data';
 import { type TableSortByFieldState } from '@grafana/schema/dist/esm/common/common.gen';
 import { LOGS_DATAPLANE_TIMESTAMP_NAME } from 'app/features/logs/logsFrame';
+const clientLog = createClientLog('public/app/features/explore/Logs/utils/table/logsTable');
+
+
 
 function getDefaultSortBy(dataFrame: DataFrame | undefined, logsSortOrder: LogsSortOrder): TableSortByFieldState[] {
   const field = dataFrame?.fields.find((field) => field.type === FieldType.time);
@@ -34,7 +37,7 @@ export const getDefaultTableSortBy = (
         return parsed;
       }
     } catch (e) {
-      console.error('failed to parse table sort from local storage!', e);
+      clientLog.error('failed to parse table sort from local storage!', e);
     }
   }
 

--- a/public/app/features/explore/PrometheusListView/utils/getRawPrometheusListItemsFromDataFrame.ts
+++ b/public/app/features/explore/PrometheusListView/utils/getRawPrometheusListItemsFromDataFrame.ts
@@ -1,6 +1,9 @@
-import { type DataFrame, formattedValueToString } from '@grafana/data';
+import {type DataFrame, formattedValueToString, createClientLog} from '@grafana/data';
 
 import { type instantQueryRawVirtualizedListData } from '../RawListContainer';
+const clientLog = createClientLog('public/app/features/explore/PrometheusListView/utils/getRawPrometheusListItemsFromDataFrame');
+
+
 
 type instantQueryMetricList = { [index: string]: { [index: string]: instantQueryRawVirtualizedListData } };
 
@@ -51,7 +54,7 @@ export const getRawPrometheusListItemsFromDataFrame = (dataFrame: DataFrame): in
             }
           }
         } else {
-          console.warn('Field display method is missing!');
+          clientLog.warn('Field display method is missing!');
         }
       }
     }

--- a/public/app/features/explore/QueryLibrary/OpenQueryLibraryExposedComponent.tsx
+++ b/public/app/features/explore/QueryLibrary/OpenQueryLibraryExposedComponent.tsx
@@ -1,3 +1,4 @@
+import { createClientLog } from '@grafana/data';
 import { useCallback } from 'react';
 
 import { t } from '@grafana/i18n';
@@ -6,6 +7,9 @@ import { type DataQuery } from '@grafana/schema';
 import { ToolbarButton } from '@grafana/ui';
 
 import { useQueryLibraryContext } from './QueryLibraryContext';
+const clientLog = createClientLog('public/app/features/explore/QueryLibrary/OpenQueryLibraryExposedComponent');
+
+
 
 interface Props {
   className?: string;
@@ -81,7 +85,7 @@ export const OpenQueryLibraryExposedComponent = ({
   }, [context, datasourceFilters, onSelectQuery, openDrawer, query]);
 
   if (!queryLibraryEnabled) {
-    console.warn(
+    clientLog.warn(
       '[OpenQueryLibraryExposedComponent]: Attempted to use unsupported exposed component. Query library is not enabled.'
     );
     return null;

--- a/public/app/features/explore/TraceView/components/CriticalPath/index.tsx
+++ b/public/app/features/explore/TraceView/components/CriticalPath/index.tsx
@@ -1,3 +1,4 @@
+import { createClientLog } from '@grafana/data';
 // Copyright (c) 2023 The Jaeger Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -19,6 +20,9 @@ import { type TraceSpan, type CriticalPathSection, type Trace } from '../types/t
 import findLastFinishingChildSpan from './utils/findLastFinishingChildSpan';
 import getChildOfSpans from './utils/getChildOfSpans';
 import sanitizeOverFlowingChildren from './utils/sanitizeOverFlowingChildren';
+const clientLog = createClientLog('public/app/features/explore/TraceView/components/CriticalPath/index');
+
+
 
 /**
  * Computes the critical path sections of a Jaeger trace.
@@ -104,7 +108,7 @@ function criticalPathForTrace(trace: Trace) {
       criticalPath = computeCriticalPath(sanitizedSpanMap, rootSpanId, criticalPath);
     } catch (error) {
       /* eslint-disable no-console */
-      console.log('error while computing critical path for a trace', error);
+      clientLog.info('error while computing critical path for a trace', error);
     }
   }
   return criticalPath;

--- a/public/app/features/explore/TraceView/components/ScrollManager.tsx
+++ b/public/app/features/explore/TraceView/components/ScrollManager.tsx
@@ -1,3 +1,4 @@
+import { createClientLog } from '@grafana/data';
 // Copyright (c) 2017 Uber Technologies, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,6 +15,9 @@
 
 import type TNil from './types/TNil';
 import { type TraceSpan, type TraceSpanReference, type Trace } from './types/trace';
+const clientLog = createClientLog('public/app/features/explore/TraceView/components/ScrollManager');
+
+
 
 /**
  * `Accessors` is necessary because `ScrollManager` needs to be created by
@@ -106,7 +110,7 @@ export default class ScrollManager {
     const position = xrs.getRowPosition(rowIndex);
     if (!position) {
       // eslint-disable-next-line no-console
-      console.warn('Invalid row index');
+      clientLog.warn('Invalid row index');
       return;
     }
     let { y } = position;

--- a/public/app/features/explore/TraceView/components/TraceTimelineViewer/ListView/index.tsx
+++ b/public/app/features/explore/TraceView/components/TraceTimelineViewer/ListView/index.tsx
@@ -1,3 +1,4 @@
+import { createClientLog } from '@grafana/data';
 // Copyright (c) 2017 Uber Technologies, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -17,6 +18,9 @@ import * as React from 'react';
 import type TNil from '../../types/TNil';
 
 import Positions from './Positions';
+const clientLog = createClientLog('public/app/features/explore/TraceView/components/TraceTimelineViewer/ListView/index');
+
+
 
 type TWrapperProps = {
   style: React.CSSProperties;
@@ -388,7 +392,7 @@ export default class ListView extends React.Component<TListViewProps> {
         const itemKey = node.getAttribute('data-item-key');
         if (!itemKey) {
           // eslint-disable-next-line no-console
-          console.warn('itemKey not found');
+          clientLog.warn('itemKey not found');
           continue;
         }
         // measure the first child, if it's available, otherwise the node itself

--- a/public/app/features/explore/TraceView/components/model/link-patterns.tsx
+++ b/public/app/features/explore/TraceView/components/model/link-patterns.tsx
@@ -1,3 +1,4 @@
+import { createClientLog } from '@grafana/data';
 // Copyright (c) 2017 The Jaeger Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -17,6 +18,9 @@ import memoize from 'lru-memoize';
 
 import { type Trace } from '../types/trace';
 import { getConfigValue } from '../utils/config/get-config';
+const clientLog = createClientLog('public/app/features/explore/TraceView/components/model/link-patterns');
+
+
 
 const parameterRegExp = /#\{([^{}]*)\}/g;
 
@@ -112,7 +116,7 @@ export function processLinkPattern(pattern: any): ProcessedLinkPattern | null {
     };
   } catch (error) {
     // eslint-disable-next-line no-console
-    console.error(`Ignoring invalid link pattern: ${error}`, pattern);
+    clientLog.error(`Ignoring invalid link pattern: ${error}`, pattern);
     return null;
   }
 }

--- a/public/app/features/explore/TraceView/components/model/transform-trace-data.tsx
+++ b/public/app/features/explore/TraceView/components/model/transform-trace-data.tsx
@@ -15,7 +15,7 @@
 import { isEqual as _isEqual } from 'lodash';
 
 // @ts-ignore
-import { type TraceKeyValuePair } from '@grafana/data';
+import {type TraceKeyValuePair, createClientLog} from '@grafana/data';
 
 import { getTraceSpanIdsAsTree } from '../selectors/trace';
 import { type TraceResponse, type Trace, type TraceSpan, type TraceProcess } from '../types/trace';
@@ -25,6 +25,9 @@ import { getConfigValue } from '../utils/config/get-config';
 import { getServiceDisplayName } from '../utils/service-name';
 
 import { getTraceName } from './trace-viewer';
+const clientLog = createClientLog('public/app/features/explore/TraceView/components/model/transform-trace-data');
+
+
 
 function asTagArray(tags: unknown): TraceKeyValuePair[] {
   return Array.isArray(tags) ? tags : [];
@@ -121,10 +124,10 @@ export default function transformTraceData(data: TraceResponse | undefined): Tra
     const idCount = spanIdCounts.get(spanID);
     if (idCount != null) {
       // eslint-disable-next-line no-console
-      console.warn(`Dupe spanID, ${idCount + 1} x ${spanID}`, span, spanMap.get(spanID));
+      clientLog.warn(`Dupe spanID, ${idCount + 1} x ${spanID}`, span, spanMap.get(spanID));
       if (_isEqual(span, spanMap.get(spanID))) {
         // eslint-disable-next-line no-console
-        console.warn('\t two spans with same ID have `isEqual(...) === true`');
+        clientLog.warn('\t two spans with same ID have `isEqual(...) === true`');
       }
       spanIdCounts.set(spanID, idCount + 1);
       spanID = `${spanID}_${idCount}`;

--- a/public/app/features/explore/TraceView/createSpanLink.tsx
+++ b/public/app/features/explore/TraceView/createSpanLink.tsx
@@ -1,5 +1,4 @@
-import {
-  type DataFrame,
+import {type DataFrame,
   type DataLink,
   type DataLinkPostProcessor,
   type DataSourceInstanceSettings,
@@ -11,8 +10,7 @@ import {
   rangeUtil,
   type ScopedVars,
   type SplitOpen,
-  type TimeRange,
-} from '@grafana/data';
+  type TimeRange, createClientLog} from '@grafana/data';
 import { t } from '@grafana/i18n';
 import {
   type TraceToProfilesOptions,
@@ -31,6 +29,9 @@ import { type ExploreFieldLinkModel, getFieldLinksForExplore, getVariableUsageIn
 
 import { type SpanLinkDef, type SpanLinkFunc, SpanLinkType } from './components/types/links';
 import { type Trace, type TraceSpan, type TraceSpanReference } from './components/types/trace';
+const clientLog = createClientLog('public/app/features/explore/TraceView/createSpanLink');
+
+
 
 /**
  * This is a factory for the link creator. It returns the function mainly so it can return undefined in which case
@@ -123,7 +124,7 @@ export function createSpanLinkFactory({
         spanLinks.push.apply(spanLinks, newSpanLinks);
       } catch (error) {
         // It's fairly easy to crash here for example if data source defines wrong interpolation in the data link
-        console.error(error);
+        clientLog.error(error);
         return spanLinks;
       }
     }

--- a/public/app/features/explore/hooks/useExplorePageContext.ts
+++ b/public/app/features/explore/hooks/useExplorePageContext.ts
@@ -1,10 +1,13 @@
 import { useEffect } from 'react';
 
 import { createAssistantContextItem, type ChatContextItem, useProvidePageContext } from '@grafana/assistant';
-import { type DataSourceApi } from '@grafana/data';
+import {type DataSourceApi, createClientLog} from '@grafana/data';
 import { getDataSourceSrv } from '@grafana/runtime';
 import { type DataQuery } from '@grafana/schema';
 import { type ExploreItemState } from 'app/types/explore';
+const clientLog = createClientLog('public/app/features/explore/hooks/useExplorePageContext');
+
+
 
 export function useExplorePageContext(panes: Array<[string, ExploreItemState]>): void {
   const setContext = useProvidePageContext(/^\/explore/);
@@ -99,7 +102,7 @@ function getDisplayText(query: DataQuery, ds?: DataSourceApi): string | undefine
   try {
     return ds?.getQueryDisplayText?.(query);
   } catch (error) {
-    console.error(error);
+    clientLog.error(error);
     return undefined;
   }
 }

--- a/public/app/features/explore/state/correlations.ts
+++ b/public/app/features/explore/state/correlations.ts
@@ -1,6 +1,6 @@
 import { Observable } from 'rxjs';
 
-import { type DataLinkTransformationConfig } from '@grafana/data';
+import {type DataLinkTransformationConfig, createClientLog} from '@grafana/data';
 import { type CorrelationData, getDataSourceSrv, reportInteraction } from '@grafana/runtime';
 import { createErrorNotification } from 'app/core/copy/appNotification';
 import { notifyApp } from 'app/core/reducers/appNotification';
@@ -12,6 +12,9 @@ import { type ThunkResult } from 'app/types/store';
 import { saveCorrelationsAction } from './explorePane';
 import { splitClose } from './main';
 import { runQueries } from './query';
+const clientLog = createClientLog('public/app/features/explore/state/correlations');
+
+
 
 /**
  * Creates an observable that emits correlations once they are loaded
@@ -95,7 +98,7 @@ export function saveCurrentCorrelation(
         })
         .catch((err) => {
           dispatch(notifyApp(createErrorNotification('Error creating correlation', err)));
-          console.error(err);
+          clientLog.error(err);
         });
     }
   };

--- a/public/app/features/explore/state/query.ts
+++ b/public/app/features/explore/state/query.ts
@@ -4,8 +4,7 @@ import { findLast, flatten, groupBy, head, map, mapValues, snakeCase, zipObject 
 import { combineLatest, identity, type Observable, of, type SubscriptionLike, type Unsubscribable } from 'rxjs';
 import { mergeMap, throttleTime } from 'rxjs/operators';
 
-import {
-  type AbsoluteTimeRange,
+import {type AbsoluteTimeRange,
   type DataFrame,
   DataQueryErrorType,
   type DataQueryResponse,
@@ -17,8 +16,7 @@ import {
   LogsVolumeType,
   type QueryFixAction,
   type ScopedVars,
-  type SupplementaryQueryType,
-} from '@grafana/data';
+  type SupplementaryQueryType, createClientLog} from '@grafana/data';
 import { combinePanelData } from '@grafana/o11y-ds-frontend';
 import { config, getDataSourceSrv } from '@grafana/runtime';
 import { type DataQuery } from '@grafana/schema';
@@ -64,6 +62,9 @@ import { addHistoryItem, loadRichHistory } from './history';
 import { changeCorrelationEditorDetails } from './main';
 import { updateTime } from './time';
 import { createCacheKey, filterLogRowsByIndex, getCorrelationsData, getResultsFromCache } from './utils';
+const clientLog = createClientLog('public/app/features/explore/state/query');
+
+
 
 /**
  * Derives from explore state if a given Explore pane is waiting for more data to be received
@@ -657,7 +658,7 @@ export const runQueries = createAsyncThunk<void, RunQueriesOptions>(
 
           // Keep scanning for results if this was the last scanning transaction
           if (exploreState!.scanning) {
-            console.log(data.series);
+            clientLog.info(data.series);
             if (data.state === LoadingState.Done && data.series.length === 0) {
               const range = getShiftedTimeRange(-1, exploreState!.range);
               dispatch(updateTime({ exploreId, absoluteRange: range }));
@@ -671,7 +672,7 @@ export const runQueries = createAsyncThunk<void, RunQueriesOptions>(
         error(error) {
           dispatch(notifyApp(createErrorNotification('Query processing error', error)));
           dispatch(changeLoadingStateAction({ exploreId, loadingState: LoadingState.Error }));
-          console.error(error);
+          clientLog.error(error);
         },
         complete() {
           // In case we don't get any response at all but the observable completed, make sure we stop loading state.
@@ -793,7 +794,7 @@ export const runLoadMoreLogsQueries = createAsyncThunk<void, RunLoadMoreLogsQuer
       error(error) {
         dispatch(notifyApp(createErrorNotification('Query processing error', error)));
         dispatch(changeLoadingStateAction({ exploreId, loadingState: LoadingState.Error }));
-        console.error(error);
+        clientLog.error(error);
       },
       complete() {
         dispatch(changeLoadingStateAction({ exploreId, loadingState: LoadingState.Done }));

--- a/public/app/features/explore/state/utils.ts
+++ b/public/app/features/explore/state/utils.ts
@@ -1,7 +1,6 @@
 import { uniq } from 'lodash';
 
-import {
-  type AbsoluteTimeRange,
+import {type AbsoluteTimeRange,
   type DataSourceApi,
   dateMath,
   type DateTime,
@@ -19,8 +18,7 @@ import {
   type TimeRange,
   toUtc,
   type URLRange,
-  type URLRangeValue,
-} from '@grafana/data';
+  type URLRangeValue, createClientLog} from '@grafana/data';
 import { getDataSourceSrv } from '@grafana/runtime';
 import { type DataQuery, type DataSourceJsonData, type DataSourceRef, type TimeZone } from '@grafana/schema';
 import { getLocalRichHistoryStorage } from 'app/core/history/richHistoryStorageProvider';
@@ -34,6 +32,9 @@ import { getDatasourceSrv } from '../../plugins/datasource_srv';
 import { loadSupplementaryQueries } from '../utils/supplementaryQueries';
 
 import { DEFAULT_RANGE } from './constants';
+const clientLog = createClientLog('public/app/features/explore/state/utils');
+
+
 
 export const MAX_HISTORY_AUTOCOMPLETE_ITEMS = 100;
 
@@ -118,7 +119,7 @@ export async function loadAndInitDatasource(
       instance.init();
     } catch (err) {
       // TODO: should probably be handled better
-      console.error(err);
+      clientLog.error(err);
     }
   }
 

--- a/public/app/features/expressions/components/QueryToolbox.tsx
+++ b/public/app/features/expressions/components/QueryToolbox.tsx
@@ -1,11 +1,14 @@
 import { css } from '@emotion/css';
 import { useCallback, useEffect, useRef, useState, type JSX } from 'react';
 
-import { type GrafanaTheme2 } from '@grafana/data';
+import {type GrafanaTheme2, createClientLog} from '@grafana/data';
 import { t } from '@grafana/i18n';
 import { IconButton, useStyles2, Stack, InlineToast, Tooltip, Icon } from '@grafana/ui';
 
 import { type SqlExpressionQuery } from '../types';
+const clientLog = createClientLog('public/app/features/expressions/components/QueryToolbox');
+
+
 
 interface QueryToolboxProps {
   onFormatCode?: () => void;
@@ -39,7 +42,7 @@ export const QueryToolbox = ({ onFormatCode, onExpand, isExpanded, query }: Quer
       await navigator.clipboard.writeText(query.expression ?? '');
       setShowCopySuccess(true);
     } catch (e) {
-      console.error(e);
+      clientLog.error(e);
     }
   }, [query.expression]);
 

--- a/public/app/features/geo/gazetteer/gazetteer.ts
+++ b/public/app/features/geo/gazetteer/gazetteer.ts
@@ -1,12 +1,15 @@
 import { getCenter } from 'ol/extent';
 import { type Geometry, Point } from 'ol/geom';
 
-import { type DataFrame, type Field, FieldType, type KeyValue, toDataFrame } from '@grafana/data';
+import {type DataFrame, type Field, FieldType, type KeyValue, toDataFrame, createClientLog} from '@grafana/data';
 
 import { frameFromGeoJSON } from '../format/geojson';
 import { pointFieldFromLonLat, pointFieldFromGeohash } from '../format/utils';
 
 import { loadWorldmapPoints } from './worldmap';
+const clientLog = createClientLog('public/app/features/geo/gazetteer/gazetteer');
+
+
 
 export interface PlacenameInfo {
   point: () => Point | undefined; // lon, lat (WGS84)
@@ -199,7 +202,7 @@ export async function getGazetteer(path?: string): Promise<Gazetteer> {
       const data = await response.json();
       lookup = loadGazetteer(path, data);
     } catch (err) {
-      console.warn('Error loading placename lookup', path, err);
+      clientLog.warn('Error loading placename lookup', path, err);
       lookup = {
         path,
         error: 'Error loading URL',

--- a/public/app/features/inspector/InspectJSONTab.tsx
+++ b/public/app/features/inspector/InspectJSONTab.tsx
@@ -4,7 +4,7 @@ import { useAsync } from 'react-use';
 import AutoSizer from 'react-virtualized-auto-sizer';
 import { firstValueFrom } from 'rxjs';
 
-import { AppEvents, type PanelData, type SelectableValue, LoadingState } from '@grafana/data';
+import {AppEvents, type PanelData, type SelectableValue, LoadingState, createClientLog} from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';
 import { Trans, t } from '@grafana/i18n';
 import { locationService } from '@grafana/runtime';
@@ -19,6 +19,9 @@ import { reportPanelInspectInteraction } from '../search/page/reporting';
 
 import { InspectTab } from './types';
 import { getPrettyJSON } from './utils/utils';
+const clientLog = createClientLog('public/app/features/inspector/InspectJSONTab');
+
+
 
 enum ShowContent {
   PanelJSON = 'panel',
@@ -104,7 +107,7 @@ export function InspectJSONTab({ panel, dashboard, data, onClose }: Props) {
           appEvents.emit(AppEvents.alertSuccess, ['Panel model updated']);
         }
       } catch (err) {
-        console.error('Error applying updates', err);
+        clientLog.error('Error applying updates', err);
         appEvents.emit(AppEvents.alertError, ['Invalid JSON text']);
       }
 

--- a/public/app/features/library-panels/components/LibraryPanelsView/actions.ts
+++ b/public/app/features/library-panels/components/LibraryPanelsView/actions.ts
@@ -1,3 +1,4 @@
+import { createClientLog } from '@grafana/data';
 import { type Action } from '@reduxjs/toolkit';
 import { type Dispatch } from 'react';
 import { from, merge, of, Subscription, timer } from 'rxjs';
@@ -6,6 +7,9 @@ import { catchError, finalize, mapTo, mergeMap, share, takeUntil } from 'rxjs/op
 import { deleteLibraryPanel as apiDeleteLibraryPanel, getLibraryPanels } from '../../state/api';
 
 import { initialLibraryPanelsViewState, initSearch, searchCompleted } from './reducer';
+const clientLog = createClientLog('public/app/features/library-panels/components/LibraryPanelsView/actions');
+
+
 
 type SearchDispatchResult = (dispatch: Dispatch<Action>, abortController?: AbortController) => void;
 
@@ -54,7 +58,7 @@ export function searchForLibraryPanels(args: SearchArgs): SearchDispatchResult {
         }
 
         // For real errors, log and show error to user
-        console.error('Error fetching library panels:', err);
+        clientLog.error('Error fetching library panels:', err);
 
         // Update state to show empty results
         return of(searchCompleted({ ...initialLibraryPanelsViewState, page: args.page, perPage: args.perPage }));
@@ -78,7 +82,7 @@ export function deleteLibraryPanel(uid: string, args: SearchArgs) {
       await apiDeleteLibraryPanel(uid);
       searchForLibraryPanels(args)(dispatch);
     } catch (e) {
-      console.error(e);
+      clientLog.error(e);
     }
   };
 }

--- a/public/app/features/live/centrifuge/LiveDataStream.ts
+++ b/public/app/features/live/centrifuge/LiveDataStream.ts
@@ -1,7 +1,6 @@
 import { map, Observable, ReplaySubject, type Subject, type Subscriber, type Subscription } from 'rxjs';
 
-import {
-  type DataFrameJSON,
+import {type DataFrameJSON,
   type DataQueryError,
   type Field,
   isLiveChannelMessageEvent,
@@ -10,8 +9,7 @@ import {
   type LiveChannelEvent,
   type LiveChannelId,
   LoadingState,
-  StreamingDataFrame,
-} from '@grafana/data';
+  StreamingDataFrame, createClientLog} from '@grafana/data';
 import { getStreamingFrameOptions } from '@grafana/data/internal';
 import {
   type LiveDataStreamOptions,
@@ -23,6 +21,9 @@ import {
 import { StreamingResponseDataType } from '../data/utils';
 
 import { type DataStreamSubscriptionKey, type StreamingDataQueryResponse } from './service';
+const clientLog = createClientLog('public/app/features/live/centrifuge/LiveDataStream');
+
+
 
 const bufferIfNot =
   (canEmitObservable: Observable<boolean>) =>
@@ -154,7 +155,7 @@ export class LiveDataStream<T = unknown> {
   };
 
   private onError = (err: unknown) => {
-    console.log('LiveQuery [error]', { err }, this.deps.channelId);
+    clientLog.info('LiveQuery [error]', { err }, this.deps.channelId);
     this.stream.next({
       type: InternalStreamMessageType.Error,
       error: toDataQueryError(err),
@@ -163,7 +164,7 @@ export class LiveDataStream<T = unknown> {
   };
 
   private onComplete = () => {
-    console.log('LiveQuery [complete]', this.deps.channelId);
+    clientLog.info('LiveQuery [complete]', this.deps.channelId);
     this.shutdown();
   };
 
@@ -280,7 +281,7 @@ export class LiveDataStream<T = unknown> {
       }
 
       if (!messages.length) {
-        console.warn(`expected to find at least one non error message ${messages.map(({ type }) => type)}`);
+        clientLog.warn(`expected to find at least one non error message ${messages.map(({ type }) => type)}`);
         // send empty frame
         return {
           key: subKey,
@@ -358,7 +359,7 @@ export class LiveDataStream<T = unknown> {
 
         const newValueSameSchemaMessages = filterMessages(messages, InternalStreamMessageType.NewValuesSameSchema);
         if (newValueSameSchemaMessages.length !== messages.length) {
-          console.warn(`unsupported message type ${messages.map(({ type }) => type)}`);
+          clientLog.warn(`unsupported message type ${messages.map(({ type }) => type)}`);
         }
 
         return getNewValuesSameSchemaResponseData(newValueSameSchemaMessages);

--- a/public/app/features/live/centrifuge/channel.ts
+++ b/public/app/features/live/centrifuge/channel.ts
@@ -9,16 +9,17 @@ import {
 } from 'centrifuge';
 import { Subject, of, Observable } from 'rxjs';
 
-import {
-  type LiveChannelStatusEvent,
+import {type LiveChannelStatusEvent,
   type LiveChannelEvent,
   LiveChannelEventType,
   LiveChannelConnectionState,
   type LiveChannelPresenceStatus,
   type LiveChannelAddress,
   type DataFrameJSON,
-  isValidLiveChannelAddress,
-} from '@grafana/data';
+  isValidLiveChannelAddress, createClientLog} from '@grafana/data';
+const clientLog = createClientLog('public/app/features/live/centrifuge/channel');
+
+
 
 /**
  * Internal class that maps Centrifuge support to GrafanaLive
@@ -81,7 +82,7 @@ export class CentrifugeLiveChannel<T = any> {
           this.sendStatus();
         }
       } catch (err) {
-        console.log('publish error', this.addr, err);
+        clientLog.info('publish error', this.addr, err);
         this.currentStatus.error = err;
         this.currentStatus.timestamp = Date.now();
         this.sendStatus();

--- a/public/app/features/live/centrifuge/service.ts
+++ b/public/app/features/live/centrifuge/service.ts
@@ -9,14 +9,12 @@ import {
 } from 'centrifuge';
 import { BehaviorSubject, type Observable, share, startWith } from 'rxjs';
 
-import {
-  type DataQueryError,
+import {type DataQueryError,
   type DataQueryResponse,
   type LiveChannelAddress,
   LiveChannelConnectionState,
   type LiveChannelId,
-  toLiveChannelId,
-} from '@grafana/data';
+  toLiveChannelId, createClientLog} from '@grafana/data';
 import {
   type FetchResponse,
   type GrafanaLiveSrv,
@@ -33,6 +31,9 @@ import { type StreamingResponseData } from '../data/utils';
 
 import { LiveDataStream } from './LiveDataStream';
 import { CentrifugeLiveChannel } from './channel';
+const clientLog = createClientLog('public/app/features/live/centrifuge/service');
+
+
 
 export type CentrifugeSrvDeps = {
   grafanaAuthToken: string | null;
@@ -126,7 +127,7 @@ export class CentrifugeService implements CentrifugeSrv {
   };
 
   private onServerSideMessage = (context: ServerPublicationContext) => {
-    console.log('Publication from server-side channel', context);
+    clientLog.info('Publication from server-side channel', context);
   };
 
   private onError = (context: ErrorContext) => {

--- a/public/app/features/live/dashboard/dashboardWatcher.ts
+++ b/public/app/features/live/dashboard/dashboardWatcher.ts
@@ -1,15 +1,13 @@
 import { type Unsubscribable } from 'rxjs';
 import { v4 as uuidv4 } from 'uuid';
 
-import {
-  AppEvents,
+import {AppEvents,
   isLiveChannelMessageEvent,
   isLiveChannelStatusEvent,
   type LiveChannelAddress,
   LiveChannelConnectionState,
   type LiveChannelEvent,
-  LiveChannelScope,
-} from '@grafana/data';
+  LiveChannelScope, createClientLog} from '@grafana/data';
 import { getGrafanaLiveSrv, locationService } from '@grafana/runtime';
 import { appEvents } from 'app/core/app_events';
 import { contextSrv } from 'app/core/services/context_srv';
@@ -19,6 +17,9 @@ import { getDashboardSrv } from '../../dashboard/services/DashboardSrv';
 
 import { DashboardChangedModal } from './DashboardChangedModal';
 import { type DashboardEvent, DashboardEventAction } from './types';
+const clientLog = createClientLog('public/app/features/live/dashboard/dashboardWatcher');
+
+
 
 // sessionId is not a security-sensitive value.
 // It is used for filtering out dashboard edit events from the same browsing session
@@ -127,7 +128,7 @@ class DashboardWatcher {
 
             const dash = getDashboardSrv().getCurrent();
             if (dash?.uid !== event.message.uid) {
-              console.log('dashboard event for different dashboard?', event, dash);
+              clientLog.info('dashboard event for different dashboard?', event, dash);
               return;
             }
 

--- a/public/app/features/live/live.ts
+++ b/public/app/features/live/live.ts
@@ -1,10 +1,13 @@
 import { map } from 'rxjs';
 
-import { toLiveChannelId, StreamingDataFrame } from '@grafana/data';
+import {toLiveChannelId, StreamingDataFrame, createClientLog} from '@grafana/data';
 import { type BackendSrv, type GrafanaLiveSrv } from '@grafana/runtime';
 
 import { type CentrifugeSrv, type StreamingDataQueryResponse } from './centrifuge/service';
 import { isStreamingResponseData, StreamingResponseDataType } from './data/utils';
+const clientLog = createClientLog('public/app/features/live/live');
+
+
 
 type GrafanaLiveServiceDeps = {
   centrifugeSrv: CentrifugeSrv;
@@ -30,7 +33,7 @@ export class GrafanaLiveService implements GrafanaLiveSrv {
     const updateBuffer = (next: StreamingDataQueryResponse): void => {
       const data = next.data[0];
       if (!buffer && !isStreamingResponseData(data, StreamingResponseDataType.FullFrame)) {
-        console.warn(`expected first packet to contain a full frame, received ${data?.type}`);
+        clientLog.warn(`expected first packet to contain a full frame, received ${data?.type}`);
         return;
       }
 

--- a/public/app/features/logs/components/ControlledLogsTable.tsx
+++ b/public/app/features/logs/components/ControlledLogsTable.tsx
@@ -1,7 +1,7 @@
 import { css } from '@emotion/css';
 import { useMemo, useRef } from 'react';
 
-import { EventBusSrv, type GrafanaTheme2 } from '@grafana/data';
+import {EventBusSrv, type GrafanaTheme2, createClientLog} from '@grafana/data';
 import { useStyles2 } from '@grafana/ui';
 
 import { LogsTableWrap } from '../../explore/Logs/LogsTableWrap';
@@ -10,6 +10,9 @@ import { type LogRowsComponentProps } from './ControlledLogRows';
 import { useLogListContext } from './panel/LogListContext';
 import { CONTROLS_WIDTH_EXPANDED, LogListControls } from './panel/LogListControls';
 import { LOG_LIST_CONTROLS_WIDTH } from './panel/virtualization';
+const clientLog = createClientLog('public/app/features/logs/components/ControlledLogsTable');
+
+
 
 export const ControlledLogsTable = ({
   loading,
@@ -38,7 +41,7 @@ export const ControlledLogsTable = ({
   const styles = useStyles2(getStyles);
 
   if (!splitOpen || !width || !updatePanelState) {
-    console.error('<ControlledLogsTable>: Missing required props.');
+    clientLog.error('<ControlledLogsTable>: Missing required props.');
     return;
   }
 

--- a/public/app/features/logs/components/fieldSelector/LogListFieldSelector.tsx
+++ b/public/app/features/logs/components/fieldSelector/LogListFieldSelector.tsx
@@ -2,7 +2,7 @@ import { useBooleanFlagValue } from '@openfeature/react-sdk';
 import { Resizable, type ResizeCallback } from 're-resizable';
 import { useCallback, useLayoutEffect, useMemo, useState } from 'react';
 
-import { type DataFrame, store } from '@grafana/data';
+import {type DataFrame, store, createClientLog} from '@grafana/data';
 import { t } from '@grafana/i18n';
 import { reportInteraction } from '@grafana/runtime';
 import { getDragStyles, IconButton, useStyles2 } from '@grafana/ui';
@@ -16,6 +16,9 @@ import { getFieldSelectorWidth } from './fieldSelectorUtils';
 import { getFieldsWithStats } from './getFieldsWithStats';
 import { logsFieldSelectorWrapperStyles } from './styles';
 import { getSuggestedFieldsFromLogList } from './suggestedFields';
+const clientLog = createClientLog('public/app/features/logs/components/fieldSelector/LogListFieldSelector');
+
+
 
 /**
  * FieldSelector wrapper for the LogList visualization.
@@ -116,7 +119,7 @@ export const LogListFieldSelector = ({ containerElement, dataFrames, logs }: Log
   const fields = useMemo(() => getFieldsWithStats(dataFrames), [dataFrames]);
 
   if (!onClickShowField || !onClickHideField || !setDisplayedFields) {
-    console.warn(
+    clientLog.warn(
       'LogListFieldSelector: Missing required props: onClickShowField, onClickHideField, setDisplayedFields'
     );
     return null;

--- a/public/app/features/logs/components/panel/grammar.ts
+++ b/public/app/features/logs/components/panel/grammar.ts
@@ -1,8 +1,11 @@
 import { type Grammar } from 'prismjs';
 
-import { escapeRegex, parseFlags } from '@grafana/data';
+import {escapeRegex, parseFlags, createClientLog} from '@grafana/data';
 
 import { type LogListModel } from './processing';
+const clientLog = createClientLog('public/app/features/logs/components/panel/grammar');
+
+
 
 // The Logs grammar is used for highlight in the logs panel
 const logsGrammar: Grammar = {
@@ -64,7 +67,7 @@ export const generateTextMatchGrammar = (highlightWords: string[] | undefined = 
       try {
         return new RegExp(`(?:${cleaned})`, flags);
       } catch (e) {
-        console.error(`generateTextMatchGrammar: cannot generate regular expression from /${cleaned}/${flags}`, e);
+        clientLog.error(`generateTextMatchGrammar: cannot generate regular expression from /${cleaned}/${flags}`, e);
       }
       return undefined;
     })
@@ -74,7 +77,7 @@ export const generateTextMatchGrammar = (highlightWords: string[] | undefined = 
     try {
       expressions.push(new RegExp(escapeRegex(search), 'gi'));
     } catch (e) {
-      console.error(`generateTextMatchGrammar: cannot generate regular expression from /${search}/gi`, e);
+      clientLog.error(`generateTextMatchGrammar: cannot generate regular expression from /${search}/gi`, e);
     }
   }
   if (!expressions.length) {

--- a/public/app/features/logs/components/panel/panelState/getLogsPanelState.ts
+++ b/public/app/features/logs/components/panel/panelState/getLogsPanelState.ts
@@ -1,4 +1,7 @@
-import { urlUtil } from '@grafana/data';
+import {urlUtil, createClientLog} from '@grafana/data';
+const clientLog = createClientLog('public/app/features/logs/components/panel/panelState/getLogsPanelState');
+
+
 
 interface LogsPermalinkUrlState {
   logs?: {
@@ -18,7 +21,7 @@ export function getLogsPanelState(): LogsPermalinkUrlState | undefined {
     try {
       return JSON.parse(panelStateEncoded[0]);
     } catch (e) {
-      console.error('error parsing logsPanelState', e);
+      clientLog.error('error parsing logsPanelState', e);
     }
   }
 

--- a/public/app/features/logs/components/panel/virtualization.ts
+++ b/public/app/features/logs/components/panel/virtualization.ts
@@ -1,10 +1,13 @@
 import ansicolor from 'ansicolor';
 
-import { BusEventWithPayload, type GrafanaTheme2 } from '@grafana/data';
+import {BusEventWithPayload, type GrafanaTheme2, createClientLog} from '@grafana/data';
 
 import { type LogLineTimestampResolution } from './LogLine';
 import { type LogListFontSize } from './LogList';
 import { type LogListModel } from './processing';
+const clientLog = createClientLog('public/app/features/logs/components/panel/virtualization');
+
+
 
 export const LOG_LIST_MIN_WIDTH = 35 * 8;
 // Controls the space between fields in the log line, timestamp, level, displayed fields, and log line body
@@ -73,7 +76,7 @@ export class LogLineVirtualization {
     const domCharWidth = this.measureTextWidthWithDOM('e');
     const diff = domCharWidth - canvasCharWidth;
     if (diff >= 0.1) {
-      console.warn('Virtualized log list: falling back to DOM for measurement');
+      clientLog.warn('Virtualized log list: falling back to DOM for measurement');
       this.measurementMode = 'dom';
     }
   };

--- a/public/app/features/logs/utils.ts
+++ b/public/app/features/logs/utils.ts
@@ -3,8 +3,7 @@ import { countBy, chain } from 'lodash';
 import { type MouseEvent } from 'react';
 import { lastValueFrom, map, type Observable } from 'rxjs';
 
-import {
-  LogLevel,
+import {LogLevel,
   type LogRowModel,
   type LogLabelStatsModel,
   type LogsModel,
@@ -29,8 +28,7 @@ import {
   getTimeField,
   type Field,
   type LogsMetaItem,
-  store,
-} from '@grafana/data';
+  store, createClientLog} from '@grafana/data';
 import { t } from '@grafana/i18n';
 import { getConfig } from 'app/core/config';
 
@@ -41,6 +39,9 @@ import { LOG_LINE_BODY_FIELD_NAME } from './components/fieldSelector/logFields';
 import { getDataframeFields } from './components/logParser';
 import { type GetRowContextQueryFn } from './components/panel/LogLineMenu';
 import { DATAPLANE_LABELS_NAME, DATAPLANE_LABEL_TYPES_NAME, parseLogsFrame } from './logsFrame';
+const clientLog = createClientLog('public/app/features/logs/utils');
+
+
 
 /**
  * Returns the log level of a log line.
@@ -368,10 +369,10 @@ export function getLogLevelInfo(dataFrame: DataFrame, allDataFrames: DataFrame[]
   const valueField = fieldCache.getFirstFieldOfType(FieldType.number);
 
   if (!timeField) {
-    console.error('Time field missing in data frame');
+    clientLog.error('Time field missing in data frame');
   }
   if (!valueField) {
-    console.error('Value field missing in data frame');
+    clientLog.error('Value field missing in data frame');
   }
 
   const level = valueField ? getFieldDisplayName(valueField, dataFrame, allDataFrames) : 'logs';

--- a/public/app/features/panel/panellinks/linkSuppliers.ts
+++ b/public/app/features/panel/panellinks/linkSuppliers.ts
@@ -1,5 +1,4 @@
-import {
-  type DataLink,
+import {type DataLink,
   type DisplayValue,
   type FieldDisplay,
   formattedValueToString,
@@ -9,14 +8,16 @@ import {
   type Labels,
   type LinkModelSupplier,
   type ScopedVar,
-  type ScopedVars,
-} from '@grafana/data';
+  type ScopedVars, createClientLog} from '@grafana/data';
 import { t } from '@grafana/i18n';
 import { type VizPanel } from '@grafana/scenes';
 import { type PanelModel } from 'app/features/dashboard/state/PanelModel';
 import { dashboardSceneGraph } from 'app/features/dashboard-scene/utils/dashboardSceneGraph';
 
 import { getLinkSrv } from './link_srv';
+const clientLog = createClientLog('public/app/features/panel/panellinks/linkSuppliers');
+
+
 
 interface SeriesVars {
   name?: string;
@@ -124,7 +125,7 @@ export const getFieldLinksSupplier = (value: FieldDisplay): LinkModelSupplier<Fi
           };
         }
       } else {
-        console.log('VALUE', value);
+        clientLog.info('VALUE', value);
       }
 
       const replace: InterpolateFunction = (value: string, vars: ScopedVars | undefined, fmt?: string | Function) => {

--- a/public/app/features/panel/state/actions.ts
+++ b/public/app/features/panel/state/actions.ts
@@ -1,4 +1,4 @@
-import { type DataTransformerConfig, type FieldConfigSource, getPanelOptionsWithDefaults } from '@grafana/data';
+import {type DataTransformerConfig, type FieldConfigSource, getPanelOptionsWithDefaults, createClientLog} from '@grafana/data';
 import { type PanelModel } from 'app/features/dashboard/state/PanelModel';
 import { getLibraryPanel } from 'app/features/library-panels/state/api';
 import { type LibraryElementDTO } from 'app/features/library-panels/types';
@@ -8,6 +8,9 @@ import { DashboardPanelsChangedEvent, PanelOptionsChangedEvent, PanelQueriesChan
 import { type ThunkResult } from 'app/types/store';
 
 import { changePanelKey, panelModelAndPluginReady, removePanel } from './reducers';
+const clientLog = createClientLog('public/app/features/panel/state/actions');
+
+
 
 export function initPanelState(panel: PanelModel): ThunkResult<Promise<void>> {
   return async (dispatch, getStore) => {
@@ -165,7 +168,7 @@ export function loadLibraryPanelAndUpdate(panel: PanelModel): ThunkResult<void> 
 
       await dispatch(initPanelState(panel));
     } catch (ex) {
-      console.log('ERROR: ', ex);
+      clientLog.info('ERROR: ', ex);
       dispatch(
         panelModelAndPluginReady({
           key: panel.key,

--- a/public/app/features/panel/suggestions/getAllSuggestions.ts
+++ b/public/app/features/panel/suggestions/getAllSuggestions.ts
@@ -1,13 +1,11 @@
-import {
-  AppEvents,
+import {AppEvents,
   type DataFrame,
   getPanelDataSummary,
   type PanelDataSummary,
   type PanelPlugin,
   type PanelPluginVisualizationSuggestion,
   type PreferredVisualisationType,
-  VisualizationSuggestionScore,
-} from '@grafana/data';
+  VisualizationSuggestionScore, createClientLog} from '@grafana/data';
 import { t } from '@grafana/i18n';
 import { config } from '@grafana/runtime';
 import { getListedPanelPluginMetas, getPanelPluginMeta } from '@grafana/runtime/internal';
@@ -16,6 +14,9 @@ import { isBuiltinPluginPath } from 'app/features/plugins/built_in_plugins';
 import { importPanelPlugin } from 'app/features/plugins/importPanelPlugin';
 
 import { panelsToCheckFirst } from './consts';
+const clientLog = createClientLog('public/app/features/panel/suggestions/getAllSuggestions');
+
+
 
 interface PluginLoadResult {
   plugins: PanelPlugin[];
@@ -58,7 +59,7 @@ export async function loadPlugins(pluginIds: string[]): Promise<PluginLoadResult
       plugins.push(settled.value);
     } else {
       const pluginId = pluginIds[i];
-      console.error(`Failed to load ${pluginId} for visualization suggestions:`, settled.reason);
+      clientLog.error(`Failed to load ${pluginId} for visualization suggestions:`, settled.reason);
 
       if (await isBuiltInPlugin(pluginId)) {
         hasErrors = true;
@@ -163,7 +164,7 @@ export async function getAllSuggestions(series?: DataFrame[]): Promise<Suggestio
         list.push(...suggestions);
       }
     } catch (e) {
-      console.warn(`error when loading suggestions from plugin "${plugin.meta.id}"`, e);
+      clientLog.warn(`error when loading suggestions from plugin "${plugin.meta.id}"`, e);
       pluginSuggestionsError = true;
     }
   }

--- a/public/app/features/plugins/admin/api.ts
+++ b/public/app/features/plugins/admin/api.ts
@@ -1,4 +1,4 @@
-import { type PluginError, type PluginMeta, renderMarkdown } from '@grafana/data';
+import {type PluginError, type PluginMeta, renderMarkdown, createClientLog} from '@grafana/data';
 import { getBackendSrv, isFetchError } from '@grafana/runtime';
 import { installPluginMeta, logPluginMetaError, uninstallPluginMeta } from '@grafana/runtime/internal';
 import { accessControlQueryParam } from 'app/core/utils/accessControl';
@@ -16,6 +16,9 @@ import {
   type InstancePlugin,
   type ProvisionedPlugin,
 } from './types';
+const clientLog = createClientLog('public/app/features/plugins/admin/api');
+
+
 
 export async function getPluginDetails(id: string): Promise<CatalogPluginDetails> {
   const remote = await getRemotePlugin(id);
@@ -92,7 +95,7 @@ export async function getRemotePlugins(): Promise<RemotePlugin[]> {
     if (isFetchError(error)) {
       // It can happen that GCOM is not available, in that case we show a limited set of information to the user.
       error.isHandled = true;
-      console.error('Failed to fetch plugins from catalog (default https://grafana.com/api/plugins)');
+      clientLog.error('Failed to fetch plugins from catalog (default https://grafana.com/api/plugins)');
       return [];
     }
 

--- a/public/app/features/plugins/admin/components/GetStartedWithPlugin/GetStartedWithApp.tsx
+++ b/public/app/features/plugins/admin/components/GetStartedWithPlugin/GetStartedWithApp.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-import { type PluginMeta } from '@grafana/data';
+import {type PluginMeta, createClientLog} from '@grafana/data';
 import { Trans } from '@grafana/i18n';
 import { reportInteraction } from '@grafana/runtime';
 import { Button } from '@grafana/ui';
@@ -10,6 +10,9 @@ import { AccessControlAction } from 'app/types/accessControl';
 import { updatePluginSettings } from '../../api';
 import { usePluginConfig } from '../../hooks/usePluginConfig';
 import { type CatalogPlugin } from '../../types';
+const clientLog = createClientLog('public/app/features/plugins/admin/components/GetStartedWithPlugin/GetStartedWithApp');
+
+
 
 type Props = {
   plugin: CatalogPlugin;
@@ -80,6 +83,6 @@ const updatePluginSettingsAndReload = async (id: string, data: Partial<PluginMet
     // Reloading the page as the plugin meta changes made here wouldn't be propagated throughout the app.
     window.location.reload();
   } catch (e) {
-    console.error('Error while updating the plugin', e);
+    clientLog.error('Error while updating the plugin', e);
   }
 };

--- a/public/app/features/plugins/admin/pages/Browse.tsx
+++ b/public/app/features/plugins/admin/pages/Browse.tsx
@@ -2,7 +2,7 @@ import { css } from '@emotion/css';
 import { useState } from 'react';
 import { useLocation } from 'react-router-dom-v5-compat';
 
-import { type SelectableValue, type GrafanaTheme2, type PluginType } from '@grafana/data';
+import {type SelectableValue, type GrafanaTheme2, type PluginType, createClientLog} from '@grafana/data';
 import { Trans, t } from '@grafana/i18n';
 import { locationSearchToObject } from '@grafana/runtime';
 import { Select, RadioButtonGroup, useStyles2, Tooltip, Field, TextLink } from '@grafana/ui';
@@ -21,6 +21,9 @@ import { UpdateAllModal } from '../components/UpdateAllModal';
 import { Sorters } from '../helpers';
 import { useHistory } from '../hooks/useHistory';
 import { useGetAll, useGetUpdatable, useIsRemotePluginsAvailable } from '../state/hooks';
+const clientLog = createClientLog('public/app/features/plugins/admin/pages/Browse');
+
+
 
 export default function Browse() {
   const location = useLocation();
@@ -72,7 +75,7 @@ export default function Browse() {
 
   // How should we handle errors?
   if (error) {
-    console.error(error.message);
+    clientLog.error(error.message);
     return null;
   }
 

--- a/public/app/features/plugins/admin/state/actions.ts
+++ b/public/app/features/plugins/admin/state/actions.ts
@@ -1,7 +1,7 @@
 import { createAction, createAsyncThunk, type Update } from '@reduxjs/toolkit';
 import { from, forkJoin, timeout, lastValueFrom, catchError, of } from 'rxjs';
 
-import { type PanelPlugin, type PluginError } from '@grafana/data';
+import {type PanelPlugin, type PluginError, createClientLog} from '@grafana/data';
 import { config, getBackendSrv, isFetchError } from '@grafana/runtime';
 import { refetchPanelPluginMetas } from '@grafana/runtime/internal';
 import { importPanelPlugin } from 'app/features/plugins/importPanelPlugin';
@@ -29,6 +29,9 @@ import {
   type ProvisionedPlugin,
   PluginStatus,
 } from '../types';
+const clientLog = createClientLog('public/app/features/plugins/admin/state/actions');
+
+
 
 // Fetches
 export const fetchAll = createAsyncThunk(`${STATE_PREFIX}/fetchAll`, async (_, thunkApi) => {
@@ -46,7 +49,7 @@ export const fetchAll = createAsyncThunk(`${STATE_PREFIX}/fetchAll`, async (_, t
     const remote$ = from(getRemotePlugins()).pipe(
       catchError((err) => {
         thunkApi.dispatch({ type: `${STATE_PREFIX}/fetchRemote/rejected` });
-        console.error(err);
+        clientLog.error(err);
         return of([]);
       })
     );
@@ -121,7 +124,7 @@ export const fetchAll = createAsyncThunk(`${STATE_PREFIX}/fetchAll`, async (_, t
           }
         },
         (error) => {
-          console.log(error);
+          clientLog.info(error);
           thunkApi.dispatch({ type: `${STATE_PREFIX}/fetchLocal/rejected` });
           thunkApi.dispatch({ type: `${STATE_PREFIX}/fetchRemote/rejected` });
           return thunkApi.rejectWithValue('Unknown error.');
@@ -235,7 +238,7 @@ export const install = createAsyncThunk<
 
     return { id, changes };
   } catch (e) {
-    console.error(e);
+    clientLog.error(e);
     if (isFetchError(e)) {
       // add id to identify errors in multiple requests
       e.data.id = id;
@@ -262,7 +265,7 @@ export const uninstall = createAsyncThunk<Update<CatalogPlugin, string>, string>
         changes: { isInstalled: false, installedVersion: undefined, isFullyInstalled: false },
       };
     } catch (e) {
-      console.error(e);
+      clientLog.error(e);
 
       return thunkApi.rejectWithValue('Unknown error.');
     }

--- a/public/app/features/plugins/components/AppRootPage.tsx
+++ b/public/app/features/plugins/components/AppRootPage.tsx
@@ -4,16 +4,14 @@ import { useCallback, useEffect, useMemo, useReducer } from 'react';
 import * as React from 'react';
 import { useLocation, useParams } from 'react-router-dom-v5-compat';
 
-import {
-  AppEvents,
+import {AppEvents,
   type AppPlugin,
   type AppPluginMeta,
   type NavModel,
   type NavModelItem,
   OrgRole,
   PluginType,
-  PluginContextProvider,
-} from '@grafana/data';
+  PluginContextProvider, createClientLog} from '@grafana/data';
 import { Trans, t } from '@grafana/i18n';
 import { config, locationSearchToObject } from '@grafana/runtime';
 import { Alert, ErrorWithStack } from '@grafana/ui';
@@ -40,6 +38,9 @@ import { buildPluginSectionNav, pluginsLogger } from '../utils';
 import { PluginErrorBoundary } from './PluginErrorBoundary';
 import { buildPluginPageContext, PluginPageContext } from './PluginPageContext';
 import { RestrictedGrafanaApisProvider } from './restrictedGrafanaApis/RestrictedGrafanaApisProvider';
+const clientLog = createClientLog('public/app/features/plugins/components/AppRootPage');
+
+
 
 interface Props {
   // The ID of the plugin we would like to load and display
@@ -249,7 +250,7 @@ async function loadAppPlugin(pluginId: string, dispatch: React.Dispatch<AnyActio
     );
     const error = err instanceof Error ? err : new Error(getMessageFromError(err));
     pluginsLogger.logError(error);
-    console.error(error);
+    clientLog.error(error);
   }
 }
 

--- a/public/app/features/plugins/components/PluginErrorBoundary.tsx
+++ b/public/app/features/plugins/components/PluginErrorBoundary.tsx
@@ -1,6 +1,9 @@
 import * as React from 'react';
 
-import { PluginContext } from '@grafana/data';
+import {PluginContext, createClientLog} from '@grafana/data';
+const clientLog = createClientLog('public/app/features/plugins/components/PluginErrorBoundary');
+
+
 
 interface PluginErrorBoundaryProps {
   children: React.ReactNode;
@@ -32,7 +35,7 @@ export class PluginErrorBoundary extends React.Component<PluginErrorBoundaryProp
     if (this.props.onError) {
       this.props.onError(error, info);
     } else {
-      console.error(`Plugin "${this.context?.meta.id}" failed to load:`, error, info);
+      clientLog.error(`Plugin "${this.context?.meta.id}" failed to load:`, error, info);
     }
 
     this.setState({ error, errorInfo: info });

--- a/public/app/features/plugins/components/restrictedGrafanaApis/dashboardMutation/dashboardMutationApi.ts
+++ b/public/app/features/plugins/components/restrictedGrafanaApis/dashboardMutation/dashboardMutationApi.ts
@@ -1,3 +1,4 @@
+import { createClientLog } from '@grafana/data';
 /**
  * Dashboard Mutation API -- Restricted API wrapper with built-in store.
  *
@@ -16,6 +17,9 @@ import { DashboardMutationClient } from 'app/features/dashboard-scene/mutation-a
 import type { MutationClient, MutationRequest } from 'app/features/dashboard-scene/mutation-api/types';
 import { provideMutationClientFactory } from 'app/features/dashboard-scene/scene/DashboardMutationClientSetter';
 import type { DashboardScene } from 'app/features/dashboard-scene/scene/DashboardScene';
+const clientLog = createClientLog('public/app/features/plugins/components/restrictedGrafanaApis/dashboardMutation/dashboardMutationApi');
+
+
 
 let _client: MutationClient | null = null;
 
@@ -26,7 +30,7 @@ provideMutationClientFactory((sceneObject) => {
   try {
     _client = new DashboardMutationClient(scene);
   } catch (error) {
-    console.error('Failed to register Dashboard Mutation API:', error);
+    clientLog.error('Failed to register Dashboard Mutation API:', error);
   }
 
   return () => {

--- a/public/app/features/plugins/extensions/logs/LogViewFilters.tsx
+++ b/public/app/features/plugins/extensions/logs/LogViewFilters.tsx
@@ -1,10 +1,13 @@
 import { isEmpty } from 'lodash';
 import { type ReactElement, useMemo } from 'react';
 
-import { type DataFrame, type MatcherConfig, type SelectableValue } from '@grafana/data';
+import {type DataFrame, type MatcherConfig, type SelectableValue, createClientLog} from '@grafana/data';
 import { t } from '@grafana/i18n';
 import { type SceneDataProvider } from '@grafana/scenes';
 import { InlineField, InlineFieldRow, MultiSelect } from '@grafana/ui';
+const clientLog = createClientLog('public/app/features/plugins/extensions/logs/LogViewFilters');
+
+
 
 export type LogFilter = {
   pluginIds?: Set<string>;
@@ -98,7 +101,7 @@ function useLogFilters(
 
   return useMemo(() => {
     if (data && data?.series.length > 1) {
-      console.warn('LogViewFilter does not support multiple series in query result.');
+      clientLog.warn('LogViewFilter does not support multiple series in query result.');
     }
 
     const frame = data?.series[0];

--- a/public/app/features/plugins/extensions/logs/log.ts
+++ b/public/app/features/plugins/extensions/logs/log.ts
@@ -2,8 +2,11 @@ import { isString } from 'lodash';
 import { nanoid } from 'nanoid';
 import { type Observable, ReplaySubject } from 'rxjs';
 
-import { type Labels, LogLevel } from '@grafana/data';
+import {type Labels, LogLevel, createClientLog} from '@grafana/data';
 import { config, createMonitoringLogger } from '@grafana/runtime';
+const clientLog = createClientLog('public/app/features/plugins/extensions/logs/log');
+
+
 
 export type ExtensionsLogItem = {
   level: LogLevel;
@@ -41,15 +44,15 @@ export class ExtensionsLog {
 
   warning(message: string, labels?: Labels): void {
     monitoringLogger.logWarning(message, { ...this.baseLabels, ...labels });
-    config.buildInfo.env === 'development' && console.warn(message, { ...this.baseLabels, ...labels });
+    config.buildInfo.env === 'development' && clientLog.warn(message, { ...this.baseLabels, ...labels });
     this.log(LogLevel.warning, message, labels);
   }
 
   error(message: string, labels?: Labels): void {
     // TODO: If Faro has console instrumentation, then the following will track the same error message twice
-    // (first: `monitoringLogger.logError()`, second: `console.error()` which gets picked up by Faro)
+    // (first: `monitoringLogger.logError()`, second: `clientLog.error()` which gets picked up by Faro)
     monitoringLogger.logError(new Error(message), { ...this.baseLabels, ...labels });
-    console.error(message, { ...this.baseLabels, ...labels });
+    clientLog.error(message, { ...this.baseLabels, ...labels });
     this.log(LogLevel.error, message, labels);
   }
 

--- a/public/app/features/plugins/extensions/utils.tsx
+++ b/public/app/features/plugins/extensions/utils.tsx
@@ -3,8 +3,7 @@ import { cloneDeep, isArray, isObject, isString } from 'lodash';
 import * as React from 'react';
 import { useAsync } from 'react-use';
 
-import {
-  type AppPluginConfig,
+import {type AppPluginConfig,
   type PluginExtensionEventHelpers,
   type PluginExtensionOpenModalOptions,
   isDateTime,
@@ -13,8 +12,7 @@ import {
   type PluginExtensionAddedLinkConfig,
   type PluginExtensionLink,
   PluginExtensionTypes,
-  urlUtil,
-} from '@grafana/data';
+  urlUtil, createClientLog} from '@grafana/data';
 import { reportInteraction, config } from '@grafana/runtime';
 import { getAppPluginMetas } from '@grafana/runtime/internal';
 import { Modal } from '@grafana/ui';
@@ -42,6 +40,9 @@ import {
 import { type ExtensionsLog, log as baseLog } from './logs/log';
 import { type AddedLinkRegistryItem } from './registry/AddedLinksRegistry';
 import { assertIsNotPromise, assertStringProps, isPromise } from './validators';
+const clientLog = createClientLog('public/app/features/plugins/extensions/utils');
+
+
 
 export function handleErrorsInFn(fn: Function, errorMessagePrefix = '') {
   return (...args: unknown[]) => {
@@ -49,7 +50,7 @@ export function handleErrorsInFn(fn: Function, errorMessagePrefix = '') {
       return fn(...args);
     } catch (e) {
       if (e instanceof Error) {
-        console.warn(`${errorMessagePrefix}${e.message}`);
+        clientLog.warn(`${errorMessagePrefix}${e.message}`);
       }
     }
   };

--- a/public/app/features/plugins/importer/addTranslationsToI18n.ts
+++ b/public/app/features/plugins/importer/addTranslationsToI18n.ts
@@ -1,7 +1,11 @@
+import { createClientLog } from '@grafana/data';
 import { addResourceBundle } from '@grafana/i18n/internal';
 
 import { SystemJS } from '../loader/systemjs';
 import { resolveModulePath } from '../loader/utils';
+const clientLog = createClientLog('public/app/features/plugins/importer/addTranslationsToI18n');
+
+
 
 interface AddTranslationsToI18nOptions {
   resolvedLanguage: string;
@@ -21,14 +25,14 @@ export async function addTranslationsToI18n({
   const path = resolvedPath ?? fallbackPath;
 
   if (!path) {
-    console.warn(`Could not find any translation for plugin ${pluginId}`, { resolvedLanguage, fallbackLanguage });
+    clientLog.warn(`Could not find any translation for plugin ${pluginId}`, { resolvedLanguage, fallbackLanguage });
     return;
   }
 
   try {
     const module = await SystemJS.import(resolveModulePath(path));
     if (!module.default) {
-      console.warn(`Could not find default export for plugin ${pluginId}`, {
+      clientLog.warn(`Could not find default export for plugin ${pluginId}`, {
         resolvedLanguage,
         fallbackLanguage,
         path,
@@ -39,7 +43,7 @@ export async function addTranslationsToI18n({
     const language = resolvedPath ? resolvedLanguage : fallbackLanguage;
     addResourceBundle(language, pluginId, module.default);
   } catch (error) {
-    console.warn(`Could not load translation for plugin ${pluginId}`, {
+    clientLog.warn(`Could not load translation for plugin ${pluginId}`, {
       resolvedLanguage,
       fallbackLanguage,
       error,

--- a/public/app/features/plugins/importer/importPluginModule.ts
+++ b/public/app/features/plugins/importer/importPluginModule.ts
@@ -1,3 +1,4 @@
+import { createClientLog } from '@grafana/data';
 import { DEFAULT_LANGUAGE } from '@grafana/i18n';
 import { getResolvedLanguage } from '@grafana/i18n/internal';
 import { config } from '@grafana/runtime';
@@ -12,6 +13,9 @@ import { pluginsLogger } from '../utils';
 
 import { addTranslationsToI18n } from './addTranslationsToI18n';
 import { type PluginImportInfo } from './types';
+const clientLog = createClientLog('public/app/features/plugins/importer/importPluginModule');
+
+
 
 export async function importPluginModule({
   path,
@@ -68,7 +72,7 @@ export async function importPluginModule({
 
   return SystemJS.import(modulePath).catch((e) => {
     let error = new Error('Could not load plugin', { cause: e });
-    console.error(error);
+    clientLog.error(error);
     pluginsLogger.logError(error, {
       path,
       pluginId,

--- a/public/app/features/plugins/importer/pluginImporter.ts
+++ b/public/app/features/plugins/importer/pluginImporter.ts
@@ -1,5 +1,4 @@
-import {
-  AppPlugin,
+import {AppPlugin,
   type AppPluginMeta,
   type DataQuery,
   type DataSourceApi,
@@ -10,8 +9,7 @@ import {
   type PanelPluginMeta,
   PluginLoadingStrategy,
   type PluginMeta,
-  throwIfAngular,
-} from '@grafana/data';
+  throwIfAngular, createClientLog} from '@grafana/data';
 import { config } from '@grafana/runtime';
 import { type GenericDataSourcePlugin } from 'app/features/datasources/types';
 import { getPanelPluginLoadError } from 'app/features/panel/components/PanelPluginError';
@@ -21,6 +19,9 @@ import { pluginsLogger } from '../utils';
 
 import { importPluginModule } from './importPluginModule';
 import { type PluginImporter, type PostImportStrategy, type PreImportStrategy } from './types';
+const clientLog = createClientLog('public/app/features/plugins/importer/pluginImporter');
+
+
 
 const defaultPreImport: PreImportStrategy = (plugin) => {
   throwIfAngular(plugin);
@@ -54,7 +55,7 @@ const panelPluginPostImport: PostImportStrategy<PanelPlugin, PanelPluginMeta> = 
     throw new Error('missing export: plugin');
   } catch (error) {
     // TODO, maybe a different error plugin
-    console.warn('Error loading panel plugin: ' + meta.id, error);
+    clientLog.warn('Error loading panel plugin: ' + meta.id, error);
     return getPanelPluginLoadError(meta, error);
   }
 };

--- a/public/app/features/plugins/loader/pluginLoader.mock.ts
+++ b/public/app/features/plugins/loader/pluginLoader.mock.ts
@@ -17,7 +17,7 @@ export const mockSystemModule = `System.register(['./dependencyA'], function (_e
 
 export const mockAmdModule = `define([], function() {
   return function() {
-    console.log('AMD module loaded');
+    // AMD module loaded
     var pluginPath = "/public/plugins/";
   }
 });`;

--- a/public/app/features/plugins/loader/systemjsHooks.ts
+++ b/public/app/features/plugins/loader/systemjsHooks.ts
@@ -1,4 +1,4 @@
-import { PluginLoadingStrategy } from '@grafana/data';
+import {PluginLoadingStrategy, createClientLog} from '@grafana/data';
 import { config } from '@grafana/runtime';
 
 import { transformPluginSourceForCDN } from '../cdn/utils';
@@ -11,6 +11,9 @@ import { SystemJS } from './systemjs';
 import { sharedDependenciesMap } from './sharedDependencies';
 import { type SystemJSWithLoaderHooks } from './types';
 import { buildImportMap, isHostedOnCDN } from './utils';
+const clientLog = createClientLog('public/app/features/plugins/loader/systemjsHooks');
+
+
 
 export function initSystemJSHooks() {
   const imports = buildImportMap(sharedDependenciesMap);
@@ -102,7 +105,7 @@ export function decorateSystemJSResolve(
       const url = originalResolve.apply(this, [resolvedUrl, parentUrl]);
       return resolvePluginUrlWithCache(url);
     }
-    console.warn(`SystemJS: failed to resolve '${id}'`);
+    clientLog.warn(`SystemJS: failed to resolve '${id}'`);
     return id;
   }
 }

--- a/public/app/features/plugins/loader/utils.ts
+++ b/public/app/features/plugins/loader/utils.ts
@@ -1,9 +1,13 @@
+import { createClientLog } from '@grafana/data';
 import { config } from '@grafana/runtime';
 
 import { sandboxPluginDependencies } from '../sandbox/pluginDependencies';
 
 import { SHARED_DEPENDENCY_PREFIX } from './constants';
 import { SystemJS } from './systemjs';
+const clientLog = createClientLog('public/app/features/plugins/loader/utils');
+
+
 
 export function buildImportMap(importMap: Record<string, System.Module>) {
   return Object.keys(importMap).reduce<Record<string, string>>((acc, key) => {
@@ -29,7 +33,7 @@ function addPreload(id: string, preload: (() => Promise<System.Module>) | System
   try {
     resolvedId = SystemJS.resolve(id);
   } catch (e) {
-    console.log(e);
+    clientLog.info(e);
   }
 
   if (resolvedId && SystemJS.has(resolvedId)) {

--- a/public/app/features/plugins/pluginPreloader.ts
+++ b/public/app/features/plugins/pluginPreloader.ts
@@ -1,3 +1,4 @@
+import { createClientLog } from '@grafana/data';
 import type {
   AppPluginConfig,
   PluginExtensionAddedLinkConfig,
@@ -8,6 +9,9 @@ import { contextSrv } from 'app/core/services/context_srv';
 import { getPluginSettings } from 'app/features/plugins/pluginSettings';
 
 import { pluginImporter } from './importer/pluginImporter';
+const clientLog = createClientLog('public/app/features/plugins/pluginPreloader');
+
+
 
 export type PluginPreloadResult = {
   pluginId: string;
@@ -46,6 +50,6 @@ async function preload(config: AppPluginConfig): Promise<void> {
       return;
     }
 
-    console.error(`[Plugins] Failed to preload plugin: ${config.path} (version: ${config.version})`, error);
+    clientLog.error(`[Plugins] Failed to preload plugin: ${config.path} (version: ${config.version})`, error);
   }
 }

--- a/public/app/features/plugins/sandbox/distortions.ts
+++ b/public/app/features/plugins/sandbox/distortions.ts
@@ -1,3 +1,4 @@
+import { createClientLog } from '@grafana/data';
 import { type ProxyTarget } from '@locker/near-membrane-shared';
 import DOMPurify from 'dompurify';
 import { cloneDeep, isFunction } from 'lodash';
@@ -9,6 +10,9 @@ import { forbiddenElements } from './constants';
 import { recursivePatchObjectAsLiveTarget } from './documentSandbox';
 import { type SandboxEnvironment, type SandboxPluginMeta } from './types';
 import { logWarning, unboxRegexesFromMembraneProxy } from './utils';
+const clientLog = createClientLog('public/app/features/plugins/sandbox/distortions');
+
+
 
 /**
  * Distortions are near-membrane mechanisms to altert JS instrics and DOM APIs.
@@ -140,7 +144,7 @@ function distortConsole(distortions: DistortionMap) {
       const pluginId = meta.id;
 
       function sandboxLog(...args: unknown[]) {
-        console.log(`[plugin ${pluginId}]`, ...args);
+        clientLog.info(`[plugin ${pluginId}]`, ...args);
       }
       return {
         log: sandboxLog,
@@ -170,7 +174,7 @@ function distortAlert(distortions: DistortionMap) {
     });
 
     return function (...args: unknown[]) {
-      console.log(`[plugin ${pluginId}]`, ...args);
+      clientLog.info(`[plugin ${pluginId}]`, ...args);
     };
   }
   const descriptor = Object.getOwnPropertyDescriptor(window, 'alert');

--- a/public/app/features/plugins/sandbox/sandboxPluginLoader.ts
+++ b/public/app/features/plugins/sandbox/sandboxPluginLoader.ts
@@ -1,7 +1,7 @@
 import createVirtualEnvironment from '@locker/near-membrane-dom';
 import { type ProxyTarget } from '@locker/near-membrane-shared';
 
-import { type BootData } from '@grafana/data';
+import {type BootData, createClientLog} from '@grafana/data';
 import { config } from '@grafana/runtime';
 import { defaultTrustedTypesPolicy } from 'app/core/trustedTypePolicies';
 
@@ -24,6 +24,9 @@ import {
   type SandboxPluginMeta,
 } from './types';
 import { logError, logInfo } from './utils';
+const clientLog = createClientLog('public/app/features/plugins/sandbox/sandboxPluginLoader');
+
+
 
 // Loads near membrane custom formatter for near membrane proxy objects.
 if (process.env.NODE_ENV !== 'production') {
@@ -139,7 +142,7 @@ async function doImportPluginModuleInSandbox(meta: SandboxPluginMeta): Promise<S
               `Error in ${meta.id}: Plugins should not use window.grafanaBootData. Use "config" from "@grafana/runtime" instead.`
             );
           } else {
-            console.error(
+            clientLog.error(
               `${meta.id.toUpperCase()}: Plugins should not use window.grafanaBootData. Use "config" from "@grafana/runtime" instead.`
             );
           }

--- a/public/app/features/profile/api.ts
+++ b/public/app/features/profile/api.ts
@@ -1,14 +1,18 @@
+import { createClientLog } from '@grafana/data';
 import { getBackendSrv } from '@grafana/runtime';
 import { type Team } from 'app/types/teams';
 import { type UserDTO, type UserOrg, type UserSession } from 'app/types/user';
 
 import { type ChangePasswordFields, type ProfileUpdateFields } from './types';
+const clientLog = createClientLog('public/app/features/profile/api');
+
+
 
 async function changePassword(payload: ChangePasswordFields): Promise<void> {
   try {
     await getBackendSrv().put('/api/user/password', payload);
   } catch (err) {
-    console.error(err);
+    clientLog.error(err);
   }
 }
 
@@ -42,7 +46,7 @@ async function updateUserProfile(payload: ProfileUpdateFields): Promise<void> {
   try {
     await getBackendSrv().put('/api/user', payload);
   } catch (err) {
-    console.error(err);
+    clientLog.error(err);
   }
 }
 

--- a/public/app/features/provisioning/utils/sourceLink.ts
+++ b/public/app/features/provisioning/utils/sourceLink.ts
@@ -1,3 +1,4 @@
+import { createClientLog } from '@grafana/data';
 import { t } from '@grafana/i18n';
 import { config } from '@grafana/runtime';
 import { type DashboardLink } from '@grafana/schema';
@@ -15,6 +16,9 @@ import { RepoTypeDisplay } from '../Wizard/types';
 import { isValidRepoType } from '../guards';
 
 import { getHasTokenInstructions, getRepoFileUrl } from './git';
+const clientLog = createClientLog('public/app/features/provisioning/utils/sourceLink');
+
+
 
 /**
  * Find and remove existing source links from the links array.
@@ -83,7 +87,7 @@ export async function buildSourceLink(annotations: ObjectMeta['annotations']): P
       keepTime: false,
     };
   } catch (e) {
-    console.warn('Failed to fetch repository info for source link:', e);
+    clientLog.warn('Failed to fetch repository info for source link:', e);
     return undefined;
   }
 }

--- a/public/app/features/query/components/QueryGroup.tsx
+++ b/public/app/features/query/components/QueryGroup.tsx
@@ -3,16 +3,14 @@ import { PureComponent, useEffect, useState } from 'react';
 import * as React from 'react';
 import { type Unsubscribable } from 'rxjs';
 
-import {
-  CoreApp,
+import {CoreApp,
   type DataSourceApi,
   type DataSourceInstanceSettings,
   type ScopedVars,
   getDataSourceRef,
   getDefaultTimeRange,
   LoadingState,
-  type PanelData,
-} from '@grafana/data';
+  type PanelData, createClientLog} from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';
 import { Trans, t } from '@grafana/i18n';
 import { getDataSourceSrv, locationService } from '@grafana/runtime';
@@ -35,6 +33,9 @@ import { updateQueries } from '../state/updateQueries';
 import { GroupActionComponents } from './QueryActionComponent';
 import { QueryEditorRows } from './QueryEditorRows';
 import { QueryGroupOptionsEditor } from './QueryGroupOptions';
+const clientLog = createClientLog('public/app/features/query/components/QueryGroup');
+
+
 
 export interface Props {
   queryRunner: PanelQueryRunner;
@@ -123,7 +124,7 @@ export class QueryGroup extends PureComponent<Props, State> {
         defaultDataSource,
       });
     } catch (error) {
-      console.error('failed to load data source', error);
+      clientLog.error('failed to load data source', error);
     }
   }
 

--- a/public/app/features/query/state/DashboardQueryRunner/DashboardQueryRunner.ts
+++ b/public/app/features/query/state/DashboardQueryRunner/DashboardQueryRunner.ts
@@ -73,7 +73,7 @@ class DashboardQueryRunnerImpl implements DashboardQueryRunner {
       takeUntil(this.runs.asObservable()),
       mergeAll(),
       reduce((acc: DashboardQueryRunnerWorkerResult, value: DashboardQueryRunnerWorkerResult) => {
-        // console.log({ acc: acc.annotations.length, value: value.annotations.length });
+        // clientLog.info({ acc: acc.annotations.length, value: value.annotations.length });
         // should we use scan or reduce here
         // reduce will only emit when all observables are completed
         // scan will emit when any observable is completed

--- a/public/app/features/query/state/DashboardQueryRunner/LegacyAnnotationQueryRunner.ts
+++ b/public/app/features/query/state/DashboardQueryRunner/LegacyAnnotationQueryRunner.ts
@@ -1,11 +1,14 @@
 import { from, type Observable, of } from 'rxjs';
 import { catchError } from 'rxjs/operators';
 
-import { type AnnotationEvent, type DataSourceApi } from '@grafana/data';
+import {type AnnotationEvent, type DataSourceApi, createClientLog} from '@grafana/data';
 import { shouldUseLegacyRunner } from 'app/features/annotations/standardAnnotationSupport';
 
 import { type AnnotationQueryRunner, type AnnotationQueryRunnerOptions } from './types';
 import { handleAnnotationQueryRunnerError } from './utils';
+const clientLog = createClientLog('public/app/features/query/state/DashboardQueryRunner/LegacyAnnotationQueryRunner');
+
+
 
 export class LegacyAnnotationQueryRunner implements AnnotationQueryRunner {
   canRun(datasource?: DataSourceApi): boolean {
@@ -26,13 +29,13 @@ export class LegacyAnnotationQueryRunner implements AnnotationQueryRunner {
     }
 
     if (datasource?.annotationQuery === undefined) {
-      console.warn('datasource does not have an annotation query');
+      clientLog.warn('datasource does not have an annotation query');
       return of([]);
     }
 
     const annotationQuery = datasource.annotationQuery({ range, rangeRaw: range.raw, annotation, dashboard });
     if (annotationQuery === undefined) {
-      console.warn('datasource does not have an annotation query');
+      clientLog.warn('datasource does not have an annotation query');
       return of([]);
     }
 

--- a/public/app/features/query/state/DashboardQueryRunner/utils.ts
+++ b/public/app/features/query/state/DashboardQueryRunner/utils.ts
@@ -1,13 +1,11 @@
 import { cloneDeep } from 'lodash';
 import { type Observable, of } from 'rxjs';
 
-import {
-  type AnnotationEvent,
+import {type AnnotationEvent,
   type AnnotationQuery,
   type DataFrame,
   DataFrameView,
-  type DataSourceApi,
-} from '@grafana/data';
+  type DataSourceApi, createClientLog} from '@grafana/data';
 import { config, toDataQueryError } from '@grafana/runtime';
 import { dispatch } from 'app/store/store';
 
@@ -15,6 +13,9 @@ import { createErrorNotification } from '../../../../core/copy/appNotification';
 import { notifyApp } from '../../../../core/reducers/appNotification';
 
 import { type DashboardQueryRunnerWorkerResult } from './types';
+const clientLog = createClientLog('public/app/features/query/state/DashboardQueryRunner/utils');
+
+
 
 export function handleAnnotationQueryRunnerError(err: any): Observable<AnnotationEvent[]> {
   if (err.cancelled) {
@@ -44,7 +45,7 @@ export function handleDashboardQueryRunnerWorkerError(err: any): Observable<Dash
 
 function notifyWithError(title: string, err: any) {
   const error = toDataQueryError(err);
-  console.error('handleAnnotationQueryRunnerError', error);
+  clientLog.error('handleAnnotationQueryRunnerError', error);
   const notification = createErrorNotification(title, error.message);
   dispatch(notifyApp(notification));
 }

--- a/public/app/features/query/state/PanelQueryRunner.ts
+++ b/public/app/features/query/state/PanelQueryRunner.ts
@@ -2,8 +2,7 @@ import { cloneDeep, isEqual } from 'lodash';
 import { forkJoin, type Observable, of, ReplaySubject, type Unsubscribable } from 'rxjs';
 import { map, mergeMap, catchError } from 'rxjs/operators';
 
-import {
-  applyFieldOverrides,
+import {applyFieldOverrides,
   compareArrayValues,
   compareDataFrameStructures,
   CoreApp,
@@ -28,8 +27,7 @@ import {
   preProcessPanelData,
   type ApplyFieldOverrideOptions,
   type StreamingDataFrame,
-  DataTopic,
-} from '@grafana/data';
+  DataTopic, createClientLog} from '@grafana/data';
 import { toDataQueryError } from '@grafana/runtime';
 import { ExpressionDatasourceRef } from '@grafana/runtime/internal';
 import { isStreamingDataFrame } from 'app/features/live/data/utils';
@@ -42,6 +40,9 @@ import { type PanelModel } from '../../dashboard/state/PanelModel';
 import { getDashboardQueryRunner } from './DashboardQueryRunner/DashboardQueryRunner';
 import { mergePanelAndDashData } from './mergePanelAndDashData';
 import { runRequest } from './runRequest';
+const clientLog = createClientLog('public/app/features/query/state/PanelQueryRunner');
+
+
 
 export interface QueryRunnerOptions<
   TQuery extends DataQuery = DataQuery,
@@ -257,7 +258,7 @@ export class PanelQueryRunner {
         return { ...data, series, annotations };
       }),
       catchError((err) => {
-        console.warn('Error running transformation:', err);
+        clientLog.warn('Error running transformation:', err);
         return of({
           ...data,
           state: LoadingState.Error,

--- a/public/app/features/query/state/QueryRunner.ts
+++ b/public/app/features/query/state/QueryRunner.ts
@@ -2,8 +2,7 @@ import { cloneDeep } from 'lodash';
 import { from, type Observable, ReplaySubject, type Unsubscribable } from 'rxjs';
 import { first } from 'rxjs/operators';
 
-import {
-  CoreApp,
+import {CoreApp,
   type DataQueryRequest,
   type DataSourceApi,
   type PanelData,
@@ -13,14 +12,16 @@ import {
   type QueryRunner as QueryRunnerSrv,
   LoadingState,
   type DataSourceRef,
-  preProcessPanelData,
-} from '@grafana/data';
+  preProcessPanelData, createClientLog} from '@grafana/data';
 import { getTemplateSrv } from '@grafana/runtime';
 import { getDatasourceSrv } from 'app/features/plugins/datasource_srv';
 
 import { getNextRequestId } from './PanelQueryRunner';
 import { setStructureRevision } from './processing/revision';
 import { runRequest } from './runRequest';
+const clientLog = createClientLog('public/app/features/query/state/QueryRunner');
+
+
 
 export class QueryRunner implements QueryRunnerSrv {
   private subject: ReplaySubject<PanelData>;
@@ -113,7 +114,7 @@ export class QueryRunner implements QueryRunnerSrv {
             },
           });
         },
-        error: (error) => console.error('PanelQueryRunner Error', error),
+        error: (error) => clientLog.error('PanelQueryRunner Error', error),
       });
   }
 

--- a/public/app/features/query/state/runRequest.ts
+++ b/public/app/features/query/state/runRequest.ts
@@ -5,8 +5,7 @@ import { catchError, map, mapTo, mergeMap, share, takeUntil, tap } from 'rxjs/op
 
 // Utils & Services
 // Types
-import {
-  CoreApp,
+import {CoreApp,
   type DataQueryError,
   type DataQueryRequest,
   type DataQueryResponse,
@@ -16,8 +15,7 @@ import {
   dateMath,
   LoadingState,
   type PanelData,
-  type TimeRange,
-} from '@grafana/data';
+  type TimeRange, createClientLog} from '@grafana/data';
 import { config, isMigrationHandler, migrateRequest, toDataQueryError, isExpressionReference } from '@grafana/runtime';
 import { backendSrv } from 'app/core/services/backend_srv';
 import { queryIsEmpty } from 'app/core/utils/query';
@@ -26,6 +24,9 @@ import { type ExpressionQuery } from 'app/features/expressions/types';
 
 import { cancelNetworkRequestsOnUnsubscribe } from './processing/canceler';
 import { emitDataRequestEvent } from './queryAnalytics';
+const clientLog = createClientLog('public/app/features/query/state/runRequest');
+
+
 
 type MapOfResponsePackets = { [str: string]: DataQueryResponse };
 
@@ -161,7 +162,7 @@ export function runRequest(
     }),
     // handle errors
     catchError((err) => {
-      console.error('runRequest.catchError', err);
+      clientLog.error('runRequest.catchError', err);
       return of({
         ...state.panelData,
         state: LoadingState.Error,

--- a/public/app/features/scopes/ScopesApiClient.ts
+++ b/public/app/features/scopes/ScopesApiClient.ts
@@ -1,10 +1,13 @@
-import { type Scope, type ScopeDashboardBinding, type ScopeNode } from '@grafana/data';
+import {type Scope, type ScopeDashboardBinding, type ScopeNode, createClientLog} from '@grafana/data';
 import { config } from '@grafana/runtime';
 import { scopeAPIv0alpha1 } from 'app/api/clients/scope/v0alpha1';
 import { getMessageFromError } from 'app/core/utils/errors';
 import { dispatch } from 'app/store/store';
 
 import { type ScopeNavigation } from './dashboards/types';
+const clientLog = createClientLog('public/app/features/scopes/ScopesApiClient');
+
+
 
 export class ScopesApiClient {
   /**
@@ -34,7 +37,7 @@ export class ScopesApiClient {
       // Check if the data is actually an error response (Kubernetes Status object)
       if (this.isStatusError(result.data)) {
         const errorMessage = getMessageFromError(result.data);
-        console.error(`Failed to fetch %s:`, context, errorMessage);
+        clientLog.error(`Failed to fetch %s:`, context, errorMessage);
         return undefined;
       }
       return result.data;
@@ -42,7 +45,7 @@ export class ScopesApiClient {
 
     if ('error' in result) {
       const errorMessage = getMessageFromError(result.error);
-      console.error(`Failed to fetch %s:`, context, errorMessage);
+      clientLog.error(`Failed to fetch %s:`, context, errorMessage);
     }
 
     return undefined;
@@ -54,7 +57,7 @@ export class ScopesApiClient {
       return this.extractDataOrHandleError(result, `scope: ${name}`);
     } catch (err) {
       const errorMessage = getMessageFromError(err);
-      console.error('Failed to fetch scope:', name, errorMessage);
+      clientLog.error('Failed to fetch scope:', name, errorMessage);
       return undefined;
     } finally {
       // Unsubscribe for extra safety, even though with subscribe: false and awaiting,
@@ -74,7 +77,7 @@ export class ScopesApiClient {
 
       if (successfulScopes.length < scopesIds.length) {
         const failedCount = scopesIds.length - successfulScopes.length;
-        console.warn(
+        clientLog.warn(
           'Failed to fetch',
           failedCount,
           'of',
@@ -87,7 +90,7 @@ export class ScopesApiClient {
       return successfulScopes;
     } catch (err) {
       const errorMessage = getMessageFromError(err);
-      console.error('Failed to fetch multiple scopes:', scopesIds, errorMessage);
+      clientLog.error('Failed to fetch multiple scopes:', scopesIds, errorMessage);
       return [];
     }
   }
@@ -110,13 +113,13 @@ export class ScopesApiClient {
 
       if ('error' in result) {
         const errorMessage = getMessageFromError(result.error);
-        console.error('Failed to fetch multiple scope nodes:', names, errorMessage);
+        clientLog.error('Failed to fetch multiple scope nodes:', names, errorMessage);
       }
 
       return [];
     } catch (err) {
       const errorMessage = getMessageFromError(err);
-      console.error('Failed to fetch multiple scope nodes:', names, errorMessage);
+      clientLog.error('Failed to fetch multiple scope nodes:', names, errorMessage);
       return [];
     } finally {
       // Unsubscribe for extra safety, even though with subscribe: false and awaiting,
@@ -170,7 +173,7 @@ export class ScopesApiClient {
         }
         contextParts.push('limit=' + limit);
         const context = contextParts.join(', ');
-        console.error('Failed to fetch scope nodes:', context, errorMessage);
+        clientLog.error('Failed to fetch scope nodes:', context, errorMessage);
       }
 
       return [];
@@ -185,7 +188,7 @@ export class ScopesApiClient {
       }
       contextParts.push('limit=' + limit);
       const context = contextParts.join(', ');
-      console.error('Failed to fetch scope nodes:', context, errorMessage);
+      clientLog.error('Failed to fetch scope nodes:', context, errorMessage);
       return [];
     } finally {
       // Unsubscribe for extra safety, even though with subscribe: false and awaiting,
@@ -213,13 +216,13 @@ export class ScopesApiClient {
 
       if ('error' in result) {
         const errorMessage = getMessageFromError(result.error);
-        console.error('Failed to fetch dashboards for scopes:', scopeNames, errorMessage);
+        clientLog.error('Failed to fetch dashboards for scopes:', scopeNames, errorMessage);
       }
 
       return [];
     } catch (err) {
       const errorMessage = getMessageFromError(err);
-      console.error('Failed to fetch dashboards for scopes:', scopeNames, errorMessage);
+      clientLog.error('Failed to fetch dashboards for scopes:', scopeNames, errorMessage);
       return [];
     } finally {
       // Unsubscribe for extra safety, even though with subscribe: false and awaiting,
@@ -252,13 +255,13 @@ export class ScopesApiClient {
 
       if ('error' in result) {
         const errorMessage = getMessageFromError(result.error);
-        console.error('Failed to fetch scope navigations for scopes:', scopeNames, errorMessage);
+        clientLog.error('Failed to fetch scope navigations for scopes:', scopeNames, errorMessage);
       }
 
       return [];
     } catch (err) {
       const errorMessage = getMessageFromError(err);
-      console.error('Failed to fetch scope navigations for scopes:', scopeNames, errorMessage);
+      clientLog.error('Failed to fetch scope navigations for scopes:', scopeNames, errorMessage);
       return [];
     } finally {
       // Unsubscribe for extra safety, even though with subscribe: false and awaiting,
@@ -280,7 +283,7 @@ export class ScopesApiClient {
       return this.extractDataOrHandleError(result, `scope node: ${scopeNodeId}`);
     } catch (err) {
       const errorMessage = getMessageFromError(err);
-      console.error('Failed to fetch scope node:', scopeNodeId, errorMessage);
+      clientLog.error('Failed to fetch scope node:', scopeNodeId, errorMessage);
       return undefined;
     } finally {
       // Unsubscribe for extra safety, even though with subscribe: false and awaiting,

--- a/public/app/features/scopes/ScopesService.ts
+++ b/public/app/features/scopes/ScopesService.ts
@@ -1,3 +1,4 @@
+import { createClientLog } from '@grafana/data';
 import { isEqual } from 'lodash';
 import { BehaviorSubject, type Observable, combineLatest, type Subscription } from 'rxjs';
 import { map, distinctUntilChanged } from 'rxjs/operators';
@@ -7,6 +8,9 @@ import { type LocationService, type ScopesContextValue, type ScopesContextValueS
 import { type ScopesDashboardsService } from './dashboards/ScopesDashboardsService';
 import { deserializeFolderPath, serializeFolderPath } from './dashboards/scopeNavgiationUtils';
 import { type ScopesSelectorService } from './selector/ScopesSelectorService';
+const clientLog = createClientLog('public/app/features/scopes/ScopesService');
+
+
 
 export interface State {
   enabled: boolean;
@@ -93,7 +97,7 @@ export class ScopesService implements ScopesContextValue {
     const nodeToPreload = scopeNodeId;
     if (nodeToPreload) {
       this.selectorService.resolvePathToRoot(nodeToPreload, this.selectorService.state.tree!).catch((error) => {
-        console.error('Failed to pre-load node path', error);
+        clientLog.error('Failed to pre-load node path', error);
       });
     }
 

--- a/public/app/features/scopes/selector/ScopesSelectorService.ts
+++ b/public/app/features/scopes/selector/ScopesSelectorService.ts
@@ -1,4 +1,4 @@
-import { type Scope, type ScopeNode, store as storeImpl } from '@grafana/data';
+import {type Scope, type ScopeNode, store as storeImpl, createClientLog} from '@grafana/data';
 import { config, locationService } from '@grafana/runtime';
 import { type performanceUtils } from '@grafana/scenes';
 import { getDashboardSceneProfiler } from 'app/features/dashboard/services/DashboardProfiler';
@@ -27,6 +27,9 @@ import {
   type SelectedScope,
   type TreeNode,
 } from './types';
+const clientLog = createClientLog('public/app/features/scopes/selector/ScopesSelectorService');
+
+
 
 export const RECENT_SCOPES_KEY = 'grafana.scopes.recent';
 
@@ -111,7 +114,7 @@ export class ScopesSelectorService extends ScopesServiceBase<ScopesSelectorServi
       }
       return node;
     } catch (error) {
-      console.error('Failed to load node', error);
+      clientLog.error('Failed to load node', error);
       return undefined;
     }
   };
@@ -119,7 +122,7 @@ export class ScopesSelectorService extends ScopesServiceBase<ScopesSelectorServi
   private getNodePath = async (scopeNodeId: string, visited: Set<string> = new Set()): Promise<ScopeNode[]> => {
     // Protect against circular references
     if (visited.has(scopeNodeId)) {
-      console.error('Circular reference detected in node path', scopeNodeId);
+      clientLog.error('Circular reference detected in node path', scopeNodeId);
       return [];
     }
 
@@ -449,7 +452,7 @@ export class ScopesSelectorService extends ScopesServiceBase<ScopesSelectorServi
 
       // Validate API response is an array
       if (!Array.isArray(fetchedScopes)) {
-        console.error('Expected fetchedScopes to be an array, got:', typeof fetchedScopes);
+        clientLog.error('Expected fetchedScopes to be an array, got:', typeof fetchedScopes);
         this.updateState({ scopes: newScopesState, loading: false });
         return;
       }
@@ -664,7 +667,7 @@ export class ScopesSelectorService extends ScopesServiceBase<ScopesSelectorServi
           newTree = expandNodes(newTree, parentPath);
         }
       } catch (error) {
-        console.error('Failed to expand to selected scope', error);
+        clientLog.error('Failed to expand to selected scope', error);
       }
     }
 
@@ -747,7 +750,7 @@ function parseScopesFromLocalStorage(content: string | undefined): RecentScope[]
   try {
     recentScopes = JSON.parse(content || '[]');
   } catch (e) {
-    console.error('Failed to parse recent scopes', e, content);
+    clientLog.error('Failed to parse recent scopes', e, content);
     return [];
   }
   if (!(Array.isArray(recentScopes) && Array.isArray(recentScopes[0]))) {

--- a/public/app/features/scopes/selector/scopesTreeUtils.ts
+++ b/public/app/features/scopes/selector/scopesTreeUtils.ts
@@ -1,6 +1,9 @@
-import { type ScopeNode } from '@grafana/data';
+import {type ScopeNode, createClientLog} from '@grafana/data';
 
 import { type NodesMap, type TreeNode } from './types';
+const clientLog = createClientLog('public/app/features/scopes/selector/scopesTreeUtils');
+
+
 
 /**
  * Creates a deep copy of the node tree with expanded prop set to false.
@@ -125,7 +128,7 @@ export const insertPathNodesIntoTree = (tree: TreeNode, path: ScopeNode[]) => {
     newTree = modifyTreeNodeAtPath(newTree, pathSlice, (treeNode) => {
       treeNode.children = { ...treeNode.children };
       if (!childNodeName) {
-        console.warn('Failed to insert full path into tree. Did not find child to' + stringPath[index]);
+        clientLog.warn('Failed to insert full path into tree. Did not find child to' + stringPath[index]);
         treeNode.childrenLoaded = treeNode.childrenLoaded ?? false;
         return;
       }

--- a/public/app/features/scopes/selector/useScopeNode.ts
+++ b/public/app/features/scopes/selector/useScopeNode.ts
@@ -1,8 +1,11 @@
 import { useEffect, useState } from 'react';
 
-import { type ScopeNode } from '@grafana/data';
+import {type ScopeNode, createClientLog} from '@grafana/data';
 
 import { useScopesServices } from '../ScopesContextProvider';
+const clientLog = createClientLog('public/app/features/scopes/selector/useScopeNode');
+
+
 
 // Light wrapper around the scopesSelectorService.getScopeNode to make it easier to use in the UI.
 export function useScopeNode(scopeNodeId?: string) {
@@ -21,7 +24,7 @@ export function useScopeNode(scopeNodeId?: string) {
         const node = await scopesSelectorService.getScopeNode(scopeNodeId);
         setNode(node);
       } catch (error) {
-        console.error('Failed to load node', error);
+        clientLog.error('Failed to load node', error);
       } finally {
         setIsLoading(false);
       }

--- a/public/app/features/search/service/deletedDashboardsCache.ts
+++ b/public/app/features/search/service/deletedDashboardsCache.ts
@@ -1,3 +1,4 @@
+import { createClientLog } from '@grafana/data';
 import { isResourceList } from 'app/features/apiserver/guards';
 import { type ResourceList } from 'app/features/apiserver/types';
 import { getDashboardAPI } from 'app/features/dashboard/api/dashboard_api';
@@ -5,6 +6,9 @@ import { type DashboardDataDTO } from 'app/types/dashboard';
 
 import { type SearchHit } from './unified';
 import { resourceToSearchResult } from './utils';
+const clientLog = createClientLog('public/app/features/search/service/deletedDashboardsCache');
+
+
 
 /**
  * Store deleted dashboards in the cache to avoid multiple calls to the API.
@@ -79,7 +83,7 @@ class DeletedDashboardsCache {
         items: [],
       };
     } catch (error) {
-      console.error('Failed to fetch deleted dashboards:', error);
+      clientLog.error('Failed to fetch deleted dashboards:', error);
       return {
         apiVersion: 'v1',
         kind: 'List',

--- a/public/app/features/search/service/unified.ts
+++ b/public/app/features/search/service/unified.ts
@@ -6,13 +6,11 @@ import {
   BASE_URL as v0alphaBaseURL,
   type ManagedBy,
 } from '@grafana/api-clients/rtkq/dashboard/v0alpha1';
-import {
-  arrayToDataFrame,
+import {arrayToDataFrame,
   type DataFrame,
   DataFrameView,
   getDisplayProcessor,
-  type SelectableValue,
-} from '@grafana/data';
+  type SelectableValue, createClientLog} from '@grafana/data';
 import { t } from '@grafana/i18n';
 import { config, getBackendSrv } from '@grafana/runtime';
 import { generatedAPI, type ListStarsApiResponse } from 'app/api/clients/collections/v1alpha1';
@@ -32,6 +30,9 @@ import {
   type SearchResultMeta,
 } from './types';
 import { appendFrame, filterSearchResults, replaceCurrentFolderQuery } from './utils';
+const clientLog = createClientLog('public/app/features/search/service/unified');
+
+
 
 // The backend returns an empty frame with a special name to indicate that the indexing engine is being rebuilt,
 // and that it can not serve any search requests. We are temporarily using the old SQL Search API as a fallback when that happens.
@@ -209,7 +210,7 @@ export class UnifiedSearcher implements GrafanaSearcher {
         const resp = await this.fetchResponse(nextPageUrl);
         const frame = toDashboardResults(resp, query.sort ?? '');
         if (!frame) {
-          console.log('no results', frame);
+          clientLog.info('no results', frame);
           return;
         }
 

--- a/public/app/features/search/service/utils.ts
+++ b/public/app/features/search/service/utils.ts
@@ -1,5 +1,5 @@
 import { type ManagedBy } from '@grafana/api-clients/rtkq/dashboard/v0alpha1';
-import { type DataFrame, type DataFrameView, type IconName, fuzzySearch } from '@grafana/data';
+import {type DataFrame, type DataFrameView, type IconName, fuzzySearch, createClientLog} from '@grafana/data';
 import { type DashboardViewItemWithUIItems } from 'app/features/browse-dashboards/types';
 import { isSharedWithMe, isVirtualTeamFolder } from 'app/features/browse-dashboards/utils/dashboards';
 import { getDashboardSrv } from 'app/features/dashboard/services/DashboardSrv';
@@ -15,6 +15,9 @@ import {
 
 import { type DashboardQueryResult, type SearchQuery, type SearchResultMeta } from './types';
 import { type SearchHit } from './unified';
+const clientLog = createClientLog('public/app/features/search/service/utils');
+
+
 
 /** prepare the query replacing folder:current */
 export async function replaceCurrentFolderQuery(query: SearchQuery): Promise<SearchQuery> {
@@ -40,7 +43,7 @@ async function getCurrentFolderUID(): Promise<string | undefined> {
     }
     return Promise.resolve(dash?.meta?.folderUid);
   } catch (e) {
-    console.error(e);
+    clientLog.error(e);
   }
   return undefined;
 }

--- a/public/app/features/serviceaccounts/ServiceAccountCreatePage.tsx
+++ b/public/app/features/serviceaccounts/ServiceAccountCreatePage.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useState, type JSX } from 'react';
 import { FormProvider, useForm } from 'react-hook-form';
 
-import { OrgRole } from '@grafana/data';
+import {OrgRole, createClientLog} from '@grafana/data';
 import { Trans, t } from '@grafana/i18n';
 import { config, getBackendSrv, locationService } from '@grafana/runtime';
 import { Button, Input, Field, FieldSet } from '@grafana/ui';
@@ -15,6 +15,9 @@ import { type Role, AccessControlAction } from 'app/types/accessControl';
 import { type ServiceAccountDTO, type ServiceAccountCreateApiResponse } from 'app/types/serviceaccount';
 
 import { OrgRolePicker } from '../admin/OrgRolePicker';
+const clientLog = createClientLog('public/app/features/serviceaccounts/ServiceAccountCreatePage');
+
+
 
 export interface Props {}
 
@@ -68,7 +71,7 @@ export const ServiceAccountCreatePage = ({}: Props): JSX.Element => {
           setRoleOptions(options);
         }
       } catch (e) {
-        console.error('Error loading options', e); // TODO: handle error
+        clientLog.error('Error loading options', e); // TODO: handle error
       }
     }
     if (contextSrv.licensedAccessControlEnabled()) {
@@ -101,7 +104,7 @@ export const ServiceAccountCreatePage = ({}: Props): JSX.Element => {
           await updateUserRoles(pendingRoles, newAccount.id, newAccount.orgId);
         }
       } catch (e) {
-        console.error(e); // TODO: handle error
+        clientLog.error(e); // TODO: handle error
       }
       locationService.push(`/org/serviceaccounts/${response.uid}`);
     },

--- a/public/app/features/serviceaccounts/components/ServiceAccountProfile.tsx
+++ b/public/app/features/serviceaccounts/components/ServiceAccountProfile.tsx
@@ -1,7 +1,7 @@
 import { css } from '@emotion/css';
 import { useEffect, useState, type JSX } from 'react';
 
-import { type GrafanaTheme2, type OrgRole, type TimeZone, dateTimeFormat } from '@grafana/data';
+import {type GrafanaTheme2, type OrgRole, type TimeZone, dateTimeFormat, createClientLog} from '@grafana/data';
 import { Trans, t } from '@grafana/i18n';
 import { Label, TextLink, useStyles2 } from '@grafana/ui';
 import { fetchRoleOptions } from 'app/core/components/RolePicker/api';
@@ -11,6 +11,9 @@ import { type ServiceAccountDTO } from 'app/types/serviceaccount';
 
 import { ServiceAccountProfileRow } from './ServiceAccountProfileRow';
 import { ServiceAccountRoleRow } from './ServiceAccountRoleRow';
+const clientLog = createClientLog('public/app/features/serviceaccounts/components/ServiceAccountProfile');
+
+
 
 interface Props {
   serviceAccount: ServiceAccountDTO;
@@ -39,7 +42,7 @@ export function ServiceAccountProfile({ serviceAccount, timeZone, onChange }: Pr
           setRoleOptions(options);
         }
       } catch (e) {
-        console.error('Error loading options for service account');
+        clientLog.error('Error loading options for service account');
       }
     }
     if (contextSrv.licensedAccessControlEnabled()) {

--- a/public/app/features/serviceaccounts/state/actions.ts
+++ b/public/app/features/serviceaccounts/state/actions.ts
@@ -1,3 +1,4 @@
+import { createClientLog } from '@grafana/data';
 import { debounce } from 'lodash';
 
 import { getBackendSrv } from '@grafana/runtime';
@@ -20,6 +21,9 @@ import {
   serviceAccountsFetchEnd,
   stateFilterChanged,
 } from './reducers';
+const clientLog = createClientLog('public/app/features/serviceaccounts/state/actions');
+
+
 
 const BASE_URL = `/api/serviceaccounts`;
 
@@ -31,7 +35,7 @@ export function fetchACOptions(): ThunkResult<void> {
         dispatch(acOptionsLoaded(options));
       }
     } catch (error) {
-      console.error(error);
+      clientLog.error(error);
     }
   };
 }
@@ -76,7 +80,7 @@ export function fetchServiceAccounts(
         dispatch(serviceAccountsFetched(result));
       }
     } catch (error) {
-      console.error(error);
+      clientLog.error(error);
     } finally {
       dispatch(serviceAccountsFetchEnd());
     }

--- a/public/app/features/serviceaccounts/state/actionsServiceAccountPage.ts
+++ b/public/app/features/serviceaccounts/state/actionsServiceAccountPage.ts
@@ -1,3 +1,4 @@
+import { createClientLog } from '@grafana/data';
 import { getBackendSrv, locationService } from '@grafana/runtime';
 import { accessControlQueryParam } from 'app/core/utils/accessControl';
 import { type ServiceAccountDTO } from 'app/types/serviceaccount';
@@ -11,6 +12,9 @@ import {
   serviceAccountLoaded,
   serviceAccountTokensLoaded,
 } from './reducers';
+const clientLog = createClientLog('public/app/features/serviceaccounts/state/actionsServiceAccountPage');
+
+
 
 const BASE_URL = `/api/serviceaccounts`;
 
@@ -21,7 +25,7 @@ export function loadServiceAccount(saUid: string): ThunkResult<void> {
       const response = await getBackendSrv().get(`${BASE_URL}/${saUid}`, accessControlQueryParam());
       dispatch(serviceAccountLoaded(response));
     } catch (error) {
-      console.error(error);
+      clientLog.error(error);
     } finally {
       dispatch(serviceAccountFetchEnd());
     }
@@ -69,7 +73,7 @@ export function loadServiceAccountTokens(saUid: string): ThunkResult<void> {
       const response = await getBackendSrv().get(`${BASE_URL}/${saUid}/tokens`);
       dispatch(serviceAccountTokensLoaded(response));
     } catch (error) {
-      console.error(error);
+      clientLog.error(error);
     }
   };
 }

--- a/public/app/features/teams/TeamList.tsx
+++ b/public/app/features/teams/TeamList.tsx
@@ -1,3 +1,4 @@
+import { createClientLog } from '@grafana/data';
 import { css } from '@emotion/css';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import Skeleton from 'react-loading-skeleton';
@@ -38,6 +39,9 @@ import { EnterpriseAuthFeaturesCard } from '../admin/EnterpriseAuthFeaturesCard'
 
 import { TeamDeleteModal } from './TeamDeleteModal';
 import { useDeleteTeam, useGetTeams } from './hooks';
+const clientLog = createClientLog('public/app/features/teams/TeamList');
+
+
 
 type Cell<T extends keyof TeamWithRoles = keyof TeamWithRoles> = CellProps<TeamWithRoles, TeamWithRoles[T]>;
 
@@ -235,7 +239,7 @@ const TeamList = () => {
                     'Failed to check if the team owns folders. Please try again.'
                   )
                 );
-                console.error(error);
+                clientLog.error(error);
                 return;
               }
 

--- a/public/app/features/templating/LegacyVariableWrapper.ts
+++ b/public/app/features/templating/LegacyVariableWrapper.ts
@@ -1,7 +1,11 @@
+import { createClientLog } from '@grafana/data';
 import { type VariableValue, type FormatVariable } from '@grafana/scenes';
 import { type VariableModel, type VariableType } from '@grafana/schema';
 
 import { ALL_VARIABLE_TEXT, ALL_VARIABLE_VALUE } from '../variables/constants';
+const clientLog = createClientLog('public/app/features/templating/LegacyVariableWrapper');
+
+
 
 export class LegacyVariableWrapper implements FormatVariable {
   state: { name: string; value: VariableValue; text: VariableValue; type: VariableType };
@@ -31,7 +35,7 @@ export class LegacyVariableWrapper implements FormatVariable {
       return text.join(' + ');
     }
 
-    console.log('value', text);
+    clientLog.info('value', text);
     return String(text);
   }
 }

--- a/public/app/features/templating/formatVariableValue.ts
+++ b/public/app/features/templating/formatVariableValue.ts
@@ -1,9 +1,13 @@
+import { createClientLog } from '@grafana/data';
 import { formatRegistry } from '@grafana/scenes';
 import { VariableFormatID } from '@grafana/schema';
 
 import { isAdHoc } from '../variables/guard';
 
 import { getVariableWrapper } from './LegacyVariableWrapper';
+const clientLog = createClientLog('public/app/features/templating/formatVariableValue');
+
+
 
 export function formatVariableValue(value: any, format?: any, variable?: any, text?: string): string {
   // for some scopedVars there is no variable
@@ -42,7 +46,7 @@ export function formatVariableValue(value: any, format?: any, variable?: any, te
   let formatItem = formatRegistry.getIfExists(format);
 
   if (!formatItem) {
-    console.error(`Variable format ${format} not found. Using glob format as fallback.`);
+    clientLog.error(`Variable format ${format} not found. Using glob format as fallback.`);
     formatItem = formatRegistry.get(VariableFormatID.Glob);
   }
 

--- a/public/app/features/theme-playground/ThemePlayground.tsx
+++ b/public/app/features/theme-playground/ThemePlayground.tsx
@@ -1,7 +1,7 @@
 import { css } from '@emotion/css';
 import { useId, useState } from 'react';
 
-import { createTheme, type GrafanaTheme2, type NewThemeOptions } from '@grafana/data';
+import {createTheme, type GrafanaTheme2, type NewThemeOptions, createClientLog} from '@grafana/data';
 import { NewThemeOptionsSchema } from '@grafana/data/internal';
 import aubergine from '@grafana/data/themes/definitions/aubergine.json';
 import debug from '@grafana/data/themes/definitions/debug.json';
@@ -32,6 +32,9 @@ import { HOME_NAV_ID } from '../../core/reducers/navModel';
 import { getNavModel } from '../../core/selectors/navModel';
 import { ThemeProvider } from '../../core/utils/ConfigProvider';
 import { useDispatch, useSelector } from '../../types/store';
+const clientLog = createClientLog('public/app/features/theme-playground/ThemePlayground');
+
+
 
 const themeMap: Record<string, NewThemeOptions> = {
   dark: {
@@ -73,7 +76,7 @@ const experimentalDefinitions: Record<string, unknown> = {
 for (const [name, json] of Object.entries(experimentalDefinitions)) {
   const result = NewThemeOptionsSchema.safeParse(json);
   if (!result.success) {
-    console.error(`Invalid theme definition for theme ${name}: ${result.error.message}`);
+    clientLog.error(`Invalid theme definition for theme ${name}: ${result.error.message}`);
   } else {
     themeMap[result.data.id] = result.data;
   }

--- a/public/app/features/transformers/calculateHeatmap/heatmap.ts
+++ b/public/app/features/transformers/calculateHeatmap/heatmap.ts
@@ -1,7 +1,6 @@
 import { map } from 'rxjs';
 
-import {
-  type DataFrame,
+import {type DataFrame,
   DataTransformerID,
   FieldType,
   incrRoundUp,
@@ -592,7 +591,7 @@ function heatmap(xs: number[], ys: number[], opts?: HeatmapOpts) {
     yBinIncr = yIncrs[Math.max(yIncrIdx, 0)];
   }
 
-  // console.log({
+  // clientLog.info({
   //   yBinIncr,
   //   xBinIncr,
   // });

--- a/public/app/features/transformers/editors/FilterByNameTransformerEditor.tsx
+++ b/public/app/features/transformers/editors/FilterByNameTransformerEditor.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
 
-import {
-  DataTransformerID,
+import {DataTransformerID,
   type KeyValue,
   standardTransformers,
   type TransformerRegistryItem,
@@ -9,8 +8,7 @@ import {
   getFieldDisplayName,
   stringToJsRegex,
   TransformerCategory,
-  type SelectableValue,
-} from '@grafana/data';
+  type SelectableValue, createClientLog} from '@grafana/data';
 import { type FilterFieldsByNameTransformerOptions } from '@grafana/data/internal';
 import { t } from '@grafana/i18n';
 import { getTemplateSrv } from '@grafana/runtime';
@@ -18,6 +16,9 @@ import { Input, FilterPill, InlineFieldRow, InlineField, InlineSwitch, Select } 
 
 import darkImage from '../images/dark/filterFieldsByName.svg';
 import lightImage from '../images/light/filterFieldsByName.svg';
+const clientLog = createClientLog('public/app/features/transformers/editors/FilterByNameTransformerEditor');
+
+
 
 interface FilterByNameTransformerEditorProps extends TransformerUIProps<FilterFieldsByNameTransformerOptions> {}
 
@@ -101,7 +102,7 @@ export class FilterByNameTransformerEditor extends React.PureComponent<
           }
         }
       } catch (error) {
-        console.error(error);
+        clientLog.error(error);
       }
     }
 

--- a/public/app/features/transformers/extractFields/fieldExtractors.ts
+++ b/public/app/features/transformers/extractFields/fieldExtractors.ts
@@ -1,6 +1,9 @@
-import { escapeStringForRegex, Registry, type RegistryItem, stringStartsAsRegEx, stringToJsRegex } from '@grafana/data';
+import {escapeStringForRegex, Registry, type RegistryItem, stringStartsAsRegEx, stringToJsRegex, createClientLog} from '@grafana/data';
 
 import { type ExtractFieldsOptions, FieldExtractorID } from './types';
+const clientLog = createClientLog('public/app/features/transformers/extractFields/fieldExtractors');
+
+
 
 type Parser = (v: string) => Record<string, any> | undefined;
 
@@ -29,7 +32,7 @@ const extRegExp: FieldExtractor = {
         regex = stringToJsRegex(options.regExp!);
       } catch (error) {
         if (error instanceof Error) {
-          console.warn(error.message);
+          clientLog.warn(error.message);
         }
       }
     }

--- a/public/app/features/transformers/spatial/SpatialTransformerEditor.tsx
+++ b/public/app/features/transformers/spatial/SpatialTransformerEditor.tsx
@@ -1,16 +1,14 @@
 import { css } from '@emotion/css';
 import { useEffect } from 'react';
 
-import {
-  DataTransformerID,
+import {DataTransformerID,
   type GrafanaTheme2,
   type PanelOptionsEditorBuilder,
   PluginState,
   type StandardEditorContext,
   type TransformerRegistryItem,
   type TransformerUIProps,
-  TransformerCategory,
-} from '@grafana/data';
+  TransformerCategory, createClientLog} from '@grafana/data';
 import { t } from '@grafana/i18n';
 import { FrameGeometrySourceMode } from '@grafana/schema';
 import { useTheme2 } from '@grafana/ui';
@@ -22,6 +20,9 @@ import lightImage from '../images/light/spatial.svg';
 import { SpatialCalculation, SpatialOperation, SpatialAction, type SpatialTransformOptions } from './models.gen';
 import { getDefaultOptions, getTransformerOptionPane } from './optionsHelper';
 import { isLineBuilderOption, getSpatialTransformer } from './spatialTransformer';
+const clientLog = createClientLog('public/app/features/transformers/spatial/SpatialTransformerEditor');
+
+
 
 // Nothing defined in state
 const supplier = (
@@ -137,7 +138,7 @@ export const SetGeometryTransformerEditor = (props: Props) => {
     if (!props.options.source?.mode) {
       const opts = getDefaultOptions(supplier);
       props.onChange({ ...opts, ...props.options });
-      console.log('geometry useEffect', opts);
+      clientLog.info('geometry useEffect', opts);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);

--- a/public/app/features/variables/adhoc/AdHocVariableEditor.tsx
+++ b/public/app/features/variables/adhoc/AdHocVariableEditor.tsx
@@ -1,6 +1,6 @@
 import { memo, useEffect } from 'react';
 
-import { type AdHocVariableModel, type DataSourceInstanceSettings, getDataSourceRef } from '@grafana/data';
+import {type AdHocVariableModel, type DataSourceInstanceSettings, getDataSourceRef, createClientLog} from '@grafana/data';
 import { AdHocVariableForm } from 'app/features/dashboard-scene/settings/variables/components/AdHocVariableForm';
 import { type StoreState, useDispatch, useSelector } from 'app/types/store';
 
@@ -11,6 +11,9 @@ import { getVariablesState } from '../state/selectors';
 import { toKeyedVariableIdentifier } from '../utils';
 
 import { changeVariableDatasource } from './actions';
+const clientLog = createClientLog('public/app/features/variables/adhoc/AdHocVariableEditor');
+
+
 
 interface Props extends VariableEditorProps<AdHocVariableModel> {}
 
@@ -30,7 +33,7 @@ export const AdHocVariableEditor = memo(function AdHocVariableEditor({ variable 
 
   useEffect(() => {
     if (!variable.rootStateKey) {
-      console.error('AdHocVariableEditor: variable has no rootStateKey');
+      clientLog.error('AdHocVariableEditor: variable has no rootStateKey');
     }
   }, [variable.rootStateKey]);
 

--- a/public/app/features/variables/datasource/DataSourceVariableEditor.tsx
+++ b/public/app/features/variables/datasource/DataSourceVariableEditor.tsx
@@ -1,6 +1,6 @@
 import { type FormEvent, memo, useEffect } from 'react';
 
-import { type DataSourceVariableModel, type SelectableValue, type VariableWithMultiSupport } from '@grafana/data';
+import {type DataSourceVariableModel, type SelectableValue, type VariableWithMultiSupport, createClientLog} from '@grafana/data';
 import { DataSourceVariableForm } from 'app/features/dashboard-scene/settings/variables/components/DataSourceVariableForm';
 import { type StoreState, useDispatch, useSelector } from 'app/types/store';
 
@@ -12,6 +12,9 @@ import { getVariablesState } from '../state/selectors';
 import { toKeyedVariableIdentifier } from '../utils';
 
 import { initDataSourceVariableEditor } from './actions';
+const clientLog = createClientLog('public/app/features/variables/datasource/DataSourceVariableEditor');
+
+
 
 interface Props extends VariableEditorProps<DataSourceVariableModel> {}
 
@@ -21,7 +24,7 @@ export const DataSourceVariableEditor = memo(function DataSourceVariableEditor({
   const extended = useSelector((state: StoreState) => {
     const { rootStateKey } = variable;
     if (!rootStateKey) {
-      console.error('DataSourceVariableEditor: variable has no rootStateKey');
+      clientLog.error('DataSourceVariableEditor: variable has no rootStateKey');
       return getDatasourceVariableEditorState(initialVariableEditorState);
     }
 
@@ -32,7 +35,7 @@ export const DataSourceVariableEditor = memo(function DataSourceVariableEditor({
   useEffect(() => {
     const { rootStateKey } = variable;
     if (!rootStateKey) {
-      console.error('DataSourceVariableEditor: variable has no rootStateKey');
+      clientLog.error('DataSourceVariableEditor: variable has no rootStateKey');
       return;
     }
 

--- a/public/app/features/variables/pickers/OptionsPicker/OptionsPicker.tsx
+++ b/public/app/features/variables/pickers/OptionsPicker/OptionsPicker.tsx
@@ -3,12 +3,10 @@ import { type ComponentType, PureComponent } from 'react';
 import { connect, type ConnectedProps } from 'react-redux';
 import { bindActionCreators } from 'redux';
 
-import {
-  LoadingState,
+import {LoadingState,
   type VariableOption,
   type VariableWithMultiSupport,
-  type VariableWithOptions,
-} from '@grafana/data';
+  type VariableWithOptions, createClientLog} from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';
 import { ClickOutsideWrapper } from '@grafana/ui';
 import { type StoreState, type ThunkDispatch } from 'app/types/store';
@@ -28,6 +26,9 @@ import { type NavigationKey, type VariablePickerProps } from '../types';
 
 import { commitChangesToVariable, filterOrSearchOptions, navigateOptions, openOptions } from './actions';
 import { initialOptionPickerState, type OptionsPickerState, toggleAllOptions, toggleOption } from './reducer';
+const clientLog = createClientLog('public/app/features/variables/pickers/OptionsPicker/OptionsPicker');
+
+
 
 export const optionPickerFactory = <Model extends VariableWithOptions | VariableWithMultiSupport>(): ComponentType<
   VariablePickerProps<Model>
@@ -52,7 +53,7 @@ export const optionPickerFactory = <Model extends VariableWithOptions | Variable
   const mapStateToProps = (state: StoreState, ownProps: OwnProps) => {
     const { rootStateKey } = ownProps.variable;
     if (!rootStateKey) {
-      console.error('OptionPickerFactory: variable has no rootStateKey');
+      clientLog.error('OptionPickerFactory: variable has no rootStateKey');
       return {
         picker: initialOptionPickerState,
       };
@@ -74,7 +75,7 @@ export const optionPickerFactory = <Model extends VariableWithOptions | Variable
       this.props.openOptions(toKeyedVariableIdentifier(this.props.variable), this.props.onVariableChange);
     onHideOptions = () => {
       if (!this.props.variable.rootStateKey) {
-        console.error('Variable has no rootStateKey');
+        clientLog.error('Variable has no rootStateKey');
         return;
       }
 
@@ -108,7 +109,7 @@ export const optionPickerFactory = <Model extends VariableWithOptions | Variable
 
     onNavigate = (key: NavigationKey, clearOthers: boolean) => {
       if (!this.props.variable.rootStateKey) {
-        console.error('Variable has no rootStateKey');
+        clientLog.error('Variable has no rootStateKey');
         return;
       }
 

--- a/public/app/features/variables/pickers/OptionsPicker/actions.ts
+++ b/public/app/features/variables/pickers/OptionsPicker/actions.ts
@@ -1,6 +1,6 @@
 import { debounce, trim } from 'lodash';
 
-import { isEmptyObject, containsSearchFilter, type VariableWithOptions, type VariableOption } from '@grafana/data';
+import {isEmptyObject, containsSearchFilter, type VariableWithOptions, type VariableOption, createClientLog} from '@grafana/data';
 import { type StoreState, type ThunkDispatch, type ThunkResult } from 'app/types/store';
 
 import { variableAdapters } from '../../adapters';
@@ -22,6 +22,9 @@ import {
   updateOptionsFromSearch,
   updateSearchQuery,
 } from './reducer';
+const clientLog = createClientLog('public/app/features/variables/pickers/OptionsPicker/actions');
+
+
 
 export const navigateOptions = (rootStateKey: string, key: NavigationKey, clearOthers: boolean): ThunkResult<void> => {
   return async (dispatch, getState) => {
@@ -180,7 +183,7 @@ const searchForOptions = async (
 
     dispatch(toKeyedAction(key, updateOptionsFromSearch(updated.options)));
   } catch (error) {
-    console.error(error);
+    clientLog.error(error);
   }
 };
 

--- a/public/app/features/variables/query/QueryVariableEditor.tsx
+++ b/public/app/features/variables/query/QueryVariableEditor.tsx
@@ -1,14 +1,12 @@
 import { type FormEvent, PureComponent } from 'react';
 import { connect, type ConnectedProps } from 'react-redux';
 
-import {
-  type DataSourceInstanceSettings,
+import {type DataSourceInstanceSettings,
   getDataSourceRef,
   type QueryVariableModel,
   type SelectableValue,
   type VariableRefresh,
-  type VariableSort,
-} from '@grafana/data';
+  type VariableSort, createClientLog} from '@grafana/data';
 import { QueryVariableEditorForm } from 'app/features/dashboard-scene/settings/variables/components/QueryVariableForm';
 import { type StoreState } from 'app/types/store';
 
@@ -21,11 +19,14 @@ import { getVariablesState } from '../state/selectors';
 import { toKeyedVariableIdentifier } from '../utils';
 
 import { changeQueryVariableDataSource, changeQueryVariableQuery, initQueryVariableEditor } from './actions';
+const clientLog = createClientLog('public/app/features/variables/query/QueryVariableEditor');
+
+
 
 const mapStateToProps = (state: StoreState, ownProps: OwnProps) => {
   const { rootStateKey } = ownProps.variable;
   if (!rootStateKey) {
-    console.error('QueryVariableEditor: variable has no rootStateKey');
+    clientLog.error('QueryVariableEditor: variable has no rootStateKey');
     return {
       extended: getQueryVariableEditorState(initialVariableEditorState),
     };

--- a/public/app/features/variables/query/actions.ts
+++ b/public/app/features/variables/query/actions.ts
@@ -1,6 +1,6 @@
 import { Subscription } from 'rxjs';
 
-import { type DataSourceRef } from '@grafana/data';
+import {type DataSourceRef, createClientLog} from '@grafana/data';
 import { getDataSourceSrv, toDataQueryError } from '@grafana/runtime';
 import { type ThunkResult } from 'app/types/store';
 
@@ -16,6 +16,9 @@ import { hasOngoingTransaction, toKeyedVariableIdentifier, toVariablePayload } f
 
 import { getVariableQueryRunner } from './VariableQueryRunner';
 import { variableQueryObserver } from './variableQueryObserver';
+const clientLog = createClientLog('public/app/features/variables/query/actions');
+
+
 
 export const updateQueryVariableOptions = (
   identifier: KeyedVariableIdentifier,
@@ -109,7 +112,7 @@ export const changeQueryVariableDataSource = (
         )
       );
     } catch (err) {
-      console.error(err);
+      clientLog.error(err);
     }
   };
 };

--- a/public/app/features/variables/query/operators.ts
+++ b/public/app/features/variables/query/operators.ts
@@ -1,15 +1,13 @@
 import { from, of, type OperatorFunction } from 'rxjs';
 import { map, mergeMap } from 'rxjs/operators';
 
-import {
-  FieldType,
+import {FieldType,
   getFieldDisplayName,
   getProcessedDataFrames,
   isDataFrame,
   type MetricFindValue,
   type PanelData,
-  type QueryVariableModel,
-} from '@grafana/data';
+  type QueryVariableModel, createClientLog} from '@grafana/data';
 import { type ThunkDispatch } from 'app/types/store';
 
 import { validateVariableSelectionState } from '../state/actions';
@@ -17,6 +15,9 @@ import { toKeyedAction } from '../state/keyedVariablesReducer';
 import { type getTemplatedRegex, toKeyedVariableIdentifier, toVariablePayload } from '../utils';
 
 import { updateVariableOptions } from './reducer';
+const clientLog = createClientLog('public/app/features/variables/query/operators');
+
+
 
 export function toMetricFindValuesOperator(): OperatorFunction<PanelData, MetricFindValue[]> {
   return (source) => source.pipe(map(toMetricFindValues));
@@ -110,7 +111,7 @@ export function updateOptionsState(args: {
       map((results) => {
         const { variable, dispatch, getTemplatedRegexFunc } = args;
         if (!variable.rootStateKey) {
-          console.error('updateOptionsState: variable.rootStateKey is not defined');
+          clientLog.error('updateOptionsState: variable.rootStateKey is not defined');
           return;
         }
         const templatedRegex = getTemplatedRegexFunc(variable);

--- a/public/app/features/variables/state/actions.ts
+++ b/public/app/features/variables/state/actions.ts
@@ -1,7 +1,6 @@
 import { castArray, isEqual } from 'lodash';
 
-import {
-  type DataQuery,
+import {type DataQuery,
   getDataSourceRef,
   isDataSourceRef,
   isEmptyObject,
@@ -18,8 +17,7 @@ import {
   VariableHide,
   type VariableOption,
   VariableRefresh,
-  type VariableWithOptions,
-} from '@grafana/data';
+  type VariableWithOptions, createClientLog} from '@grafana/data';
 import { config, locationService, logWarning, reportInteraction } from '@grafana/runtime';
 import { notifyApp } from 'app/core/reducers/appNotification';
 import { contextSrv } from 'app/core/services/context_srv';
@@ -81,6 +79,9 @@ import {
 } from './transactionReducer';
 import { type KeyedVariableIdentifier } from './types';
 import { cleanVariables } from './variablesReducer';
+const clientLog = createClientLog('public/app/features/variables/state/actions');
+
+
 
 export const initDashboardTemplating = (key: string, dashboard: DashboardModel): ThunkResult<void> => {
   return (dispatch, getState) => {
@@ -779,7 +780,7 @@ export const onTimeRangeUpdated =
       await Promise.all(promises);
       dependencies.events.publish(new VariablesTimeRangeProcessDone({ variableIds }));
     } catch (error) {
-      console.error(error);
+      clientLog.error(error);
       dispatch(notifyApp(createVariableErrorNotification('Template variable service failed', error)));
     }
   };
@@ -933,7 +934,7 @@ export const initVariablesTransaction =
       dispatch(toKeyedAction(uid, variablesCompleteTransaction({ uid })));
     } catch (err) {
       dispatch(notifyApp(createVariableErrorNotification('Templating init failed', err)));
-      console.error(err);
+      clientLog.error(err);
     }
   };
 
@@ -1004,7 +1005,7 @@ export const updateOptions =
       dispatch(toKeyedAction(rootStateKey, variableStateFailed(toVariablePayload(identifier, { error }))));
 
       if (!rethrow) {
-        console.error(error);
+        clientLog.error(error);
         dispatch(notifyApp(createVariableErrorNotification('Error updating options:', error, identifier)));
       }
 
@@ -1084,7 +1085,7 @@ export function upgradeLegacyQueries(
       );
     } catch (err) {
       dispatch(notifyApp(createVariableErrorNotification('Failed to upgrade legacy queries', err)));
-      console.error(err);
+      clientLog.error(err);
     }
   };
 }

--- a/public/app/features/variables/switch/SwitchVariablePicker.tsx
+++ b/public/app/features/variables/switch/SwitchVariablePicker.tsx
@@ -1,10 +1,13 @@
 import { type ChangeEvent, type ReactElement, useCallback } from 'react';
 
-import { type SwitchVariableModel } from '@grafana/data';
+import {type SwitchVariableModel, createClientLog} from '@grafana/data';
 import { Switch } from '@grafana/ui';
 
 import { variableAdapters } from '../adapters';
 import { type VariablePickerProps } from '../pickers/types';
+const clientLog = createClientLog('public/app/features/variables/switch/SwitchVariablePicker');
+
+
 
 export interface Props extends VariablePickerProps<SwitchVariableModel> {}
 
@@ -12,7 +15,7 @@ export function SwitchVariablePicker({ variable, onVariableChange }: Props): Rea
   const updateVariable = useCallback(
     (event: ChangeEvent<HTMLInputElement>) => {
       if (!variable.rootStateKey) {
-        console.error('Cannot update variable without rootStateKey');
+        clientLog.error('Cannot update variable without rootStateKey');
         return;
       }
 

--- a/public/app/features/variables/textbox/TextBoxVariablePicker.tsx
+++ b/public/app/features/variables/textbox/TextBoxVariablePicker.tsx
@@ -8,7 +8,7 @@ import {
   useState,
 } from 'react';
 
-import { type TextBoxVariableModel, isEmptyObject } from '@grafana/data';
+import {type TextBoxVariableModel, isEmptyObject, createClientLog} from '@grafana/data';
 import { t } from '@grafana/i18n';
 import { Input } from '@grafana/ui';
 import { useDispatch } from 'app/types/store';
@@ -19,6 +19,9 @@ import { type VariablePickerProps } from '../pickers/types';
 import { toKeyedAction } from '../state/keyedVariablesReducer';
 import { changeVariableProp } from '../state/sharedReducer';
 import { toVariablePayload } from '../utils';
+const clientLog = createClientLog('public/app/features/variables/textbox/TextBoxVariablePicker');
+
+
 
 export interface Props extends VariablePickerProps<TextBoxVariableModel> {}
 
@@ -31,7 +34,7 @@ export function TextBoxVariablePicker({ variable, onVariableChange, readOnly }: 
 
   const updateVariable = useCallback(() => {
     if (!variable.rootStateKey) {
-      console.error('Cannot update variable without rootStateKey');
+      clientLog.error('Cannot update variable without rootStateKey');
       return;
     }
 

--- a/public/app/index.ts
+++ b/public/app/index.ts
@@ -1,3 +1,7 @@
+import { createClientLog } from '@grafana/data';
+const clientLog = createClientLog('public/app/index');
+
+
 // The new index.html fetches window.grafanaBootData asynchronously.
 // Since much of Grafana depends on it in includes side effects at import time,
 // we delay loading the rest of the app using import() until the boot data is ready.
@@ -32,7 +36,7 @@ bootstrapWindowData().catch((error) => {
   const isRedirect = error && error.redirect && typeof error.redirect === 'string';
   // If a redirect was thrown, just ignore this. The index.html will handle the redirect
   if (!isRedirect) {
-    console.error('Error bootstrapping Grafana', error);
+    clientLog.error('Error bootstrapping Grafana', error);
     window.__grafana_load_failed();
   }
 });

--- a/public/app/plugins/datasource/azuremonitor/azure_monitor/azure_monitor_datasource.ts
+++ b/public/app/plugins/datasource/azuremonitor/azure_monitor/azure_monitor_datasource.ts
@@ -1,7 +1,7 @@
 import { find } from 'lodash';
 
 import { type AzureCredentials } from '@grafana/azure-sdk';
-import { type ScopedVars } from '@grafana/data';
+import {type ScopedVars, createClientLog} from '@grafana/data';
 import { DataSourceWithBackend, getTemplateSrv, type TemplateSrv } from '@grafana/runtime';
 
 import { getCredentials } from '../credentials';
@@ -32,6 +32,9 @@ import migrateQuery from '../utils/migrateQuery';
 
 import ResponseParser from './response_parser';
 import UrlBuilder from './url_builder';
+const clientLog = createClientLog('public/app/plugins/datasource/azuremonitor/azure_monitor/azure_monitor_datasource');
+
+
 
 const defaultDropdownValue = 'select';
 
@@ -218,7 +221,7 @@ export default class AzureMonitorDatasource extends DataSourceWithBackend<
         return result;
       })
       .catch((reason) => {
-        console.error(`Failed to get metric namespaces: ${reason}`);
+        clientLog.error(`Failed to get metric namespaces: ${reason}`);
         return [];
       });
   }

--- a/public/app/plugins/datasource/azuremonitor/components/LogsQueryEditor/LogsQueryEditor.tsx
+++ b/public/app/plugins/datasource/azuremonitor/components/LogsQueryEditor/LogsQueryEditor.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 
-import { type PanelData, type TimeRange } from '@grafana/data';
+import {type PanelData, type TimeRange, createClientLog} from '@grafana/data';
 import { Trans } from '@grafana/i18n';
 import { EditorFieldGroup, EditorRow, EditorRows } from '@grafana/plugin-ui';
 import { config, getTemplateSrv } from '@grafana/runtime';
@@ -25,6 +25,9 @@ import { TimeManagement } from './TimeManagement';
 import { onLoad, setBasicLogsQuery, setFormatAs, setKustoQuery } from './setQueryValue';
 import useMigrations from './useMigrations';
 import { shouldShowBasicLogsToggle } from './utils';
+const clientLog = createClientLog('public/app/plugins/datasource/azuremonitor/components/LogsQueryEditor/LogsQueryEditor');
+
+
 
 interface LogsQueryEditorProps {
   query: AzureMonitorQuery;
@@ -193,11 +196,11 @@ const LogsQueryEditor = ({
           setDataIngestedWarning(null);
         }
       } catch (err) {
-        console.error(err);
+        clientLog.error(err);
       }
     };
 
-    getBasicLogsUsage(query).catch((err) => console.error(err));
+    getBasicLogsUsage(query).catch((err) => clientLog.error(err));
   }, [datasource.azureLogAnalyticsDatasource, query, showBasicLogsToggle, from, to]);
   let portalLinkButton = null;
 

--- a/public/app/plugins/datasource/azuremonitor/components/LogsQueryEditor/QueryField.tsx
+++ b/public/app/plugins/datasource/azuremonitor/components/LogsQueryEditor/QueryField.tsx
@@ -1,3 +1,4 @@
+import { createClientLog } from '@grafana/data';
 import { type EngineSchema, getKustoWorker } from '@kusto/monaco-kusto';
 import { useCallback, useEffect, useState } from 'react';
 
@@ -6,6 +7,9 @@ import { CodeEditor, type Monaco, type MonacoEditor } from '@grafana/ui';
 import { type AzureQueryEditorFieldProps } from '../../types/types';
 
 import { setKustoQuery } from './setQueryValue';
+const clientLog = createClientLog('public/app/plugins/datasource/azuremonitor/components/LogsQueryEditor/QueryField');
+
+
 
 interface MonacoEditorValues {
   editor: MonacoEditor;
@@ -29,11 +33,11 @@ const QueryField = ({ query, onQueryChange, schema }: AzureQueryEditorFieldProps
           await kustoMode.setSchema(schema);
         }
       } catch (err) {
-        console.error(err);
+        clientLog.error(err);
       }
     };
 
-    setupEditor(monaco, schema).catch((err) => console.error(err));
+    setupEditor(monaco, schema).catch((err) => clientLog.error(err));
   }, [schema, monaco]);
 
   const handleEditorMount = useCallback((editor: MonacoEditor, monaco: Monaco) => {

--- a/public/app/plugins/datasource/azuremonitor/credentials.ts
+++ b/public/app/plugins/datasource/azuremonitor/credentials.ts
@@ -1,3 +1,4 @@
+import { createClientLog } from '@grafana/data';
 import {
   type AzureCredentials,
   getDatasourceCredentials,
@@ -9,6 +10,9 @@ import {
 import { config } from '@grafana/runtime';
 
 import { type AzureMonitorDataSourceInstanceSettings, type AzureMonitorDataSourceSettings } from './types/types';
+const clientLog = createClientLog('public/app/plugins/datasource/azuremonitor/credentials');
+
+
 
 export function getCredentials(
   options: AzureMonitorDataSourceSettings | AzureMonitorDataSourceInstanceSettings
@@ -57,7 +61,7 @@ function getLegacyCredentials(
     return { authType: options.jsonData.azureAuthType };
   } catch (e) {
     if (e instanceof Error) {
-      console.error('Unable to restore legacy credentials: %s', e.message);
+      clientLog.error('Unable to restore legacy credentials: %s', e.message);
     }
     return undefined;
   }

--- a/public/app/plugins/datasource/cloud-monitoring/CloudMonitoringMetricFindQuery.ts
+++ b/public/app/plugins/datasource/cloud-monitoring/CloudMonitoringMetricFindQuery.ts
@@ -1,3 +1,4 @@
+import { createClientLog } from '@grafana/data';
 import { isString } from 'lodash';
 
 import { ALIGNMENT_PERIODS, SELECTORS } from './constants';
@@ -11,6 +12,9 @@ import {
   getMetricTypesByService,
 } from './functions';
 import { type CloudMonitoringVariableQuery, type MetricDescriptor } from './types/types';
+const clientLog = createClientLog('public/app/plugins/datasource/cloud-monitoring/CloudMonitoringMetricFindQuery');
+
+
 
 export default class CloudMonitoringMetricFindQuery {
   constructor(private datasource: CloudMonitoringDatasource) {}
@@ -50,7 +54,7 @@ export default class CloudMonitoringMetricFindQuery {
           return [];
       }
     } catch (error) {
-      console.error(`Could not run CloudMonitoringMetricFindQuery ${query}`, error);
+      clientLog.error(`Could not run CloudMonitoringMetricFindQuery ${query}`, error);
       return [];
     }
   }

--- a/public/app/plugins/datasource/cloudwatch/components/shared/LogGroups/LogGroupsField.tsx
+++ b/public/app/plugins/datasource/cloudwatch/components/shared/LogGroups/LogGroupsField.tsx
@@ -1,3 +1,4 @@
+import { createClientLog } from '@grafana/data';
 import { useEffect, useState } from 'react';
 
 import { EditorField, EditorRow } from '@grafana/plugin-ui';
@@ -17,6 +18,9 @@ import { LogGroupPrefixInput } from './LogGroupPrefixInput';
 import { LogGroupQueryScopeSelector } from './LogGroupQueryScopeSelector';
 import { LogGroupsSelector } from './LogGroupsSelector';
 import { SelectedLogGroups } from './SelectedLogGroups';
+const clientLog = createClientLog('public/app/plugins/datasource/cloudwatch/components/shared/LogGroups/LogGroupsField');
+
+
 
 type Props = {
   datasource: CloudWatchDatasource;
@@ -92,7 +96,7 @@ export const LogGroupsField = ({
           onChange([...logGroups, ...variables.map((v) => ({ name: v, arn: v }))]);
         })
         .catch((err) => {
-          console.error(err);
+          clientLog.error(err);
         });
     }
   }, [datasource, legacyLogGroupNames, logGroups, onChange, region, loadingLogGroupsStarted]);

--- a/public/app/plugins/datasource/cloudwatch/tracking.ts
+++ b/public/app/plugins/datasource/cloudwatch/tracking.ts
@@ -1,4 +1,4 @@
-import { type DashboardLoadedEvent } from '@grafana/data';
+import {type DashboardLoadedEvent, createClientLog} from '@grafana/data';
 import { config, reportInteraction } from '@grafana/runtime';
 
 import {
@@ -15,6 +15,9 @@ import { migrateMetricQuery } from './migrations/metricQueryMigrations';
 import pluginJson from './plugin.json';
 import { type CloudWatchQuery } from './types';
 import { filterMetricsQuery } from './utils/utils';
+const clientLog = createClientLog('public/app/plugins/datasource/cloudwatch/tracking');
+
+
 
 type CloudWatchOnDashboardLoadedTrackingEvent = {
   grafana_version?: string;
@@ -146,7 +149,7 @@ export const onDashboardLoadedHandler = ({
 
     reportInteraction('grafana_ds_cloudwatch_dashboard_loaded', e);
   } catch (error) {
-    console.error('error in cloudwatch tracking handler', error);
+    clientLog.error('error in cloudwatch tracking handler', error);
   }
 };
 

--- a/public/app/plugins/datasource/cloudwatch/utils/datalinks.ts
+++ b/public/app/plugins/datasource/cloudwatch/utils/datalinks.ts
@@ -1,17 +1,18 @@
-import {
-  type DataFrame,
+import {type DataFrame,
   type DataLink,
   type DataQueryRequest,
   type DataQueryResponse,
   FieldType,
   type ScopedVars,
-  type TimeRange,
-} from '@grafana/data';
+  type TimeRange, createClientLog} from '@grafana/data';
 import { getDataSourceSrv } from '@grafana/runtime';
 
 import { type AwsUrl, encodeUrl } from '../aws_url';
 import { type CloudWatchLogsQuery } from '../dataquery.gen';
 import { type CloudWatchQuery } from '../types';
+const clientLog = createClientLog('public/app/plugins/datasource/cloudwatch/utils/datalinks');
+
+
 
 type ReplaceFn = (
   target?: string,
@@ -66,7 +67,7 @@ async function createInternalXrayLink(datasourceUid: string, region: string): Pr
   try {
     ds = await getDataSourceSrv().get(datasourceUid);
   } catch (e) {
-    console.error('Could not load linked xray data source, it was probably deleted after it was linked', e);
+    clientLog.error('Could not load linked xray data source, it was probably deleted after it was linked', e);
     return undefined;
   }
 

--- a/public/app/plugins/datasource/cloudwatch/variables.ts
+++ b/public/app/plugins/datasource/cloudwatch/variables.ts
@@ -1,13 +1,11 @@
 import { from, type Observable } from 'rxjs';
 import { map } from 'rxjs/operators';
 
-import {
-  CustomVariableSupport,
+import {CustomVariableSupport,
   type DataQueryRequest,
   type DataQueryResponse,
   type MetricFindValue,
-  type SelectableValue,
-} from '@grafana/data';
+  type SelectableValue, createClientLog} from '@grafana/data';
 
 import { VariableQueryEditor } from './components/VariableQueryEditor/VariableQueryEditor';
 import { ALL_ACCOUNTS_OPTION } from './components/shared/Account';
@@ -17,6 +15,9 @@ import { migrateVariableQuery } from './migrations/variableQueryMigrations';
 import { type ResourcesAPI } from './resources/ResourcesAPI';
 import { standardStatistics } from './standardStatistics';
 import { type VariableQuery, VariableQueryType } from './types';
+const clientLog = createClientLog('public/app/plugins/datasource/cloudwatch/variables');
+
+
 
 export class CloudWatchVariableSupport extends CustomVariableSupport<CloudWatchDatasource, VariableQuery> {
   constructor(private readonly resources: ResourcesAPI) {
@@ -57,7 +58,7 @@ export class CloudWatchVariableSupport extends CustomVariableSupport<CloudWatchD
           return this.handleAccountsQuery(query);
       }
     } catch (error) {
-      console.error(`Could not run CloudWatchMetricFindQuery ${query}`, error);
+      clientLog.error(`Could not run CloudWatchMetricFindQuery ${query}`, error);
       return [];
     }
   }

--- a/public/app/plugins/datasource/dashboard/datasource.ts
+++ b/public/app/plugins/datasource/dashboard/datasource.ts
@@ -1,7 +1,6 @@
 import { type Observable, debounce, debounceTime, defer, finalize, first, interval, map, of } from 'rxjs';
 
-import {
-  DataSourceApi,
+import {DataSourceApi,
   type DataQueryRequest,
   type DataQueryResponse,
   type DataSourceInstanceSettings,
@@ -18,8 +17,7 @@ import {
   getValueMatcher,
   ValueMatcherID,
   type DataSourceGetDrilldownsApplicabilityOptions,
-  type DrilldownsApplicability,
-} from '@grafana/data';
+  type DrilldownsApplicability, createClientLog} from '@grafana/data';
 import { isSceneObject, type SceneDataProvider, SceneDataTransformer, type SceneObject } from '@grafana/scenes';
 import {
   activateSceneObjectAndParentTree,
@@ -30,6 +28,9 @@ import {
 import { MIXED_REQUEST_PREFIX } from '../mixed/MixedDataSource';
 
 import { type DashboardQuery } from './types';
+const clientLog = createClientLog('public/app/plugins/datasource/dashboard/datasource');
+
+
 
 /**
  * This should not really be called
@@ -270,7 +271,7 @@ export class DashboardDatasource extends DataSourceApi<DashboardQuery> {
         options: { value: filter.value },
       });
     } catch (error) {
-      console.warn('Failed to create value matcher for filter:', filter, error);
+      clientLog.warn('Failed to create value matcher for filter:', filter, error);
       return null;
     }
   }

--- a/public/app/plugins/datasource/grafana-testdata-datasource/components/RawFrameEditor.tsx
+++ b/public/app/plugins/datasource/grafana-testdata-datasource/components/RawFrameEditor.tsx
@@ -1,11 +1,14 @@
 import { isArray } from 'lodash';
 import { useState } from 'react';
 
-import { dataFrameToJSON, toDataFrame, toDataFrameDTO } from '@grafana/data';
+import {dataFrameToJSON, toDataFrame, toDataFrameDTO, createClientLog} from '@grafana/data';
 import { toDataQueryResponse } from '@grafana/runtime';
 import { Alert, CodeEditor } from '@grafana/ui';
 
 import { type EditorProps } from '../QueryEditor';
+const clientLog = createClientLog('public/app/plugins/datasource/grafana-testdata-datasource/components/RawFrameEditor');
+
+
 
 export const RawFrameEditor = ({ onChange, query }: EditorProps) => {
   const [error, setError] = useState<string>();
@@ -35,8 +38,8 @@ export const RawFrameEditor = ({ onChange, query }: EditorProps) => {
       }
 
       if (data) {
-        console.log('Original', json);
-        console.log('Save', data);
+        clientLog.info('Original', json);
+        clientLog.info('Save', data);
         setError(undefined);
         setWarning('Converted to direct frame result');
         onChange({ ...query, rawFrameContent: JSON.stringify(data, null, 2) });
@@ -45,7 +48,7 @@ export const RawFrameEditor = ({ onChange, query }: EditorProps) => {
 
       setError('Unable to read dataframes in text');
     } catch (e) {
-      console.log('Error parsing json', e);
+      clientLog.info('Error parsing json', e);
       setError('Enter JSON array of data frames (or raw query results body)');
       setWarning(undefined);
     }

--- a/public/app/plugins/datasource/grafana-testdata-datasource/runStreams.ts
+++ b/public/app/plugins/datasource/grafana-testdata-datasource/runStreams.ts
@@ -2,8 +2,7 @@ import { defaults } from 'lodash';
 import { Observable, throwError } from 'rxjs';
 import { v4 as uuidv4 } from 'uuid';
 
-import {
-  type DataQueryRequest,
+import {type DataQueryRequest,
   type DataQueryResponse,
   FieldType,
   CircularDataFrame,
@@ -16,12 +15,14 @@ import {
   createDataFrame,
   addRow,
   getDisplayProcessor,
-  createTheme,
-} from '@grafana/data';
+  createTheme, createClientLog} from '@grafana/data';
 import { getBackendSrv } from '@grafana/runtime';
 
 import { getRandomLine } from './LogIpsum';
 import { type TestDataDataQuery, type StreamingQuery } from './dataquery';
+const clientLog = createClientLog('public/app/plugins/datasource/grafana-testdata-datasource/runStreams');
+
+
 
 export const defaultStreamQuery: StreamingQuery = {
   type: 'signal',
@@ -125,7 +126,7 @@ export function runSignalStream(
     setTimeout(pushNextEvent, 5);
 
     return () => {
-      console.log('unsubscribing to stream ' + streamId);
+      clientLog.info('unsubscribing to stream ' + streamId);
       clearTimeout(timeoutId);
     };
   });
@@ -171,7 +172,7 @@ export function runLogsStream(
     setTimeout(pushNextEvent, 5);
 
     return () => {
-      console.log('unsubscribing to stream ' + streamId);
+      clientLog.info('unsubscribing to stream ' + streamId);
       clearTimeout(timeoutId);
     };
   });
@@ -219,7 +220,7 @@ export function runWatchStream(
       .subscribe({
         next: (chunk) => {
           if (!chunk.data || !chunk.ok) {
-            console.info('chunk missing data', chunk);
+            clientLog.info('chunk missing data', chunk);
             return;
           }
           decoder
@@ -240,21 +241,21 @@ export function runWatchStream(
                     state: LoadingState.Streaming,
                   });
                 } catch (err) {
-                  console.warn('error parsing line', line, err);
+                  clientLog.warn('error parsing line', line, err);
                 }
               }
             });
         },
         error: (err) => {
-          console.warn('error in stream', streamId, err);
+          clientLog.warn('error in stream', streamId, err);
         },
         complete: () => {
-          console.info('complete stream', streamId);
+          clientLog.info('complete stream', streamId);
         },
       });
 
     return () => {
-      console.log('unsubscribing to stream', streamId);
+      clientLog.info('unsubscribing to stream', streamId);
       sub.unsubscribe();
     };
   });
@@ -314,7 +315,7 @@ export function runFetchStream(
       });
 
       if (value.done) {
-        console.log('Finished stream');
+        clientLog.info('Finished stream');
         subscriber.complete(); // necessary?
         return;
       }
@@ -335,7 +336,7 @@ export function runFetchStream(
 
     return () => {
       // Cancel fetch?
-      console.log('unsubscribing to stream ' + streamId);
+      clientLog.info('unsubscribing to stream ' + streamId);
     };
   });
 }
@@ -368,7 +369,7 @@ export function runTracesStream(
     setTimeout(pushNextEvent, 5);
 
     return () => {
-      console.log('unsubscribing to stream ' + streamId);
+      clientLog.info('unsubscribing to stream ' + streamId);
       clearTimeout(timeoutId);
     };
   });

--- a/public/app/plugins/datasource/grafana/components/QueryEditor.tsx
+++ b/public/app/plugins/datasource/grafana/components/QueryEditor.tsx
@@ -1,13 +1,11 @@
 import pluralize from 'pluralize';
 import * as React from 'react';
 
-import {
-  type QueryEditorProps,
+import {type QueryEditorProps,
   type SelectableValue,
   rangeUtil,
   type DataQueryRequest,
-  type Field,
-} from '@grafana/data';
+  type Field, createClientLog} from '@grafana/data';
 import { config, getDataSourceSrv } from '@grafana/runtime';
 import {
   InlineField,
@@ -27,6 +25,9 @@ import { type GrafanaDatasource } from '../datasource';
 import { defaultQuery, type GrafanaQuery, GrafanaQueryType } from '../types';
 
 import { RandomWalkEditor } from './RandomWalkEditor';
+const clientLog = createClientLog('public/app/plugins/datasource/grafana/components/QueryEditor');
+
+
 
 interface Props extends QueryEditorProps<GrafanaDatasource, GrafanaQuery>, Themeable2 {}
 
@@ -148,7 +149,7 @@ export class UnthemedQueryEditor extends React.PureComponent<Props, State> {
         try {
           buffer = rangeUtil.intervalToSeconds(txt) * 1000;
         } catch (err) {
-          console.warn('ERROR', err);
+          clientLog.warn('ERROR', err);
         }
       }
       onChange({

--- a/public/app/plugins/datasource/graphite/datasource.ts
+++ b/public/app/plugins/datasource/graphite/datasource.ts
@@ -4,8 +4,7 @@ import { lastValueFrom, merge, Observable, of, type OperatorFunction, pipe, thro
 import { catchError, map } from 'rxjs/operators';
 import { coerce, gte, SemVer, valid } from 'semver';
 
-import {
-  type AbstractLabelMatcher,
+import {type AbstractLabelMatcher,
   AbstractLabelOperator,
   type AbstractQuery,
   type DataFrame,
@@ -20,8 +19,7 @@ import {
   type QueryResultMetaStat,
   type ScopedVars,
   type TimeRange,
-  toDataFrame,
-} from '@grafana/data';
+  toDataFrame, createClientLog} from '@grafana/data';
 import {
   type BackendSrvRequest,
   config,
@@ -54,6 +52,9 @@ import {
 } from './types';
 import { reduceError } from './utils';
 import { DEFAULT_GRAPHITE_VERSION } from './versions';
+const clientLog = createClientLog('public/app/plugins/datasource/graphite/datasource');
+
+
 
 const GRAPHITE_TAG_COMPARATORS = {
   '=': AbstractLabelOperator.Equal,
@@ -555,7 +556,7 @@ export class GraphiteDatasource
       return this.events({ range: range, tags: tags }).then((results) => {
         const list = [];
         if (!isArray(results.data)) {
-          console.error(`Unable to get annotations.`);
+          clientLog.error(`Unable to get annotations.`);
           return [];
         }
         for (let i = 0; i < results.data.length; i++) {
@@ -1047,7 +1048,7 @@ export class GraphiteDatasource
         this.funcDefs = gfunc.parseFuncDefs(functions);
         return this.funcDefs;
       } catch (error) {
-        console.error('Fetching graphite functions error', error);
+        clientLog.error('Fetching graphite functions error', error);
         this.funcDefs = gfunc.getFuncDefs(this.graphiteVersion);
         return this.funcDefs;
       }
@@ -1066,7 +1067,7 @@ export class GraphiteDatasource
           return this.funcDefs;
         }),
         catchError((error) => {
-          console.error('Fetching graphite functions error', error);
+          clientLog.error('Fetching graphite functions error', error);
           this.funcDefs = gfunc.getFuncDefs(this.graphiteVersion);
           return of(this.funcDefs);
         })

--- a/public/app/plugins/datasource/graphite/graphite_query.ts
+++ b/public/app/plugins/datasource/graphite/graphite_query.ts
@@ -1,6 +1,6 @@
 import { compact, each, findIndex, flatten, get, join, keyBy, last, map, reduce, without } from 'lodash';
 
-import { type ScopedVars } from '@grafana/data';
+import {type ScopedVars, createClientLog} from '@grafana/data';
 import { type TemplateSrv } from '@grafana/runtime';
 
 import { type GraphiteDatasource } from './datasource';
@@ -8,6 +8,9 @@ import { type FuncInstance } from './gfunc';
 import { type AstNode, Parser } from './parser';
 import { type GraphiteSegment } from './types';
 import { arrayMove } from './utils';
+const clientLog = createClientLog('public/app/plugins/datasource/graphite/graphite_query');
+
+
 
 export type GraphiteTagOperator = '=' | '=~' | '!=' | '!=~';
 
@@ -94,7 +97,7 @@ export default class GraphiteQuery {
       }
     } catch (err) {
       if (err instanceof Error) {
-        console.error('error parsing target:', err.message);
+        clientLog.error('error parsing target:', err.message);
         this.error = err.message;
       }
       this.target.textEditor = true;

--- a/public/app/plugins/datasource/influxdb/components/editor/config-v2/UrlAndAuthenticationSection.tsx
+++ b/public/app/plugins/datasource/influxdb/components/editor/config-v2/UrlAndAuthenticationSection.tsx
@@ -1,7 +1,7 @@
 import { css } from '@emotion/css';
 import { firstValueFrom } from 'rxjs';
 
-import { onUpdateDatasourceJsonDataOptionSelect, onUpdateDatasourceOption } from '@grafana/data';
+import {onUpdateDatasourceJsonDataOptionSelect, onUpdateDatasourceOption, createClientLog} from '@grafana/data';
 import { getBackendSrv } from '@grafana/runtime';
 import {
   Box,
@@ -30,6 +30,9 @@ import {
 } from './tracking';
 import { type Props } from './types';
 import { INFLUXDB_VERSION_MAP, type InfluxDBProduct } from './versions';
+const clientLog = createClientLog('public/app/plugins/datasource/influxdb/components/editor/config-v2/UrlAndAuthenticationSection');
+
+
 
 const getQueryLanguageOptions = (productName: string): Array<{ value: string }> => {
   const product = INFLUXDB_VERSION_MAP.find(({ name }) => name === productName);
@@ -104,7 +107,7 @@ export const UrlAndAuthenticationSection = (props: Props) => {
         }
       }
     } catch (err) {
-      console.error('Failed to get InfluxDB version:', err);
+      clientLog.error('Failed to get InfluxDB version:', err);
     }
 
     return { product: undefined, version: undefined };

--- a/public/app/plugins/datasource/influxdb/components/editor/query/influxql/visual/TagsSection.tsx
+++ b/public/app/plugins/datasource/influxdb/components/editor/query/influxql/visual/TagsSection.tsx
@@ -1,6 +1,6 @@
 import type { JSX } from 'react';
 
-import { type SelectableValue } from '@grafana/data';
+import {type SelectableValue, createClientLog} from '@grafana/data';
 import { AccessoryButton } from '@grafana/plugin-ui';
 
 import { type InfluxQueryTag } from '../../../../../types';
@@ -9,6 +9,9 @@ import { toSelectableValue } from '../utils/toSelectableValue';
 
 import { AddButton } from './AddButton';
 import { Seg } from './Seg';
+const clientLog = createClientLog('public/app/plugins/datasource/influxdb/components/editor/query/influxql/visual/TagsSection');
+
+
 
 type KnownOperator = '=' | '!=' | '<>' | '<' | '>' | '>=' | '<=' | '=~' | '!~' | 'Is' | 'Is Not';
 const knownOperators: KnownOperator[] = ['=', '!=', '<>', '<', '>', '>=', '<=', '=~', '!~', 'Is', 'Is Not'];
@@ -54,7 +57,7 @@ const Tag = ({ tag, isFirst, onRemove, onChange, getTagKeyOptions, getTagValueOp
         // to avoid it, we catch any potential errors coming from `getTagKeyOptions`,
         // log the error, and pretend that the list of options is an empty list.
         // this way the remove-item option can always be added to the list.
-        console.error(err);
+        clientLog.error(err);
         return [];
       })
       .then((tags) => tags.map(toSelectableValue));

--- a/public/app/plugins/datasource/influxdb/datasource.ts
+++ b/public/app/plugins/datasource/influxdb/datasource.ts
@@ -2,8 +2,7 @@ import { map as _map, cloneDeep, extend, has, isString, omit, pick, reduce } fro
 import { lastValueFrom, merge, Observable, of, throwError } from 'rxjs';
 import { catchError, map } from 'rxjs/operators';
 
-import {
-  type AdHocVariableFilter,
+import {type AdHocVariableFilter,
   type AnnotationEvent,
   type DataFrame,
   type DataQueryError,
@@ -24,8 +23,7 @@ import {
   TIME_SERIES_TIME_FIELD_NAME,
   TIME_SERIES_VALUE_FIELD_NAME,
   type TimeSeries,
-  toDataFrame,
-} from '@grafana/data';
+  toDataFrame, createClientLog} from '@grafana/data';
 import {
   type BackendDataSourceResponse,
   DataSourceWithBackend,
@@ -49,6 +47,9 @@ import { buildRawQuery, removeRegexWrapper } from './queryUtils';
 import ResponseParser from './response_parser';
 import { DEFAULT_POLICY, type InfluxOptions, type InfluxQuery, type InfluxVariableQuery, InfluxVersion } from './types';
 import { InfluxVariableSupport } from './variables';
+const clientLog = createClientLog('public/app/plugins/datasource/influxdb/datasource');
+
+
 
 export default class InfluxDatasource extends DataSourceWithBackend<InfluxQuery, InfluxOptions> {
   type: string;
@@ -388,7 +389,7 @@ export default class InfluxDatasource extends DataSourceWithBackend<InfluxQuery,
         // then put inside parenthesis.
         return typeof value === 'string' ? escapeRegex(value) : `(${value.map((v) => escapeRegex(v)).join('|')})`;
       } catch (e) {
-        console.warn(`Supplied match is not valid regex: ${match}`);
+        clientLog.warn(`Supplied match is not valid regex: ${match}`);
       }
     }
 

--- a/public/app/plugins/datasource/loki/LanguageProvider.ts
+++ b/public/app/plugins/datasource/loki/LanguageProvider.ts
@@ -1,14 +1,12 @@
 import { flatten } from 'lodash';
 import { LRUCache } from 'lru-cache';
 
-import {
-  type AbstractQuery,
+import {type AbstractQuery,
   getDefaultTimeRange,
   type KeyValue,
   LanguageProvider,
   type ScopedVars,
-  type TimeRange,
-} from '@grafana/data';
+  type TimeRange, createClientLog} from '@grafana/data';
 import { type BackendSrvRequest, config } from '@grafana/runtime';
 
 import { LokiQueryType } from './dataquery.gen';
@@ -22,6 +20,9 @@ import {
   extractUnwrapLabelKeysFromDataFrame,
 } from './responseUtils';
 import { type DetectedFieldsResult, LabelType, type LokiQuery, type ParserAndLabelKeysResult } from './types';
+const clientLog = createClientLog('public/app/plugins/datasource/loki/LanguageProvider');
+
+
 
 const NS_IN_MS = 1000000;
 const EMPTY_SELECTOR = '{}';
@@ -63,7 +64,7 @@ export default class LokiLanguageProvider extends LanguageProvider {
       if (throwError) {
         throw error;
       } else {
-        console.error(error);
+        clientLog.error(error);
       }
     }
 
@@ -293,7 +294,7 @@ export default class LokiLanguageProvider extends LanguageProvider {
         const data = await this.request(url, params, true, requestOptions);
         resolve(data);
       } catch (error) {
-        console.error('error', error);
+        clientLog.error('error', error);
         reject(error);
       }
     });
@@ -374,7 +375,7 @@ export default class LokiLanguageProvider extends LanguageProvider {
         if (queryOptions?.throwError) {
           reject(error);
         } else {
-          console.error(error);
+          clientLog.error(error);
           resolve([]);
         }
       }
@@ -444,7 +445,7 @@ export default class LokiLanguageProvider extends LanguageProvider {
           resolve(labelValues);
         }
       } catch (error) {
-        console.error(error);
+        clientLog.error(error);
         resolve([]);
       }
     });

--- a/public/app/plugins/datasource/loki/LiveStreams.ts
+++ b/public/app/plugins/datasource/loki/LiveStreams.ts
@@ -2,10 +2,13 @@ import { type Observable, throwError, timer } from 'rxjs';
 import { finalize, map, retryWhen, mergeMap } from 'rxjs/operators';
 import { webSocket } from 'rxjs/webSocket';
 
-import { type DataFrame, FieldType, type KeyValue, CircularDataFrame } from '@grafana/data';
+import {type DataFrame, FieldType, type KeyValue, CircularDataFrame, createClientLog} from '@grafana/data';
 
 import { appendResponseToBufferedData } from './liveStreamsResultTransformer';
 import { type LokiTailResponse } from './types';
+const clientLog = createClientLog('public/app/plugins/datasource/loki/LiveStreams');
+
+
 
 /**
  * Maps directly to a query in the UI (refId is key)
@@ -53,7 +56,7 @@ export class LiveStreams {
             if (error.code === 1006 && retryAttempt < 30) {
               if (retryAttempt > 10) {
                 // If more than 10 times retried, consol.warn, but keep reconnecting
-                console.warn(
+                clientLog.warn(
                   `Websocket connection is being disrupted. We keep reconnecting but consider starting new live tailing again. Error: ${error.reason}`
                 );
               }

--- a/public/app/plugins/datasource/loki/components/LokiLabelBrowser.tsx
+++ b/public/app/plugins/datasource/loki/components/LokiLabelBrowser.tsx
@@ -4,7 +4,7 @@ import { type ChangeEvent } from 'react';
 import * as React from 'react';
 import { FixedSizeList } from 'react-window';
 
-import { type CoreApp, type GrafanaTheme2, type TimeRange } from '@grafana/data';
+import {type CoreApp, type GrafanaTheme2, type TimeRange, createClientLog} from '@grafana/data';
 import { reportInteraction } from '@grafana/runtime';
 import {
   Button,
@@ -20,6 +20,9 @@ import {
 
 import type LokiLanguageProvider from '../LanguageProvider';
 import { escapeLabelValueInExactSelector, escapeLabelValueInRegexSelector } from '../languageUtils';
+const clientLog = createClientLog('public/app/plugins/datasource/loki/components/LokiLabelBrowser');
+
+
 
 // Hard limit on labels to render
 const MAX_LABEL_COUNT = 1000;
@@ -376,7 +379,7 @@ export class UnthemedLokiLabelBrowser extends React.Component<BrowserProps, Brow
       const values: FacettableValue[] = rawValues.map((value) => ({ name: value }));
       this.updateLabelState(name, { values, loading: false });
     } catch (error) {
-      console.error(error);
+      clientLog.error(error);
     }
   }
 
@@ -404,7 +407,7 @@ export class UnthemedLokiLabelBrowser extends React.Component<BrowserProps, Brow
         this.updateLabelState(lastFacetted, { loading: false });
       }
     } catch (error) {
-      console.error(error);
+      clientLog.error(error);
     }
   }
 

--- a/public/app/plugins/datasource/loki/components/monaco-query-field/getOverrideServices.ts
+++ b/public/app/plugins/datasource/loki/components/monaco-query-field/getOverrideServices.ts
@@ -1,4 +1,8 @@
+import { createClientLog } from '@grafana/data';
 import { type monacoTypes } from '@grafana/ui';
+const clientLog = createClientLog('public/app/plugins/datasource/loki/components/monaco-query-field/getOverrideServices');
+
+
 
 // this thing here is a workaround in a way.
 // what we want to achieve, is that when the autocomplete-window
@@ -81,7 +85,7 @@ function makeStorageService() {
     },
 
     logStorage: (): void => {
-      console.log('logStorage: not implemented');
+      clientLog.info('logStorage: not implemented');
     },
 
     migrate: (): Promise<void> => {

--- a/public/app/plugins/datasource/loki/mergeResponses.ts
+++ b/public/app/plugins/datasource/loki/mergeResponses.ts
@@ -1,5 +1,4 @@
-import {
-  closestIdx,
+import {closestIdx,
   type DataFrame,
   DataFrameType,
   type DataQueryResponse,
@@ -9,10 +8,12 @@ import {
   LoadingState,
   type QueryResultMetaNotice,
   type QueryResultMetaStat,
-  shallowCompare,
-} from '@grafana/data';
+  shallowCompare, createClientLog} from '@grafana/data';
 
 import { LOADING_FRAME_NAME } from './querySplitting';
+const clientLog = createClientLog('public/app/plugins/datasource/loki/mergeResponses');
+
+
 
 function getFrameKey(frame: DataFrame): string | undefined {
   // Metric range query data
@@ -142,7 +143,7 @@ export function mergeFrames(dest: DataFrame, source: DataFrame) {
   const sourceIdField = source.fields.find((field) => field.type === FieldType.string && field.name === 'id');
 
   if (!destTimeField || !sourceTimeField) {
-    console.error(new Error(`Time fields not found in the data frames`));
+    clientLog.error(new Error(`Time fields not found in the data frames`));
     return;
   }
 

--- a/public/app/plugins/datasource/loki/querySplitting.ts
+++ b/public/app/plugins/datasource/loki/querySplitting.ts
@@ -2,8 +2,7 @@ import { groupBy, partition } from 'lodash';
 import { Observable, type Subscriber, type Subscription, tap } from 'rxjs';
 import { v4 as uuidv4 } from 'uuid';
 
-import {
-  arrayToDataFrame,
+import {arrayToDataFrame,
   type DataQueryRequest,
   type DataQueryResponse,
   DataTopic,
@@ -11,8 +10,7 @@ import {
   LoadingState,
   rangeUtil,
   store,
-  type TimeRange,
-} from '@grafana/data';
+  type TimeRange, createClientLog} from '@grafana/data';
 import { config } from '@grafana/runtime';
 
 import { LokiQueryType, LokiQueryDirection } from './dataquery.gen';
@@ -30,6 +28,9 @@ import { addQueryLimitsContext, isLogsQuery, isQueryWithRangeVariable } from './
 import { isRetriableError } from './responseUtils';
 import { trackGroupedQueries } from './tracking';
 import { type LokiGroupedRequest, type LokiQuery } from './types';
+const clientLog = createClientLog('public/app/plugins/datasource/loki/querySplitting');
+
+
 
 export function partitionTimeRange(
   isLogsQuery: boolean,
@@ -187,7 +188,7 @@ export function runSplitGroupedQueries(
           return false;
         }
       } catch (e) {
-        console.error(e);
+        clientLog.error(e);
         shouldStop = true;
         return false;
       }

--- a/public/app/plugins/datasource/loki/querybuilder/LokiQueryModeller.ts
+++ b/public/app/plugins/datasource/loki/querybuilder/LokiQueryModeller.ts
@@ -1,3 +1,4 @@
+import { createClientLog } from '@grafana/data';
 import {
   QueryModellerBase,
   type QueryBuilderLabelFilter,
@@ -13,6 +14,9 @@ import {
   LokiQueryPatternType,
   LokiVisualQueryOperationCategory,
 } from './types';
+const clientLog = createClientLog('public/app/plugins/datasource/loki/querybuilder/LokiQueryModeller');
+
+
 
 export class LokiQueryModeller extends QueryModellerBase {
   constructor() {
@@ -35,7 +39,7 @@ export class LokiQueryModeller extends QueryModellerBase {
       }
       const def = this.operationsRegistry.getIfExists(operation.id);
       if (!def) {
-        console.error(`Could not find operation ${operation.id} in the registry`);
+        clientLog.error(`Could not find operation ${operation.id} in the registry`);
         continue;
       }
       queryString = def.renderer(operation, def, queryString);

--- a/public/app/plugins/datasource/loki/querybuilder/parsing.ts
+++ b/public/app/plugins/datasource/loki/querybuilder/parsing.ts
@@ -1,3 +1,4 @@
+import { createClientLog } from '@grafana/data';
 import { type SyntaxNode } from '@lezer/common';
 
 import {
@@ -71,6 +72,9 @@ import {
   replaceVariables,
 } from './parsingUtils';
 import { LokiOperationId, type LokiVisualQuery, type LokiVisualQueryBinary } from './types';
+const clientLog = createClientLog('public/app/plugins/datasource/loki/querybuilder/parsing');
+
+
 
 interface Context {
   query: LokiVisualQuery;
@@ -109,7 +113,7 @@ export function buildVisualQueryFromString(expr: string): Context {
     handleExpression(replacedExpr, node, context);
   } catch (err) {
     // Not ideal to log it here, but otherwise we would lose the stack trace.
-    console.error(err);
+    clientLog.error(err);
     if (err instanceof Error) {
       context.errors.push({
         text: err.message,

--- a/public/app/plugins/datasource/loki/shardQuerySplitting.ts
+++ b/public/app/plugins/datasource/loki/shardQuerySplitting.ts
@@ -2,7 +2,7 @@ import { groupBy, partition } from 'lodash';
 import { Observable, type Subscriber, type Subscription } from 'rxjs';
 import { v4 as uuidv4 } from 'uuid';
 
-import { type DataQueryRequest, type DataQueryResponse, LoadingState, type QueryResultMetaStat } from '@grafana/data';
+import {type DataQueryRequest, type DataQueryResponse, LoadingState, type QueryResultMetaStat, createClientLog} from '@grafana/data';
 import { config } from '@grafana/runtime';
 
 import { type LokiDatasource } from './datasource';
@@ -16,6 +16,9 @@ import {
 } from './queryUtils';
 import { isRetriableError } from './responseUtils';
 import { type LokiQuery } from './types';
+const clientLog = createClientLog('public/app/plugins/datasource/loki/shardQuerySplitting');
+
+
 /**
  * Query splitting by stream shards.
  * Query splitting was introduced in Loki to optimize querying for long intervals and high volume of data,
@@ -130,7 +133,7 @@ function splitQueriesByStreamShard(
           return false;
         }
       } catch (e) {
-        console.error(e);
+        clientLog.error(e);
         shouldStop = true;
         return false;
       }
@@ -155,7 +158,7 @@ function splitQueriesByStreamShard(
 
       retryTimer = setTimeout(
         () => {
-          console.warn(`Retrying ${group} ${cycle} (${retries + 1})`);
+          clientLog.warn(`Retrying ${group} ${cycle} (${retries + 1})`);
           runNextRequest(subscriber, group, groups);
           retryTimer = null;
         },
@@ -224,7 +227,7 @@ function splitQueriesByStreamShard(
         nextRequest();
       },
       error: (error: unknown) => {
-        console.error(error, { msg: 'failed to shard' });
+        clientLog.error(error, { msg: 'failed to shard' });
         subscriber.next(mergedResponse);
         if (retry()) {
           return;
@@ -293,7 +296,7 @@ async function groupTargetsByQueryType(
         cycle: 0,
       });
     } catch (error) {
-      console.error(error, { msg: 'failed to fetch label values for __stream_shard__' });
+      clientLog.error(error, { msg: 'failed to fetch label values for __stream_shard__' });
       groups.push({
         targets: selectorPartition[selector],
       });
@@ -375,5 +378,5 @@ function debug(message: string) {
   if (!DEBUG_ENABLED) {
     return;
   }
-  console.log(message);
+  clientLog.info(message);
 }

--- a/public/app/plugins/datasource/loki/tracking.ts
+++ b/public/app/plugins/datasource/loki/tracking.ts
@@ -1,4 +1,4 @@
-import { CoreApp, type DashboardLoadedEvent, type DataQueryRequest, type DataQueryResponse } from '@grafana/data';
+import {CoreApp, type DashboardLoadedEvent, type DataQueryRequest, type DataQueryResponse, createClientLog} from '@grafana/data';
 import { QueryEditorMode } from '@grafana/plugin-ui';
 import { reportInteraction, config } from '@grafana/runtime';
 
@@ -14,6 +14,9 @@ import pluginJson from './plugin.json';
 import { getNormalizedLokiQuery, isLogsQuery, obfuscate } from './queryUtils';
 import { variableRegex } from './querybuilder/parsingUtils';
 import { type LokiGroupedRequest, type LokiQuery } from './types';
+const clientLog = createClientLog('public/app/plugins/datasource/loki/tracking');
+
+
 
 type LokiOnDashboardLoadedTrackingEvent = {
   grafana_version?: string;
@@ -97,7 +100,7 @@ export const onDashboardLoadedHandler = ({
 
     reportInteraction('grafana_loki_dashboard_loaded', event);
   } catch (error) {
-    console.error('error in loki tracking handler', error);
+    clientLog.error('error in loki tracking handler', error);
   }
 };
 

--- a/public/app/plugins/datasource/tempo/datasource.ts
+++ b/public/app/plugins/datasource/tempo/datasource.ts
@@ -2,8 +2,7 @@ import { groupBy } from 'lodash';
 import { EMPTY, from, merge, type Observable, of } from 'rxjs';
 import { catchError, concatMap, finalize, map, mergeMap, toArray } from 'rxjs/operators';
 
-import {
-  CoreApp,
+import {CoreApp,
   type DataFrame,
   type DataFrameDTO,
   type DataFrameJSON,
@@ -22,8 +21,7 @@ import {
   type ScopedVars,
   type SelectableValue,
   type TestDataSourceResponse,
-  type TimeRange,
-} from '@grafana/data';
+  type TimeRange, createClientLog} from '@grafana/data';
 import { type NodeGraphOptions, type SpanBarOptions, type TraceToLogsOptions } from '@grafana/o11y-ds-frontend';
 import {
   config,
@@ -63,6 +61,9 @@ import { doTempoMetricsStreaming, doTempoSearchStreaming } from './streaming';
 import { type TempoJsonData, type TempoQuery } from './types';
 import { getErrorMessage, mapErrorMessage, migrateFromSearchToTraceQLSearch } from './utils';
 import { TempoVariableSupport } from './variables';
+const clientLog = createClientLog('public/app/plugins/datasource/tempo/datasource');
+
+
 
 export const DEFAULT_LIMIT = 20;
 export const DEFAULT_SPSS = 3; // spans per span set
@@ -295,7 +296,7 @@ export class TempoDatasource extends DataSourceWithBackend<TempoQuery, TempoJson
 
       return false;
     } catch (error) {
-      console.warn('Failed to check for native histograms:', error);
+      clientLog.warn('Failed to check for native histograms:', error);
       return false;
     }
   }

--- a/public/app/plugins/datasource/tempo/resultTransformer.ts
+++ b/public/app/plugins/datasource/tempo/resultTransformer.ts
@@ -3,8 +3,7 @@ import { type collectorTypes } from '@opentelemetry/exporter-collector';
 import { SemanticResourceAttributes } from '@opentelemetry/semantic-conventions';
 import { isEqual } from 'lodash';
 
-import {
-  createDataFrame,
+import {createDataFrame,
   createTheme,
   type DataFrame,
   type DataLink,
@@ -21,13 +20,15 @@ import {
   type TraceKeyValuePair,
   type TraceLog,
   type TraceSpanReference,
-  type TraceSpanRow,
-} from '@grafana/data';
+  type TraceSpanRow, createClientLog} from '@grafana/data';
 import { createNodeGraphFrames, type TraceToProfilesData } from '@grafana/o11y-ds-frontend';
 import { getDataSourceSrv } from '@grafana/runtime';
 
 import { SearchTableType } from './dataquery.gen';
 import { type Span, type SpanAttributes, type Spanset, type TempoJsonData, type TraceSearchMetadata } from './types';
+const clientLog = createClientLog('public/app/plugins/datasource/tempo/resultTransformer');
+
+
 
 function getAttributeValue(value: collectorTypes.opentelemetryProto.common.v1.AnyValue): any {
   if (value.stringValue) {
@@ -196,7 +197,7 @@ export function transformFromOTLP(
       }
     }
   } catch (error) {
-    console.error(error);
+    clientLog.error(error);
     return { error: { message: 'JSON is not valid OpenTelemetry format: ' + error }, data: [] };
   }
 

--- a/public/app/plugins/datasource/tempo/traceql/TraceQLEditor.tsx
+++ b/public/app/plugins/datasource/tempo/traceql/TraceQLEditor.tsx
@@ -1,7 +1,7 @@
 import { css } from '@emotion/css';
 import { useEffect, useRef, useState } from 'react';
 
-import { type GrafanaTheme2, type TimeRange } from '@grafana/data';
+import {type GrafanaTheme2, type TimeRange, createClientLog} from '@grafana/data';
 import { TemporaryAlert } from '@grafana/o11y-ds-frontend';
 import { reportInteraction } from '@grafana/runtime';
 import { CodeEditor, type Monaco, type monacoTypes, useTheme2 } from '@grafana/ui';
@@ -13,6 +13,9 @@ import { type TempoQuery } from '../types';
 import { CompletionProvider, type CompletionItemType } from './autocomplete';
 import { getErrorNodes, setMarkers } from './highlighting';
 import { languageDefinition } from './traceql';
+const clientLog = createClientLog('public/app/plugins/datasource/tempo/traceql/TraceQLEditor');
+
+
 
 interface Props {
   placeholder: string;
@@ -94,7 +97,7 @@ export function TraceQLEditor(props: Props) {
               const errorNodes = getErrorNodes(model.getValue());
               setMarkers(monaco, model, errorNodes);
             } catch (err) {
-              console.warn('TraceQL editor: failed to update syntax error markers', err);
+              clientLog.warn('TraceQL editor: failed to update syntax error markers', err);
             }
           }
 
@@ -127,11 +130,11 @@ export function TraceQLEditor(props: Props) {
                 try {
                   setMarkers(monaco, model, errorNodes);
                 } catch (err) {
-                  console.warn('TraceQL editor: failed to update syntax error markers', err);
+                  clientLog.warn('TraceQL editor: failed to update syntax error markers', err);
                 }
               }, 500);
             } catch (err) {
-              console.warn('TraceQL editor: failed to parse query for error highlighting', err);
+              clientLog.warn('TraceQL editor: failed to parse query for error highlighting', err);
             }
           });
         }}

--- a/public/app/plugins/datasource/tempo/traceql/situation.ts
+++ b/public/app/plugins/datasource/tempo/traceql/situation.ts
@@ -1,3 +1,4 @@
+import { createClientLog } from '@grafana/data';
 import { type SyntaxNode, type Tree } from '@lezer/common';
 
 import {
@@ -22,6 +23,9 @@ import {
   String as StringNode,
   TraceQL,
 } from '@grafana/lezer-traceql';
+const clientLog = createClientLog('public/app/plugins/datasource/tempo/traceql/situation');
+
+
 
 type Direction = 'parent' | 'firstChild' | 'lastChild' | 'nextSibling' | 'prevSibling';
 type NodeType = number;
@@ -444,7 +448,7 @@ function resolveNewSpansetExpression(node: SyntaxNode, text: string, offset: num
       previousNode = previousNode!.nextSibling;
     }
   } catch (error) {
-    console.error('Unexpected error while searching for previous node', error);
+    clientLog.error('Unexpected error while searching for previous node', error);
   }
 
   if (previousNode?.type.id === And || previousNode?.type.id === Or) {

--- a/public/app/plugins/datasource/tempo/tracking.ts
+++ b/public/app/plugins/datasource/tempo/tracking.ts
@@ -1,8 +1,11 @@
-import { type DashboardLoadedEvent } from '@grafana/data';
+import {type DashboardLoadedEvent, createClientLog} from '@grafana/data';
 import { getTemplateSrv, reportInteraction } from '@grafana/runtime';
 
 import pluginJson from './plugin.json';
 import { type TempoQuery } from './types';
+const clientLog = createClientLog('public/app/plugins/datasource/tempo/tracking');
+
+
 
 type TempoOnDashboardLoadedTrackingEvent = {
   grafana_version?: string;
@@ -58,7 +61,7 @@ export const onDashboardLoadedHandler = ({
 
     reportInteraction('grafana_tempo_dashboard_loaded', stats);
   } catch (error) {
-    console.error('error in tempo tracking handler', error);
+    clientLog.error('error in tempo tracking handler', error);
   }
 };
 

--- a/public/app/plugins/datasource/tempo/utils.ts
+++ b/public/app/plugins/datasource/tempo/utils.ts
@@ -1,9 +1,12 @@
-import { type DataSourceApi, parseDuration } from '@grafana/data';
+import {type DataSourceApi, parseDuration, createClientLog} from '@grafana/data';
 import { getDataSourceSrv } from '@grafana/runtime';
 
 import { generateId } from './SearchTraceQLEditor/TagsInput';
 import { type TraceqlFilter, TraceqlSearchScope } from './dataquery.gen';
 import { type TempoQuery } from './types';
+const clientLog = createClientLog('public/app/plugins/datasource/tempo/utils');
+
+
 
 const LIMIT_MESSAGE = /.*range specified by start and end.*exceeds.*/;
 const LIMIT_MESSAGE_METRICS = /.*metrics query time range exceeds the maximum allowed duration of.*/;
@@ -32,7 +35,7 @@ export async function getDS(uid?: string): Promise<DataSourceApi | undefined> {
   try {
     return await dsSrv.get(uid);
   } catch (error) {
-    console.error('Failed to load data source', error);
+    clientLog.error('Failed to load data source', error);
     return undefined;
   }
 }

--- a/public/app/plugins/panel/canvas/components/connections/Connections.tsx
+++ b/public/app/plugins/panel/canvas/components/connections/Connections.tsx
@@ -1,3 +1,4 @@
+import { createClientLog } from '@grafana/data';
 import * as React from 'react';
 import { BehaviorSubject } from 'rxjs';
 
@@ -26,6 +27,9 @@ import {
   HALF_SIZE,
 } from './ConnectionAnchors';
 import { ConnectionSVG } from './ConnectionSVG';
+const clientLog = createClientLog('public/app/plugins/panel/canvas/components/connections/Connections');
+
+
 
 export const CONNECTION_VERTEX_ID = 'vertex';
 export const CONNECTION_VERTEX_ADD_ID = 'vertexAdd';
@@ -131,7 +135,7 @@ export class Connections {
     let element: ElementState | undefined = this.findElementTarget(event.target);
 
     if (!element) {
-      console.log('no element');
+      clientLog.info('no element');
       return;
     }
 
@@ -140,7 +144,7 @@ export class Connections {
     } else {
       this.connectionSource = element;
       if (!this.connectionSource) {
-        console.log('no connection source');
+        clientLog.info('no connection source');
         return;
       }
     }

--- a/public/app/plugins/panel/canvas/components/connections/Connections2.tsx
+++ b/public/app/plugins/panel/canvas/components/connections/Connections2.tsx
@@ -1,3 +1,4 @@
+import { createClientLog } from '@grafana/data';
 import * as React from 'react';
 import { BehaviorSubject } from 'rxjs';
 
@@ -28,6 +29,9 @@ import {
 } from './ConnectionAnchors';
 import { ConnectionAnchors } from './ConnectionAnchors2';
 import { ConnectionSVG } from './ConnectionSVG2';
+const clientLog = createClientLog('public/app/plugins/panel/canvas/components/connections/Connections2');
+
+
 
 export const CONNECTION_VERTEX_ID = 'vertex';
 export const CONNECTION_VERTEX_ADD_ID = 'vertexAdd';
@@ -126,7 +130,7 @@ export class Connections2 {
     let element: ElementState | undefined = this.findElementTarget(event.target);
 
     if (!element) {
-      console.log('no element');
+      clientLog.info('no element');
       return;
     }
 
@@ -135,7 +139,7 @@ export class Connections2 {
     } else {
       this.connectionSource = element;
       if (!this.connectionSource) {
-        console.log('no connection source');
+        clientLog.info('no connection source');
         return;
       }
     }

--- a/public/app/plugins/panel/canvas/editor/element/elementEditor.tsx
+++ b/public/app/plugins/panel/canvas/editor/element/elementEditor.tsx
@@ -1,3 +1,4 @@
+import { createClientLog } from '@grafana/data';
 import { get as lodashGet } from 'lodash';
 
 import { type NestedPanelOptions, type NestedValueAccess } from '@grafana/data/internal';
@@ -17,6 +18,9 @@ import { getElementTypes } from '../../utils';
 import { optionBuilder } from '../options';
 
 import { PlacementEditor } from './PlacementEditor';
+const clientLog = createClientLog('public/app/plugins/panel/canvas/editor/element/elementEditor');
+
+
 
 export interface CanvasEditorOptions {
   element: ElementState;
@@ -45,7 +49,7 @@ export function getElementEditor(opts: CanvasEditorOptions): NestedPanelOptions<
         if (path === 'type' && value) {
           const layer = canvasElementRegistry.getIfExists(value);
           if (!layer) {
-            console.warn('layer does not exist', value);
+            clientLog.warn('layer does not exist', value);
             return;
           }
           options = {

--- a/public/app/plugins/panel/canvas/editor/element/utils.ts
+++ b/public/app/plugins/panel/canvas/editor/element/utils.ts
@@ -1,4 +1,4 @@
-import { AppEvents, textUtil } from '@grafana/data';
+import {AppEvents, textUtil, createClientLog} from '@grafana/data';
 import { type BackendSrvRequest, getBackendSrv, getTemplateSrv } from '@grafana/runtime';
 import { appEvents } from 'app/core/app_events';
 import { createAbsoluteUrl, type RelativeUrl } from 'app/features/alerting/unified/utils/url';
@@ -7,6 +7,9 @@ import { getDashboardSrv } from 'app/features/dashboard/services/DashboardSrv';
 import { HttpRequestMethod } from '../../panelcfg.gen';
 
 import { type APIEditorConfig } from './APIEditor';
+const clientLog = createClientLog('public/app/plugins/panel/canvas/editor/element/utils');
+
+
 
 type IsLoadingCallback = (loading: boolean) => void;
 
@@ -23,7 +26,7 @@ export const callApi = (api: APIEditorConfig, updateLoadingStateCallback?: IsLoa
     .subscribe({
       error: (error) => {
         appEvents.emit(AppEvents.alertError, ['An error has occurred. Check console output for more details.']);
-        console.error('API call error: ', error);
+        clientLog.error('API call error: ', error);
         updateLoadingStateCallback && updateLoadingStateCallback(false);
       },
       complete: () => {

--- a/public/app/plugins/panel/canvas/editor/layer/TreeNavigationEditor.tsx
+++ b/public/app/plugins/panel/canvas/editor/layer/TreeNavigationEditor.tsx
@@ -3,7 +3,7 @@ import { Global } from '@emotion/react';
 import Tree, { type TreeNodeProps } from '@rc-component/tree';
 import { type Key, useEffect, useMemo, useState } from 'react';
 
-import { type GrafanaTheme2, type StandardEditorProps } from '@grafana/data';
+import {type GrafanaTheme2, type StandardEditorProps, createClientLog} from '@grafana/data';
 import { Trans, t } from '@grafana/i18n';
 import { config } from '@grafana/runtime';
 import { Button, Icon, Stack, useStyles2, useTheme2 } from '@grafana/ui';
@@ -19,6 +19,9 @@ import { type TreeViewEditorProps } from '../element/elementEditor';
 
 import { TreeNodeTitle } from './TreeNodeTitle';
 import { getTreeData, onNodeDrop, type TreeElement } from './tree';
+const clientLog = createClientLog('public/app/plugins/panel/canvas/editor/layer/TreeNavigationEditor');
+
+
 
 let allowSelection = true;
 
@@ -130,7 +133,7 @@ export const TreeNavigationEditor = ({ item }: StandardEditorProps<unknown, Tree
     if (layer.scene) {
       frameSelection(layer.scene);
     } else {
-      console.warn('no scene!');
+      clientLog.warn('no scene!');
     }
   };
 

--- a/public/app/plugins/panel/canvas/editor/layer/layerEditor.tsx
+++ b/public/app/plugins/panel/canvas/editor/layer/layerEditor.tsx
@@ -1,3 +1,4 @@
+import { createClientLog } from '@grafana/data';
 import { get as lodashGet } from 'lodash';
 
 import { type NestedPanelOptions, type NestedValueAccess } from '@grafana/data/internal';
@@ -12,6 +13,9 @@ import { PlacementEditor } from '../element/PlacementEditor';
 import { optionBuilder } from '../options';
 
 import { TreeNavigationEditor } from './TreeNavigationEditor';
+const clientLog = createClientLog('public/app/plugins/panel/canvas/editor/layer/layerEditor');
+
+
 
 export interface LayerEditorProps {
   scene: Scene;
@@ -53,7 +57,7 @@ export function getLayerEditor(opts: InstanceState): NestedPanelOptions<LayerEdi
       },
       onChange: (path, value) => {
         if (path === 'type' && value) {
-          console.warn('unable to change layer type');
+          clientLog.warn('unable to change layer type');
           return;
         }
         const c = setOptionImmutably(options, path, value);

--- a/public/app/plugins/panel/dashlist/migrations.ts
+++ b/public/app/plugins/panel/dashlist/migrations.ts
@@ -1,8 +1,11 @@
-import { type PanelModel } from '@grafana/data';
+import {type PanelModel, createClientLog} from '@grafana/data';
 import { getBackendSrv } from '@grafana/runtime';
 import { type FolderDTO } from 'app/types/folders';
 
 import { type Options } from './panelcfg.gen';
+const clientLog = createClientLog('public/app/plugins/panel/dashlist/migrations');
+
+
 
 async function getFolderUID(folderID: number): Promise<string> {
   // folderID 0 is always the fake General/Dashboards folder, which always has a UID of empty string
@@ -67,7 +70,7 @@ export async function dashlistMigrationHandler(panel: PanelModel<Options> & Angu
       newOptions.folderUID = folderUID;
       delete newOptions.folderId;
     } catch (err) {
-      console.warn('Dashlist: Error migrating folder ID to UID', err);
+      clientLog.warn('Dashlist: Error migrating folder ID to UID', err);
     }
   }
 

--- a/public/app/plugins/panel/geomap/GeomapPanel.tsx
+++ b/public/app/plugins/panel/geomap/GeomapPanel.tsx
@@ -15,7 +15,7 @@ import { Component, type ReactNode } from 'react';
 import * as React from 'react';
 import { Subscription } from 'rxjs';
 
-import { DataHoverEvent, type PanelData, type PanelProps } from '@grafana/data';
+import {DataHoverEvent, type PanelData, type PanelProps, createClientLog} from '@grafana/data';
 import { t } from '@grafana/i18n';
 import { config, locationService } from '@grafana/runtime';
 import { type PanelContext, PanelContextRoot } from '@grafana/ui';
@@ -46,6 +46,9 @@ import {
   hasLayerData,
 } from './utils/utils';
 import { centerPointRegistry, MapCenterID } from './view';
+const clientLog = createClientLog('public/app/plugins/panel/geomap/GeomapPanel');
+
+
 
 // Allows multiple panels to share the same view instance
 let sharedView: View | undefined = undefined;
@@ -323,7 +326,7 @@ export class GeomapPanel extends Component<Props, State> {
         layers.push(await initLayer(this, map, lyr, false));
       }
     } catch (ex) {
-      console.error('error loading layers', ex);
+      clientLog.error('error loading layers', ex);
     }
 
     for (const lyr of layers) {

--- a/public/app/plugins/panel/geomap/layers/basemaps/maplibre.ts
+++ b/public/app/plugins/panel/geomap/layers/basemaps/maplibre.ts
@@ -2,7 +2,10 @@ import type Map from 'ol/Map';
 import LayerGroup from 'ol/layer/Group';
 import { apply } from 'ol-mapbox-style';
 
-import { type MapLayerRegistryItem, type MapLayerOptions, type GrafanaTheme2, type EventBus } from '@grafana/data';
+import {type MapLayerRegistryItem, type MapLayerOptions, type GrafanaTheme2, type EventBus, createClientLog} from '@grafana/data';
+const clientLog = createClientLog('public/app/plugins/panel/geomap/layers/basemaps/maplibre');
+
+
 
 // MapLibre Style Specification constants
 const LAYER_TYPE_BACKGROUND = 'background';
@@ -63,13 +66,13 @@ export const maplibreLayer: MapLayerRegistryItem<MaplibreConfig> = {
       const loadStyle = async () => {
         try {
           if (!cfg.url) {
-            console.warn('No URL provided for MapLibre style, layer will be empty');
+            clientLog.warn('No URL provided for MapLibre style, layer will be empty');
             return;
           }
 
           const res = await fetch(cfg.url);
           if (!res.ok) {
-            console.warn(`Failed to load MapLibre style from ${cfg.url}: ${res.status} ${res.statusText}`);
+            clientLog.warn(`Failed to load MapLibre style from ${cfg.url}: ${res.status} ${res.statusText}`);
             // Try fallback approach
             await tryFallbackApply();
             return;
@@ -90,7 +93,7 @@ export const maplibreLayer: MapLayerRegistryItem<MaplibreConfig> = {
           await apply(layer, style, { styleUrl: cfg.url, accessToken: cfg.accessToken });
           applyNoRepeat();
         } catch (error) {
-          console.warn('Failed to parse or apply MapLibre style JSON:', error);
+          clientLog.warn('Failed to parse or apply MapLibre style JSON:', error);
           // Try fallback approach
           await tryFallbackApply();
         }
@@ -99,13 +102,13 @@ export const maplibreLayer: MapLayerRegistryItem<MaplibreConfig> = {
       const tryFallbackApply = async () => {
         try {
           if (!cfg.url) {
-            console.warn('No URL available for MapLibre fallback, layer will be empty');
+            clientLog.warn('No URL available for MapLibre fallback, layer will be empty');
             return;
           }
           await apply(layer, cfg.url, { accessToken: cfg.accessToken });
           applyNoRepeat();
         } catch (fallbackError) {
-          console.warn('Failed to load MapLibre style from both JSON and direct URL approaches:', fallbackError);
+          clientLog.warn('Failed to load MapLibre style from both JSON and direct URL approaches:', fallbackError);
         }
       };
 

--- a/public/app/plugins/panel/geomap/style/markers.ts
+++ b/public/app/plugins/panel/geomap/style/markers.ts
@@ -2,12 +2,15 @@ import { Fill, RegularShape, Stroke, Circle, Style, Icon, Text } from 'ol/style'
 import type { FlatStyle } from 'ol/style/flat';
 import tinycolor from 'tinycolor2';
 
-import { Registry, type RegistryItem, textUtil } from '@grafana/data';
+import {Registry, type RegistryItem, textUtil, createClientLog} from '@grafana/data';
 import { config } from '@grafana/runtime';
 import { getPublicOrAbsoluteUrl } from 'app/features/dimensions/resource';
 
 import { defaultStyleConfig, DEFAULT_SIZE, type StyleConfigValues, type StyleMaker } from './types';
 import { getDisplacement } from './utils';
+const clientLog = createClientLog('public/app/plugins/panel/geomap/style/markers');
+
+
 
 interface SymbolMaker extends RegistryItem {
   aliasIds: string[];
@@ -297,7 +300,7 @@ async function prepareSVG(url: string, size?: number, backgroundOpacity?: number
       return `data:image/svg+xml,${svgURI}`;
     })
     .catch((error) => {
-      console.error(error); // eslint-disable-line no-console
+      clientLog.error(error); // eslint-disable-line no-console
       return '';
     });
 }

--- a/public/app/plugins/panel/geomap/style/utils.ts
+++ b/public/app/plugins/panel/geomap/style/utils.ts
@@ -1,3 +1,4 @@
+import { createClientLog } from '@grafana/data';
 import { config } from '@grafana/runtime';
 import { TextDimensionMode } from '@grafana/schema';
 
@@ -12,6 +13,9 @@ import {
   type SymbolAlign,
   type ColorValue,
 } from './types';
+const clientLog = createClientLog('public/app/plugins/panel/geomap/style/utils');
+
+
 
 /** Indicate if the style wants to show text values */
 export function styleUsesText(config: StyleConfig): boolean {
@@ -106,7 +110,7 @@ export function getRGBValues(colorString: string): ColorValue | null {
 
   // Handle other color formats if needed
   else {
-    console.warn(`Unsupported color format: ${colorString}`);
+    clientLog.warn(`Unsupported color format: ${colorString}`);
   }
   return null;
 }
@@ -142,10 +146,10 @@ function getRGBFromRGBString(rgbString: string): ColorValue | null {
         a: parseFloat(matches[3]), // Using parseFloat for alpha as it can be decimal (0-1)
       };
     } else {
-      console.warn(`Unsupported color format: ${rgbString}`);
+      clientLog.warn(`Unsupported color format: ${rgbString}`);
     }
   } else {
-    console.warn(`Unsupported color format: ${rgbString}`);
+    clientLog.warn(`Unsupported color format: ${rgbString}`);
   }
   return null;
 }

--- a/public/app/plugins/panel/geomap/utils/layers.ts
+++ b/public/app/plugins/panel/geomap/utils/layers.ts
@@ -5,7 +5,7 @@ import LayerGroup from 'ol/layer/Group';
 import WebGLPointsLayer from 'ol/layer/WebGLPoints';
 import { Subject } from 'rxjs';
 
-import { getFrameMatchers, type MapLayerHandler, type MapLayerOptions, type PanelData, textUtil } from '@grafana/data';
+import {getFrameMatchers, type MapLayerHandler, type MapLayerOptions, type PanelData, textUtil, createClientLog} from '@grafana/data';
 import { config } from '@grafana/runtime';
 
 import { type GeomapPanel } from '../GeomapPanel';
@@ -14,6 +14,9 @@ import { DEFAULT_BASEMAP_CONFIG, geomapLayerRegistry } from '../layers/registry'
 import { type MapLayerState } from '../types';
 
 import { getNextLayerName } from './utils';
+const clientLog = createClientLog('public/app/plugins/panel/geomap/utils/layers');
+
+
 
 const layerStateMap = new WeakMap<BaseLayer, MapLayerState>();
 
@@ -91,7 +94,7 @@ export async function updateLayer(panel: GeomapPanel, uid: string, newOptions: M
     // initialize with new data
     applyLayerFilter(info.handler, newOptions, panel.props.data);
   } catch (err) {
-    console.warn('ERROR', err); // eslint-disable-line no-console
+    clientLog.warn('ERROR', err); // eslint-disable-line no-console
     return false;
   }
 

--- a/public/app/plugins/panel/heatmap/HeatmapPanel.tsx
+++ b/public/app/plugins/panel/heatmap/HeatmapPanel.tsx
@@ -1,7 +1,7 @@
 import { css } from '@emotion/css';
 import { useMemo, useRef, useState } from 'react';
 
-import { DashboardCursorSync, type PanelProps, type TimeRange } from '@grafana/data';
+import {DashboardCursorSync, type PanelProps, type TimeRange, createClientLog} from '@grafana/data';
 import { PanelDataErrorView } from '@grafana/runtime';
 import { type ScaleDistributionConfig } from '@grafana/schema';
 import {
@@ -29,6 +29,9 @@ import { type HeatmapData, prepareHeatmapData } from './fields';
 import { quantizeScheme } from './palettes';
 import { type Options } from './panelcfg.gen';
 import { calculateYSizeDivisor, prepConfig } from './utils';
+const clientLog = createClientLog('public/app/plugins/panel/heatmap/HeatmapPanel');
+
+
 
 interface HeatmapPanelProps extends PanelProps<Options> {}
 
@@ -54,7 +57,7 @@ export const HeatmapPanel = (props: HeatmapPanelProps) => {
         timeRange,
       });
     } catch (ex) {
-      console.error(ex);
+      clientLog.error(ex);
       return { warning: `${ex}` };
     }
   }, [data.series, data.annotations, options, palette, theme, replaceVariables, timeRange]);

--- a/public/app/plugins/panel/live/LivePanel.tsx
+++ b/public/app/plugins/panel/live/LivePanel.tsx
@@ -3,8 +3,7 @@ import { isEqual } from 'lodash';
 import { PureComponent } from 'react';
 import { type Unsubscribable, type PartialObserver } from 'rxjs';
 
-import {
-  type GrafanaTheme2,
+import {type GrafanaTheme2,
   type PanelProps,
   type LiveChannelStatusEvent,
   isValidLiveChannelAddress,
@@ -16,8 +15,7 @@ import {
   LoadingState,
   applyFieldOverrides,
   type LiveChannelAddress,
-  StreamingDataFrame,
-} from '@grafana/data';
+  StreamingDataFrame, createClientLog} from '@grafana/data';
 import { Trans, t } from '@grafana/i18n';
 import { config, getGrafanaLiveSrv } from '@grafana/runtime';
 import { Alert, stylesFactory, JSONFormatter, CustomScrollbar } from '@grafana/ui';
@@ -26,6 +24,9 @@ import { TablePanel } from '../table/TablePanel';
 
 import { LivePublish } from './LivePublish';
 import { type LivePanelOptions, MessageDisplayMode, MessagePublishMode } from './types';
+const clientLog = createClientLog('public/app/plugins/panel/live/LivePanel');
+
+
 
 interface Props extends PanelProps<LivePanelOptions> {}
 
@@ -72,7 +73,7 @@ export class LivePanel extends PureComponent<Props, State> {
       } else if (isLiveChannelMessageEvent(event)) {
         this.setState({ message: event.message, changed: Date.now() });
       } else {
-        console.log('ignore', event);
+        clientLog.info('ignore', event);
       }
     },
   };
@@ -87,7 +88,7 @@ export class LivePanel extends PureComponent<Props, State> {
   async loadChannel() {
     const addr = this.props.options?.channel;
     if (!isValidLiveChannelAddress(addr)) {
-      console.log('INVALID', addr);
+      clientLog.info('INVALID', addr);
       this.unsubscribe();
       this.setState({
         addr: undefined,
@@ -96,13 +97,13 @@ export class LivePanel extends PureComponent<Props, State> {
     }
 
     if (isEqual(addr, this.state.addr)) {
-      console.log('Same channel', this.state.addr);
+      clientLog.info('Same channel', this.state.addr);
       return;
     }
 
     const live = getGrafanaLiveSrv();
     if (!live) {
-      console.log('INVALID', addr);
+      clientLog.info('INVALID', addr);
       this.unsubscribe();
       this.setState({
         addr: undefined,
@@ -111,7 +112,7 @@ export class LivePanel extends PureComponent<Props, State> {
     }
     this.unsubscribe();
 
-    console.log('LOAD', addr);
+    clientLog.info('LOAD', addr);
 
     // Subscribe to new events
     try {

--- a/public/app/plugins/panel/live/LivePublish.tsx
+++ b/public/app/plugins/panel/live/LivePublish.tsx
@@ -1,11 +1,14 @@
 import { useMemo } from 'react';
 
-import { type LiveChannelAddress, isValidLiveChannelAddress } from '@grafana/data';
+import {type LiveChannelAddress, isValidLiveChannelAddress, createClientLog} from '@grafana/data';
 import { Trans } from '@grafana/i18n';
 import { getBackendSrv, getGrafanaLiveSrv } from '@grafana/runtime';
 import { CodeEditor, Button } from '@grafana/ui';
 
 import { MessagePublishMode } from './types';
+const clientLog = createClientLog('public/app/plugins/panel/live/LivePublish');
+
+
 
 interface Props {
   height: number;
@@ -46,7 +49,7 @@ export function LivePublish({ height, mode, body, addr, onSave }: Props) {
     }
 
     const rsp = await getGrafanaLiveSrv().publish(addr, body);
-    console.log('onPublishClicked (response from publish)', rsp);
+    clientLog.info('onPublishClicked (response from publish)', rsp);
   };
 
   return (

--- a/public/app/plugins/panel/logs/LogsPanel.tsx
+++ b/public/app/plugins/panel/logs/LogsPanel.tsx
@@ -4,8 +4,7 @@ import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } fr
 import * as React from 'react';
 import { isObservable, lastValueFrom } from 'rxjs';
 
-import {
-  type AbsoluteTimeRange,
+import {type AbsoluteTimeRange,
   CoreApp,
   type DataFrame,
   DataHoverClearEvent,
@@ -29,8 +28,7 @@ import {
   LoadingState,
   rangeUtil,
   transformDataFrame,
-  store,
-} from '@grafana/data';
+  store, createClientLog} from '@grafana/data';
 import { Trans } from '@grafana/i18n';
 import { config, getAppEvents } from '@grafana/runtime';
 import { ScrollContainer, usePanelContext, useStyles2 } from '@grafana/ui';
@@ -70,6 +68,9 @@ import {
   type onNewLogsReceivedType,
 } from './types';
 import { useDatasourcesFromTargets } from './useDatasourcesFromTargets';
+const clientLog = createClientLog('public/app/plugins/panel/logs/LogsPanel');
+
+
 
 interface LogsPanelProps extends PanelProps<Options> {
   /**
@@ -488,7 +489,7 @@ export const LogsPanel = ({ data, timeZone, fieldConfig, options, onOptionsChang
           newSeries = await lastValueFrom(transformDataFrame(panel?.transformations, newSeries));
         }
       } catch (e) {
-        console.error(e);
+        clientLog.error(e);
       } finally {
         setInfiniteScrolling(false);
         loadingRef.current = false;
@@ -851,7 +852,7 @@ export async function requestMoreLogs(
   for (const uid in targetGroups) {
     const dataSource = dataSourcesMap.get(panelData.request.targets[0].refId);
     if (!dataSource) {
-      console.warn(`Could not resolve data source for target ${panelData.request.targets[0].refId}`);
+      clientLog.warn(`Could not resolve data source for target ${panelData.request.targets[0].refId}`);
       continue;
     }
     dataRequests.push(

--- a/public/app/plugins/panel/logstable/fieldSelector/buildColumnsWithMeta.ts
+++ b/public/app/plugins/panel/logstable/fieldSelector/buildColumnsWithMeta.ts
@@ -1,6 +1,9 @@
-import { type DataFrame, type FieldWithIndex, getFieldDisplayName } from '@grafana/data';
+import {type DataFrame, type FieldWithIndex, getFieldDisplayName, createClientLog} from '@grafana/data';
 import { type FieldNameMeta, type FieldNameMetaStore } from 'app/features/explore/Logs/LogsTableWrap';
 import { LOG_LINE_BODY_FIELD_NAME } from 'app/features/logs/components/fieldSelector/logFields';
+const clientLog = createClientLog('public/app/plugins/panel/logstable/fieldSelector/buildColumnsWithMeta');
+
+
 
 type FieldName = string;
 
@@ -104,7 +107,7 @@ export const buildColumnsWithMeta = (
       pendingLabelState[logsFrameFields.bodyField?.name].active = true;
       pendingLabelState[logsFrameFields.bodyField?.name].index = idx;
     } else {
-      console.error(`Unknown field ${fieldName}`, { pendingLabelState, displayedFields });
+      clientLog.error(`Unknown field ${fieldName}`, { pendingLabelState, displayedFields });
     }
   });
 

--- a/public/app/plugins/panel/logstable/hooks/useExtractFields.ts
+++ b/public/app/plugins/panel/logstable/hooks/useExtractFields.ts
@@ -2,19 +2,20 @@ import { useState, useEffect } from 'react';
 import useMountedState from 'react-use/lib/useMountedState';
 import { lastValueFrom } from 'rxjs';
 
-import {
-  applyFieldOverrides,
+import {applyFieldOverrides,
   type DataFrame,
   type FieldConfigSource,
   type TimeZone,
   transformDataFrame,
-  useDataLinksContext,
-} from '@grafana/data';
+  useDataLinksContext, createClientLog} from '@grafana/data';
 import { getTemplateSrv } from '@grafana/runtime';
 import { useTheme2 } from '@grafana/ui';
 import { replaceVariables } from '@grafana-plugins/loki/querybuilder/parsingUtils';
 
 import { extractLogsFieldsTransform } from '../transforms/extractLogsFieldsTransform';
+const clientLog = createClientLog('public/app/plugins/panel/logstable/hooks/useExtractFields');
+
+
 
 interface Props {
   rawTableFrame: DataFrame | null;
@@ -56,7 +57,7 @@ export function useExtractFields({ rawTableFrame, fieldConfig, timeZone }: Props
         }
       })
       .catch((err) => {
-        console.error('LogsTable: Extract fields transform error', err);
+        clientLog.error('LogsTable: Extract fields transform error', err);
       });
     // @todo hook re-renders unexpectedly when data frame isn't changing if we add `rawTableFrame` as dependency, so we check for changes in the timestamps instead
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/public/app/plugins/panel/logstable/hooks/useOrganizeFields.tsx
+++ b/public/app/plugins/panel/logstable/hooks/useOrganizeFields.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from 'react';
 import useMountedState from 'react-use/lib/useMountedState';
 import { lastValueFrom } from 'rxjs';
 
-import { type DataFrame, type FieldConfigSource, transformDataFrame } from '@grafana/data';
+import {type DataFrame, type FieldConfigSource, transformDataFrame, createClientLog} from '@grafana/data';
 import { type CustomCellRendererProps, TableCellDisplayMode } from '@grafana/ui';
 import { type LogsFrame } from 'app/features/logs/logsFrame';
 
@@ -16,6 +16,9 @@ import { getDisplayedFields } from '../options/getDisplayedFields';
 import type { Options as LogsTableOptions } from '../panelcfg.gen';
 import { organizeLogsFieldsTransform } from '../transforms/organizeLogsFieldsTransform';
 import { type BuildLinkToLogLine, isBuildLinkToLogLine } from '../types';
+const clientLog = createClientLog('public/app/plugins/panel/logstable/hooks/useOrganizeFields');
+
+
 
 interface Props {
   extractedFrame: DataFrame | null;
@@ -68,7 +71,7 @@ export function useOrganizeFields({
         }
       })
       .catch((err) => {
-        console.error('LogsTable: Organize fields transform error', err);
+        clientLog.error('LogsTable: Organize fields transform error', err);
       });
   }, [
     bodyFieldName,

--- a/public/app/plugins/panel/logstable/rows/LogsTableRowActionButtons.tsx
+++ b/public/app/plugins/panel/logstable/rows/LogsTableRowActionButtons.tsx
@@ -1,7 +1,7 @@
 import { css } from '@emotion/css';
 import { useState } from 'react';
 
-import { type GrafanaTheme2 } from '@grafana/data';
+import {type GrafanaTheme2, createClientLog} from '@grafana/data';
 import { t } from '@grafana/i18n';
 import {
   ClipboardButton,
@@ -14,6 +14,9 @@ import {
 import { type LogsFrame } from 'app/features/logs/logsFrame';
 
 import { type BuildLinkToLogLine } from '../types';
+const clientLog = createClientLog('public/app/plugins/panel/logstable/rows/LogsTableRowActionButtons');
+
+
 
 interface Props extends CustomCellRendererProps {
   buildLinkToLog?: BuildLinkToLogLine;
@@ -71,7 +74,7 @@ export function LogsTableRowActionButtons(props: Props) {
                 if (logId) {
                   return buildLinkToLog(logId) ?? '';
                 } else {
-                  console.error('failed to copy log line link!');
+                  clientLog.error('failed to copy log line link!');
                 }
                 return '';
               }}

--- a/public/app/plugins/panel/news/utils.ts
+++ b/public/app/plugins/panel/news/utils.ts
@@ -1,6 +1,9 @@
-import { FieldType, type DataFrame, dateTime } from '@grafana/data';
+import {FieldType, type DataFrame, dateTime, createClientLog} from '@grafana/data';
 
 import { type Feed } from './types';
+const clientLog = createClientLog('public/app/plugins/panel/news/utils');
+
+
 
 export function feedToDataFrame(feed: Feed): DataFrame {
   const date: number[] = [];
@@ -23,7 +26,7 @@ export function feedToDataFrame(feed: Feed): DataFrame {
         content.push(body);
       }
     } catch (err) {
-      console.warn('Error reading news item:', err, item);
+      clientLog.warn('Error reading news item:', err, item);
     }
   }
 

--- a/public/app/plugins/panel/table/migrations.ts
+++ b/public/app/plugins/panel/table/migrations.ts
@@ -1,7 +1,6 @@
 import { omitBy, isNil, isNumber, defaultTo, groupBy, omit } from 'lodash';
 
-import {
-  type PanelModel,
+import {type PanelModel,
   FieldMatcherID,
   type ConfigOverrideRule,
   ThresholdsMode,
@@ -9,11 +8,13 @@ import {
   type FieldConfig,
   type DataFrame,
   FieldType,
-  ByNamesMatcherMode,
-} from '@grafana/data';
+  ByNamesMatcherMode, createClientLog} from '@grafana/data';
 import { type ReduceTransformerOptions } from '@grafana/data/internal';
 
 import { type Options } from './panelcfg.gen';
+const clientLog = createClientLog('public/app/plugins/panel/table/migrations');
+
+
 
 /**
  * At 7.0, the `table` panel was swapped from an angular implementation to a react one.
@@ -23,7 +24,7 @@ import { type Options } from './panelcfg.gen';
 export const tableMigrationHandler = (panel: PanelModel<Options>): Partial<Options> => {
   // Table was saved as an angular table, lets just swap to the 'table-old' panel
   if (!panel.pluginVersion && 'columns' in panel) {
-    console.log('Was angular table', panel);
+    clientLog.info('Was angular table', panel);
   }
 
   // ensure overrides array exists before applying rest of overrides

--- a/public/app/plugins/panel/timeseries/NullsThresholdInput.tsx
+++ b/public/app/plugins/panel/timeseries/NullsThresholdInput.tsx
@@ -1,8 +1,11 @@
 import * as React from 'react';
 
-import { rangeUtil } from '@grafana/data';
+import {rangeUtil, createClientLog} from '@grafana/data';
 import { t } from '@grafana/i18n';
 import { Input } from '@grafana/ui';
+const clientLog = createClientLog('public/app/plugins/panel/timeseries/NullsThresholdInput');
+
+
 
 export enum InputPrefix {
   LessThan = 'lessthan',
@@ -31,7 +34,7 @@ export const NullsThresholdInput = ({ value, onChange, inputPrefix, isTime }: Pr
           val = Number(txt);
         }
       } catch (err) {
-        console.warn('ERROR', err);
+        clientLog.warn('ERROR', err);
       }
     }
     onChange(val);

--- a/public/app/plugins/panel/timeseries/migrations.ts
+++ b/public/app/plugins/panel/timeseries/migrations.ts
@@ -1,7 +1,6 @@
 import { omitBy, pickBy, isNil, isNumber, isString } from 'lodash';
 
-import {
-  type ConfigOverrideRule,
+import {type ConfigOverrideRule,
   type DynamicConfigValue,
   FieldColorModeId,
   type FieldConfig,
@@ -14,8 +13,7 @@ import {
   type PanelTypeChangedHandler,
   ReducerID,
   type Threshold,
-  ThresholdsMode,
-} from '@grafana/data';
+  ThresholdsMode, createClientLog} from '@grafana/data';
 import {
   LegendDisplayMode,
   TooltipDisplayMode,
@@ -44,6 +42,9 @@ import { type GrafanaQuery, GrafanaQueryType } from 'app/plugins/datasource/graf
 
 import { defaultGraphConfig } from './config';
 import { type Options } from './panelcfg.gen';
+const clientLog = createClientLog('public/app/plugins/panel/timeseries/migrations');
+
+
 
 let dashboardRefreshDebouncer: ReturnType<typeof setTimeout> | null = null;
 
@@ -283,7 +284,7 @@ export function graphToTimeseriesOptions(angular: any): {
             });
             break;
           default:
-            console.log('Ignore override migration:', seriesOverride.alias, p, v);
+            clientLog.info('Ignore override migration:', seriesOverride.alias, p, v);
         }
       }
       if (dashOverride) {

--- a/public/app/plugins/panel/timeseries/plugins/annotations2-cluster/useAnnotationClustering.tsx
+++ b/public/app/plugins/panel/timeseries/plugins/annotations2-cluster/useAnnotationClustering.tsx
@@ -1,11 +1,14 @@
 import { useMemo } from 'react';
 import uPlot from 'uplot';
 
-import { type DataFrame, FieldType } from '@grafana/data';
+import {type DataFrame, FieldType, createClientLog} from '@grafana/data';
 import { maybeSortFrame } from '@grafana/data/internal';
 import { type TimeRange2 } from '@grafana/ui/internal';
 
 import { DEFAULT_CLUSTERING_ANNOTATION_SPACING } from './constants';
+const clientLog = createClientLog('public/app/plugins/panel/timeseries/plugins/annotations2-cluster/useAnnotationClustering');
+
+
 
 interface Props {
   annotations: DataFrame[];
@@ -120,7 +123,7 @@ export const useAnnotationClustering = ({ annotations, clusteringMode, plotWidth
       }
     } else if (clusteringMode === ClusteringMode.Hover) {
       // Have the tooltip be clustered, but not the annotations: https://github.com/grafana/grafana/issues/119436
-      console.warn('Hover mode not implemented');
+      clientLog.warn('Hover mode not implemented');
     }
 
     // Sort clustered frames

--- a/scripts/fix-clientlog-import-order.mjs
+++ b/scripts/fix-clientlog-import-order.mjs
@@ -1,0 +1,105 @@
+/**
+ * Place `const clientLog = createClientLog('...');` right after the last
+ * `import` line (all static import forms).
+ */
+import { readFileSync, writeFileSync, existsSync } from 'node:fs';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { execSync } from 'node:child_process';
+
+const root = join(fileURLToPath(new URL('.', import.meta.url)), '..');
+const STRIP_RE = /const clientLog = createClientLog\([^;]*\);\n?/m;
+
+/**
+ * @param {string} line
+ */
+function closesImportLine(t) {
+  t = t.trim();
+  if (!t.endsWith(';') || t.startsWith('//')) {
+    return false;
+  }
+  if (/^import\s*\(/.test(t) || t.startsWith('import(') || t.startsWith('import (')) {
+    return false;
+  }
+  if (t.match(/^import ['"]/)) {
+    return true;
+  }
+  if (t.match(/} from [\"']| from [\"']/)) {
+    return true;
+  }
+  return false;
+}
+
+/**
+ * @param {string[]} lines
+ * @returns {number}
+ */
+function lineIndexOfLastImportEnd(lines) {
+  let last = -1;
+  for (let i = 0; i < lines.length; i++) {
+    if (!/^\s*import\s+/.test(lines[i])) {
+      continue;
+    }
+    if (/^\s*import\s*\(/.test(lines[i].trim()) || /^\s*import\s*\.meta/.test(lines[i].trim())) {
+      continue;
+    }
+    for (let j = i; j < lines.length; j++) {
+      if (closesImportLine(lines[j])) {
+        if (i <= j) {
+          last = j;
+        }
+        i = j;
+        break;
+      }
+    }
+  }
+  return last;
+}
+
+/**
+ * @param {string} text
+ * @returns {string | null}
+ */
+function processText(text) {
+  if (!/const clientLog = createClientLog\(/m.test(text)) {
+    return null;
+  }
+  if (!STRIP_RE.test(text)) {
+    return null;
+  }
+  const m = text.match(STRIP_RE);
+  if (!m) {
+    return null;
+  }
+  const constBlock = m[0];
+  const noConst = text.replace(STRIP_RE, '');
+  const lines = noConst.split('\n');
+  const li = lineIndexOfLastImportEnd(lines);
+  if (li < 0) {
+    return constBlock + (constBlock.endsWith('\n') ? '' : '\n') + noConst;
+  }
+  return [...lines.slice(0, li + 1), constBlock, ...lines.slice(li + 1)].join('\n');
+}
+
+const fileList = execSync(`cd "${root}" && git ls-files "*.ts" "*.tsx"`, { encoding: 'utf8' })
+  .split('\n')
+  .map((l) => l.trim())
+  .filter(Boolean);
+
+let count = 0;
+for (const f of fileList) {
+  const p = join(root, f);
+  if (!existsSync(p)) {
+    continue;
+  }
+  const t0 = readFileSync(p, 'utf8');
+  if (!/const clientLog = createClientLog/.test(t0)) {
+    continue;
+  }
+  const t1 = processText(t0);
+  if (t1 != null && t1 !== t0) {
+    writeFileSync(p, t1);
+    count++;
+  }
+}
+process.stdout.write(`fix-clientlog-import: ${count} files\n`);

--- a/scripts/replace-console-with-structured-logs.mjs
+++ b/scripts/replace-console-with-structured-logs.mjs
@@ -1,0 +1,166 @@
+/**
+ * Replaces `console.log|info|debug|warn|error(` with `clientLog.*(` and adds
+ * `createClientLog` + `const clientLog = createClientLog('<repo-relative-path>')`.
+ * Run: node scripts/replace-console-with-structured-logs.mjs
+ */
+import { readFileSync, writeFileSync, existsSync } from 'node:fs';
+import { join, relative, sep, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { execSync } from 'node:child_process';
+
+const __dirname = fileURLToPath(new URL('.', import.meta.url));
+const root = join(__dirname, '..');
+
+const RE = /\bconsole\.(log|info|debug|warn|error)\s*\(/g;
+
+const SKIP = [
+  '.test.',
+  '.spec.',
+  '/e2e/',
+  '/e2e-playwright/',
+  'public/test/',
+  'devenv/',
+  'node_modules',
+  'jest.config',
+  'clientStructuredLog.ts',
+  'webpack',
+  'replace-console-with-structured-logs.mjs',
+  '/.storybook/',
+  '.stories.',
+  '.story.',
+  'grafana-data/scripts',
+  'grafana-openapi/src/scripts',
+  'grafana-api-clients',
+  'public/swagger',
+];
+
+const SKIP_DIR_PREFIX = ['scripts/'];
+
+function skipPath(f) {
+  const n = f.replaceAll('\\', '/');
+  for (const s of SKIP) {
+    if (n.includes(s)) {
+      return true;
+    }
+  }
+  for (const p of SKIP_DIR_PREFIX) {
+    if (n.startsWith(p) && !n.startsWith('public/')) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function mapMethod(m) {
+  if (m === 'log' || m === 'info') {
+    return 'info';
+  }
+  if (m === 'debug') {
+    return 'debug';
+  }
+  if (m === 'warn') {
+    return 'warn';
+  }
+  return 'error';
+}
+
+function toSourceId(pathRel) {
+  return pathRel.split(sep).join('/').replace(/\.(tsx?)$/, '');
+}
+
+function grafanaDataImportPath(absFile) {
+  const rel = relative(dirname(absFile), join(root, 'packages/grafana-data/src/utils/clientStructuredLog.ts'));
+  let p = rel.replaceAll('\\', '/').replace(/\.ts$/, '');
+  if (!p.startsWith('.')) {
+    p = './' + p;
+  }
+  return p;
+}
+
+function hasCreateClientLogImport(s) {
+  return /import\s*\{[^}]*\bcreateClientLog\b/.test(s);
+}
+
+function addImport(s, absPath, inGrafanaData) {
+  if (hasCreateClientLogImport(s)) {
+    return s;
+  }
+  const from = inGrafanaData ? grafanaDataImportPath(absPath) : '@grafana/data';
+  return `import { createClientLog } from '${from}';\n` + s;
+}
+
+function addToExistingGrafanaDataImport(s) {
+  return s.replace(
+    /(import\s*\{)([^}]*)(}\s*from\s*['"][^'"]*clientStructuredLog['"]\s*;?)/m,
+    (_, a, b, c) => (b.includes('createClientLog') ? _ : `${a}${b.trim() ? b.trim() + ', ' : ''}createClientLog${c}`)
+  );
+}
+
+function addToGrafanaDataPackageImport(s) {
+  if (!/from ['"]@grafana\/data['"]/.test(s) || s.includes("import { createClientLog }")) {
+    return s;
+  }
+  s = s.replace(
+    /(import\s*\{)([^}]*)(}\s*from\s*['"]@grafana\/data['"]\s*;?)/m,
+    (full, a, b, c) => (b.includes('createClientLog') ? full : `${a}${b.trim() ? b.trim() + ', ' : ''}createClientLog${c}`)
+  );
+  return s;
+}
+
+function ensureConst(s, sourceId) {
+  if (/const clientLog = createClientLog\(/m.test(s)) {
+    return s;
+  }
+  const c = `const clientLog = createClientLog('${sourceId}');\n`;
+  if (hasCreateClientLogImport(s)) {
+    s = s.replace(
+      /(import\s*\{[^}]*\bcreateClientLog\b[^}]*\}\s*from\s*['"][^'"]+['"]\s*;?\n)/m,
+      (h) => h + c
+    );
+  }
+  if (!/const clientLog = createClientLog\(/m.test(s)) {
+    s = c + s;
+  }
+  return s;
+}
+
+function processFile(absPath) {
+  let s = readFileSync(absPath, 'utf8');
+  if (!RE.test(s)) {
+    return 0;
+  }
+  RE.lastIndex = 0;
+
+  const f = relative(root, absPath);
+  if (skipPath(f)) {
+    return 0;
+  }
+
+  s = s.replace(RE, (_, m) => `clientLog.${mapMethod(m)}(`);
+
+  const n = f.replaceAll('\\', '/');
+  const inGrafanaData = n.startsWith('packages/grafana-data/src/') && n !== 'packages/grafana-data/src/utils/clientStructuredLog.ts';
+  s = inGrafanaData ? addToExistingGrafanaDataImport(s) : addToGrafanaDataPackageImport(s);
+  s = addImport(s, absPath, inGrafanaData);
+  s = ensureConst(s, toSourceId(f));
+
+  writeFileSync(absPath, s);
+  return 1;
+}
+
+const files = execSync(`cd "${root}" && git ls-files "*.ts" "*.tsx"`, {
+  encoding: 'utf8',
+  maxBuffer: 200 * 1024 * 1024,
+})
+  .split('\n')
+  .map((l) => l.trim())
+  .filter(Boolean);
+
+let count = 0;
+for (const f of files) {
+  const abs = join(root, f);
+  if (existsSync(abs)) {
+    count += processFile(abs) || 0;
+  }
+}
+process.stdout.write(`replace-console-structured-logs: updated ${count} files\n`);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Introduce `createClientLog` in `@grafana/data` and wire it to Faro in `@grafana/runtime` via `setClientStructuredLog` so the same `logInfo` / `logWarning` / `logDebug` / `logError` path is used for browser telemetry.
- Replace `console.log|info|debug|warn|error` in production `*.ts`/`*.tsx` with a per-file `const clientLog = createClientLog('<path>')` and `clientLog.*` calls.
- Keep **opt-in dev logging** on the browser console: `createLogger` in `@grafana/ui` and `createDebugLog` in the app.
- Add codemod scripts: `scripts/replace-console-with-structured-logs.mjs`, `scripts/fix-clientlog-import-order.mjs`, and documentation under `.cursor/docs/structured-client-logging.md`.

## Test plan
- `npx tsc --noEmit` (passes on this branch)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-66ff6e86-85b7-418b-95fc-354e0bc24074"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-66ff6e86-85b7-418b-95fc-354e0bc24074"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

