### PR TITLE
feat(themes): surface Aubergine theme (CUR-54)

### DIFF
--- a/public/app/core/components/AppChrome/TopBar/ProfileButton.tsx
+++ b/public/app/core/components/AppChrome/TopBar/ProfileButton.tsx
@@ -9,6 +9,7 @@ import { Dropdown, Menu, MenuItem, ToolbarButton, useStyles2 } from '@grafana/ui
 import { contextSrv } from 'app/core/services/context_srv';
 
 import { ThemeSelectorDrawer } from '../../ThemeSelector/ThemeSelectorDrawer';
+import { getSelectableThemes } from '../../ThemeSelector/getSelectableThemes';
 import { enrichWithInteractionTracking } from '../MegaMenu/utils';
 import { NewsContainer } from '../News/NewsDrawer';
 
@@ -32,7 +33,7 @@ export function ProfileButton({ profileNode, onToggleKioskMode }: Props) {
   const renderMenu = () => (
     <TopNavBarMenu node={profileNode}>
       <>
-        {config.featureToggles.grafanaconThemes && (
+        {getSelectableThemes().some((theme) => theme.isExtra) && (
           <MenuItem icon="palette" onClick={onToggleThemeDrawer} label={t('profile.change-theme', 'Change theme')} />
         )}
         <Menu.Item

--- a/public/app/core/components/AppChrome/TopBar/ProfileButton.tsx
+++ b/public/app/core/components/AppChrome/TopBar/ProfileButton.tsx
@@ -30,10 +30,12 @@ export function ProfileButton({ profileNode, onToggleKioskMode }: Props) {
     return null;
   }
 
+  const hasSelectableExtraThemes = getSelectableThemes().some((theme) => theme.isExtra);
+
   const renderMenu = () => (
     <TopNavBarMenu node={profileNode}>
       <>
-        {getSelectableThemes().some((theme) => theme.isExtra) && (
+        {hasSelectableExtraThemes && (
           <MenuItem icon="palette" onClick={onToggleThemeDrawer} label={t('profile.change-theme', 'Change theme')} />
         )}
         <Menu.Item

--- a/public/app/core/components/ThemeSelector/getSelectableThemes.test.ts
+++ b/public/app/core/components/ThemeSelector/getSelectableThemes.test.ts
@@ -1,0 +1,89 @@
+import { getBuiltInThemes } from '@grafana/data';
+
+import { getSelectableThemes } from './getSelectableThemes';
+
+jest.mock('@grafana/data', () => ({
+  getBuiltInThemes: jest.fn(() => []),
+}));
+
+jest.mock('@grafana/runtime', () => ({
+  config: {
+    featureToggles: {
+      grafanaconThemes: false,
+      colorblindThemes: false,
+    },
+  },
+}));
+
+const { config } = jest.requireMock('@grafana/runtime');
+
+describe('getSelectableThemes', () => {
+  const originalGrafanaConThemesFlag = config.featureToggles.grafanaconThemes;
+  const originalColorblindThemesFlag = config.featureToggles.colorblindThemes;
+
+  afterEach(() => {
+    config.featureToggles.grafanaconThemes = originalGrafanaConThemesFlag;
+    config.featureToggles.colorblindThemes = originalColorblindThemesFlag;
+    jest.clearAllMocks();
+  });
+
+  it('always includes the aubergine theme without optional bundles', () => {
+    config.featureToggles.grafanaconThemes = false;
+    config.featureToggles.colorblindThemes = false;
+
+    getSelectableThemes();
+
+    expect(getBuiltInThemes).toHaveBeenCalledWith(['aubergine']);
+  });
+
+  it('includes grafanacon extra themes plus aubergine when grafanacon bundle is enabled', () => {
+    config.featureToggles.grafanaconThemes = true;
+    config.featureToggles.colorblindThemes = false;
+
+    getSelectableThemes();
+
+    expect(getBuiltInThemes).toHaveBeenCalledWith([
+      'aubergine',
+      'desertbloom',
+      'gildedgrove',
+      'sapphiredusk',
+      'tron',
+      'gloom',
+    ]);
+  });
+
+  it('includes accessibility themes plus aubergine when colorblind themes toggle is enabled', () => {
+    config.featureToggles.grafanaconThemes = false;
+    config.featureToggles.colorblindThemes = true;
+
+    getSelectableThemes();
+
+    expect(getBuiltInThemes).toHaveBeenCalledWith([
+      'aubergine',
+      'deuteranopia_protanopia_dark',
+      'deuteranopia_protanopia_light',
+      'tritanopia_dark',
+      'tritanopia_light',
+    ]);
+  });
+
+  it('includes aubergine, grafanacon, and accessibility themes when both toggles are enabled', () => {
+    config.featureToggles.grafanaconThemes = true;
+    config.featureToggles.colorblindThemes = true;
+
+    getSelectableThemes();
+
+    expect(getBuiltInThemes).toHaveBeenCalledWith([
+      'aubergine',
+      'deuteranopia_protanopia_dark',
+      'deuteranopia_protanopia_light',
+      'tritanopia_dark',
+      'tritanopia_light',
+      'desertbloom',
+      'gildedgrove',
+      'sapphiredusk',
+      'tron',
+      'gloom',
+    ]);
+  });
+});

--- a/public/app/core/components/ThemeSelector/getSelectableThemes.ts
+++ b/public/app/core/components/ThemeSelector/getSelectableThemes.ts
@@ -4,12 +4,7 @@ import { config } from '@grafana/runtime';
 export function getSelectableThemes() {
   // Purple/amethyst (CUR-54): available without Grafanacon bundle; GrafanaCon extras still flag-gated
   const colorblindExtras: string[] = config.featureToggles.colorblindThemes
-    ? [
-        'deuteranopia_protanopia_dark',
-        'deuteranopia_protanopia_light',
-        'tritanopia_dark',
-        'tritanopia_light',
-      ]
+    ? ['deuteranopia_protanopia_dark', 'deuteranopia_protanopia_light', 'tritanopia_dark', 'tritanopia_light']
     : [];
 
   const grafanaconExtras: string[] = config.featureToggles.grafanaconThemes

--- a/public/app/core/components/ThemeSelector/getSelectableThemes.ts
+++ b/public/app/core/components/ThemeSelector/getSelectableThemes.ts
@@ -2,7 +2,8 @@ import { getBuiltInThemes } from '@grafana/data';
 import { config } from '@grafana/runtime';
 
 export function getSelectableThemes() {
-  const allowedExtraThemes = [];
+  // Purple/amethyst (CUR-54): available without Grafanacon bundle; GrafanaCon extras still flag-gated
+  const allowedExtraThemes = ['aubergine'];
 
   if (config.featureToggles.colorblindThemes) {
     allowedExtraThemes.push('deuteranopia_protanopia_dark');

--- a/public/app/core/components/ThemeSelector/getSelectableThemes.ts
+++ b/public/app/core/components/ThemeSelector/getSelectableThemes.ts
@@ -3,22 +3,18 @@ import { config } from '@grafana/runtime';
 
 export function getSelectableThemes() {
   // Purple/amethyst (CUR-54): available without Grafanacon bundle; GrafanaCon extras still flag-gated
-  const allowedExtraThemes = ['aubergine'];
+  const colorblindExtras: string[] = config.featureToggles.colorblindThemes
+    ? [
+        'deuteranopia_protanopia_dark',
+        'deuteranopia_protanopia_light',
+        'tritanopia_dark',
+        'tritanopia_light',
+      ]
+    : [];
 
-  if (config.featureToggles.colorblindThemes) {
-    allowedExtraThemes.push('deuteranopia_protanopia_dark');
-    allowedExtraThemes.push('deuteranopia_protanopia_light');
-    allowedExtraThemes.push('tritanopia_dark');
-    allowedExtraThemes.push('tritanopia_light');
-  }
+  const grafanaconExtras: string[] = config.featureToggles.grafanaconThemes
+    ? ['desertbloom', 'gildedgrove', 'sapphiredusk', 'tron', 'gloom']
+    : [];
 
-  if (config.featureToggles.grafanaconThemes) {
-    allowedExtraThemes.push('desertbloom');
-    allowedExtraThemes.push('gildedgrove');
-    allowedExtraThemes.push('sapphiredusk');
-    allowedExtraThemes.push('tron');
-    allowedExtraThemes.push('gloom');
-  }
-
-  return getBuiltInThemes(allowedExtraThemes);
+  return getBuiltInThemes(['aubergine', ...colorblindExtras, ...grafanaconExtras]);
 }


### PR DESCRIPTION
## Summary
- Makes the purple **Aubergine** built-in theme always selectable (not gated on `grafanaconThemes`).
- Shows **Profile → Change theme** when any selectable experimental theme exists so the drawer works without Grafanacon.
- Adds `getSelectableThemes` tests covering Grafanacon and accessibility theme bundles merged on `main`.

## Context
[Jira CUR-54](https://fe-cursor-demos.atlassian.net/browse/CUR-54): Add purple/amethyst theme to the Grafana theme switcher.

## Verification
```bash
yarn test:ci --runTestsByPath public/app/core/components/ThemeSelector/getSelectableThemes.test.ts
```

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI/feature-toggle behavior change limited to theme selection and profile menu rendering, with added unit tests to guard toggle combinations.
> 
> **Overview**
> Makes the `aubergine` built-in theme always included in `getSelectableThemes()` (independent of `grafanaconThemes`), while still gating GrafanaCon and colorblind theme bundles behind their respective feature toggles.
> 
> Updates the Profile menu to show **Change theme** whenever `getSelectableThemes()` contains any `isExtra` themes (instead of checking `config.featureToggles.grafanaconThemes` directly), and adds Jest coverage for the theme-selection matrix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aa5533aff6d41d17849bfc937b991a114bcec351. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->