### PR TITLE
feat(nav): Labs section and feature flags UI

### DIFF
--- a/pkg/services/navtree/models.go
+++ b/pkg/services/navtree/models.go
@@ -38,6 +38,9 @@ const (
 	WeightHelp
 )
 
+// WeightLabs is placed between Connections (-2100) and Apps (-2000); do not use iota here to avoid renumbering.
+const WeightLabs = -2050
+
 const (
 	NavIDRoot                 = "root"
 	NavIDDashboards           = "dashboards/browse"
@@ -56,6 +59,7 @@ const (
 	NavIDCfgPlugins           = "cfg/plugins"
 	NavIDCfgAccess            = "cfg/access"
 	NavIDBookmarks            = "bookmarks"
+	NavIDLabs                 = "labs"
 )
 
 type NavLink struct {

--- a/pkg/services/navtree/navtreeimpl/applinks.go
+++ b/pkg/services/navtree/navtreeimpl/applinks.go
@@ -117,6 +117,7 @@ func (s *ServiceImpl) processAppPlugin(plugin pluginstore.Plugin, c *contextmode
 		PluginID:   plugin.ID,
 		Url:        s.cfg.AppSubURL + "/a/" + plugin.ID,
 	}
+	navChildCount := 0
 
 	for _, include := range plugin.Includes {
 		if !hasAccessToInclude(include) {
@@ -176,6 +177,7 @@ func (s *ServiceImpl) processAppPlugin(plugin pluginstore.Plugin, c *contextmode
 				// Register the page under the app
 			} else if include.AddToNav {
 				appLink.Children = append(appLink.Children, link)
+				navChildCount++
 			}
 		}
 
@@ -188,12 +190,13 @@ func (s *ServiceImpl) processAppPlugin(plugin pluginstore.Plugin, c *contextmode
 					PluginID: plugin.ID,
 				}
 				appLink.Children = append(appLink.Children, link)
+				navChildCount++
 			}
 		}
 	}
 
-	// Apps without any nav children are not part of navtree
-	if len(appLink.Children) == 0 {
+	// No pages or dashboards registered for this app in the nav tree
+	if navChildCount == 0 {
 		return nil
 	}
 	// If we only have one child and it's the app default nav then remove it from children
@@ -347,6 +350,22 @@ func (s *ServiceImpl) addPluginToSection(c *contextmodel.ReqContext, treeRoot *n
 				Img:   s.cfg.AppSubURL + plugin.Info.Logos.Large,
 				IsNew: true,
 			})
+		// Apps can use navigation.app_sections: my-plugin-id = labs [weight] to nest under Labs (nav id from navtree.NavIDLabs).
+		case navtree.NavIDLabs:
+			if labsNode := treeRoot.FindById(navtree.NavIDLabs); labsNode != nil {
+				labsNode.Children = append(labsNode.Children, sectionChildren...)
+			} else {
+				treeRoot.AddSection(&navtree.NavLink{
+					Text:       "Labs",
+					Id:         navtree.NavIDLabs,
+					SubTitle:   "Experimental tools and internal feature visibility",
+					Icon:       "flask",
+					SortWeight: navtree.WeightLabs,
+					Children:   sectionChildren,
+					Url:        s.cfg.AppSubURL + "/labs",
+					IsNew:      true,
+				})
+			}
 		default:
 			s.log.Error("Plugin app nav id not found", "pluginId", plugin.ID, "navId", sectionID)
 		}

--- a/pkg/services/navtree/navtreeimpl/labs.go
+++ b/pkg/services/navtree/navtreeimpl/labs.go
@@ -1,0 +1,39 @@
+package navtreeimpl
+
+import (
+	ac "github.com/grafana/grafana/pkg/services/accesscontrol"
+	contextmodel "github.com/grafana/grafana/pkg/services/contexthandler/model"
+	"github.com/grafana/grafana/pkg/services/navtree"
+)
+
+func (s *ServiceImpl) buildLabsNavLink(c *contextmodel.ReqContext) *navtree.NavLink {
+	if !c.IsSignedIn {
+		return nil
+	}
+	hasAccess := ac.HasAccess(s.accessControl, c)
+	if !hasAccess(ac.EvalPermission(ac.ActionFeatureManagementRead)) {
+		return nil
+	}
+
+	baseURL := s.cfg.AppSubURL + "/labs"
+	children := []*navtree.NavLink{
+		{
+			Id:       "labs-feature-flags",
+			Text:     "Feature flags",
+			SubTitle: "View which Grafana feature toggles are enabled for this instance",
+			Url:      baseURL + "/feature-flags",
+			Icon:     "sliders-v-alt",
+		},
+	}
+
+	return &navtree.NavLink{
+		Text:       "Labs",
+		Id:         navtree.NavIDLabs,
+		SubTitle:   "Experimental tools and internal feature visibility",
+		Icon:       "flask",
+		Url:        baseURL,
+		Children:   children,
+		SortWeight: navtree.WeightLabs,
+		IsNew:      true,
+	}
+}

--- a/pkg/services/navtree/navtreeimpl/labs_test.go
+++ b/pkg/services/navtree/navtreeimpl/labs_test.go
@@ -1,0 +1,173 @@
+package navtreeimpl
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/grafana/pkg/infra/log"
+	"github.com/grafana/grafana/pkg/plugins"
+	ac "github.com/grafana/grafana/pkg/services/accesscontrol"
+	"github.com/grafana/grafana/pkg/services/accesscontrol/acimpl"
+	accesscontrolmock "github.com/grafana/grafana/pkg/services/accesscontrol/mock"
+	contextmodel "github.com/grafana/grafana/pkg/services/contexthandler/model"
+	"github.com/grafana/grafana/pkg/services/featuremgmt"
+	"github.com/grafana/grafana/pkg/services/navtree"
+	"github.com/grafana/grafana/pkg/services/org"
+	"github.com/grafana/grafana/pkg/services/pluginsintegration/pluginaccesscontrol"
+	"github.com/grafana/grafana/pkg/services/pluginsintegration/pluginsettings"
+	"github.com/grafana/grafana/pkg/services/pluginsintegration/pluginstore"
+	"github.com/grafana/grafana/pkg/services/user"
+	"github.com/grafana/grafana/pkg/setting"
+	"github.com/grafana/grafana/pkg/web"
+)
+
+func TestBuildLabsNavLink(t *testing.T) {
+	cfg := setting.NewCfg()
+
+	t.Run("returns nil when user is not signed in", func(t *testing.T) {
+		httpReq, _ := http.NewRequest(http.MethodGet, "", nil)
+		reqCtx := &contextmodel.ReqContext{Context: &web.Context{Req: httpReq}}
+		s := ServiceImpl{cfg: cfg, accessControl: acimpl.ProvideAccessControl(featuremgmt.WithFeatures())}
+		require.Nil(t, s.buildLabsNavLink(reqCtx))
+	})
+
+	t.Run("returns nil without featuremgmt.read", func(t *testing.T) {
+		httpReq, _ := http.NewRequest(http.MethodGet, "", nil)
+		reqCtx := &contextmodel.ReqContext{
+			IsSignedIn:   true,
+			SignedInUser: &user.SignedInUser{UserID: 1, OrgID: 1},
+			Context:      &web.Context{Req: httpReq},
+		}
+		s := ServiceImpl{cfg: cfg, accessControl: acimpl.ProvideAccessControl(featuremgmt.WithFeatures())}
+		require.Nil(t, s.buildLabsNavLink(reqCtx))
+	})
+
+	t.Run("returns Labs section with child when user has featuremgmt.read", func(t *testing.T) {
+		httpReq, _ := http.NewRequest(http.MethodGet, "", nil)
+		reqCtx := &contextmodel.ReqContext{
+			IsSignedIn: true,
+			SignedInUser: &user.SignedInUser{
+				UserID:      1,
+				OrgID:       1,
+				OrgRole:     org.RoleAdmin,
+				Permissions: map[int64]map[string][]string{1: {ac.ActionFeatureManagementRead: {"*"}}},
+			},
+			Context: &web.Context{Req: httpReq},
+		}
+		s := ServiceImpl{cfg: cfg, accessControl: acimpl.ProvideAccessControl(featuremgmt.WithFeatures())}
+		link := s.buildLabsNavLink(reqCtx)
+		require.NotNil(t, link)
+		require.Equal(t, navtree.NavIDLabs, link.Id)
+		require.Equal(t, "Labs", link.Text)
+		require.True(t, link.IsNew)
+		require.Equal(t, int64(navtree.WeightLabs), link.SortWeight)
+		require.Len(t, link.Children, 1)
+		require.Equal(t, "labs-feature-flags", link.Children[0].Id)
+		require.Equal(t, "/labs/feature-flags", link.Children[0].Url)
+	})
+}
+
+func TestAddAppLinks_LabsSection(t *testing.T) {
+	httpReq, _ := http.NewRequest(http.MethodGet, "", nil)
+	reqCtx := &contextmodel.ReqContext{
+		IsSignedIn: true,
+		SignedInUser: &user.SignedInUser{
+			UserID:         1,
+			OrgID:          1,
+			OrgRole:        org.RoleAdmin,
+			IsGrafanaAdmin: true,
+			Permissions: map[int64]map[string][]string{
+				1: {
+					ac.ActionFeatureManagementRead:      {"*"},
+					pluginaccesscontrol.ActionAppAccess: {pluginaccesscontrol.ScopeProvider.GetResourceScope("test-app1")},
+				},
+			},
+		},
+		Context: &web.Context{Req: httpReq},
+	}
+
+	testApp1 := pluginstore.Plugin{
+		JSONData: plugins.JSONData{
+			ID:   "test-app1",
+			Name: "Test app1 name",
+			Type: plugins.TypeApp,
+			Includes: []*plugins.Includes{
+				{
+					Name:       "Catalog",
+					Path:       "/a/test-app1/catalog",
+					Type:       "page",
+					AddToNav:   true,
+					DefaultNav: true,
+				},
+				{
+					Name:     "Page2",
+					Path:     "/a/test-app1/page2",
+					Type:     "page",
+					AddToNav: true,
+				},
+			},
+		},
+	}
+
+	permissions := []ac.Permission{
+		{Action: pluginaccesscontrol.ActionAppAccess, Scope: pluginaccesscontrol.ScopeProvider.GetResourceScope("test-app1")},
+		{Action: ac.ActionFeatureManagementRead, Scope: "*"},
+	}
+
+	t.Run("merges app into existing Labs node", func(t *testing.T) {
+		service := ServiceImpl{
+			log:           log.New("navtree"),
+			cfg:           setting.NewCfg(),
+			accessControl: accesscontrolmock.New().WithPermissions(permissions),
+			pluginSettings: &pluginsettings.FakePluginSettings{
+				Plugins: map[string]*pluginsettings.DTO{
+					testApp1.ID: {ID: 0, OrgID: 1, PluginID: testApp1.ID, PluginVersion: "1.0.0", Enabled: true},
+				},
+			},
+			features:    featuremgmt.WithFeatures(),
+			pluginStore: &pluginstore.FakePluginStore{PluginList: []pluginstore.Plugin{testApp1}},
+		}
+		service.readNavigationSettings()
+		service.navigationAppConfig["test-app1"] = NavigationAppConfig{SectionID: navtree.NavIDLabs}
+
+		treeRoot := navtree.NavTreeRoot{}
+		labs := service.buildLabsNavLink(reqCtx)
+		require.NotNil(t, labs)
+		treeRoot.AddSection(labs)
+
+		err := service.addAppLinks(&treeRoot, reqCtx)
+		require.NoError(t, err)
+
+		labsNode := treeRoot.FindById(navtree.NavIDLabs)
+		require.NotNil(t, labsNode)
+		require.GreaterOrEqual(t, len(labsNode.Children), 2)
+	})
+
+	t.Run("creates Labs section when app targets labs but core Labs nav was absent", func(t *testing.T) {
+		service := ServiceImpl{
+			log:           log.New("navtree"),
+			cfg:           setting.NewCfg(),
+			accessControl: accesscontrolmock.New().WithPermissions(permissions),
+			pluginSettings: &pluginsettings.FakePluginSettings{
+				Plugins: map[string]*pluginsettings.DTO{
+					testApp1.ID: {ID: 0, OrgID: 1, PluginID: testApp1.ID, PluginVersion: "1.0.0", Enabled: true},
+				},
+			},
+			features:    featuremgmt.WithFeatures(),
+			pluginStore: &pluginstore.FakePluginStore{PluginList: []pluginstore.Plugin{testApp1}},
+		}
+		service.readNavigationSettings()
+		service.navigationAppConfig["test-app1"] = NavigationAppConfig{SectionID: navtree.NavIDLabs}
+
+		treeRoot := navtree.NavTreeRoot{}
+		err := service.addAppLinks(&treeRoot, reqCtx)
+		require.NoError(t, err)
+
+		labsNode := treeRoot.FindById(navtree.NavIDLabs)
+		require.NotNil(t, labsNode)
+		require.Len(t, labsNode.Children, 1)
+		require.Equal(t, "plugin-page-test-app1", labsNode.Children[0].Id)
+	})
+}

--- a/pkg/services/navtree/navtreeimpl/navtree.go
+++ b/pkg/services/navtree/navtreeimpl/navtree.go
@@ -164,6 +164,10 @@ func (s *ServiceImpl) GetNavTree(c *contextmodel.ReqContext, prefs *pref.Prefere
 		treeRoot.AddSection(connectionsSection)
 	}
 
+	if labsSection := s.buildLabsNavLink(c); labsSection != nil {
+		treeRoot.AddSection(labsSection)
+	}
+
 	orgAdminNode, err := s.getAdminNode(c)
 
 	if orgAdminNode != nil && len(orgAdminNode.Children) > 0 {

--- a/public/app/features/labs/LabsFeatureFlagsPage.test.tsx
+++ b/public/app/features/labs/LabsFeatureFlagsPage.test.tsx
@@ -1,0 +1,36 @@
+import { render, screen } from 'test/test-utils';
+
+import { config } from '@grafana/runtime';
+
+import { contextSrv } from 'app/core/services/context_srv';
+import { AccessControlAction } from 'app/types/accessControl';
+
+import LabsFeatureFlagsPage from './LabsFeatureFlagsPage';
+
+describe('LabsFeatureFlagsPage', () => {
+  const originalToggles = config.featureToggles;
+
+  afterEach(() => {
+    config.featureToggles = originalToggles;
+    jest.restoreAllMocks();
+  });
+
+  it('shows access denied without featuremgmt.read', () => {
+    jest.spyOn(contextSrv, 'hasPermission').mockImplementation((action) => action !== AccessControlAction.FeatureManagementRead);
+
+    render(<LabsFeatureFlagsPage />);
+
+    expect(screen.getByText(/Access denied/i)).toBeInTheDocument();
+  });
+
+  it('lists feature toggles when user has featuremgmt.read', () => {
+    jest.spyOn(contextSrv, 'hasPermission').mockImplementation((action) => action === AccessControlAction.FeatureManagementRead);
+    config.featureToggles = { ...originalToggles, someTestToggle: true, anotherToggle: false };
+
+    render(<LabsFeatureFlagsPage />);
+
+    expect(screen.getByText('someTestToggle')).toBeInTheDocument();
+    expect(screen.getByText('anotherToggle')).toBeInTheDocument();
+    expect(screen.getByPlaceholderText(/Filter by name/i)).toBeInTheDocument();
+  });
+});

--- a/public/app/features/labs/LabsFeatureFlagsPage.tsx
+++ b/public/app/features/labs/LabsFeatureFlagsPage.tsx
@@ -1,0 +1,116 @@
+import { useMemo, useState } from 'react';
+
+import { Trans, t } from '@grafana/i18n';
+import { config } from '@grafana/runtime';
+import {
+  Alert,
+  Badge,
+  type CellProps,
+  type Column,
+  InteractiveTable,
+  Input,
+  Stack,
+  Text,
+} from '@grafana/ui';
+import { Page } from 'app/core/components/Page/Page';
+import { useNavModel } from 'app/core/hooks/useNavModel';
+import { contextSrv } from 'app/core/services/context_srv';
+import { AccessControlAction } from 'app/types/accessControl';
+
+interface FeatureToggleRow {
+  name: string;
+  enabled: boolean;
+}
+
+type Cell<T extends keyof FeatureToggleRow = keyof FeatureToggleRow> = CellProps<FeatureToggleRow, FeatureToggleRow[T]>;
+
+export default function LabsFeatureFlagsPage() {
+  const navModel = useNavModel('labs-feature-flags');
+  const [filter, setFilter] = useState('');
+
+  const rows = useMemo<FeatureToggleRow[]>(() => {
+    const toggles = config.featureToggles ?? {};
+    return Object.keys(toggles)
+      .map((name) => ({ name, enabled: Boolean(toggles[name as keyof typeof toggles]) }))
+      .sort((a, b) => a.name.localeCompare(b.name));
+  }, []);
+
+  const filteredRows = useMemo(() => {
+    const q = filter.trim().toLowerCase();
+    if (!q) {
+      return rows;
+    }
+    return rows.filter((r) => r.name.toLowerCase().includes(q));
+  }, [filter, rows]);
+
+  const enabledCount = useMemo(() => rows.filter((r) => r.enabled).length, [rows]);
+
+  const columns: Array<Column<FeatureToggleRow>> = useMemo(
+    () => [
+      {
+        id: 'name',
+        header: t('labs.feature-flags.columns.name', 'Toggle'),
+        cell: ({ cell: { value } }: Cell<'name'>) => <Text truncate>{value}</Text>,
+        sortType: 'string',
+      },
+      {
+        id: 'enabled',
+        header: t('labs.feature-flags.columns.enabled', 'Enabled'),
+        disableGrow: true,
+        cell: ({ cell: { value } }: Cell<'enabled'>) =>
+          value ? (
+            <Badge text={t('labs.feature-flags.badge-yes', 'Yes')} color="green" />
+          ) : (
+            <Badge text={t('labs.feature-flags.badge-no', 'No')} color="blue" />
+          ),
+        sortType: 'basic',
+      },
+    ],
+    []
+  );
+
+  if (!contextSrv.hasPermission(AccessControlAction.FeatureManagementRead)) {
+    return (
+      <Page navModel={navModel}>
+        <Page.Contents>
+          <Alert severity="warning" title={t('labs.feature-flags.no-access-title', 'Access denied')}>
+            <Trans i18nKey="labs.feature-flags.no-access-body">
+              You need permission to read feature toggles to view this page.
+            </Trans>
+          </Alert>
+        </Page.Contents>
+      </Page>
+    );
+  }
+
+  return (
+    <Page navModel={navModel}>
+      <Page.Contents>
+        <Stack direction="column" gap={2}>
+          <Text color="secondary">
+            {t('labs.feature-flags.summary', '{{enabled}} of {{total}} toggles are enabled for this browser session.', {
+              enabled: enabledCount,
+              total: rows.length,
+            })}
+          </Text>
+
+          <Alert severity="info" title="">
+            <Trans i18nKey="labs.feature-flags.config-info">
+              Values come from the server configuration. Changing feature toggles requires updating Grafana config (for
+              example grafana.ini) and usually restarting the instance.
+            </Trans>
+          </Alert>
+
+          <Input
+            width={50}
+            placeholder={t('labs.feature-flags.filter-placeholder', 'Filter by name')}
+            value={filter}
+            onChange={(e) => setFilter(e.currentTarget.value)}
+          />
+
+          <InteractiveTable columns={columns} data={filteredRows} getRowId={(row) => row.name} pageSize={25} />
+        </Stack>
+      </Page.Contents>
+    </Page>
+  );
+}

--- a/public/app/routes/routes.tsx
+++ b/public/app/routes/routes.tsx
@@ -223,6 +223,18 @@ export function getAppRoutes(): RouteDescriptor[] {
       component: () => <NavLandingPage navId="frontend" />,
     },
     {
+      path: '/labs',
+      roles: () => contextSrv.evaluatePermission([AccessControlAction.FeatureManagementRead]),
+      component: () => <NavLandingPage navId="labs" />,
+    },
+    {
+      path: '/labs/feature-flags',
+      roles: () => contextSrv.evaluatePermission([AccessControlAction.FeatureManagementRead]),
+      component: SafeDynamicImport(
+        () => import(/* webpackChunkName: "LabsFeatureFlagsPage" */ 'app/features/labs/LabsFeatureFlagsPage')
+      ),
+    },
+    {
       path: '/admin/general',
       component: () => <NavLandingPage navId="cfg/general" />,
     },

--- a/public/app/types/accessControl.ts
+++ b/public/app/types/accessControl.ts
@@ -57,6 +57,9 @@ export enum AccessControlAction {
 
   ActionServerStatsRead = 'server.stats:read',
 
+  FeatureManagementRead = 'featuremgmt.read',
+  FeatureManagementWrite = 'featuremgmt.write',
+
   ActionTeamsCreate = 'teams:create',
   ActionTeamsDelete = 'teams:delete',
   ActionTeamsRead = 'teams:read',


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a top-level **Labs** navigation section (with the standard **New** badge) between **Connections** and **Administration** for users who have `featuremgmt.read`. The section includes a **Feature flags** child that opens `/labs/feature-flags`, a page that lists Grafana feature toggles from `config.featureToggles` with search and pagination.

Apps can nest under Labs via `[navigation.app_sections]` with section id `labs` (same as `navtree.NavIDLabs`).

## Additional fix

`processAppPlugin` previously returned early when the only nav page was the default URL, which dropped single-page apps from section placement (including Labs). It now counts nav children added and still calls `addPluginToSection` when the default child is stripped.

## Testing

- `go test ./pkg/services/navtree/navtreeimpl/ -run 'TestBuildLabsNavLink|TestAddAppLinks'`
- Frontend: `yarn jest public/app/features/labs/LabsFeatureFlagsPage.test.tsx --watchAll=false` (not run in this agent environment; `yarn install` failed on a git dependency needing `npm`)

## Follow-up

Run `make i18n-extract` locally if you want new `t()` keys mirrored into locale JSON (English defaults are inline in components).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ede02fa3-6721-4f87-af7b-8d61f8061f94"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ede02fa3-6721-4f87-af7b-8d61f8061f94"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

