### PR TITLE
Administration: Add experiments feature flag page

### DIFF
--- a/pkg/api/admin.go
+++ b/pkg/api/admin.go
@@ -3,12 +3,14 @@ package api
 import (
 	"context"
 	"net/http"
+	"sort"
 	"time"
 
 	"github.com/grafana/grafana/pkg/api/response"
 	"github.com/grafana/grafana/pkg/apimachinery/identity"
 	ac "github.com/grafana/grafana/pkg/services/accesscontrol"
 	contextmodel "github.com/grafana/grafana/pkg/services/contexthandler/model"
+	"github.com/grafana/grafana/pkg/services/featuremgmt"
 	"github.com/grafana/grafana/pkg/services/stats"
 	"github.com/grafana/grafana/pkg/setting"
 )
@@ -45,6 +47,37 @@ func (hs *HTTPServer) AdminGetVerboseSettings(c *contextmodel.ReqContext) respon
 		return response.Error(http.StatusForbidden, "Failed to authorize settings", err)
 	}
 	return response.JSON(http.StatusOK, verboseSettings)
+}
+
+func (hs *HTTPServer) AdminGetFeatureToggles(c *contextmodel.ReqContext) response.Response {
+	featureList, err := featuremgmt.GetEmbeddedFeatureList()
+	if err != nil {
+		return response.Error(http.StatusInternalServerError, "Failed to load feature toggles", err)
+	}
+
+	enabled := hs.Features.GetEnabled(c.Req.Context())
+	result := AdminFeatureTogglesResponse{
+		Toggles: make([]AdminFeatureToggleDTO, 0, len(featureList.Items)),
+	}
+
+	for _, feature := range featureList.Items {
+		result.Toggles = append(result.Toggles, AdminFeatureToggleDTO{
+			Name:            feature.Name,
+			Description:     feature.Spec.Description,
+			Stage:           feature.Spec.Stage,
+			Enabled:         enabled[feature.Name],
+			FrontendOnly:    feature.Spec.FrontendOnly,
+			RequiresRestart: feature.Spec.RequiresRestart,
+			RequiresDevMode: feature.Spec.RequiresDevMode,
+			HideFromDocs:    feature.Spec.HideFromDocs,
+		})
+	}
+
+	sort.Slice(result.Toggles, func(i, j int) bool {
+		return result.Toggles[i].Name < result.Toggles[j].Name
+	})
+
+	return response.JSON(http.StatusOK, result)
 }
 
 // swagger:route GET /admin/stats admin adminGetStats
@@ -164,6 +197,21 @@ func (hs *HTTPServer) getAuthorizedVerboseSettings(ctx context.Context, user ide
 type GetSettingsResponse struct {
 	// in:body
 	Body setting.SettingsBag `json:"body"`
+}
+
+type AdminFeatureTogglesResponse struct {
+	Toggles []AdminFeatureToggleDTO `json:"toggles"`
+}
+
+type AdminFeatureToggleDTO struct {
+	Name            string `json:"name"`
+	Description     string `json:"description,omitempty"`
+	Stage           string `json:"stage"`
+	Enabled         bool   `json:"enabled"`
+	FrontendOnly    bool   `json:"frontendOnly,omitempty"`
+	RequiresRestart bool   `json:"requiresRestart,omitempty"`
+	RequiresDevMode bool   `json:"requiresDevMode,omitempty"`
+	HideFromDocs    bool   `json:"hideFromDocs,omitempty"`
 }
 
 // swagger:response adminGetStatsResponse

--- a/pkg/api/admin_test.go
+++ b/pkg/api/admin_test.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"encoding/json"
 	"io"
 	"net/http"
 	"testing"
@@ -11,6 +12,7 @@ import (
 	"github.com/grafana/grafana/pkg/infra/db/dbtest"
 	"github.com/grafana/grafana/pkg/services/accesscontrol"
 	"github.com/grafana/grafana/pkg/services/anonymous/anontest"
+	"github.com/grafana/grafana/pkg/services/featuremgmt"
 	"github.com/grafana/grafana/pkg/services/stats"
 	"github.com/grafana/grafana/pkg/services/stats/statstest"
 	"github.com/grafana/grafana/pkg/setting"
@@ -99,6 +101,35 @@ func TestAPI_AdminGetSettings(t *testing.T) {
 	}
 }
 
+func TestAPI_AdminGetFeatureToggles(t *testing.T) {
+	server := SetupAPITestServer(t, func(hs *HTTPServer) {
+		hs.Features = featuremgmt.WithFeatures(featuremgmt.FlagPanelTitleSearch)
+	})
+
+	res, err := server.Send(webtest.RequestWithSignedInUser(
+		server.NewGetRequest("/api/admin/feature-toggles"),
+		userWithPermissions(1, []accesscontrol.Permission{{Action: accesscontrol.ActionSettingsRead}}),
+	))
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, res.StatusCode)
+	defer func() { require.NoError(t, res.Body.Close()) }()
+
+	var body AdminFeatureTogglesResponse
+	require.NoError(t, json.NewDecoder(res.Body).Decode(&body))
+	require.NotEmpty(t, body.Toggles)
+
+	var found bool
+	for _, toggle := range body.Toggles {
+		if toggle.Name == featuremgmt.FlagPanelTitleSearch {
+			found = true
+			assert.NotEmpty(t, toggle.Stage)
+			assert.NotEmpty(t, toggle.Description)
+			assert.True(t, toggle.Enabled)
+		}
+	}
+	assert.True(t, found)
+}
+
 func TestAdmin_AccessControl(t *testing.T) {
 	type testCase struct {
 		desc         string
@@ -142,6 +173,26 @@ func TestAdmin_AccessControl(t *testing.T) {
 			expectedCode: http.StatusForbidden,
 			desc:         "AdminGetSettings should return 403 for user without required permissions",
 			url:          "/api/admin/settings",
+			permissions: []accesscontrol.Permission{
+				{
+					Action: "wrong",
+				},
+			},
+		},
+		{
+			expectedCode: http.StatusOK,
+			desc:         "AdminGetFeatureToggles should return 200 for user with correct permissions",
+			url:          "/api/admin/feature-toggles",
+			permissions: []accesscontrol.Permission{
+				{
+					Action: accesscontrol.ActionSettingsRead,
+				},
+			},
+		},
+		{
+			expectedCode: http.StatusForbidden,
+			desc:         "AdminGetFeatureToggles should return 403 for user without required permissions",
+			url:          "/api/admin/feature-toggles",
 			permissions: []accesscontrol.Permission{
 				{
 					Action: "wrong",

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -114,6 +114,7 @@ func (hs *HTTPServer) registerRoutes() {
 	r.Get("/configuration", reqGrafanaAdmin, hs.Index)
 	r.Get("/admin", reqOrgAdmin, hs.Index)
 	r.Get("/admin/settings", authorize(ac.EvalPermission(ac.ActionSettingsRead, ac.ScopeSettingsAll)), hs.Index)
+	r.Get("/admin/feature-toggles", authorize(ac.EvalPermission(ac.ActionSettingsRead)), hs.Index)
 	r.Get("/admin/users", authorize(ac.EvalAny(ac.EvalPermission(ac.ActionOrgUsersRead), ac.EvalPermission(ac.ActionUsersRead, ac.ScopeGlobalUsersAll))), hs.Index)
 	r.Get("/admin/users/create", authorize(ac.EvalPermission(ac.ActionUsersCreate)), hs.Index)
 	r.Get("/admin/users/edit/:id", authorize(ac.EvalPermission(ac.ActionUsersRead)), hs.Index)
@@ -560,6 +561,7 @@ func (hs *HTTPServer) registerRoutes() {
 		// There is additional filter which will ensure that user sees only settings that they are allowed to see, so we don't need provide additional scope here for ActionSettingsRead.
 		adminRoute.Get("/settings", authorize(ac.EvalPermission(ac.ActionSettingsRead)), routing.Wrap(hs.AdminGetSettings))
 		adminRoute.Get("/settings-verbose", authorize(ac.EvalPermission(ac.ActionSettingsRead)), routing.Wrap(hs.AdminGetVerboseSettings))
+		adminRoute.Get("/feature-toggles", authorize(ac.EvalPermission(ac.ActionSettingsRead)), routing.Wrap(hs.AdminGetFeatureToggles))
 		adminRoute.Get("/stats", authorize(ac.EvalPermission(ac.ActionServerStatsRead)), routing.Wrap(hs.AdminGetStats))
 
 		adminRoute.Post("/encryption/rotate-data-keys", reqGrafanaAdmin, routing.Wrap(hs.AdminRotateDataEncryptionKeys))

--- a/pkg/services/navtree/navtreeimpl/admin.go
+++ b/pkg/services/navtree/navtreeimpl/admin.go
@@ -38,6 +38,9 @@ func (s *ServiceImpl) getAdminNode(c *contextmodel.ReqContext) (*navtree.NavLink
 		generalNodeLinks = append(generalNodeLinks, &navtree.NavLink{
 			Text: "Settings", SubTitle: "View the settings defined in your Grafana config", Id: "server-settings", Url: s.cfg.AppSubURL + "/admin/settings", Icon: "sliders-v-alt",
 		})
+		generalNodeLinks = append(generalNodeLinks, &navtree.NavLink{
+			Text: "Experiments", SubTitle: "Preview and override experimental feature flags in this browser", Id: "feature-toggles", Url: s.cfg.AppSubURL + "/admin/feature-toggles", Icon: "flask",
+		})
 	}
 	if hasGlobalAccess(orgsAccessEvaluator) {
 		generalNodeLinks = append(generalNodeLinks, &navtree.NavLink{

--- a/public/app/core/utils/navBarItem-translations.ts
+++ b/public/app/core/utils/navBarItem-translations.ts
@@ -129,6 +129,8 @@ export function getNavTitle(navId: string | undefined) {
       return t('nav.global-orgs.title', 'Organizations');
     case 'server-settings':
       return t('nav.server-settings.title', 'Settings');
+    case 'feature-toggles':
+      return t('nav.feature-toggles.title', 'Experiments');
     case 'storage':
       return t('nav.storage.title', 'Storage');
     case 'migrate-to-cloud':

--- a/public/app/features/admin/FeatureTogglesPage.test.tsx
+++ b/public/app/features/admin/FeatureTogglesPage.test.tsx
@@ -1,0 +1,78 @@
+import { screen, waitFor } from '@testing-library/react';
+
+import { render } from 'test/test-utils';
+
+import { getBackendSrv } from '@grafana/runtime';
+
+import FeatureTogglesPage, { type FeatureTogglesResponse } from './FeatureTogglesPage';
+
+jest.mock('@grafana/runtime', () => ({
+  ...jest.requireActual('@grafana/runtime'),
+  getBackendSrv: jest.fn(),
+}));
+
+const featureToggles: FeatureTogglesResponse = {
+  toggles: [
+    {
+      name: 'newDashboards',
+      description: 'Try the new dashboard experience.',
+      stage: 'experimental',
+      enabled: false,
+      frontendOnly: true,
+    },
+    {
+      name: 'backendExperiment',
+      description: 'A backend experiment.',
+      stage: 'preview',
+      enabled: true,
+      requiresRestart: true,
+    },
+    {
+      name: 'gaFeature',
+      description: 'A generally available feature.',
+      stage: 'GA',
+      enabled: true,
+    },
+  ],
+};
+
+describe('FeatureTogglesPage', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+    jest.mocked(getBackendSrv).mockReturnValue({
+      get: jest.fn().mockResolvedValue(featureToggles),
+    } as never);
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it('filters experiments and persists browser overrides', async () => {
+    const { user } = render(<FeatureTogglesPage />);
+
+    expect(await screen.findByRole('heading', { name: 'Experiments' })).toBeInTheDocument();
+    expect(screen.getByText('newDashboards')).toBeInTheDocument();
+    expect(screen.getByText('backendExperiment')).toBeInTheDocument();
+    expect(screen.queryByText('gaFeature')).not.toBeInTheDocument();
+
+    await user.type(screen.getByPlaceholderText('Search experiments'), 'dash');
+    expect(screen.getByText('newDashboards')).toBeInTheDocument();
+    expect(screen.queryByText('backendExperiment')).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole('switch', { name: 'Enable newDashboards' }));
+    expect(window.localStorage.getItem('grafana.featureToggles')).toBe('newDashboards=true');
+    expect(screen.getByRole('button', { name: 'Apply and reload' })).toBeInTheDocument();
+  });
+
+  it('loads existing overrides and can reset them', async () => {
+    window.localStorage.setItem('grafana.featureToggles', 'newDashboards=true,backendExperiment=false');
+
+    const { user } = render(<FeatureTogglesPage />);
+
+    expect(await screen.findByRole('switch', { name: 'Enable newDashboards' })).toBeChecked();
+
+    await user.click(screen.getByRole('button', { name: 'Reset overrides' }));
+    await waitFor(() => expect(window.localStorage.getItem('grafana.featureToggles')).toBeNull());
+  });
+});

--- a/public/app/features/admin/FeatureTogglesPage.test.tsx
+++ b/public/app/features/admin/FeatureTogglesPage.test.tsx
@@ -60,7 +60,7 @@ describe('FeatureTogglesPage', () => {
     expect(screen.getByText('newDashboards')).toBeInTheDocument();
     expect(screen.queryByText('backendExperiment')).not.toBeInTheDocument();
 
-    await user.click(screen.getByRole('switch', { name: 'Enable newDashboards' }));
+    await user.click(screen.getByRole('switch', { name: 'Toggle newDashboards' }));
     expect(window.localStorage.getItem('grafana.featureToggles')).toBe('newDashboards=true');
     expect(screen.getByRole('button', { name: 'Apply and reload' })).toBeInTheDocument();
   });
@@ -70,7 +70,7 @@ describe('FeatureTogglesPage', () => {
 
     const { user } = render(<FeatureTogglesPage />);
 
-    expect(await screen.findByRole('switch', { name: 'Enable newDashboards' })).toBeChecked();
+    expect(await screen.findByRole('switch', { name: 'Toggle newDashboards' })).toBeChecked();
 
     await user.click(screen.getByRole('button', { name: 'Reset overrides' }));
     await waitFor(() => expect(window.localStorage.getItem('grafana.featureToggles')).toBeNull());

--- a/public/app/features/admin/FeatureTogglesPage.tsx
+++ b/public/app/features/admin/FeatureTogglesPage.tsx
@@ -1,0 +1,221 @@
+import { css } from '@emotion/css';
+import { useMemo, useState } from 'react';
+import { useAsync } from 'react-use';
+
+import { FeatureState, type GrafanaTheme2 } from '@grafana/data';
+import { Trans, t } from '@grafana/i18n';
+import { getBackendSrv } from '@grafana/runtime';
+import { Alert, Badge, Button, FilterInput, LoadingPlaceholder, Stack, Switch, Text, useStyles2 } from '@grafana/ui';
+import { Page } from 'app/core/components/Page/Page';
+
+const FEATURE_TOGGLE_STORAGE_KEY = 'grafana.featureToggles';
+
+export interface FeatureToggleDTO {
+  name: string;
+  description?: string;
+  stage: string;
+  enabled: boolean;
+  frontendOnly?: boolean;
+  requiresRestart?: boolean;
+  requiresDevMode?: boolean;
+  hideFromDocs?: boolean;
+}
+
+export interface FeatureTogglesResponse {
+  toggles: FeatureToggleDTO[];
+}
+
+type FeatureToggleOverride = Record<string, boolean>;
+
+function getStoredOverrides(): FeatureToggleOverride {
+  const stored = window.localStorage.getItem(FEATURE_TOGGLE_STORAGE_KEY);
+  if (!stored) {
+    return {};
+  }
+
+  return stored.split(',').reduce<FeatureToggleOverride>((acc, feature) => {
+    const [name, value] = feature.split('=');
+    if (name) {
+      acc[name] = value === 'true' || value === '1';
+    }
+    return acc;
+  }, {});
+}
+
+function persistOverrides(overrides: FeatureToggleOverride) {
+  const serialized = Object.entries(overrides)
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([name, value]) => `${name}=${value}`)
+    .join(',');
+
+  if (serialized) {
+    window.localStorage.setItem(FEATURE_TOGGLE_STORAGE_KEY, serialized);
+  } else {
+    window.localStorage.removeItem(FEATURE_TOGGLE_STORAGE_KEY);
+  }
+}
+
+function isVisibleExperiment(toggle: FeatureToggleDTO) {
+  return toggle.stage === FeatureState.experimental || toggle.stage === FeatureState.preview || toggle.stage === 'privatePreview';
+}
+
+function getStageBadge(toggle: FeatureToggleDTO) {
+  switch (toggle.stage) {
+    case FeatureState.experimental:
+      return <Badge color="purple" text={t('admin.feature-toggles.stage-experimental', 'Experimental')} />;
+    case FeatureState.preview:
+      return <Badge color="blue" text={t('admin.feature-toggles.stage-preview', 'Preview')} />;
+    case 'privatePreview':
+      return <Badge color="blue" text={t('admin.feature-toggles.stage-private-preview', 'Private preview')} />;
+    default:
+      return <Badge color="darkgrey" text={toggle.stage || t('admin.feature-toggles.stage-unknown', 'Unknown')} />;
+  }
+}
+
+export function FeatureTogglesPage() {
+  const styles = useStyles2(getStyles);
+  const [query, setQuery] = useState('');
+  const [overrides, setOverrides] = useState<FeatureToggleOverride>(() => getStoredOverrides());
+  const { loading, error, value } = useAsync(
+    () => getBackendSrv().get<FeatureTogglesResponse>('/api/admin/feature-toggles'),
+    []
+  );
+
+  const visibleToggles = useMemo(() => {
+    const normalizedQuery = query.trim().toLowerCase();
+    return (value?.toggles ?? [])
+      .filter(isVisibleExperiment)
+      .filter((toggle) => {
+        return (
+          !normalizedQuery ||
+          toggle.name.toLowerCase().includes(normalizedQuery) ||
+          toggle.description?.toLowerCase().includes(normalizedQuery)
+        );
+      });
+  }, [query, value]);
+
+  const updateOverride = (name: string, enabled: boolean) => {
+    setOverrides((current) => {
+      const next = { ...current, [name]: enabled };
+      persistOverrides(next);
+      return next;
+    });
+  };
+
+  const resetOverrides = () => {
+    persistOverrides({});
+    setOverrides({});
+  };
+
+  return (
+    <Page navId="feature-toggles">
+      <Page.Contents>
+        <Stack direction="column" gap={3}>
+          <Text element="h2" variant="h2">
+            <Trans i18nKey="admin.feature-toggles.title">Experiments</Trans>
+          </Text>
+
+          <Alert severity="info" title={t('admin.feature-toggles.info-title', 'Browser overrides')}>
+            <Trans i18nKey="admin.feature-toggles.info-description">
+              Toggle experimental Grafana features for this browser only. Changes are saved locally and apply after a
+              reload. Server-side and startup features may still require Grafana configuration or a restart.
+            </Trans>
+          </Alert>
+
+          {error && (
+            <Alert severity="error" title={t('admin.feature-toggles.load-error-title', 'Failed to load experiments')}>
+              {error.message}
+            </Alert>
+          )}
+
+          <Stack alignItems="center" justifyContent="space-between" wrap>
+            <FilterInput
+              width={40}
+              placeholder={t('admin.feature-toggles.search-placeholder', 'Search experiments')}
+              value={query}
+              onChange={setQuery}
+            />
+            <Stack gap={1}>
+              <Button variant="secondary" disabled={Object.keys(overrides).length === 0} onClick={resetOverrides}>
+                <Trans i18nKey="admin.feature-toggles.reset-overrides">Reset overrides</Trans>
+              </Button>
+              <Button onClick={() => window.location.reload()}>
+                <Trans i18nKey="admin.feature-toggles.reload">Apply and reload</Trans>
+              </Button>
+            </Stack>
+          </Stack>
+
+          {loading && <LoadingPlaceholder text={t('admin.feature-toggles.loading', 'Loading experiments...')} />}
+
+          {!loading && visibleToggles.length === 0 && (
+            <Text color="secondary">
+              <Trans i18nKey="admin.feature-toggles.no-results">No experiments match your search.</Trans>
+            </Text>
+          )}
+
+          <Stack direction="column" gap={2}>
+            {visibleToggles.map((toggle) => {
+              const hasOverride = Object.prototype.hasOwnProperty.call(overrides, toggle.name);
+              const enabled = hasOverride ? overrides[toggle.name] : toggle.enabled;
+
+              return (
+                <section
+                  aria-label={t('admin.feature-toggles.row-label', '{{name}} feature toggle', { name: toggle.name })}
+                  className={styles.toggleCard}
+                  key={toggle.name}
+                >
+                  <Stack alignItems="flex-start" justifyContent="space-between" gap={2}>
+                    <Stack direction="column" gap={1}>
+                      <Stack alignItems="center" gap={1} wrap>
+                        <Text element="h3" variant="h4">
+                          {toggle.name}
+                        </Text>
+                        {getStageBadge(toggle)}
+                        {hasOverride && (
+                          <Badge color="orange" text={t('admin.feature-toggles.override-badge', 'Override')} />
+                        )}
+                      </Stack>
+                      {toggle.description && <Text color="secondary">{toggle.description}</Text>}
+                      <Stack gap={1} wrap>
+                        {toggle.frontendOnly ? (
+                          <Badge color="green" text={t('admin.feature-toggles.frontend-only', 'Frontend only')} />
+                        ) : (
+                          <Badge color="orange" text={t('admin.feature-toggles.backend-feature', 'Backend feature')} />
+                        )}
+                        {toggle.requiresRestart && (
+                          <Badge color="orange" text={t('admin.feature-toggles.requires-restart', 'Requires restart')} />
+                        )}
+                        {toggle.requiresDevMode && (
+                          <Badge color="darkgrey" text={t('admin.feature-toggles.requires-dev', 'Requires dev mode')} />
+                        )}
+                        {toggle.hideFromDocs && (
+                          <Badge color="darkgrey" text={t('admin.feature-toggles.hidden-docs', 'Hidden from docs')} />
+                        )}
+                      </Stack>
+                    </Stack>
+                    <Switch
+                      label={t('admin.feature-toggles.toggle-label', 'Toggle {{name}}', { name: toggle.name })}
+                      value={enabled}
+                      onChange={(event) => updateOverride(toggle.name, event.currentTarget.checked)}
+                    />
+                  </Stack>
+                </section>
+              );
+            })}
+          </Stack>
+        </Stack>
+      </Page.Contents>
+    </Page>
+  );
+}
+
+const getStyles = (theme: GrafanaTheme2) => ({
+  toggleCard: css({
+    border: `1px solid ${theme.colors.border.weak}`,
+    borderRadius: theme.shape.radius.default,
+    padding: theme.spacing(2),
+    background: theme.colors.background.secondary,
+  }),
+});
+
+export default FeatureTogglesPage;

--- a/public/app/routes/routes.tsx
+++ b/public/app/routes/routes.tsx
@@ -345,6 +345,13 @@ export function getAppRoutes(): RouteDescriptor[] {
       ),
     },
     {
+      path: '/admin/feature-toggles',
+      roles: () => contextSrv.evaluatePermission([AccessControlAction.SettingsRead]),
+      component: SafeDynamicImport(
+        () => import(/* webpackChunkName: "FeatureTogglesPage" */ 'app/features/admin/FeatureTogglesPage')
+      ),
+    },
+    {
       path: '/admin/upgrading',
       component: SafeDynamicImport(() => import('app/features/admin/UpgradePage')),
     },


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
**What is this feature?**

Adds an Administration > General > Experiments page that lists experimental and preview feature toggles, shows their current enabled state and metadata, and lets admins save browser-local overrides using Grafana's existing `grafana.featureToggles` localStorage mechanism.

**Why do we need this feature?**

Admins need a discoverable place to inspect and try Grafana team experiments without hand-editing browser storage or URL parameters.

**Who is this feature for?**

Grafana admins evaluating experimental or preview functionality in a single browser session.

**Which issue(s) does this PR fix?**:

Fixes #

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a notable improvement, it's added to What's New.

Testing performed:
- `go test -run 'TestAPI_AdminGetFeatureToggles|TestAdmin_AccessControl' ./pkg/api`
- `go test ./pkg/api ./pkg/services/navtree/navtreeimpl`
- `git diff --check`

Frontend Jest/manual UI verification could not be run in this cloud environment because Node, Yarn, and Corepack are unavailable, and no Grafana dev server is already running.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b7b1cff9-7ee2-4151-abef-38409fab0cfc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b7b1cff9-7ee2-4151-abef-38409fab0cfc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

