### PR TITLE
refactor(runtime): structured JSON console logging

### DIFF
--- a/packages/grafana-runtime/src/config.ts
+++ b/packages/grafana-runtime/src/config.ts
@@ -1,5 +1,6 @@
 import { merge } from 'lodash';
 
+import { structuredConsoleLog } from './utils/structuredConsole';
 import {
   type AppPluginConfig as AppPluginConfigGrafanaData,
   type AuthSettings,
@@ -313,7 +314,11 @@ function overrideFeatureTogglesFromLocalStorage(config: GrafanaBootConfig) {
       const toggleState = featureValue === 'true' || featureValue === '1';
       // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
       featureToggles[featureName as keyof FeatureToggles] = toggleState;
-      console.log(`Setting feature toggle ${featureName} = ${toggleState} via localstorage`);
+      structuredConsoleLog('info', 'Feature toggle overridden from localStorage', {
+        source: 'config.overrideFeatureTogglesFromLocalStorage',
+        featureName,
+        toggleState,
+      });
     }
   }
 }
@@ -339,9 +344,16 @@ function overrideFeatureTogglesFromUrl(config: GrafanaBootConfig) {
       if (toggleState !== featureToggles[key]) {
         if (isDevelopment || safeRuntimeFeatureFlags.has(featureName)) {
           featureToggles[featureName] = toggleState;
-          console.log(`Setting feature toggle ${featureName} = ${toggleState} via url`);
+          structuredConsoleLog('info', 'Feature toggle overridden from URL', {
+            source: 'config.overrideFeatureTogglesFromUrl',
+            featureName,
+            toggleState,
+          });
         } else {
-          console.log(`Unable to change feature toggle ${featureName} via url in production.`);
+          structuredConsoleLog('warn', 'Feature toggle URL override ignored in production', {
+            source: 'config.overrideFeatureTogglesFromUrl',
+            featureName,
+          });
         }
       }
     }
@@ -352,7 +364,9 @@ let bootData = window.grafanaBootData;
 
 if (!bootData) {
   if (process.env.NODE_ENV !== 'test') {
-    console.error('window.grafanaBootData was not set by the time config was initialized');
+    structuredConsoleLog('error', 'window.grafanaBootData was not set by the time config was initialized', {
+      source: 'config',
+    });
   }
 
   bootData = {

--- a/packages/grafana-runtime/src/internal/openFeature/index.ts
+++ b/packages/grafana-runtime/src/internal/openFeature/index.ts
@@ -18,7 +18,6 @@ function checkDefaultProvider(event?: EventDetails) {
       'OpenFeature default domain provider has been unexpectedly changed. This may be caused by a plugin that is incorrectly using the default domain.',
       { cause: OpenFeature.getProvider() }
     );
-    console.error(err);
     logError(err);
   }
 }

--- a/packages/grafana-runtime/src/services/pluginMeta/apps.test.ts
+++ b/packages/grafana-runtime/src/services/pluginMeta/apps.test.ts
@@ -107,9 +107,12 @@ describe('when useMTPlugins flag is enabled', () => {
           await func();
 
           expect(console.warn).toHaveBeenCalledTimes(1);
-          expect(console.warn).toHaveBeenCalledWith(
-            'PluginMeta: plugin meta yielded an empty result so Grafana is falling back to bootdata'
-          );
+          expect(JSON.parse(String(console.warn.mock.calls[0][0]))).toMatchObject({
+            level: 'warn',
+            message: 'PluginMeta: plugin meta yielded an empty result so Grafana is falling back to bootdata',
+            source: 'pluginMeta',
+            type: 'app',
+          });
           expect(logger.logWarning).toHaveBeenCalledTimes(1);
           expect(logger.logWarning).toHaveBeenCalledWith(
             'PluginMeta: plugin meta yielded an empty result so Grafana is falling back to bootdata',
@@ -124,9 +127,12 @@ describe('when useMTPlugins flag is enabled', () => {
           await func('');
 
           expect(console.warn).toHaveBeenCalledTimes(1);
-          expect(console.warn).toHaveBeenCalledWith(
-            'PluginMeta: plugin meta yielded an empty result so Grafana is falling back to bootdata'
-          );
+          expect(JSON.parse(String(console.warn.mock.calls[0][0]))).toMatchObject({
+            level: 'warn',
+            message: 'PluginMeta: plugin meta yielded an empty result so Grafana is falling back to bootdata',
+            source: 'pluginMeta',
+            type: 'app',
+          });
           expect(logger.logWarning).toHaveBeenCalledTimes(1);
           expect(logger.logWarning).toHaveBeenCalledWith(
             'PluginMeta: plugin meta yielded an empty result so Grafana is falling back to bootdata',

--- a/packages/grafana-runtime/src/services/pluginMeta/logging.ts
+++ b/packages/grafana-runtime/src/services/pluginMeta/logging.ts
@@ -1,6 +1,7 @@
 import { type PluginType } from '@grafana/data';
 
 import { createMonitoringLogger, type MonitoringLogger } from '../../utils/logging';
+import { structuredConsoleLog } from '../../utils/structuredConsole';
 
 let logger: MonitoringLogger;
 
@@ -14,12 +15,12 @@ function getLogger() {
 
 export function logPluginMetaWarning(message: string, type: PluginType): void {
   getLogger().logWarning(message, { type });
-  console.warn(message);
+  structuredConsoleLog('warn', message, { source: 'pluginMeta', type });
 }
 
 export function logPluginMetaError(message: string, error: unknown): void {
   getLogger().logError(new Error(message, { cause: error }));
-  console.error(message, error);
+  structuredConsoleLog('error', message, { source: 'pluginMeta', error });
 }
 
 export function setPluginMetaLogger(override: MonitoringLogger) {

--- a/packages/grafana-runtime/src/services/pluginMeta/panels.test.ts
+++ b/packages/grafana-runtime/src/services/pluginMeta/panels.test.ts
@@ -160,9 +160,12 @@ describe('when useMTPlugins flag is enabled', () => {
         await func();
 
         expect(console.warn).toHaveBeenCalledTimes(1);
-        expect(console.warn).toHaveBeenCalledWith(
-          'PluginMeta: plugin meta yielded an empty result so Grafana is falling back to bootdata'
-        );
+        expect(JSON.parse(String(console.warn.mock.calls[0][0]))).toMatchObject({
+          level: 'warn',
+          message: 'PluginMeta: plugin meta yielded an empty result so Grafana is falling back to bootdata',
+          source: 'pluginMeta',
+          type: 'panel',
+        });
         expect(logger.logWarning).toHaveBeenCalledTimes(1);
         expect(logger.logWarning).toHaveBeenCalledWith(
           'PluginMeta: plugin meta yielded an empty result so Grafana is falling back to bootdata',
@@ -176,9 +179,12 @@ describe('when useMTPlugins flag is enabled', () => {
           await func('');
 
           expect(console.warn).toHaveBeenCalledTimes(1);
-          expect(console.warn).toHaveBeenCalledWith(
-            'PluginMeta: plugin meta yielded an empty result so Grafana is falling back to bootdata'
-          );
+          expect(JSON.parse(String(console.warn.mock.calls[0][0]))).toMatchObject({
+            level: 'warn',
+            message: 'PluginMeta: plugin meta yielded an empty result so Grafana is falling back to bootdata',
+            source: 'pluginMeta',
+            type: 'panel',
+          });
           expect(logger.logWarning).toHaveBeenCalledTimes(1);
           expect(logger.logWarning).toHaveBeenCalledWith(
             'PluginMeta: plugin meta yielded an empty result so Grafana is falling back to bootdata',

--- a/packages/grafana-runtime/src/utils/chromeHeaderHeight.ts
+++ b/packages/grafana-runtime/src/utils/chromeHeaderHeight.ts
@@ -1,3 +1,5 @@
+import { structuredConsoleLog } from './structuredConsole';
+
 type ChromeHeaderHeightHook = () => number;
 
 let chromeHeaderHeightHook: ChromeHeaderHeightHook | undefined = undefined;
@@ -11,7 +13,9 @@ export const useChromeHeaderHeight = () => {
     if (process.env.NODE_ENV !== 'production') {
       throw new Error('useChromeHeaderHeight hook not found in @grafana/runtime');
     }
-    console.error('useChromeHeaderHeight hook not found');
+    structuredConsoleLog('error', 'useChromeHeaderHeight hook not found', {
+      source: 'useChromeHeaderHeight',
+    });
   }
 
   return chromeHeaderHeightHook?.();

--- a/packages/grafana-runtime/src/utils/megaMenuOpen.ts
+++ b/packages/grafana-runtime/src/utils/megaMenuOpen.ts
@@ -1,3 +1,5 @@
+import { structuredConsoleLog } from './structuredConsole';
+
 type MegaMenuOpenHook = () => Readonly<[boolean, (open: boolean, persist?: boolean) => void]>;
 
 let megaMenuOpenHook: MegaMenuOpenHook | undefined = undefined;
@@ -15,7 +17,13 @@ export const useMegaMenuOpen: MegaMenuOpenHook = () => {
     if (process.env.NODE_ENV !== 'production') {
       throw new Error('useMegaMenuOpen hook not found in @grafana/runtime');
     }
-    return [false, () => console.error('MegaMenuOpen hook not found')];
+    return [
+      false,
+      () =>
+        structuredConsoleLog('error', 'MegaMenuOpen hook not found', {
+          source: 'useMegaMenuOpen',
+        }),
+    ];
   }
 
   return megaMenuOpenHook();

--- a/packages/grafana-runtime/src/utils/migrationHandler.ts
+++ b/packages/grafana-runtime/src/utils/migrationHandler.ts
@@ -2,6 +2,7 @@ import { type DataQueryRequest } from '@grafana/data';
 import { type DataQuery } from '@grafana/schema';
 
 import { config } from '../config';
+import { structuredConsoleLog } from './structuredConsole';
 import { getBackendSrv } from '../services';
 
 import { DataSourceWithBackend } from './DataSourceWithBackend';
@@ -20,7 +21,9 @@ export function isMigrationHandler(object: unknown): object is MigrationHandler 
 
 async function postMigrateRequest<TQuery extends DataQuery>(queries: TQuery[]): Promise<TQuery[]> {
   if (!(config.featureToggles.grafanaAPIServerWithExperimentalAPIs || config.featureToggles.datasourceAPIServers)) {
-    console.warn('migrateQuery is only available with the experimental API server');
+    structuredConsoleLog('warn', 'migrateQuery is only available with the experimental API server', {
+      source: 'migrationHandler.postMigrateRequest',
+    });
     return queries;
   }
 

--- a/packages/grafana-runtime/src/utils/plugin.ts
+++ b/packages/grafana-runtime/src/utils/plugin.ts
@@ -1,6 +1,7 @@
 import { type PanelPlugin } from '@grafana/data';
 
 import { config } from '../config';
+import { structuredConsoleLog } from './structuredConsole';
 
 /**
  * Option to specify a plugin css that should be applied for the dark
@@ -25,7 +26,10 @@ export async function loadPluginCss(options: PluginCssOptions): Promise<System.M
     const cssPath = config.bootData.user.theme === 'light' ? options.light : options.dark;
     return window.System.import(cssPath);
   } catch (err) {
-    console.error(err);
+    structuredConsoleLog('error', 'Failed to load plugin CSS', {
+      source: 'loadPluginCss',
+      error: err,
+    });
   }
 }
 

--- a/packages/grafana-runtime/src/utils/qscheck.ts
+++ b/packages/grafana-runtime/src/utils/qscheck.ts
@@ -1,5 +1,7 @@
 import { type DataSourceInstanceSettings, type DataSourceJsonData } from '@grafana/data';
 
+import { structuredConsoleLog } from './structuredConsole';
+
 interface JsonData extends DataSourceJsonData {
   oauthPassThru?: unknown; // we do not assume boolean, to be more robust
   azureCredentials?: {
@@ -48,11 +50,15 @@ function parseAllowedTypes(data: unknown): AllowedTypes {
     if (types.every((x) => typeof x === 'string')) {
       return { types };
     } else {
-      console.error('qscheck.parseFlags: non-string item in allowed');
+      structuredConsoleLog('error', 'qscheck.parseFlags: non-string item in allowed', {
+        source: 'qscheck.parseAllowedTypes',
+      });
       return { types: [] };
     }
   } else {
-    console.error('qscheck.parseFlags: invalid data');
+    structuredConsoleLog('error', 'qscheck.parseFlags: invalid data', {
+      source: 'qscheck.parseAllowedTypes',
+    });
     return { types: [] };
   }
 }

--- a/packages/grafana-runtime/src/utils/returnToPrevious.ts
+++ b/packages/grafana-runtime/src/utils/returnToPrevious.ts
@@ -1,3 +1,5 @@
+import { structuredConsoleLog } from './structuredConsole';
+
 type ReturnToPreviousHook = () => (title: string, href?: string) => void;
 
 let rtpHook: ReturnToPreviousHook | undefined = undefined;
@@ -16,7 +18,10 @@ export const useReturnToPrevious: ReturnToPreviousHook = () => {
     if (process.env.NODE_ENV !== 'production') {
       throw new Error('useReturnToPrevious hook not found in @grafana/runtime');
     }
-    return () => console.error('ReturnToPrevious hook not found');
+    return () =>
+      structuredConsoleLog('error', 'ReturnToPrevious hook not found', {
+        source: 'useReturnToPrevious',
+      });
   }
 
   return rtpHook();

--- a/packages/grafana-runtime/src/utils/structuredConsole.test.ts
+++ b/packages/grafana-runtime/src/utils/structuredConsole.test.ts
@@ -1,0 +1,42 @@
+import { structuredConsoleLog } from './structuredConsole';
+
+describe('structuredConsoleLog', () => {
+  let logSpy: jest.SpyInstance;
+  let warnSpy: jest.SpyInstance;
+  let errorSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    logSpy = jest.spyOn(console, 'log').mockImplementation();
+    warnSpy = jest.spyOn(console, 'warn').mockImplementation();
+    errorSpy = jest.spyOn(console, 'error').mockImplementation();
+  });
+
+  afterEach(() => {
+    logSpy.mockRestore();
+    warnSpy.mockRestore();
+    errorSpy.mockRestore();
+  });
+
+  it('writes JSON with info level to console.log', () => {
+    structuredConsoleLog('info', 'hello', { source: 'test', key: 'value' });
+    expect(logSpy).toHaveBeenCalledTimes(1);
+    expect(JSON.parse(String(logSpy.mock.calls[0][0]))).toEqual({
+      level: 'info',
+      message: 'hello',
+      source: 'test',
+      key: 'value',
+    });
+  });
+
+  it('serializes Error fields', () => {
+    const err = new Error('boom');
+    structuredConsoleLog('error', 'failed', { source: 'test', error: err });
+    expect(errorSpy).toHaveBeenCalledTimes(1);
+    const parsed = JSON.parse(String(errorSpy.mock.calls[0][0]));
+    expect(parsed.level).toBe('error');
+    expect(parsed.message).toBe('failed');
+    expect(parsed.source).toBe('test');
+    expect(parsed.error).toMatchObject({ name: 'Error', message: 'boom' });
+    expect(typeof parsed.error.stack).toBe('string');
+  });
+});

--- a/packages/grafana-runtime/src/utils/structuredConsole.ts
+++ b/packages/grafana-runtime/src/utils/structuredConsole.ts
@@ -1,0 +1,52 @@
+/**
+ * Single-line JSON logs for browser console output (structured logging).
+ * Uses console levels so devtools filtering still applies.
+ *
+ * @internal
+ */
+export type StructuredConsoleLevel = 'debug' | 'info' | 'warn' | 'error';
+
+export interface StructuredConsolePayload extends Record<string, unknown> {
+  level: StructuredConsoleLevel;
+  message: string;
+  source?: string;
+}
+
+function serializeUnknown(value: unknown): unknown {
+  if (value instanceof Error) {
+    return {
+      name: value.name,
+      message: value.message,
+      ...(value.stack ? { stack: value.stack } : {}),
+    };
+  }
+  return value;
+}
+
+/**
+ * Emits one JSON object per line to the appropriate console method.
+ */
+export function structuredConsoleLog(
+  level: StructuredConsoleLevel,
+  message: string,
+  fields?: Record<string, unknown>
+): void {
+  const payload: StructuredConsolePayload = {
+    level,
+    message,
+    ...(fields ? Object.fromEntries(Object.entries(fields).map(([k, v]) => [k, serializeUnknown(v)])) : {}),
+  };
+  const line = JSON.stringify(payload);
+  switch (level) {
+    case 'debug':
+    case 'info':
+      console.log(line);
+      break;
+    case 'warn':
+      console.warn(line);
+      break;
+    case 'error':
+      console.error(line);
+      break;
+  }
+}

--- a/public/app/index.ts
+++ b/public/app/index.ts
@@ -32,7 +32,16 @@ bootstrapWindowData().catch((error) => {
   const isRedirect = error && error.redirect && typeof error.redirect === 'string';
   // If a redirect was thrown, just ignore this. The index.html will handle the redirect
   if (!isRedirect) {
-    console.error('Error bootstrapping Grafana', error);
+    const payload = {
+      level: 'error' as const,
+      message: 'Error bootstrapping Grafana',
+      source: 'bootstrapWindowData',
+      error:
+        error instanceof Error
+          ? { name: error.name, message: error.message, stack: error.stack }
+          : error,
+    };
+    console.error(JSON.stringify(payload));
     window.__grafana_load_failed();
   }
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Replaces ad-hoc `console.log` / `console.warn` / `console.error` usage in `@grafana/runtime` with single-line JSON payloads (`level`, `message`, and contextual fields like `source`, `featureName`, etc.) via a small `structuredConsoleLog` helper.

Also aligns the early bootstrap failure path in `public/app/index.ts` with the same JSON shape and removes a duplicate `console.error` in OpenFeature init when `logError` already reports to Faro.

## Testing

- Added `structuredConsole.test.ts` for the helper.
- Updated plugin meta tests that asserted plain-string `console.warn` calls.

*(Jest was not executed in this environment due to missing Node/yarn on PATH; CI should run the suite.)*
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5f5968f0-3d6b-4122-a680-a1577b0c61db"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5f5968f0-3d6b-4122-a680-a1577b0c61db"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

