### PR TITLE
refactor(app): factor console logging to structured logging (Faro)

### DIFF
--- a/public/app/core/services/FetchQueue.ts
+++ b/public/app/core/services/FetchQueue.ts
@@ -1,6 +1,8 @@
 import { type Observable, Subject } from 'rxjs';
 
-import { type BackendSrvRequest } from '@grafana/runtime';
+import { createMonitoringLogger, type BackendSrvRequest } from '@grafana/runtime';
+
+const fetchQueueLogger = createMonitoringLogger('core.FetchQueue');
 
 export interface QueueState extends Record<string, { state: FetchStatus; options: BackendSrvRequest }> {}
 
@@ -90,8 +92,10 @@ export class FetchQueue {
       []
     );
 
-    console.log('FetchQueue noOfStarted', update.noOfInProgress);
-    console.log('FetchQueue noOfNotStarted', update.noOfPending);
-    console.log('FetchQueue state', entriesWithoutOptions);
+    fetchQueueLogger.logDebug('FetchQueue debug snapshot', {
+      noOfInProgress: update.noOfInProgress,
+      noOfPending: update.noOfPending,
+      entries: entriesWithoutOptions,
+    });
   };
 }

--- a/public/app/core/services/backend_srv.ts
+++ b/public/app/core/services/backend_srv.ts
@@ -31,9 +31,12 @@ import {
   type BackendSrv as BackendService,
   type BackendSrvRequest,
   config,
+  createMonitoringLogger,
   type FetchError,
   type FetchResponse,
 } from '@grafana/runtime';
+
+const backendSrvLogger = createMonitoringLogger('core.backend_srv');
 import { appEvents } from 'app/core/app_events';
 import { getConfig } from 'app/core/config';
 import { getSessionExpiry, hasSessionExpiry } from 'app/core/utils/auth';
@@ -116,7 +119,9 @@ export class BackendSrv implements BackendService {
       const result = await fp.get();
       this.deviceID = result.visitorId;
     } catch (error) {
-      console.error(error);
+      backendSrvLogger.logError(error instanceof Error ? error : new Error(String(error)), {
+        fn: 'initGrafanaDeviceID',
+      });
     }
   }
 
@@ -241,7 +246,10 @@ export class BackendSrv implements BackendService {
             observer.complete();
           }) // runs in background
           .catch((e) => {
-            console.log(requestId, 'catch', e);
+            backendSrvLogger.logError(e instanceof Error ? e : new Error(String(e)), {
+              fn: 'chunkedStreamProcess',
+              requestId,
+            });
             observer.error(e);
           }); // from abort
       },

--- a/public/app/core/utils/dag.ts
+++ b/public/app/core/utils/dag.ts
@@ -1,3 +1,7 @@
+import { createMonitoringLogger } from '@grafana/runtime';
+
+const dagLogger = createMonitoringLogger('core.dag');
+
 export class Edge {
   inputNode?: Node;
   outputNode?: Node;
@@ -268,7 +272,7 @@ export const printGraph = (g: Graph) => {
     if (!inputEdges) {
       inputEdges = '<none>';
     }
-    console.log(`${n.name}:\n - links to:   ${outputEdges}\n - links from: ${inputEdges}`);
+    dagLogger.logDebug(`node ${n.name}: links to ${outputEdges}; links from ${inputEdges}`);
   });
 };
 

--- a/public/app/core/utils/explore.ts
+++ b/public/app/core/utils/explore.ts
@@ -24,10 +24,12 @@ import {
   toURLRange,
   urlUtil,
 } from '@grafana/data';
-import { getDataSourceSrv } from '@grafana/runtime';
+import { createMonitoringLogger, getDataSourceSrv } from '@grafana/runtime';
 import { RefreshPicker } from '@grafana/ui';
 import { ExpressionDatasourceUID } from 'app/features/expressions/types';
 import { type QueryOptions, type QueryTransaction } from 'app/types/explore';
+
+const exploreUtilsLogger = createMonitoringLogger('core.explore.utils');
 
 export const DEFAULT_UI_STATE = {
   dedupStrategy: LogsDedupStrategy.none,
@@ -159,7 +161,9 @@ export const safeStringifyValue = (value: unknown, space?: number) => {
   try {
     return JSON.stringify(value, null, space);
   } catch (error) {
-    console.error(error);
+    exploreUtilsLogger.logError(error instanceof Error ? error : new Error(String(error)), {
+      fn: 'safeStringifyValue',
+    });
   }
 
   return '';
@@ -232,7 +236,9 @@ export async function ensureQueries(
         try {
           await getDataSourceSrv().get(query.datasource.uid);
         } catch {
-          console.error(`One of the queries has a datasource that is no longer available and was removed.`);
+          exploreUtilsLogger.logWarning('Query datasource no longer available; query removed', {
+            datasourceUid: query.datasource?.uid,
+          });
           validDS = false;
         }
       }

--- a/public/app/core/utils/fetch.test.ts
+++ b/public/app/core/utils/fetch.test.ts
@@ -10,6 +10,19 @@ import {
   parseUrlFromOptions,
 } from './fetch';
 
+const mockLogWarning = jest.fn();
+
+jest.mock('@grafana/runtime', () => ({
+  ...jest.requireActual('@grafana/runtime'),
+  createMonitoringLogger: () => ({
+    logWarning: mockLogWarning,
+    logError: jest.fn(),
+    logInfo: jest.fn(),
+    logDebug: jest.fn(),
+    logMeasurement: jest.fn(),
+  }),
+}));
+
 jest.mock('@grafana/data', () => ({
   ...jest.requireActual('@grafana/data'),
   deprecationWarning: () => {},
@@ -179,7 +192,7 @@ describe('parseResponseBody', () => {
 
   it('returns an empty object {} when the response is empty but is declared as JSON type', async () => {
     rsp.headers.set('Content-Length', '0');
-    jest.spyOn(console, 'warn').mockImplementation();
+    mockLogWarning.mockClear();
 
     const json = jest.fn();
     const body = await parseResponseBody(
@@ -192,7 +205,11 @@ describe('parseResponseBody', () => {
 
     expect(body).toEqual({});
     expect(json).not.toHaveBeenCalled();
-    expect(console.warn).toHaveBeenCalledTimes(1);
+    expect(mockLogWarning).toHaveBeenCalledTimes(1);
+    expect(mockLogWarning).toHaveBeenCalledWith(
+      'Response declared JSON but body was empty',
+      expect.objectContaining({ url: rsp.url })
+    );
   });
 
   it('parses text', async () => {

--- a/public/app/core/utils/fetch.ts
+++ b/public/app/core/utils/fetch.ts
@@ -2,7 +2,9 @@ import { omitBy } from 'lodash';
 import { type Observable, of, throwError } from 'rxjs';
 
 import { deprecationWarning, validatePath } from '@grafana/data';
-import { type BackendSrvRequest } from '@grafana/runtime';
+import { createMonitoringLogger, type BackendSrvRequest } from '@grafana/runtime';
+
+const fetchLogger = createMonitoringLogger('core.fetch');
 
 export const parseInitFromOptions = (options: BackendSrvRequest): RequestInit => {
   const method = options.method;
@@ -139,7 +141,7 @@ export async function parseResponseBody<T>(
         // An empty string is not a valid JSON.
         // Sometimes (unfortunately) our APIs declare their Content-Type as JSON, however they return an empty body.
         if (response.headers.get('Content-Length') === '0') {
-          console.warn(`${response.url} returned an invalid JSON`);
+          fetchLogger.logWarning('Response declared JSON but body was empty', { url: response.url });
           return {} as T;
         }
         return await response.json();

--- a/public/app/core/utils/metrics.ts
+++ b/public/app/core/utils/metrics.ts
@@ -1,4 +1,8 @@
+import { createMonitoringLogger } from '@grafana/runtime';
+
 import { reportPerformance } from '../services/echo/EchoSrv';
+
+const metricsLogger = createMonitoringLogger('core.metrics');
 
 export function startMeasure(eventName: string) {
   if (!performance || !performance.mark) {
@@ -8,7 +12,10 @@ export function startMeasure(eventName: string) {
   try {
     performance.mark(`${eventName}_started`);
   } catch (error) {
-    console.error(`[Metrics] Failed to startMeasure ${eventName}`, error);
+    metricsLogger.logError(
+      error instanceof Error ? error : new Error(String(error)),
+      { eventName, phase: 'startMeasure' }
+    );
   }
 }
 
@@ -31,7 +38,10 @@ export function stopMeasure(eventName: string) {
     performance.clearMeasures(measured);
     return measure;
   } catch (error) {
-    console.error(`[Metrics] Failed to stopMeasure ${eventName}`, error);
+    metricsLogger.logError(
+      error instanceof Error ? error : new Error(String(error)),
+      { eventName, phase: 'stopMeasure' }
+    );
     return;
   }
 }

--- a/public/app/core/utils/shortLinks.ts
+++ b/public/app/core/utils/shortLinks.ts
@@ -2,7 +2,9 @@ import memoizeOne from 'memoize-one';
 
 import { type AbsoluteTimeRange, type LogRowModel, type UrlQueryMap } from '@grafana/data';
 import { t } from '@grafana/i18n';
-import { getBackendSrv, config, locationService } from '@grafana/runtime';
+import { createMonitoringLogger, getBackendSrv, config, locationService } from '@grafana/runtime';
+
+const shortLinksLogger = createMonitoringLogger('core.shortLinks');
 import { sceneGraph, type SceneTimeRangeLike, type VizPanel } from '@grafana/scenes';
 import { shortURLAPIv1beta1 } from 'app/api/clients/shorturl/v1beta1';
 import { createErrorNotification, createSuccessNotification } from 'app/core/copy/appNotification';
@@ -73,7 +75,7 @@ export const createShortLink = memoizeOne(async (path: string): Promise<string> 
       return await createShortLinkLegacy(path);
     }
   } catch (err) {
-    console.error('Error when creating shortened link: ', err);
+    shortLinksLogger.logError(err instanceof Error ? err : new Error(String(err)), { fn: 'createShortLink' });
     dispatch(notifyApp(createErrorNotification('Error generating shortened link')));
     createShortLink.clear();
     throw err; // Re-throw so callers know it failed
@@ -104,7 +106,9 @@ export const createAndCopyShortLink = async (path: string) => {
     }
   } catch (error) {
     // createShortLink already handles error notifications, just log
-    console.error('Error in createAndCopyShortLink:', error);
+    shortLinksLogger.logError(error instanceof Error ? error : new Error(String(error)), {
+      fn: 'createAndCopyShortLink',
+    });
   }
 };
 

--- a/public/app/core/utils/timeRegions.ts
+++ b/public/app/core/utils/timeRegions.ts
@@ -1,6 +1,9 @@
 import { Cron } from 'croner';
 
 import { type AbsoluteTimeRange, type TimeRange, durationToMilliseconds, parseDuration } from '@grafana/data';
+import { createMonitoringLogger } from '@grafana/runtime';
+
+const timeRegionsLogger = createMonitoringLogger('core.timeRegions');
 
 export type TimeRegionMode = null | 'cron';
 export interface TimeRegionConfig {
@@ -160,7 +163,7 @@ export function calculateTimesWithin(cfg: TimeRegionConfig, tRange: TimeRange): 
     }
   } catch (e) {
     // invalid expression
-    console.error(e);
+    timeRegionsLogger.logError(e instanceof Error ? e : new Error(String(e)), { fn: 'buildCronRanges' });
   }
 
   return ranges;

--- a/public/app/features/actions/utils.ts
+++ b/public/app/features/actions/utils.ts
@@ -16,10 +16,17 @@ import {
   textUtil,
   type ValueLinkConfig,
 } from '@grafana/data';
-import { type BackendSrvRequest, config as grafanaConfig, getBackendSrv } from '@grafana/runtime';
+import {
+  createMonitoringLogger,
+  type BackendSrvRequest,
+  config as grafanaConfig,
+  getBackendSrv,
+} from '@grafana/runtime';
 import { appEvents } from 'app/core/app_events';
 
 import { HttpRequestMethod } from '../../plugins/panel/canvas/panelcfg.gen';
+
+const actionsUtilsLogger = createMonitoringLogger('features.actions.utils');
 import { createAbsoluteUrl, type RelativeUrl } from '../alerting/unified/utils/url';
 import { getTimeSrv } from '../dashboard/services/TimeSrv';
 import { getNextRequestId } from '../query/state/PanelQueryRunner';
@@ -120,7 +127,10 @@ export const getActions = (
                   appEvents.emit(AppEvents.alertError, [
                     'An error has occurred. Check console output for more details.',
                   ]);
-                  console.error(error);
+                  actionsUtilsLogger.logError(
+                    error instanceof Error ? error : new Error(String(error)),
+                    { fn: 'actionBackendFetch' }
+                  );
                 },
                 complete: () => {
                   appEvents.emit(AppEvents.alertSuccess, ['API call was successful']);
@@ -128,7 +138,9 @@ export const getActions = (
               });
           } catch (error) {
             appEvents.emit(AppEvents.alertError, ['An error has occurred. Check console output for more details.']);
-            console.error(error);
+            actionsUtilsLogger.logError(error instanceof Error ? error : new Error(String(error)), {
+              fn: 'actionBackendFetchSync',
+            });
             return;
           }
         },

--- a/public/app/features/admin/UserOrgs.tsx
+++ b/public/app/features/admin/UserOrgs.tsx
@@ -7,7 +7,11 @@ import { Button, ConfirmButton, Field, Icon, Modal, Tooltip, useStyles2, Stack, 
 import { UserRolePicker } from 'app/core/components/RolePicker/UserRolePicker';
 import { fetchRoleOptions, updateUserRoles } from 'app/core/components/RolePicker/api';
 import { OrgPicker, type OrgSelectItem } from 'app/core/components/Select/OrgPicker';
+import { createMonitoringLogger } from '@grafana/runtime';
+
 import { contextSrv } from 'app/core/services/context_srv';
+
+const userOrgsLogger = createMonitoringLogger('features.admin.UserOrgs');
 import { AccessControlAction, type Role } from 'app/types/accessControl';
 import { type Organization } from 'app/types/organization';
 import { type UserOrg, type UserDTO } from 'app/types/user';
@@ -128,7 +132,12 @@ const OrgRow = memo(({ user, org, isExternalUser, onOrgRemove, onOrgRoleChange }
       if (contextSrv.hasPermission(AccessControlAction.ActionRolesList)) {
         fetchRoleOptions(org.orgId)
           .then((roles) => setRoleOptions(roles))
-          .catch((e) => console.error(e));
+          .catch((e) =>
+            userOrgsLogger.logError(e instanceof Error ? e : new Error(String(e)), {
+              fn: 'fetchRoleOptions',
+              context: 'OrgRow',
+            })
+          );
       }
     }
   }, [org.orgId]);
@@ -266,7 +275,12 @@ export const AddToOrgModal = memo(({ isOpen, user, userOrgs, onOrgAdd, onDismiss
       if (contextSrv.hasPermission(AccessControlAction.ActionRolesList)) {
         fetchRoleOptions(org.value?.id)
           .then((roles) => setRoleOptions(roles))
-          .catch((e) => console.error(e));
+          .catch((e) =>
+            userOrgsLogger.logError(e instanceof Error ? e : new Error(String(e)), {
+              fn: 'fetchRoleOptions',
+              context: 'OrgRow',
+            })
+          );
       }
     }
   };

--- a/public/app/features/admin/Users/OrgUsersTable.tsx
+++ b/public/app/features/admin/Users/OrgUsersTable.tsx
@@ -25,7 +25,11 @@ import { UserRolePicker } from 'app/core/components/RolePicker/UserRolePicker';
 import { fetchRoleOptions, updateUserRoles } from 'app/core/components/RolePicker/api';
 import { RolePickerBadges } from 'app/core/components/RolePickerDrawer/RolePickerBadges';
 import { TagBadge } from 'app/core/components/TagFilter/TagBadge';
+import { createMonitoringLogger } from '@grafana/runtime';
+
 import { contextSrv } from 'app/core/services/context_srv';
+
+const orgUsersTableLogger = createMonitoringLogger('features.admin.OrgUsersTable');
 import { AccessControlAction, type Role } from 'app/types/accessControl';
 import { type OrgUser } from 'app/types/user';
 
@@ -79,7 +83,7 @@ export const OrgUsersTable = ({
           setRoleOptions(options);
         }
       } catch (e) {
-        console.error('Error loading options');
+        orgUsersTableLogger.logError(e instanceof Error ? e : new Error(String(e)), { fn: 'fetchRoleOptions' });
       }
     }
     if (contextSrv.licensedAccessControlEnabled()) {

--- a/public/app/features/admin/state/actions.ts
+++ b/public/app/features/admin/state/actions.ts
@@ -1,7 +1,15 @@
 import { debounce } from 'lodash';
 
 import { dateTimeFormatTimeAgo } from '@grafana/data';
-import { featureEnabled, getBackendSrv, isFetchError, locationService } from '@grafana/runtime';
+import {
+  createMonitoringLogger,
+  featureEnabled,
+  getBackendSrv,
+  isFetchError,
+  locationService,
+} from '@grafana/runtime';
+
+const adminActionsLogger = createMonitoringLogger('features.admin.actions');
 import { type FetchDataArgs } from '@grafana/ui';
 import config from 'app/core/config';
 import { contextSrv } from 'app/core/services/context_srv';
@@ -50,7 +58,9 @@ export function loadAdminUserPage(userUid: string): ThunkResult<void> {
       }
       dispatch(userAdminPageLoadedAction(true));
     } catch (error) {
-      console.error(error);
+      adminActionsLogger.logError(error instanceof Error ? error : new Error(String(error)), {
+        fn: 'loadAdminUserPage',
+      });
 
       if (isFetchError(error)) {
         const userError = {
@@ -300,7 +310,7 @@ export function fetchUsers(): ThunkResult<void> {
       dispatch(usersFetched(result));
     } catch (error) {
       usersFetchEnd();
-      console.error(error);
+      adminActionsLogger.logError(error instanceof Error ? error : new Error(String(error)), { fn: 'fetchUsers' });
     }
   };
 }
@@ -366,7 +376,9 @@ export function fetchUsersAnonymousDevices(): ThunkResult<void> {
       const result = await getBackendSrv().get(url);
       dispatch(usersAnonymousDevicesFetched(result));
     } catch (error) {
-      console.error(error);
+      adminActionsLogger.logError(error instanceof Error ? error : new Error(String(error)), {
+        fn: 'fetchUsersAnonymousDevices',
+      });
     }
   };
 }

--- a/public/app/features/admin/state/apis.tsx
+++ b/public/app/features/admin/state/apis.tsx
@@ -1,4 +1,6 @@
-import { getBackendSrv } from '@grafana/runtime';
+import { createMonitoringLogger, getBackendSrv } from '@grafana/runtime';
+
+const adminApisLogger = createMonitoringLogger('features.admin.apis');
 
 interface AnonServerStat {
   activeDevices?: number;
@@ -28,7 +30,7 @@ export const getServerStats = async (): Promise<ServerStat | null> => {
   return getBackendSrv()
     .get('api/admin/stats')
     .catch((err) => {
-      console.error(err);
+      adminApisLogger.logError(err instanceof Error ? err : new Error(String(err)), { fn: 'getServerStats' });
       return null;
     });
 };


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Replaces `console.log` / `console.warn` / `console.error` in targeted app code with `createMonitoringLogger` from `@grafana/runtime`, which emits structured logs via the Grafana JavaScript Agent (Faro) when enabled.

## Areas touched

- **Core**: `fetch` (empty JSON body warning), `metrics`, `explore` helpers, `shortLinks`, `timeRegions`, `dag` (`printGraph`), `backend_srv`, `FetchQueue` (debug path only)
- **Admin**: user/org actions, server stats API wrapper, `OrgUsersTable`, `UserOrgs`
- **Actions**: panel action backend fetch errors

## Tests

- `fetch.test.ts` updated to mock `createMonitoringLogger` and assert `logWarning` with URL context instead of `console.warn`.

## Notes

- Faro logging only runs when `config.grafanaJavascriptAgent.enabled` is true (existing behavior); dev consoles without the agent will not see these entries unless Faro is on.
- Further `console.*` usage remains elsewhere in the repo (plugins, dashboard-scene, etc.) for follow-up if desired.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-853dd3f6-52ac-47c0-9cb8-62b0e7b640e3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-853dd3f6-52ac-47c0-9cb8-62b0e7b640e3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

