### PR TITLE
feat(frontend): structured logging replaces ad-hoc console usage

### DIFF
--- a/packages/grafana-data/src/dataframe/FieldCache.ts
+++ b/packages/grafana-data/src/dataframe/FieldCache.ts
@@ -1,4 +1,5 @@
 import { type DataFrame, type Field, FieldType } from '../types/dataFrame';
+import { structuredLog } from '../utils/structuredConsole';
 
 import { guessFieldTypeForField } from './processDataFrame';
 
@@ -36,7 +37,7 @@ export class FieldCache {
       });
 
       if (this.fieldByName[field.name]) {
-        console.warn('Duplicate field names in DataFrame: ', field.name);
+        structuredLog('warn', 'Duplicate field names in DataFrame', { fieldName: field.name });
       } else {
         this.fieldByName[field.name] = { ...field, index: i };
       }

--- a/packages/grafana-data/src/dataframe/processDataFrame.ts
+++ b/packages/grafana-data/src/dataframe/processDataFrame.ts
@@ -19,6 +19,7 @@ import {
 import { type DataQueryResponseData } from '../types/datasource';
 import { type GraphSeriesXY, type GraphSeriesValue } from '../types/graph';
 import { type PanelData } from '../types/panel';
+import { structuredLog, toLogContextPart } from '../utils/structuredConsole';
 
 import { arrayToDataFrame } from './ArrayDataFrame';
 import { dataFrameFromJSON } from './DataFrameJSON';
@@ -340,7 +341,9 @@ export function toDataFrame(data: any): DataFrame {
     return arrayToDataFrame(data);
   }
 
-  console.warn('Can not convert', data);
+  structuredLog('warn', 'Unsupported data format: cannot convert payload', {
+    preview: typeof data === 'object' && data !== null ? toLogContextPart(data) : { type: typeof data },
+  });
   throw new Error('Unsupported data format');
 }
 

--- a/packages/grafana-data/src/index.ts
+++ b/packages/grafana-data/src/index.ts
@@ -243,6 +243,12 @@ export {
 } from './utils/datasource';
 export { deprecationWarning } from './utils/deprecationWarning';
 export {
+  structuredLog,
+  toLogContextPart,
+  type StructuredLogEntry,
+  type StructuredLogLevel,
+} from './utils/structuredConsole';
+export {
   CSVHeaderStyle,
   type CSVConfig,
   type CSVParseCallbacks,

--- a/packages/grafana-data/src/text/sanitize.ts
+++ b/packages/grafana-data/src/text/sanitize.ts
@@ -2,6 +2,8 @@ import { sanitizeUrl as braintreeSanitizeUrl } from '@braintree/sanitize-url';
 import DOMPurify from 'dompurify';
 import * as xss from 'xss';
 
+import { structuredLog, toLogContextPart } from '../utils/structuredConsole';
+
 const XSSWL = Object.keys(xss.whiteList).reduce<xss.IWhiteList>((acc, element) => {
   acc[element] = xss.whiteList[element]?.concat(['class', 'style']);
   return acc;
@@ -68,7 +70,10 @@ export function sanitize(unsanitizedString: string): string {
       ADD_ATTR: ['target'],
     });
   } catch (error) {
-    console.error('String could not be sanitized', unsanitizedString);
+    structuredLog('error', 'String could not be sanitized', {
+      unsanitizedString,
+      error: toLogContextPart(error),
+    });
     return escapeHtml(unsanitizedString);
   } finally {
     DOMPurify.removeHook('afterSanitizeAttributes');
@@ -99,7 +104,10 @@ export function sanitizeTextPanelContent(unsanitizedString: string): string {
   try {
     return sanitizeTextPanelWhitelist.process(unsanitizedString);
   } catch (error) {
-    console.error('String could not be sanitized', unsanitizedString);
+    structuredLog('error', 'Text panel string could not be sanitized', {
+      unsanitizedString,
+      error: toLogContextPart(error),
+    });
     return 'Text string could not be sanitized';
   }
 }

--- a/packages/grafana-data/src/themes/colorManipulator.ts
+++ b/packages/grafana-data/src/themes/colorManipulator.ts
@@ -4,6 +4,8 @@
 
 import tinycolor from 'tinycolor2';
 
+import { structuredLog } from '../utils/structuredConsole';
+
 /**
  * Returns a number whose value is limited to the given range.
  * @param value The value to be clamped
@@ -15,7 +17,7 @@ import tinycolor from 'tinycolor2';
 function clamp(value: number, min = 0, max = 1) {
   if (process.env.NODE_ENV !== 'production') {
     if (value < min || value > max) {
-      console.error(`The value provided ${value} is out of range [${min}, ${max}].`);
+      structuredLog('error', `Color clamp input is out of range [${min}, ${max}]`, { value });
     }
   }
 

--- a/packages/grafana-data/src/themes/createSpacing.ts
+++ b/packages/grafana-data/src/themes/createSpacing.ts
@@ -3,6 +3,8 @@
 // Copyright (c) 2014 Call-Em-All
 import { z } from 'zod';
 
+import { structuredLog } from '../utils/structuredConsole';
+
 /** @internal */
 export const ThemeSpacingOptionsSchema = z.object({
   gridSize: z.int().positive().optional(),
@@ -52,7 +54,7 @@ export function createSpacing(options: ThemeSpacingOptions = {}): ThemeSpacing {
 
     if (process.env.NODE_ENV !== 'production') {
       if (typeof value !== 'number') {
-        console.error(`Expected spacing argument to be a number or a string, got ${value}.`);
+        structuredLog('error', `Expected spacing argument to be a number or a string, got ${value}`);
       }
     }
     return value * gridSize;
@@ -61,7 +63,7 @@ export function createSpacing(options: ThemeSpacingOptions = {}): ThemeSpacing {
   const spacing = (...args: Array<number | string>): string => {
     if (process.env.NODE_ENV !== 'production') {
       if (!(args.length <= 4)) {
-        console.error(`Too many arguments provided, expected between 0 and 4, got ${args.length}`);
+        structuredLog('error', `Too many spacing arguments provided, expected between 0 and 4, got ${args.length}`);
       }
     }
 

--- a/packages/grafana-data/src/themes/createTypography.ts
+++ b/packages/grafana-data/src/themes/createTypography.ts
@@ -3,6 +3,7 @@
 // Copyright (c) 2014 Call-Em-All
 import { z } from 'zod';
 
+import { structuredLog } from '../utils/structuredConsole';
 import { type ThemeColors } from './createColors';
 
 /** @beta */
@@ -76,11 +77,11 @@ export function createTypography(colors: ThemeColors, typographyInput: ThemeTypo
 
   if (process.env.NODE_ENV !== 'production') {
     if (typeof fontSize !== 'number') {
-      console.error('Grafana-UI: `fontSize` is required to be a number.');
+      structuredLog('error', 'Grafana-UI: `fontSize` is required to be a number');
     }
 
     if (typeof htmlFontSize !== 'number') {
-      console.error('Grafana-UI: `htmlFontSize` is required to be a number.');
+      structuredLog('error', 'Grafana-UI: `htmlFontSize` is required to be a number');
     }
   }
 

--- a/packages/grafana-data/src/themes/registry.ts
+++ b/packages/grafana-data/src/themes/registry.ts
@@ -1,5 +1,6 @@
 import { Registry, type RegistryItem } from '../utils/Registry';
 
+import { structuredLog, toLogContextPart } from '../utils/structuredConsole';
 import { createTheme, NewThemeOptionsSchema } from './createTheme';
 import aubergine from './themeDefinitions/aubergine.json';
 import debug from './themeDefinitions/debug.json';
@@ -87,7 +88,10 @@ const themeRegistry = new Registry<ThemeRegistryItem>(() => {
 for (const [name, json] of Object.entries(extraThemes)) {
   const result = NewThemeOptionsSchema.safeParse(json);
   if (!result.success) {
-    console.error(`Invalid theme definition for theme ${name}: ${result.error.message}`);
+    structuredLog('error', `Invalid theme definition for theme ${name}`, {
+      errorMessage: result.error.message,
+      details: toLogContextPart(result.error),
+    });
   } else {
     const theme = result.data;
     themeRegistry.register({

--- a/packages/grafana-data/src/transformations/matchers/nameMatcher.ts
+++ b/packages/grafana-data/src/transformations/matchers/nameMatcher.ts
@@ -1,5 +1,6 @@
 import { getFieldDisplayName } from '../../field/fieldState';
 import { stringToJsRegex } from '../../text/string';
+import { structuredLog, toLogContextPart } from '../../utils/structuredConsole';
 import { type DataFrame, type Field, FieldType, TIME_SERIES_VALUE_FIELD_NAME } from '../../types/dataFrame';
 import { type FieldMatcher, type FieldMatcherInfo, type FrameMatcherInfo } from '../../types/transformations';
 
@@ -201,7 +202,7 @@ const patternToRegex = (pattern?: string): RegExp | undefined => {
   try {
     return stringToJsRegex(pattern);
   } catch (error) {
-    console.error(error);
+    structuredLog('error', 'Invalid field name pattern for matcher', { error: toLogContextPart(error), pattern });
     return undefined;
   }
 };

--- a/packages/grafana-data/src/transformations/matchers/refIdMatcher.ts
+++ b/packages/grafana-data/src/transformations/matchers/refIdMatcher.ts
@@ -1,4 +1,5 @@
 import { escapeStringForRegex, stringStartsAsRegEx, stringToJsRegex } from '../../text/string';
+import { structuredLog, toLogContextPart } from '../../utils/structuredConsole';
 import { type DataFrame } from '../../types/dataFrame';
 import { type FrameMatcherInfo } from '../../types/transformations';
 
@@ -19,7 +20,7 @@ const refIdMatcher: FrameMatcherInfo<string> = {
         regex = stringToJsRegex(pattern);
       } catch (error) {
         if (error instanceof Error) {
-          console.warn(error.message);
+          structuredLog('warn', error.message, { error: toLogContextPart(error) });
         }
       }
     }

--- a/packages/grafana-data/src/transformations/transformers/filterByValue.ts
+++ b/packages/grafana-data/src/transformations/transformers/filterByValue.ts
@@ -1,6 +1,7 @@
 import { map } from 'rxjs/operators';
 
 import { getFieldDisplayName } from '../../field/fieldState';
+import { structuredLog } from '../../utils/structuredConsole';
 import { type DataFrame, type Field } from '../../types/dataFrame';
 import { type DataTransformerInfo, type MatcherConfig } from '../../types/transformations';
 import { getValueMatcher } from '../matchers';
@@ -139,7 +140,7 @@ const createFilterValueMatchers = (
     const fieldIndex = fieldIndexByName[filter.fieldName] ?? -1;
 
     if (fieldIndex < 0) {
-      console.warn(`[FilterByValue] Could not find index for field name: ${filter.fieldName}`);
+      structuredLog('warn', `[FilterByValue] Could not find index for field name: ${filter.fieldName}`);
       return noop;
     }
 

--- a/packages/grafana-data/src/types/app.ts
+++ b/packages/grafana-data/src/types/app.ts
@@ -1,6 +1,7 @@
 import { type ComponentType } from 'react';
 
 import { throwIfAngular } from '../utils/throwIfAngular';
+import { structuredLog, toLogContextPart } from '../utils/structuredConsole';
 
 import { type KeyValue } from './data';
 import { type NavModel } from './navModel';
@@ -93,7 +94,10 @@ export class AppPlugin<T extends KeyValue = KeyValue> extends GrafanaPlugin<AppP
           const exp = pluginExports[include.component];
 
           if (!exp) {
-            console.warn('App Page uses unknown component: ', include.component, this.meta);
+            structuredLog('warn', 'App Page uses unknown component', {
+              component: include.component,
+              pluginMeta: toLogContextPart(this.meta),
+            });
             continue;
           }
         }

--- a/packages/grafana-data/src/types/plugin.ts
+++ b/packages/grafana-data/src/types/plugin.ts
@@ -2,6 +2,7 @@ import { type ComponentType } from 'react';
 
 import { type KeyValue } from './data';
 import { type IconName } from './icon';
+import { structuredLog, toLogContextPart } from '../utils/structuredConsole';
 
 /** Describes plugins life cycle status */
 export enum PluginState {
@@ -260,7 +261,9 @@ export class GrafanaPlugin<T extends PluginMeta = PluginMeta> {
    * @deprecated -- this is no longer necessary and will be removed
    */
   setChannelSupport() {
-    console.warn('[deprecation] plugin is using ignored option: setChannelSupport', this.meta);
+    structuredLog('warn', '[deprecation] plugin is using ignored option: setChannelSupport', {
+      meta: toLogContextPart(this.meta) as Record<string, unknown>,
+    });
     return this;
   }
 

--- a/packages/grafana-data/src/utils/LocalStorageValueProvider.tsx
+++ b/packages/grafana-data/src/utils/LocalStorageValueProvider.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react';
 import * as React from 'react';
 
+import { structuredLog, toLogContextPart } from './structuredConsole';
 import { store } from './store';
 
 export interface Props<T> {
@@ -32,7 +33,7 @@ export const LocalStorageValueProvider = <T,>(props: Props<T>) => {
     try {
       store.setObject(storageKey, value);
     } catch (error) {
-      console.error(error);
+      structuredLog('error', 'Failed to save object to localStorage', { error: toLogContextPart(error), storageKey });
     }
     setState({ value });
   };
@@ -41,7 +42,7 @@ export const LocalStorageValueProvider = <T,>(props: Props<T>) => {
     try {
       store.delete(storageKey);
     } catch (error) {
-      console.log(error);
+      structuredLog('warn', 'Failed to delete localStorage key', { error: toLogContextPart(error), storageKey });
     }
     setState({ value: defaultValue });
   };

--- a/packages/grafana-data/src/utils/deprecationWarning.test.ts
+++ b/packages/grafana-data/src/utils/deprecationWarning.test.ts
@@ -4,6 +4,7 @@ test('It should not output deprecation warnings too often', () => {
   let dateNowValue = 10000000;
 
   const spyConsoleWarn = jest.spyOn(console, 'warn').mockImplementation();
+  // structuredLog routes warn level to console.warn
   const spyDateNow = jest.spyOn(global.Date, 'now').mockImplementation(() => dateNowValue);
   // Make sure the mock works
   expect(Date.now()).toEqual(dateNowValue);

--- a/packages/grafana-data/src/utils/deprecationWarning.ts
+++ b/packages/grafana-data/src/utils/deprecationWarning.ts
@@ -1,5 +1,7 @@
 import { type KeyValue } from '../types/data';
 
+import { structuredLog } from './structuredConsole';
+
 // Avoid writing the warning message more than once every 10s
 const history: KeyValue<number> = {};
 
@@ -11,7 +13,7 @@ export const deprecationWarning = (file: string, oldName: string, newName?: stri
   const now = Date.now();
   const last = history[message];
   if (!last || now - last > 10000) {
-    console.warn(message);
+    structuredLog('warn', message, { file, oldName, newName });
     history[message] = now;
   }
 };

--- a/packages/grafana-data/src/utils/store.ts
+++ b/packages/grafana-data/src/utils/store.ts
@@ -1,3 +1,5 @@
+import { structuredLog, toLogContextPart } from './structuredConsole';
+
 type StoreValue = string | number | boolean | null;
 type StoreSubscriber = () => void;
 
@@ -65,7 +67,10 @@ export class Store {
       try {
         ret = JSON.parse(json);
       } catch (error) {
-        console.error(`Error parsing store object: ${key}. Returning default: ${def}. [${error}]`);
+        structuredLog('error', `Error parsing store object: ${key}. Returning default: ${def}`, {
+          error: toLogContextPart(error),
+          key,
+        });
       }
     }
     return ret;

--- a/packages/grafana-data/src/utils/structuredConsole.test.ts
+++ b/packages/grafana-data/src/utils/structuredConsole.test.ts
@@ -1,0 +1,33 @@
+import { structuredLog, toLogContextPart } from './structuredConsole';
+
+describe('structuredLog', () => {
+  it('emits a JSON line to the appropriate console channel', () => {
+    const spy = jest.spyOn(console, 'warn').mockImplementation();
+
+    structuredLog('warn', 'hello', { foo: 1 });
+
+    expect(spy).toHaveBeenCalledTimes(1);
+    const line = spy.mock.calls[0][0] as string;
+    const parsed = JSON.parse(line);
+    expect(parsed.level).toBe('warn');
+    expect(parsed.message).toBe('hello');
+    expect(parsed.context).toEqual({ foo: 1 });
+
+    spy.mockRestore();
+  });
+});
+
+describe('toLogContextPart', () => {
+  it('serializes Errors', () => {
+    const err = new Error('boom');
+    expect(toLogContextPart(err)).toMatchObject({
+      name: 'Error',
+      message: 'boom',
+    });
+  });
+
+  it('returns primitives as-is', () => {
+    expect(toLogContextPart(42)).toBe(42);
+    expect(toLogContextPart('x')).toBe('x');
+  });
+});

--- a/packages/grafana-data/src/utils/structuredConsole.ts
+++ b/packages/grafana-data/src/utils/structuredConsole.ts
@@ -1,0 +1,62 @@
+/** @internal */
+export type StructuredLogLevel = 'debug' | 'info' | 'warn' | 'error';
+
+export interface StructuredLogEntry {
+  level: StructuredLogLevel;
+  message: string;
+  timestamp: string;
+  context?: Record<string, unknown>;
+}
+
+/**
+ * Normalizes arbitrary values into something safe to place in structured log context.
+ * @public
+ */
+export function toLogContextPart(value: unknown): unknown {
+  if (value instanceof Error) {
+    return { name: value.name, message: value.message, stack: value.stack };
+  }
+  if (value === null || typeof value !== 'object') {
+    return value;
+  }
+  try {
+    return JSON.parse(JSON.stringify(value));
+  } catch {
+    return String(value);
+  }
+}
+
+function buildEntry(
+  level: StructuredLogLevel,
+  message: string,
+  context?: Record<string, unknown>
+): StructuredLogEntry {
+  return {
+    level,
+    message,
+    timestamp: new Date().toISOString(),
+    ...(context && Object.keys(context).length > 0 ? { context } : {}),
+  };
+}
+
+/**
+ * Single-line JSON logging for the browser (and Node). This is the standard replacement
+ * for ad-hoc `console.*` calls when Faro / GJA is not available.
+ *
+ * @public
+ */
+export function structuredLog(level: StructuredLogLevel, message: string, context?: Record<string, unknown>): void {
+  const line = JSON.stringify(buildEntry(level, message, context));
+  switch (level) {
+    case 'debug':
+    case 'info':
+      console.log(line);
+      break;
+    case 'warn':
+      console.warn(line);
+      break;
+    case 'error':
+      console.error(line);
+      break;
+  }
+}

--- a/packages/grafana-data/src/utils/url.ts
+++ b/packages/grafana-data/src/utils/url.ts
@@ -6,6 +6,8 @@ import { isDateTime } from '../datetime/moment_wrapper';
 import { type ExploreUrlState, type URLRange } from '../types/explore';
 import { type RawTimeRange } from '../types/time';
 
+import { structuredLog } from './structuredConsole';
+
 /**
  * Type to represent the value of a single query variable.
  *
@@ -226,7 +228,7 @@ export const urlUtil = {
  */
 export function serializeStateToUrlParam(urlState: Partial<ExploreUrlState>, compact?: boolean): string {
   if (compact !== undefined) {
-    console.warn('`compact` parameter is deprecated and will be removed in a future release');
+    structuredLog('warn', '`compact` parameter is deprecated and will be removed in a future release');
   }
   return JSON.stringify(urlState);
 }

--- a/packages/grafana-data/src/vector/ArrayVector.ts
+++ b/packages/grafana-data/src/vector/ArrayVector.ts
@@ -1,3 +1,5 @@
+import { structuredLog } from '../utils/structuredConsole';
+
 const notice = 'ArrayVector is deprecated and will be removed in Grafana 11. Please use plain arrays for field.values.';
 let notified = false;
 
@@ -47,7 +49,7 @@ export class ArrayVector<T = unknown> extends Array<T> {
     this.buffer = buffer ?? [];
 
     if (!notified) {
-      console.warn(notice);
+      structuredLog('warn', notice);
       notified = true;
     }
   }

--- a/packages/grafana-i18n/src/i18n.tsx
+++ b/packages/grafana-i18n/src/i18n.tsx
@@ -1,3 +1,4 @@
+import { structuredLog, toLogContextPart } from './utils/structuredLog';
 import i18n, { type InitOptions, type ReactOptions, type TFunction as I18NextTFunction } from 'i18next';
 import LanguageDetector, { type DetectorOptions } from 'i18next-browser-languagedetector';
 import React from 'react';
@@ -44,7 +45,7 @@ export async function loadNamespacedResources(namespace: string, language: strin
         const resources = await loader(resolvedLanguage);
         addResourceBundle(resolvedLanguage, namespace, resources);
       } catch (error) {
-        console.error(`Error loading resources for namespace ${namespace} and language: ${resolvedLanguage}`, error);
+        structuredLog('error', `Error loading resources for namespace ${namespace} and language: ${resolvedLanguage}`, { error: toLogContextPart(error) });
       }
     })
   );
@@ -202,9 +203,7 @@ export const t: TFunction = (id: string, defaultMessage: string, values?: Record
   initDefaultI18nInstance();
   if (!tFunc) {
     if (process.env.NODE_ENV !== 'test') {
-      console.warn(
-        't() was called before i18n was initialized. This is probably caused by calling t() in the root module scope, instead of lazily on render'
-      );
+      structuredLog('warn', 't() was called before i18n was initialized. This is probably caused by calling t() in the root module scope, instead of lazily on render');
     }
 
     if (process.env.NODE_ENV === 'development') {

--- a/packages/grafana-i18n/src/utils/structuredLog.ts
+++ b/packages/grafana-i18n/src/utils/structuredLog.ts
@@ -1,0 +1,38 @@
+/** Mirrors @grafana/data structured logs without taking a dependency on that package (i18n has a narrower TS/browser surface). */
+
+type StructuredLevel = 'debug' | 'info' | 'warn' | 'error';
+
+export function toLogContextPart(value: unknown): unknown {
+  if (value instanceof Error) {
+    return { name: value.name, message: value.message, stack: value.stack };
+  }
+  if (value === null || typeof value !== 'object') {
+    return value;
+  }
+  try {
+    return JSON.parse(JSON.stringify(value));
+  } catch {
+    return String(value);
+  }
+}
+
+export function structuredLog(level: StructuredLevel, message: string, context?: Record<string, unknown>): void {
+  const payload = JSON.stringify({
+    level,
+    message,
+    timestamp: new Date().toISOString(),
+    ...(context && Object.keys(context).length > 0 ? { context } : {}),
+  });
+  switch (level) {
+    case 'debug':
+    case 'info':
+      console.log(payload);
+      break;
+    case 'warn':
+      console.warn(payload);
+      break;
+    case 'error':
+      console.error(payload);
+      break;
+  }
+}

--- a/packages/grafana-openapi/package.json
+++ b/packages/grafana-openapi/package.json
@@ -54,6 +54,7 @@
   },
   "packageManager": "yarn@4.11.0",
   "devDependencies": {
+    "@grafana/data": "13.0.0-pre",
     "openapi-types": "^12.1.3",
     "prettier": "3.6.2"
   }

--- a/packages/grafana-openapi/src/scripts/process-specs.ts
+++ b/packages/grafana-openapi/src/scripts/process-specs.ts
@@ -1,3 +1,6 @@
+import {
+  structuredLog, toLogContextPart
+} from '@grafana/data';
 import fs from 'fs';
 import { type OpenAPIV3 } from 'openapi-types';
 import path from 'path';
@@ -154,7 +157,7 @@ function processDirectory(sourceDir: string, outputDir: string) {
     const inputPath = path.join(sourceDir, file);
     const outputPath = path.join(outputDir, file);
 
-    console.log(`Processing file "${file}"...`);
+    structuredLog('info', `Processing file "${file}"...`);
 
     const fileContent = fs.readFileSync(inputPath, 'utf-8');
 
@@ -162,13 +165,13 @@ function processDirectory(sourceDir: string, outputDir: string) {
     try {
       inputSpec = JSON.parse(fileContent);
     } catch (err) {
-      console.error(`Invalid JSON file "${file}". Skipping this file.`);
+      structuredLog('error', `Invalid JSON file "${file}". Skipping this file.`);
       continue;
     }
 
     const outputSpec = processOpenAPISpec(inputSpec);
     fs.writeFileSync(outputPath, JSON.stringify(outputSpec, null, 2), 'utf-8');
-    console.log(`Processing completed for file "${file}".`);
+    structuredLog('info', `Processing completed for file "${file}".`);
   }
 }
 

--- a/packages/grafana-prometheus/src/components/metrics-browser/ValueSelector.tsx
+++ b/packages/grafana-prometheus/src/components/metrics-browser/ValueSelector.tsx
@@ -1,3 +1,4 @@
+import { structuredLog, toLogContextPart } from '@grafana/data';
 import { useEffect, useState } from 'react';
 import { FixedSizeList } from 'react-window';
 
@@ -59,7 +60,7 @@ export function ValueSelector() {
         <div className={styles.valueListArea}>
           {Object.entries(filteredLabelValues).map(([lk, lv]) => {
             if (!lk || !lv) {
-              console.error('label values are empty:', { lk, lv });
+              structuredLog('error', 'label values are empty:', { details: { lk, lv } });
               return null;
             }
             return (

--- a/packages/grafana-prometheus/src/components/monaco-query-field/getOverrideServices.ts
+++ b/packages/grafana-prometheus/src/components/monaco-query-field/getOverrideServices.ts
@@ -1,4 +1,5 @@
 // Core Grafana history https://github.com/grafana/grafana/blob/v11.0.0-preview/public/app/plugins/datasource/prometheus/components/monaco-query-field/getOverrideServices.ts
+import { structuredLog, toLogContextPart } from '@grafana/data';
 import { type monacoTypes } from '@grafana/ui';
 
 // this thing here is a workaround in a way.
@@ -82,7 +83,7 @@ function makeStorageService() {
     },
 
     logStorage: (): void => {
-      console.log('logStorage: not implemented');
+      structuredLog('info', 'logStorage: not implemented');
     },
 
     migrate: (): Promise<void> => {

--- a/packages/grafana-prometheus/src/components/monaco-query-field/monaco-completion-provider/data_provider.ts
+++ b/packages/grafana-prometheus/src/components/monaco-query-field/monaco-completion-provider/data_provider.ts
@@ -1,4 +1,7 @@
-import { type HistoryItem, type TimeRange } from '@grafana/data';
+import {
+  type HistoryItem, type TimeRange,
+  structuredLog
+} from '@grafana/data';
 
 import { DEFAULT_COMPLETION_LIMIT, METRIC_LABEL } from '../../../constants';
 import { type PrometheusLanguageProviderInterface } from '../../../language_provider';
@@ -80,7 +83,7 @@ export class DataProvider {
 
       return Array.isArray(result) ? result : [];
     } catch (error) {
-      console.warn('Failed to query metric names:', error);
+      structuredLog('warn', 'Failed to query metric names:', { details: error });
       return [];
     }
   };

--- a/packages/grafana-prometheus/src/datasource.ts
+++ b/packages/grafana-prometheus/src/datasource.ts
@@ -1,4 +1,5 @@
-import { defaults } from 'lodash';
+import {
+  defaults } from 'lodash';
 import { tz } from 'moment-timezone';
 import { lastValueFrom, type Observable, throwError } from 'rxjs';
 import { map, tap } from 'rxjs/operators';
@@ -27,6 +28,8 @@ import {
   scopeFilterOperatorMap,
   type ScopeSpecFilter,
   type TimeRange,
+  structuredLog,
+  toLogContextPart
 } from '@grafana/data';
 import {
   type BackendSrvRequest,
@@ -172,8 +175,8 @@ export class PrometheusDatasource
         this.ruleMappings = extractRuleMappingFromGroups(ruleGroups);
       }
     } catch (err) {
-      console.log('Rules API is experimental. Ignore next error.');
-      console.error(err);
+      structuredLog('info', 'Rules API is experimental. Ignore next error.');
+      structuredLog('error', 'Error', { error: toLogContextPart(err) });
     }
   }
 
@@ -352,7 +355,7 @@ export class PrometheusDatasource
       } catch (err) {
         // If status code of error is Method Not Allowed (405) and HTTP method is POST, retry with GET
         if (this.httpMethod === 'POST' && isFetchError(err) && (err.status === 405 || err.status === 400)) {
-          console.warn(`Couldn't use configured POST HTTP method for this request. Trying to use GET method instead.`);
+          structuredLog('warn', `Couldn't use configured POST HTTP method for this request. Trying to use GET method instead.`);
         } else {
           throw err;
         }

--- a/packages/grafana-prometheus/src/language_provider.ts
+++ b/packages/grafana-prometheus/src/language_provider.ts
@@ -11,6 +11,8 @@ import {
   scopeFilterOperatorMap,
   type ScopeSpecFilter,
   type TimeRange,
+  structuredLog,
+  toLogContextPart
 } from '@grafana/data';
 import { type BackendSrvRequest } from '@grafana/runtime';
 
@@ -132,7 +134,7 @@ export class PrometheusLanguageProvider implements PrometheusLanguageProviderInt
       return res.data.data;
     } catch (error) {
       if (!isCancelledError(error)) {
-        console.error(error);
+        structuredLog('error', 'Error', { error: toLogContextPart(error) });
       }
     }
 

--- a/packages/grafana-prometheus/src/querybuilder/components/metrics-modal/MetricsModalContext.tsx
+++ b/packages/grafana-prometheus/src/querybuilder/components/metrics-modal/MetricsModalContext.tsx
@@ -11,7 +11,10 @@ import {
   useState,
 } from 'react';
 
-import { type SelectableValue, type TimeRange } from '@grafana/data';
+import { type SelectableValue, type TimeRange,
+  structuredLog,
+  toLogContextPart
+} from '@grafana/data';
 
 import { METRIC_LABEL, PROMETHEUS_QUERY_BUILDER_MAX_RESULTS } from '../../../constants';
 import { type PrometheusLanguageProviderInterface } from '../../../language_provider';
@@ -167,7 +170,7 @@ export const MetricsModalContextProvider: FC<PropsWithChildren<MetricsModalConte
         } catch (error) {
           // Only update state if this is still the latest search
           if (searchId === latestSearchIdRef.current) {
-            console.error('Backend search failed:', error);
+            structuredLog('error', 'Backend search failed:', { error: toLogContextPart(error) });
             setMetricsData([]); // Clear results on error
             setIsLoading(false);
           }

--- a/packages/grafana-prometheus/src/querybuilder/parsing.ts
+++ b/packages/grafana-prometheus/src/querybuilder/parsing.ts
@@ -1,4 +1,5 @@
 // Core Grafana history https://github.com/grafana/grafana/blob/v11.0.0-preview/public/app/plugins/datasource/prometheus/querybuilder/parsing.ts
+import { structuredLog, toLogContextPart } from '@grafana/data';
 import { type SyntaxNode } from '@lezer/common';
 import {
   AggregateExpr,
@@ -72,7 +73,7 @@ export function buildVisualQueryFromString(expr: string): Omit<Context, 'replace
     handleExpression(replacedExpr, node, context);
   } catch (err) {
     // Not ideal to log it here, but otherwise we would lose the stack trace.
-    console.error(err);
+    structuredLog('error', 'Error', { error: toLogContextPart(err) });
     if (err instanceof Error) {
       context.errors.push({
         text: err.message,

--- a/packages/grafana-prometheus/src/result_transformer.ts
+++ b/packages/grafana-prometheus/src/result_transformer.ts
@@ -1,5 +1,6 @@
 // Core Grafana history https://github.com/grafana/grafana/blob/v11.0.0-preview/public/app/plugins/datasource/prometheus/result_transformer.ts
-import { flatten, forOwn, groupBy, partition } from 'lodash';
+import {
+  flatten, forOwn, groupBy, partition } from 'lodash';
 
 import {
   CoreApp,
@@ -18,6 +19,8 @@ import {
   sortDataFrame,
   TIME_SERIES_TIME_FIELD_NAME,
   TIME_SERIES_VALUE_FIELD_NAME,
+  structuredLog,
+  toLogContextPart
 } from '@grafana/data';
 import { getDataSourceSrv } from '@grafana/runtime';
 
@@ -437,7 +440,7 @@ export function sortSeriesByLabel(s1: DataFrame, s2: DataFrame): number {
     le2 = parseSampleValue(s2.fields[1].state?.displayName ?? s2.name ?? s2.fields[1].name);
   } catch (err) {
     // fail if not integer. might happen with bad queries
-    console.error(err);
+    structuredLog('error', 'Error', { error: toLogContextPart(err) });
     return 0;
   }
 

--- a/packages/grafana-runtime/src/config.ts
+++ b/packages/grafana-runtime/src/config.ts
@@ -18,6 +18,7 @@ import {
   systemDateFormats,
   type SystemDateFormatSettings,
   getThemeById,
+  structuredLog,
   type AngularMeta,
   type PluginLoadingStrategy,
   type PluginDependencies,
@@ -313,7 +314,11 @@ function overrideFeatureTogglesFromLocalStorage(config: GrafanaBootConfig) {
       const toggleState = featureValue === 'true' || featureValue === '1';
       // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
       featureToggles[featureName as keyof FeatureToggles] = toggleState;
-      console.log(`Setting feature toggle ${featureName} = ${toggleState} via localstorage`);
+      structuredLog('info', `Setting feature toggle ${featureName} = ${toggleState} via localstorage`, {
+        featureName,
+        toggleState,
+        source: 'localStorage',
+      });
     }
   }
 }
@@ -339,9 +344,15 @@ function overrideFeatureTogglesFromUrl(config: GrafanaBootConfig) {
       if (toggleState !== featureToggles[key]) {
         if (isDevelopment || safeRuntimeFeatureFlags.has(featureName)) {
           featureToggles[featureName] = toggleState;
-          console.log(`Setting feature toggle ${featureName} = ${toggleState} via url`);
+          structuredLog('info', `Setting feature toggle ${featureName} = ${toggleState} via url`, {
+            featureName,
+            toggleState,
+            source: 'url',
+          });
         } else {
-          console.log(`Unable to change feature toggle ${featureName} via url in production.`);
+          structuredLog('warn', `Unable to change feature toggle ${featureName} via url in production`, {
+            featureName,
+          });
         }
       }
     }
@@ -352,7 +363,7 @@ let bootData = window.grafanaBootData;
 
 if (!bootData) {
   if (process.env.NODE_ENV !== 'test') {
-    console.error('window.grafanaBootData was not set by the time config was initialized');
+    structuredLog('error', 'window.grafanaBootData was not set by the time config was initialized');
   }
 
   bootData = {

--- a/packages/grafana-runtime/src/internal/openFeature/index.ts
+++ b/packages/grafana-runtime/src/internal/openFeature/index.ts
@@ -18,7 +18,6 @@ function checkDefaultProvider(event?: EventDetails) {
       'OpenFeature default domain provider has been unexpectedly changed. This may be caused by a plugin that is incorrectly using the default domain.',
       { cause: OpenFeature.getProvider() }
     );
-    console.error(err);
     logError(err);
   }
 }

--- a/packages/grafana-runtime/src/services/pluginMeta/apps.test.ts
+++ b/packages/grafana-runtime/src/services/pluginMeta/apps.test.ts
@@ -98,7 +98,6 @@ describe('when useMTPlugins flag is enabled', () => {
     describe('and initPluginMetas returns an empty result', () => {
       beforeEach(() => {
         initPluginMetasMock.mockResolvedValue({ items: [] });
-        jest.spyOn(console, 'warn').mockImplementation();
       });
 
       it.each([{ func: getAppPluginMetas }])(
@@ -106,10 +105,6 @@ describe('when useMTPlugins flag is enabled', () => {
         async ({ func }) => {
           await func();
 
-          expect(console.warn).toHaveBeenCalledTimes(1);
-          expect(console.warn).toHaveBeenCalledWith(
-            'PluginMeta: plugin meta yielded an empty result so Grafana is falling back to bootdata'
-          );
           expect(logger.logWarning).toHaveBeenCalledTimes(1);
           expect(logger.logWarning).toHaveBeenCalledWith(
             'PluginMeta: plugin meta yielded an empty result so Grafana is falling back to bootdata',
@@ -123,10 +118,6 @@ describe('when useMTPlugins flag is enabled', () => {
         async ({ func }) => {
           await func('');
 
-          expect(console.warn).toHaveBeenCalledTimes(1);
-          expect(console.warn).toHaveBeenCalledWith(
-            'PluginMeta: plugin meta yielded an empty result so Grafana is falling back to bootdata'
-          );
           expect(logger.logWarning).toHaveBeenCalledTimes(1);
           expect(logger.logWarning).toHaveBeenCalledWith(
             'PluginMeta: plugin meta yielded an empty result so Grafana is falling back to bootdata',

--- a/packages/grafana-runtime/src/services/pluginMeta/logging.ts
+++ b/packages/grafana-runtime/src/services/pluginMeta/logging.ts
@@ -14,12 +14,10 @@ function getLogger() {
 
 export function logPluginMetaWarning(message: string, type: PluginType): void {
   getLogger().logWarning(message, { type });
-  console.warn(message);
 }
 
 export function logPluginMetaError(message: string, error: unknown): void {
   getLogger().logError(new Error(message, { cause: error }));
-  console.error(message, error);
 }
 
 export function setPluginMetaLogger(override: MonitoringLogger) {

--- a/packages/grafana-runtime/src/services/pluginMeta/panels.test.ts
+++ b/packages/grafana-runtime/src/services/pluginMeta/panels.test.ts
@@ -147,7 +147,6 @@ describe('when useMTPlugins flag is enabled', () => {
       beforeEach(() => {
         initPluginMetasMock.mockResolvedValue({ items: [] });
         refetchPluginMetasMock.mockResolvedValue({ items: [] });
-        jest.spyOn(console, 'warn').mockImplementation();
       });
 
       it.each([
@@ -159,10 +158,6 @@ describe('when useMTPlugins flag is enabled', () => {
       ])(`when func:$func is called then a warning should be logged`, async ({ func }) => {
         await func();
 
-        expect(console.warn).toHaveBeenCalledTimes(1);
-        expect(console.warn).toHaveBeenCalledWith(
-          'PluginMeta: plugin meta yielded an empty result so Grafana is falling back to bootdata'
-        );
         expect(logger.logWarning).toHaveBeenCalledTimes(1);
         expect(logger.logWarning).toHaveBeenCalledWith(
           'PluginMeta: plugin meta yielded an empty result so Grafana is falling back to bootdata',
@@ -175,10 +170,6 @@ describe('when useMTPlugins flag is enabled', () => {
         async ({ func }) => {
           await func('');
 
-          expect(console.warn).toHaveBeenCalledTimes(1);
-          expect(console.warn).toHaveBeenCalledWith(
-            'PluginMeta: plugin meta yielded an empty result so Grafana is falling back to bootdata'
-          );
           expect(logger.logWarning).toHaveBeenCalledTimes(1);
           expect(logger.logWarning).toHaveBeenCalledWith(
             'PluginMeta: plugin meta yielded an empty result so Grafana is falling back to bootdata',

--- a/packages/grafana-runtime/src/utils/chromeHeaderHeight.ts
+++ b/packages/grafana-runtime/src/utils/chromeHeaderHeight.ts
@@ -1,3 +1,5 @@
+import { structuredLog } from '@grafana/data';
+
 type ChromeHeaderHeightHook = () => number;
 
 let chromeHeaderHeightHook: ChromeHeaderHeightHook | undefined = undefined;
@@ -11,7 +13,7 @@ export const useChromeHeaderHeight = () => {
     if (process.env.NODE_ENV !== 'production') {
       throw new Error('useChromeHeaderHeight hook not found in @grafana/runtime');
     }
-    console.error('useChromeHeaderHeight hook not found');
+    structuredLog('error', 'useChromeHeaderHeight hook not found');
   }
 
   return chromeHeaderHeightHook?.();

--- a/packages/grafana-runtime/src/utils/logging.ts
+++ b/packages/grafana-runtime/src/utils/logging.ts
@@ -1,8 +1,15 @@
+import { structuredLog, toLogContextPart } from '@grafana/data';
 import { faro, type LogContext, LogLevel } from '@grafana/faro-web-sdk';
 
 import { config } from '../config';
 
 export { LogLevel };
+
+function contextsAsRecord(contexts?: LogContext): Record<string, unknown> | undefined {
+  return contexts !== undefined ? (contexts as Record<string, unknown>) : undefined;
+}
+
+export type MeasurementValues = Record<string, number>;
 
 /**
  * Log a message at INFO level
@@ -14,7 +21,9 @@ export function logInfo(message: string, contexts?: LogContext) {
       level: LogLevel.INFO,
       context: contexts,
     });
+    return;
   }
+  structuredLog('info', message, contextsAsRecord(contexts));
 }
 
 /**
@@ -28,7 +37,9 @@ export function logWarning(message: string, contexts?: LogContext) {
       level: LogLevel.WARN,
       context: contexts,
     });
+    return;
   }
+  structuredLog('warn', message, contextsAsRecord(contexts));
 }
 
 /**
@@ -42,7 +53,9 @@ export function logDebug(message: string, contexts?: LogContext) {
       level: LogLevel.DEBUG,
       context: contexts,
     });
+    return;
   }
+  structuredLog('debug', message, contextsAsRecord(contexts));
 }
 
 /**
@@ -55,7 +68,12 @@ export function logError(err: Error, contexts?: LogContext) {
     faro.api.pushError(err, {
       context: contexts,
     });
+    return;
   }
+  structuredLog('error', err.message, {
+    ...contextsAsRecord(contexts),
+    error: toLogContextPart(err),
+  });
 }
 
 /**
@@ -63,7 +81,6 @@ export function logError(err: Error, contexts?: LogContext) {
  *
  * @public
  */
-export type MeasurementValues = Record<string, number>;
 export function logMeasurement(type: string, values: MeasurementValues, context?: LogContext) {
   if (config.grafanaJavascriptAgent.enabled) {
     faro.api.pushMeasurement(
@@ -73,7 +90,9 @@ export function logMeasurement(type: string, values: MeasurementValues, context?
       },
       { context: context }
     );
+    return;
   }
+  structuredLog('info', `measurement.${type}`, { ...contextsAsRecord(context), metrics: values });
 }
 
 export interface MonitoringLogger {

--- a/packages/grafana-runtime/src/utils/megaMenuOpen.ts
+++ b/packages/grafana-runtime/src/utils/megaMenuOpen.ts
@@ -1,3 +1,5 @@
+import { structuredLog } from '@grafana/data';
+
 type MegaMenuOpenHook = () => Readonly<[boolean, (open: boolean, persist?: boolean) => void]>;
 
 let megaMenuOpenHook: MegaMenuOpenHook | undefined = undefined;
@@ -15,7 +17,7 @@ export const useMegaMenuOpen: MegaMenuOpenHook = () => {
     if (process.env.NODE_ENV !== 'production') {
       throw new Error('useMegaMenuOpen hook not found in @grafana/runtime');
     }
-    return [false, () => console.error('MegaMenuOpen hook not found')];
+    return [false, () => structuredLog('error', 'MegaMenuOpen hook not found')];
   }
 
   return megaMenuOpenHook();

--- a/packages/grafana-runtime/src/utils/migrationHandler.ts
+++ b/packages/grafana-runtime/src/utils/migrationHandler.ts
@@ -1,4 +1,4 @@
-import { type DataQueryRequest } from '@grafana/data';
+import { type DataQueryRequest, structuredLog } from '@grafana/data';
 import { type DataQuery } from '@grafana/schema';
 
 import { config } from '../config';
@@ -20,7 +20,7 @@ export function isMigrationHandler(object: unknown): object is MigrationHandler 
 
 async function postMigrateRequest<TQuery extends DataQuery>(queries: TQuery[]): Promise<TQuery[]> {
   if (!(config.featureToggles.grafanaAPIServerWithExperimentalAPIs || config.featureToggles.datasourceAPIServers)) {
-    console.warn('migrateQuery is only available with the experimental API server');
+    structuredLog('warn', 'migrateQuery is only available with the experimental API server');
     return queries;
   }
 

--- a/packages/grafana-runtime/src/utils/plugin.ts
+++ b/packages/grafana-runtime/src/utils/plugin.ts
@@ -1,4 +1,4 @@
-import { type PanelPlugin } from '@grafana/data';
+import { type PanelPlugin, structuredLog, toLogContextPart } from '@grafana/data';
 
 import { config } from '../config';
 
@@ -25,7 +25,7 @@ export async function loadPluginCss(options: PluginCssOptions): Promise<System.M
     const cssPath = config.bootData.user.theme === 'light' ? options.light : options.dark;
     return window.System.import(cssPath);
   } catch (err) {
-    console.error(err);
+    structuredLog('error', 'Failed to load plugin CSS', { error: toLogContextPart(err) });
   }
 }
 

--- a/packages/grafana-runtime/src/utils/qscheck.ts
+++ b/packages/grafana-runtime/src/utils/qscheck.ts
@@ -1,4 +1,4 @@
-import { type DataSourceInstanceSettings, type DataSourceJsonData } from '@grafana/data';
+import { type DataSourceInstanceSettings, type DataSourceJsonData, structuredLog } from '@grafana/data';
 
 interface JsonData extends DataSourceJsonData {
   oauthPassThru?: unknown; // we do not assume boolean, to be more robust
@@ -48,11 +48,11 @@ function parseAllowedTypes(data: unknown): AllowedTypes {
     if (types.every((x) => typeof x === 'string')) {
       return { types };
     } else {
-      console.error('qscheck.parseFlags: non-string item in allowed');
+      structuredLog('error', 'qscheck.parseFlags: non-string item in allowed');
       return { types: [] };
     }
   } else {
-    console.error('qscheck.parseFlags: invalid data');
+    structuredLog('error', 'qscheck.parseFlags: invalid data');
     return { types: [] };
   }
 }

--- a/packages/grafana-runtime/src/utils/returnToPrevious.ts
+++ b/packages/grafana-runtime/src/utils/returnToPrevious.ts
@@ -1,3 +1,5 @@
+import { structuredLog } from '@grafana/data';
+
 type ReturnToPreviousHook = () => (title: string, href?: string) => void;
 
 let rtpHook: ReturnToPreviousHook | undefined = undefined;
@@ -16,7 +18,7 @@ export const useReturnToPrevious: ReturnToPreviousHook = () => {
     if (process.env.NODE_ENV !== 'production') {
       throw new Error('useReturnToPrevious hook not found in @grafana/runtime');
     }
-    return () => console.error('ReturnToPrevious hook not found');
+    return () => structuredLog('error', 'ReturnToPrevious hook not found');
   }
 
   return rtpHook();

--- a/packages/grafana-sql/src/datasource/SqlDatasource.ts
+++ b/packages/grafana-sql/src/datasource/SqlDatasource.ts
@@ -1,4 +1,5 @@
-import { lastValueFrom, type Observable, throwError } from 'rxjs';
+import {
+  lastValueFrom, type Observable, throwError } from 'rxjs';
 import { map } from 'rxjs/operators';
 
 import {
@@ -16,6 +17,8 @@ import {
   type LegacyMetricFindQueryOptions,
   type VariableWithMultiSupport,
   type TimeRange,
+  structuredLog,
+  toLogContextPart
 } from '@grafana/data';
 import { EditorMode } from '@grafana/plugin-ui';
 import {
@@ -215,7 +218,7 @@ export abstract class SqlDatasource extends DataSourceWithBackend<SQLQuery, SQLO
     try {
       response = await this.runMetaQuery(interpolatedQuery, range);
     } catch (error) {
-      console.error(error);
+      structuredLog('error', 'Error', { error: toLogContextPart(error) });
       throw new Error('error when executing the sql query');
     }
     return this.getResponseParser().transformMetricFindResponse(response);

--- a/packages/grafana-ui/src/components/Card/Card.story.tsx
+++ b/packages/grafana-ui/src/components/Card/Card.story.tsx
@@ -1,5 +1,6 @@
 import { type Meta, type StoryFn } from '@storybook/react';
 
+import { structuredLog } from '@grafana/data';
 import { Button } from '../Button/Button';
 import { IconButton } from '../IconButton/IconButton';
 import { TextLink } from '../Link/TextLink';
@@ -93,7 +94,7 @@ export const Tags: StoryFn<typeof Card> = (args) => {
       <Card.Heading>Test dashboard</Card.Heading>
       <Card.Description>Card with a list of tags</Card.Description>
       <Card.Tags>
-        <TagList tags={['tag1', 'tag2', 'tag3']} onClick={(tag) => console.log(tag)} />
+        <TagList tags={['tag1', 'tag2', 'tag3']} onClick={(tag) => structuredLog('info', 'Card story tag click', { tag })} />
       </Card.Tags>
     </Card>
   );

--- a/packages/grafana-ui/src/components/Cascader/Cascader.story.tsx
+++ b/packages/grafana-ui/src/components/Cascader/Cascader.story.tsx
@@ -1,12 +1,13 @@
 import { type StoryFn, type Meta } from '@storybook/react';
 import { useId, useState } from 'react';
 
+import { structuredLog } from '@grafana/data';
 import { Field } from '../Forms/Field';
 
 import { Cascader, type CascaderOption } from './Cascader';
 import mdx from './Cascader.mdx';
 
-const onSelect = (val: string) => console.log(val);
+const onSelect = (val: string) => structuredLog('info', 'Cascader story select', { value: val });
 const options = [
   {
     label: 'First',

--- a/packages/grafana-ui/src/components/Combobox/storyUtils.ts
+++ b/packages/grafana-ui/src/components/Combobox/storyUtils.ts
@@ -1,3 +1,4 @@
+import { structuredLog } from '@grafana/data';
 import { type ComboboxOption } from './types';
 
 let fakeApiOptions: Array<ComboboxOption<string>>;
@@ -13,7 +14,7 @@ export async function fakeSearchAPI(urlString: string): Promise<Array<ComboboxOp
 
   if (!fakeApiOptions) {
     fakeApiOptions = await generateOptions(1000);
-    console.log('fakeApiOptions', fakeApiOptions);
+    structuredLog('info', 'Combobox fake API options seeded', { optionCount: fakeApiOptions.length });
   }
 
   if (!searchQuery || searchQuery.length === 0) {

--- a/packages/grafana-ui/src/components/Combobox/useOptions.ts
+++ b/packages/grafana-ui/src/components/Combobox/useOptions.ts
@@ -1,6 +1,7 @@
 /* Spreading unbound arrays can be very slow or even crash the browser if used for arguments */
 /* eslint no-restricted-syntax: ["error", "SpreadElement"] */
 
+import { structuredLog, toLogContextPart } from '@grafana/data';
 import { debounce } from 'lodash';
 import { useState, useCallback, useMemo } from 'react';
 
@@ -51,7 +52,7 @@ export function useOptions<T extends string | number>(
               setAsyncLoading(false);
 
               if (error) {
-                console.error('Error loading async options for Combobox', error);
+                structuredLog('error', 'Error loading async options for Combobox', { error: toLogContextPart(error) });
               }
             }
           });

--- a/packages/grafana-ui/src/components/Combobox/utils.ts
+++ b/packages/grafana-ui/src/components/Combobox/utils.ts
@@ -1,4 +1,7 @@
-import { isIconName, type SelectableValue } from '@grafana/data';
+import {
+  isIconName, type SelectableValue,
+  structuredLog
+} from '@grafana/data';
 
 import { type ComboboxOption } from './types';
 
@@ -25,11 +28,11 @@ export const selectableValueToComboboxOption = <T extends string | number>(
   v: SelectableValue<T>
 ): ComboboxOption<T> | undefined => {
   if (v == null || v.value == null) {
-    console.warn('selectableValueToComboboxOption: value is null or undefined', v);
+    structuredLog('warn', 'selectableValueToComboboxOption: value is null or undefined', { details: v });
     return undefined;
   }
   if (v.icon != null && !isIconName(v.icon)) {
-    console.warn('selectableValueToComboboxOption: icon is not a valid icon name', v.icon);
+    structuredLog('warn', 'selectableValueToComboboxOption: icon is not a valid icon name', { details: v.icon });
     return undefined;
   }
   return {

--- a/packages/grafana-ui/src/components/DateTimePickers/TimeRangePicker/CalendarBody.tsx
+++ b/packages/grafana-ui/src/components/DateTimePickers/TimeRangePicker/CalendarBody.tsx
@@ -1,8 +1,11 @@
-import { css } from '@emotion/css';
+import {
+  css } from '@emotion/css';
 import { useCallback } from 'react';
 import Calendar, { type CalendarType } from 'react-calendar';
 
-import { type GrafanaTheme2, dateTimeParse, type DateTime, type TimeZone } from '@grafana/data';
+import { type GrafanaTheme2, dateTimeParse, type DateTime, type TimeZone,
+  structuredLog
+} from '@grafana/data';
 import { t } from '@grafana/i18n';
 
 import { useStyles2 } from '../../../themes/ThemeContext';
@@ -70,7 +73,7 @@ function useOnCalendarChange(onChange: (from: DateTime, to: DateTime) => void, t
   return useCallback<NonNullable<React.ComponentProps<typeof Calendar>['onChange']>>(
     (value) => {
       if (!Array.isArray(value)) {
-        return console.error('onCalendarChange: should be run in selectRange={true}');
+        return structuredLog('error', 'onCalendarChange: should be run in selectRange={true}');
       }
 
       if (value[0] && value[1]) {

--- a/packages/grafana-ui/src/components/FileUpload/FileUpload.story.tsx
+++ b/packages/grafana-ui/src/components/FileUpload/FileUpload.story.tsx
@@ -1,5 +1,7 @@
 import { type Meta, type StoryFn } from '@storybook/react';
 
+import { structuredLog } from '@grafana/data';
+
 import { FileUpload } from './FileUpload';
 import mdx from './FileUpload.mdx';
 
@@ -28,7 +30,11 @@ export const Basic: StoryFn<typeof FileUpload> = (args) => {
   return (
     <FileUpload
       size={args.size}
-      onFileUpload={({ currentTarget }) => console.log('file', currentTarget?.files && currentTarget.files[0])}
+      onFileUpload={({ currentTarget }) =>
+        structuredLog('info', 'FileUpload story upload', {
+          fileName: currentTarget?.files?.[0]?.name,
+        })
+      }
     />
   );
 };

--- a/packages/grafana-ui/src/components/Forms/FieldArray.story.tsx
+++ b/packages/grafana-ui/src/components/Forms/FieldArray.story.tsx
@@ -1,6 +1,7 @@
 import { type Meta, type StoryFn } from '@storybook/react';
 import { type FieldValues } from 'react-hook-form';
 
+import { structuredLog, toLogContextPart } from '@grafana/data';
 import { withStoryContainer } from '../../utils/storybook/withStoryContainer';
 import { Button } from '../Button/Button';
 import { Input } from '../Input/Input';
@@ -36,7 +37,7 @@ export const Simple: StoryFn = (args) => {
     people: [{ firstName: 'Janis', lastName: 'Joplin' }],
   };
   return (
-    <Form onSubmit={(values) => console.log(values)} defaultValues={defaultValues}>
+    <Form onSubmit={(values) => structuredLog('info', 'FieldArray story submit', { values: toLogContextPart(values) })} defaultValues={defaultValues}>
       {({ control, register }) => (
         <div>
           <FieldArray control={control} name="people">

--- a/packages/grafana-ui/src/components/Forms/FieldSet.story.tsx
+++ b/packages/grafana-ui/src/components/Forms/FieldSet.story.tsx
@@ -1,6 +1,7 @@
 import { type Meta, type StoryFn } from '@storybook/react';
 import { useId } from 'react';
 
+import { structuredLog } from '@grafana/data';
 import { Button } from '../Button/Button';
 import { Input } from '../Input/Input';
 
@@ -34,7 +35,7 @@ export const Basic: StoryFn<typeof FieldSet> = (args: Props) => {
   const colorId = useId();
   const fontSizeId = useId();
   return (
-    <Form onSubmit={() => console.log('Submit')}>
+    <Form onSubmit={() => structuredLog('info', 'FieldSet story form submit')}>
       {() => (
         <>
           <FieldSet {...args}>

--- a/packages/grafana-ui/src/components/Forms/Form.story.tsx
+++ b/packages/grafana-ui/src/components/Forms/Form.story.tsx
@@ -2,6 +2,7 @@ import { type StoryFn } from '@storybook/react';
 import { useId } from 'react';
 import { type ValidateResult } from 'react-hook-form';
 
+import { structuredLog, toLogContextPart } from '@grafana/data';
 import { withStoryContainer } from '../../utils/storybook/withStoryContainer';
 import { Button } from '../Button/Button';
 import { Input } from '../Input/Input';
@@ -70,11 +71,13 @@ const renderForm = (defaultValues?: FormDTO) => {
     <Form
       defaultValues={defaultValues}
       onSubmit={(data: FormDTO) => {
-        console.log(data);
+        structuredLog('info', 'Deprecated Form story submit', { data: toLogContextPart(data) });
       }}
     >
       {({ register, control, errors }) => {
-        console.log(errors);
+        structuredLog('debug', 'Deprecated Form story errors snapshot', {
+          errors: toLogContextPart(errors),
+        });
         return (
           <>
             <Legend>Edit user</Legend>
@@ -162,7 +165,9 @@ export const AsyncValidation: StoryFn = ({ passAsyncValidation }) => {
         }}
       >
         {({ register, control, errors, formState }) => {
-          console.log(errors);
+          structuredLog('debug', 'Deprecated Form async validation errors snapshot', {
+            errors: toLogContextPart(errors),
+          });
           return (
             <>
               <Legend>Edit user</Legend>
@@ -201,7 +206,7 @@ const validateAsync = (shouldPass: boolean) => async () => {
     });
     return true;
   } catch (e) {
-    console.log(e);
+    structuredLog('warn', 'Deprecated Form story async validator failed', { error: toLogContextPart(e) });
     return false;
   }
 };

--- a/packages/grafana-ui/src/components/Icon/Icon.tsx
+++ b/packages/grafana-ui/src/components/Icon/Icon.tsx
@@ -1,8 +1,11 @@
-import { css, cx } from '@emotion/css';
+import {
+  css, cx } from '@emotion/css';
 import { useCallback, useState, useRef, memo, forwardRef } from 'react';
 import SVG from 'react-inlinesvg';
 
-import { type GrafanaTheme2, isIconName } from '@grafana/data';
+import { type GrafanaTheme2, isIconName,
+  structuredLog
+} from '@grafana/data';
 
 import { useStyles2 } from '../../themes/ThemeContext';
 import { type IconName, type IconType, type IconSize } from '../../types/icon';
@@ -96,7 +99,7 @@ export const Icon = memo(
       const { nameToUse: name, handleLoad } = useIconWorkaround(nameProp);
 
       if (!isIconName(name)) {
-        console.warn('Icon component passed an invalid icon name', name);
+        structuredLog('warn', 'Icon component passed an invalid icon name', { details: name });
       }
 
       // handle the deprecated 'fa fa-spinner'

--- a/packages/grafana-ui/src/components/Input/AutoSizeInput.tsx
+++ b/packages/grafana-ui/src/components/Input/AutoSizeInput.tsx
@@ -1,3 +1,4 @@
+import { structuredLog } from '@grafana/data';
 import { useCallback, useEffect, useMemo, useRef } from 'react';
 import * as React from 'react';
 
@@ -119,9 +120,7 @@ function useControlledState<T>(controlledValue: T, onChange: Function | undefine
 
   const hasLoggedControlledWarning = useRef(false);
   if (isControlledNow !== isControlledRef.current && !hasLoggedControlledWarning.current) {
-    console.warn(
-      'An AutoSizeInput is changing from an uncontrolled to a controlled input. If you want to control the input, the empty value should be an empty string.'
-    );
+    structuredLog('warn', 'An AutoSizeInput is changing from an uncontrolled to a controlled input. If you want to control the input, the empty value should be an empty string.');
     hasLoggedControlledWarning.current = true;
   }
 

--- a/packages/grafana-ui/src/components/Monaco/CodeEditor.tsx
+++ b/packages/grafana-ui/src/components/Monaco/CodeEditor.tsx
@@ -1,8 +1,11 @@
-import { css, cx } from '@emotion/css';
+import {
+  css, cx } from '@emotion/css';
 import type * as monacoType from 'monaco-editor/esm/vs/editor/editor.api';
 import { PureComponent } from 'react';
 
-import { type GrafanaTheme2, monacoLanguageRegistry } from '@grafana/data';
+import { type GrafanaTheme2, monacoLanguageRegistry,
+  structuredLog
+} from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';
 
 import { withTheme2 } from '../../themes/ThemeContext';
@@ -43,7 +46,7 @@ class UnthemedCodeEditor extends PureComponent<Props> {
       }
 
       if (!this.monaco) {
-        console.warn('Monaco instance not loaded yet');
+        structuredLog('warn', 'Monaco instance not loaded yet');
         return;
       }
 

--- a/packages/grafana-ui/src/components/StatsPicker/StatsPicker.tsx
+++ b/packages/grafana-ui/src/components/StatsPicker/StatsPicker.tsx
@@ -1,7 +1,10 @@
-import { difference } from 'lodash';
+import {
+  difference } from 'lodash';
 import { memo, useEffect } from 'react';
 
-import { fieldReducers, type FieldReducerInfo } from '@grafana/data';
+import { fieldReducers, type FieldReducerInfo,
+  structuredLog
+} from '@grafana/data';
 import { t } from '@grafana/i18n';
 
 import { Combobox, type ComboboxProps } from '../Combobox/Combobox';
@@ -53,13 +56,13 @@ export const StatsPicker = memo<StatsPickerProps>(
       if (current.length !== stats.length) {
         const found = current.map((v) => v.id);
         const notFound = difference(stats, found);
-        console.warn('Unknown stats', notFound, stats);
+        structuredLog('warn', 'Unknown stats', { details: notFound, stats });
         onChange(current.map((stat) => stat.id));
       }
 
       // Make sure there is only one
       if (!allowMultiple && stats.length > 1) {
-        console.warn('Removing extra stat', stats);
+        structuredLog('warn', 'Removing extra stat', { details: stats });
         onChange([stats[0]]);
       }
 

--- a/packages/grafana-ui/src/components/Table/TableNG/utils.ts
+++ b/packages/grafana-ui/src/components/Table/TableNG/utils.ts
@@ -1,4 +1,5 @@
-import { type Property } from 'csstype';
+import {
+  type Property } from 'csstype';
 import memoize from 'micro-memoize';
 import WKT from 'ol/format/WKT';
 import Geometry from 'ol/geom/Geometry';
@@ -20,6 +21,8 @@ import {
   isDataFrame,
   type FieldSparkline,
   type DecimalCount,
+  structuredLog,
+  toLogContextPart
 } from '@grafana/data';
 import {
   BarGaugeDisplayMode,
@@ -1184,7 +1187,7 @@ export function parseStyleJson(rawValue: unknown): CSSProperties | void {
       }
     } catch (e) {
       if (!warnedAboutStyleJsonSet.has(rawValue)) {
-        console.error(`encountered invalid cell style JSON: ${rawValue}`, e);
+        structuredLog('error', `encountered invalid cell style JSON: ${rawValue}`, { error: toLogContextPart(e) });
         warnedAboutStyleJsonSet.add(rawValue);
       }
     }

--- a/packages/grafana-ui/src/components/ThemeDemos/EmotionPerfTest.tsx
+++ b/packages/grafana-ui/src/components/ThemeDemos/EmotionPerfTest.tsx
@@ -1,17 +1,18 @@
 /* eslint-disable @grafana/i18n/no-untranslated-strings */
 /** @jsxImportSource @emotion/react */
-import { css, cx } from '@emotion/css';
+import {
+  css, cx } from '@emotion/css';
 import classnames from 'classnames';
 import React, { Profiler, type ProfilerOnRenderCallback, useState, type FC } from 'react';
 
-import { type GrafanaTheme2 } from '@grafana/data';
+import { type GrafanaTheme2, structuredLog } from '@grafana/data';
 
 import { useStyles2, useTheme2 } from '../../themes/ThemeContext';
 import { Button } from '../Button/Button';
 import { Stack } from '../Layout/Stack/Stack';
 
 export function EmotionPerfTest() {
-  console.log('process.env.NODE_ENV', process.env.NODE_ENV);
+  structuredLog('info', 'process.env.NODE_ENV', { details: process.env.NODE_ENV });
 
   return (
     <Stack direction="column">
@@ -126,7 +127,7 @@ function NoStyles({ index }: TestComponentProps) {
 
 function MeasureRender({ children, id }: { children: React.ReactNode; id: string }) {
   const onRender: ProfilerOnRenderCallback = (id, phase, actualDuration, baseDuration, startTime, commitTime) => {
-    console.log('Profile ' + id, actualDuration);
+    structuredLog('info', `Profile ${id}`, { actualDuration, phase, baseDuration, startTime, commitTime });
   };
 
   return (

--- a/packages/grafana-ui/src/components/ValuePicker/ValuePicker.story.tsx
+++ b/packages/grafana-ui/src/components/ValuePicker/ValuePicker.story.tsx
@@ -1,5 +1,6 @@
 import { type Meta, type StoryFn } from '@storybook/react';
 
+import { structuredLog, toLogContextPart } from '@grafana/data';
 import { getAvailableIcons } from '../../types/icon';
 import { generateOptions } from '../Select/mockOptions';
 
@@ -43,7 +44,7 @@ const options = generateOptions();
 export const Simple: StoryFn<typeof ValuePicker> = (args) => {
   return (
     <div style={{ width: '200px' }}>
-      <ValuePicker {...args} options={options} onChange={(v) => console.log(v)} />
+      <ValuePicker {...args} options={options} onChange={(v) => structuredLog('info', 'ValuePicker story change', { value: toLogContextPart(v) })} />
     </div>
   );
 };

--- a/packages/grafana-ui/src/components/VizTooltip/VizTooltipRow.tsx
+++ b/packages/grafana-ui/src/components/VizTooltip/VizTooltipRow.tsx
@@ -1,9 +1,13 @@
-import { css } from '@emotion/css';
+import {
+  css } from '@emotion/css';
 import clsx from 'clsx';
 import { type CSSProperties, type ReactNode, useEffect, useRef, useState } from 'react';
 import * as React from 'react';
 
-import { type GrafanaTheme2 } from '@grafana/data';
+import { type GrafanaTheme2,
+  structuredLog,
+  toLogContextPart
+} from '@grafana/data';
 
 import { useStyles2 } from '../../themes/ThemeContext';
 import { InlineToast } from '../InlineToast/InlineToast';
@@ -112,7 +116,7 @@ export const VizTooltipRow = ({
         setShowCopySuccess(true);
       }
     } catch (err) {
-      console.error('Unable to copy to clipboard', err);
+      structuredLog('error', 'Unable to copy to clipboard', { error: toLogContextPart(err) });
     }
 
     textarea.remove();

--- a/packages/grafana-ui/src/utils/logOptions.ts
+++ b/packages/grafana-ui/src/utils/logOptions.ts
@@ -1,3 +1,5 @@
+import { structuredLog } from '@grafana/data';
+
 /**
  * This function logs a warning if the amount of items exceeds the recommended amount.
  *
@@ -13,7 +15,7 @@ export function logOptions(
 ): void {
   if (amount > recommendedAmount) {
     const msg = `[Combobox] Items exceed the recommended amount ${recommendedAmount}.`;
-    console.warn(msg, {
+    structuredLog('warn', msg, {
       itemsCount: '' + amount,
       recommendedAmount: '' + recommendedAmount,
       'aria-labelledby': ariaLabelledBy ?? '',

--- a/packages/grafana-ui/src/utils/logger.ts
+++ b/packages/grafana-ui/src/utils/logger.ts
@@ -1,3 +1,4 @@
+import { structuredLog, toLogContextPart } from '@grafana/data';
 import { throttle } from 'lodash';
 
 type Args = Parameters<typeof console.log>;
@@ -5,8 +6,8 @@ type Args = Parameters<typeof console.log>;
 /**
  * @internal
  * */
-const throttledLog = throttle((...t: Args) => {
-  console.log(...t);
+const throttledLog = throttle((prefix: string, ...t: Args) => {
+  structuredLog('info', prefix, { extras: t.map((x) => toLogContextPart(x)) });
 }, 500);
 
 /**
@@ -32,8 +33,12 @@ export const createLogger = (name: string): Logger => {
       if (process.env.NODE_ENV === 'production' || process.env.NODE_ENV === 'test' || !loggingEnabled) {
         return;
       }
-      const fn = throttle ? throttledLog : console.log;
-      fn(`[${name}: ${id}]:`, ...t);
+      const label = `[${name}: ${id}]:`;
+      if (throttle) {
+        throttledLog(label, ...t);
+        return;
+      }
+      structuredLog('info', label, { extras: t.map((x) => toLogContextPart(x)) });
     },
     enable: () => (loggingEnabled = true),
     disable: () => (loggingEnabled = false),

--- a/public/app/AppWrapper.tsx
+++ b/public/app/AppWrapper.tsx
@@ -1,3 +1,4 @@
+import { structuredLog, toLogContextPart } from '@grafana/data';
 import { OpenFeatureProvider } from '@openfeature/react-sdk';
 import { UNSAFE_PortalProvider } from '@react-aria/overlays';
 import { type Action, KBarProvider } from 'kbar';
@@ -77,7 +78,7 @@ export class AppWrapper extends Component<AppWrapperProps, AppWrapperState> {
     if (preloader) {
       preloader.remove();
     } else {
-      console.warn('Preloader element not found');
+      structuredLog('warn', 'Preloader element not found');
     }
   }
 

--- a/public/app/api/clients/provisioning/utils/createOnCacheEntryAdded.ts
+++ b/public/app/api/clients/provisioning/utils/createOnCacheEntryAdded.ts
@@ -1,3 +1,4 @@
+import { structuredLog, toLogContextPart } from '@grafana/data';
 import { type ThunkDispatch, type UnknownAction } from '@reduxjs/toolkit';
 import { type Subscription } from 'rxjs';
 
@@ -80,7 +81,7 @@ export function createOnCacheEntryAdded<Spec, Status>(
           },
         });
     } catch (error) {
-      console.error('Error in onCacheEntryAdded:', error);
+      structuredLog('error', 'Error in onCacheEntryAdded:', { error: toLogContextPart(error) });
       return;
     }
 

--- a/public/app/api/clients/provisioning/v0alpha1/index.ts
+++ b/public/app/api/clients/provisioning/v0alpha1/index.ts
@@ -1,3 +1,4 @@
+import { structuredLog, toLogContextPart } from '@grafana/data';
 import {
   generatedAPI,
   type ConnectionSpec,
@@ -271,7 +272,7 @@ export const provisioningAPIv0alpha1 = generatedAPI.enhanceEndpoints({
             dispatch(clearFolders(childrenKeys));
           }
         } catch (e) {
-          console.error('Error in getRepositoryJobsWithPath:', e);
+          structuredLog('error', 'Error in getRepositoryJobsWithPath:', { error: toLogContextPart(e) });
         }
       },
     },

--- a/public/app/app.ts
+++ b/public/app/app.ts
@@ -5,7 +5,8 @@ import 'whatwg-fetch'; // fetch polyfill needed for PhantomJs rendering
 import 'file-saver';
 import 'jquery';
 
-import { createElement } from 'react';
+import {
+  createElement } from 'react';
 import { createRoot } from 'react-dom/client';
 
 import {
@@ -17,6 +18,8 @@ import {
   standardEditorsRegistry,
   standardFieldConfigEditorRegistry,
   standardTransformersRegistry,
+  structuredLog,
+  toLogContextPart
 } from '@grafana/data';
 import { DEFAULT_LANGUAGE } from '@grafana/i18n';
 import { initializeI18n, loadNamespacedResources } from '@grafana/i18n/internal';
@@ -146,7 +149,7 @@ export class GrafanaApp {
         try {
           await initOpenFeature();
         } catch (err) {
-          console.error('Failed to initialize OpenFeature provider', err);
+          structuredLog('error', 'Failed to initialize OpenFeature provider', { error: toLogContextPart(err) });
         }
       }
 
@@ -286,7 +289,7 @@ export class GrafanaApp {
       try {
         cleanupOldExpandedFolders();
       } catch (err) {
-        console.warn('Failed to clean up old expanded folders', err);
+        structuredLog('warn', 'Failed to clean up old expanded folders', { details: err });
       }
 
       this.context = {
@@ -316,7 +319,7 @@ export class GrafanaApp {
 
       await postInitTasks();
     } catch (error) {
-      console.error('Failed to start Grafana', error);
+      structuredLog('error', 'Failed to start Grafana', { error: toLogContextPart(error) });
       window.__grafana_load_failed();
     } finally {
       stopMeasure('frontend_app_init');

--- a/public/app/core/components/AccessControl/Permissions.tsx
+++ b/public/app/core/components/AccessControl/Permissions.tsx
@@ -1,10 +1,14 @@
-import { css } from '@emotion/css';
+import {
+  css } from '@emotion/css';
 import { sortBy } from 'lodash';
 import { useEffect, useMemo, useState } from 'react';
 import * as React from 'react';
 import useAsyncFn from 'react-use/lib/useAsyncFn';
 
-import { type GrafanaTheme2 } from '@grafana/data';
+import { type GrafanaTheme2,
+  structuredLog,
+  toLogContextPart
+} from '@grafana/data';
 import { Trans, t } from '@grafana/i18n';
 import { Text, Box, Button, useStyles2, LoadingPlaceholder } from '@grafana/ui';
 import { SlideDown } from 'app/core/components/Animations/SlideDown';
@@ -248,7 +252,7 @@ const getDescription = async (resource: string, queryParams?: Record<string, str
   try {
     return await getBackendSrv().get(`/api/access-control/${resource}/description`, queryParams);
   } catch (e) {
-    console.error('failed to load resource description: ', e);
+    structuredLog('error', 'failed to load resource description: ', { error: toLogContextPart(e) });
     return INITIAL_DESCRIPTION;
   }
 };

--- a/public/app/core/components/AppChrome/TopBar/InviteUserButton.tsx
+++ b/public/app/core/components/AppChrome/TopBar/InviteUserButton.tsx
@@ -1,3 +1,4 @@
+import { structuredLog, toLogContextPart } from '@grafana/data';
 import { skipToken } from '@reduxjs/toolkit/query';
 
 import { t } from '@grafana/i18n';
@@ -42,7 +43,7 @@ export function InviteUserButton() {
         performInviteUserClick('top_bar_right', 'invite-user-top-bar');
       }
     } catch (error) {
-      console.error('Failed to handle invite/upgrade user click:', error);
+      structuredLog('error', 'Failed to handle invite/upgrade user click:', { error: toLogContextPart(error) });
     }
   };
 

--- a/public/app/core/components/Login/LoginCtrl.tsx
+++ b/public/app/core/components/Login/LoginCtrl.tsx
@@ -1,3 +1,4 @@
+import { structuredLog, toLogContextPart } from '@grafana/data';
 import { memo, useState, useCallback, type JSX } from 'react';
 
 import { t } from '@grafana/i18n';
@@ -88,7 +89,7 @@ export const LoginCtrl = memo(({ resetCode, children }: Props) => {
           .then(() => {
             toGrafana();
           })
-          .catch((err) => console.error(err));
+          .catch((err) => structuredLog('error', 'Error', { error: toLogContextPart(err) }));
       }
     },
     [resetCode, toGrafana]

--- a/public/app/core/components/NavLandingPage/NavLandingPage.tsx
+++ b/public/app/core/components/NavLandingPage/NavLandingPage.tsx
@@ -1,7 +1,7 @@
 import { css } from '@emotion/css';
 import * as React from 'react';
 
-import { type GrafanaTheme2, type NavModelItem } from '@grafana/data';
+import { type GrafanaTheme2, type NavModelItem, structuredLog } from '@grafana/data';
 import { usePluginComponents, usePluginLinks } from '@grafana/runtime';
 import { useStyles2 } from '@grafana/ui';
 import { Page } from 'app/core/components/Page/Page';
@@ -36,7 +36,8 @@ export function NavLandingPage({ navId, header }: Props) {
   // Warn if both extension points are being used (they are mutually exclusive)
   React.useEffect(() => {
     if (components && components.length > 0 && additionalCards && additionalCards.length > 0) {
-      console.warn(
+      structuredLog(
+        'warn',
         `[NavLandingPage] Both NavLandingPage and NavLandingPageCards extensions are registered for "${node.id}". ` +
           `The NavLandingPage extension will take precedence and NavLandingPageCards will be ignored. ` +
           `Please use only one extension point.`

--- a/public/app/core/components/RolePicker/TeamRolePicker.tsx
+++ b/public/app/core/components/RolePicker/TeamRolePicker.tsx
@@ -1,3 +1,4 @@
+import { structuredLog, toLogContextPart } from '@grafana/data';
 import { skipToken } from '@reduxjs/toolkit/query';
 import { useMemo } from 'react';
 
@@ -79,7 +80,7 @@ export const TeamRolePicker = ({
           },
         }).unwrap();
       } catch (error) {
-        console.error('Error updating team roles', error);
+        structuredLog('error', 'Error updating team roles', { error: toLogContextPart(error) });
       }
     } else if (onApplyRoles) {
       onApplyRoles(newRoles);

--- a/public/app/core/components/RolePicker/UserRolePicker.tsx
+++ b/public/app/core/components/RolePicker/UserRolePicker.tsx
@@ -1,7 +1,11 @@
-import { skipToken } from '@reduxjs/toolkit/query';
+import {
+  skipToken } from '@reduxjs/toolkit/query';
 import { useMemo } from 'react';
 
-import { type OrgRole } from '@grafana/data';
+import { type OrgRole,
+  structuredLog,
+  toLogContextPart
+} from '@grafana/data';
 import { useListUserRolesQuery, useSetUserRolesMutation } from 'app/api/clients/roles';
 import { contextSrv } from 'app/core/services/context_srv';
 import { AccessControlAction, type Role } from 'app/types/accessControl';
@@ -90,7 +94,7 @@ export const UserRolePicker = ({
           },
         }).unwrap();
       } catch (error) {
-        console.error('Error updating user roles', error);
+        structuredLog('error', 'Error updating user roles', { error: toLogContextPart(error) });
       }
     } else if (onApplyRoles) {
       onApplyRoles(newRoles, userId, orgId);

--- a/public/app/core/components/SharedPreferences/SharedPreferencesFunctional.tsx
+++ b/public/app/core/components/SharedPreferences/SharedPreferencesFunctional.tsx
@@ -1,8 +1,12 @@
-import { useBooleanFlagValue } from '@openfeature/react-sdk';
+import {
+  useBooleanFlagValue } from '@openfeature/react-sdk';
 import { memo, useMemo, useState, useEffect } from 'react';
 
 import { type PreferencesSpec as UserPreferencesDTO } from '@grafana/api-clients/rtkq/preferences/v1alpha1';
-import { FeatureState } from '@grafana/data';
+import { FeatureState,
+  structuredLog,
+  toLogContextPart
+} from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';
 import { t, Trans } from '@grafana/i18n';
 import { config, reportInteraction } from '@grafana/runtime';
@@ -89,7 +93,7 @@ export const SharedPreferencesFunctional = memo((props: Props) => {
           navbar: prefs.navbar ?? prev.navbar,
         }));
       } catch (err) {
-        console.error('Failed to load preferences', err);
+        structuredLog('error', 'Failed to load preferences', { error: toLogContextPart(err) });
       } finally {
         setState((prev) => ({ ...prev, isLoading: false }));
       }

--- a/public/app/core/components/TimePicker/TimePickerWithHistory.tsx
+++ b/public/app/core/components/TimePicker/TimePickerWithHistory.tsx
@@ -1,4 +1,5 @@
-import { uniqBy } from 'lodash';
+import {
+  uniqBy } from 'lodash';
 
 import {
   AppEvents,
@@ -7,6 +8,7 @@ import {
   type TimeRange,
   isDateTime,
   rangeUtil,
+  structuredLog
 } from '@grafana/data';
 import { t } from '@grafana/i18n';
 import { type TimeRangePickerProps, TimeRangePicker } from '@grafana/ui';
@@ -136,7 +138,7 @@ function convertToISOString(value: DateTime | string): string {
   }
 
   if (!value?.toISOString) {
-    throw console.error('Invalid DateTime object passed to convertToISOString');
+    throw structuredLog('error', 'Invalid DateTime object passed to convertToISOString');
   }
 
   return value.toISOString();

--- a/public/app/core/navigation/errorModels.ts
+++ b/public/app/core/navigation/errorModels.ts
@@ -1,7 +1,11 @@
-import { type NavModel, type NavModelItem } from '@grafana/data';
+import {
+  type NavModel, type NavModelItem,
+  structuredLog,
+  toLogContextPart
+} from '@grafana/data';
 
 export function getExceptionNav(error: unknown): NavModel {
-  console.error(error);
+  structuredLog('error', 'Error', { error: toLogContextPart(error) });
   return getWarningNav('Exception thrown', 'See console for details');
 }
 

--- a/public/app/core/reducers/appNotification.ts
+++ b/public/app/core/reducers/appNotification.ts
@@ -1,3 +1,6 @@
+import {
+  structuredLog, toLogContextPart
+} from '@grafana/data';
 import { createSelector, createSlice, type PayloadAction } from '@reduxjs/toolkit';
 
 import { type AppNotification, AppNotificationSeverity, type AppNotificationsState } from 'app/types/appNotifications';
@@ -122,7 +125,7 @@ function serializeNotifications(notifs: Record<string, StoredNotification>) {
   try {
     window.localStorage.setItem(STORAGE_KEY, JSON.stringify(reducedNotifs));
   } catch (err) {
-    console.error('Unable to persist notifications to local storage');
-    console.error(err);
+    structuredLog('error', 'Unable to persist notifications to local storage');
+    structuredLog('error', 'Error', { error: toLogContextPart(err) });
   }
 }

--- a/public/app/core/services/FetchQueue.ts
+++ b/public/app/core/services/FetchQueue.ts
@@ -1,3 +1,4 @@
+import { structuredLog, toLogContextPart } from '@grafana/data';
 import { type Observable, Subject } from 'rxjs';
 
 import { type BackendSrvRequest } from '@grafana/runtime';
@@ -90,8 +91,8 @@ export class FetchQueue {
       []
     );
 
-    console.log('FetchQueue noOfStarted', update.noOfInProgress);
-    console.log('FetchQueue noOfNotStarted', update.noOfPending);
-    console.log('FetchQueue state', entriesWithoutOptions);
+    structuredLog('info', 'FetchQueue noOfStarted', { details: update.noOfInProgress });
+    structuredLog('info', 'FetchQueue noOfNotStarted', { details: update.noOfPending });
+    structuredLog('info', 'FetchQueue state', { details: entriesWithoutOptions });
   };
 }

--- a/public/app/core/services/backend_srv.ts
+++ b/public/app/core/services/backend_srv.ts
@@ -26,7 +26,13 @@ import {
 } from 'rxjs/operators';
 import { v4 as uuidv4 } from 'uuid';
 
-import { AppEvents, DataQueryErrorType, deprecationWarning } from '@grafana/data';
+import {
+  AppEvents,
+  DataQueryErrorType,
+  deprecationWarning,
+  structuredLog,
+  toLogContextPart,
+} from '@grafana/data';
 import {
   type BackendSrv as BackendService,
   type BackendSrvRequest,
@@ -116,7 +122,7 @@ export class BackendSrv implements BackendService {
       const result = await fp.get();
       this.deviceID = result.visitorId;
     } catch (error) {
-      console.error(error);
+      structuredLog('error', 'Error', { error: toLogContextPart(error) });
     }
   }
 
@@ -241,7 +247,10 @@ export class BackendSrv implements BackendService {
             observer.complete();
           }) // runs in background
           .catch((e) => {
-            console.log(requestId, 'catch', e);
+            structuredLog('info', 'BackendSrv stream reader catch', {
+              requestId,
+              error: toLogContextPart(e),
+            });
             observer.error(e);
           }); // from abort
       },

--- a/public/app/core/services/context_srv.ts
+++ b/public/app/core/services/context_srv.ts
@@ -1,4 +1,5 @@
-import { extend } from 'lodash';
+import {
+  extend } from 'lodash';
 
 import {
   type AnalyticsSettings,
@@ -8,6 +9,8 @@ import {
   userHasPermission,
   userHasPermissionInMetadata,
   userHasAnyPermission,
+  structuredLog,
+  toLogContextPart
 } from '@grafana/data';
 import { featureEnabled, getBackendSrv } from '@grafana/runtime';
 import { getSessionExpiry } from 'app/core/utils/auth';
@@ -112,7 +115,7 @@ export class ContextSrv {
         reloadcache: true,
       });
     } catch (e) {
-      console.error(e);
+      structuredLog('error', 'Error', { error: toLogContextPart(e) });
     }
   }
 
@@ -262,7 +265,7 @@ export class ContextSrv {
         }
       })
       .catch((e) => {
-        console.error(e);
+        structuredLog('error', 'Error', { error: toLogContextPart(e) });
       });
   }
 }

--- a/public/app/core/services/echo/backends/analytics/BrowseConsoleBackend.ts
+++ b/public/app/core/services/echo/backends/analytics/BrowseConsoleBackend.ts
@@ -1,4 +1,4 @@
-/* eslint-disable no-console */
+import { structuredLog, toLogContextPart } from '@grafana/data';
 import {
   type EchoBackend,
   EchoEventType,
@@ -16,14 +16,16 @@ export class BrowserConsoleBackend implements EchoBackend<PageviewEchoEvent, unk
 
   addEvent = (e: PageviewEchoEvent) => {
     if (isPageviewEvent(e)) {
-      console.log('[EchoSrv:pageview]', e.payload.page);
+      structuredLog('info', 'EchoSrv pageview', { page: e.payload.page });
     }
 
     if (isInteractionEvent(e)) {
       const eventName = e.payload.interactionName;
-      console.log('[EchoSrv:event]', eventName, e.payload.properties);
+      structuredLog('info', 'EchoSrv interaction event', {
+        interactionName: eventName,
+        properties: toLogContextPart(e.payload.properties ?? {}),
+      });
 
-      // Warn for non-scalar property values. We're not yet making this a hard a
       const invalidTypeProperties = Object.entries(e.payload.properties ?? {}).filter(([_, value]) => {
         const valueType = typeof value;
         const isValidType =
@@ -32,17 +34,15 @@ export class BrowserConsoleBackend implements EchoBackend<PageviewEchoEvent, unk
       });
 
       if (invalidTypeProperties.length > 0) {
-        console.warn(
-          'Event',
-          eventName,
-          'has invalid property types. Event properties should only be string, number or boolean. Invalid properties:',
-          Object.fromEntries(invalidTypeProperties)
-        );
+        structuredLog('warn', 'EchoSrv interaction event has invalid property types', {
+          interactionName: eventName,
+          invalidProperties: Object.fromEntries(invalidTypeProperties),
+        });
       }
     }
 
     if (isExperimentViewEvent(e)) {
-      console.log('[EchoSrv:experiment]', e.payload);
+      structuredLog('info', 'EchoSrv experiment view', { payload: toLogContextPart(e.payload) });
     }
   };
 

--- a/public/app/core/services/echo/init.ts
+++ b/public/app/core/services/echo/init.ts
@@ -1,3 +1,4 @@
+import { structuredLog, toLogContextPart } from '@grafana/data';
 import { config, registerEchoBackend, setEchoSrv } from '@grafana/runtime';
 import { reportMetricPerformanceMark } from 'app/core/utils/metrics';
 
@@ -28,43 +29,43 @@ export async function initEchoSrv() {
   try {
     await initPerformanceBackend();
   } catch (error) {
-    console.error('Error initializing EchoSrv Performance backend', error);
+    structuredLog('error', 'Error initializing EchoSrv Performance backend', { error: toLogContextPart(error) });
   }
 
   try {
     await initFaroBackend();
   } catch (error) {
-    console.error('Error initializing EchoSrv Faro backend', error);
+    structuredLog('error', 'Error initializing EchoSrv Faro backend', { error: toLogContextPart(error) });
   }
 
   try {
     await initGoogleAnalyticsBackend();
   } catch (error) {
-    console.error('Error initializing EchoSrv GoogleAnalytics backend', error);
+    structuredLog('error', 'Error initializing EchoSrv GoogleAnalytics backend', { error: toLogContextPart(error) });
   }
 
   try {
     await initGoogleAnalaytics4Backend();
   } catch (error) {
-    console.error('Error initializing EchoSrv GoogleAnalaytics4 backend', error);
+    structuredLog('error', 'Error initializing EchoSrv GoogleAnalaytics4 backend', { error: toLogContextPart(error) });
   }
 
   try {
     await initRudderstackBackend();
   } catch (error) {
-    console.error('Error initializing EchoSrv Rudderstack backend', error);
+    structuredLog('error', 'Error initializing EchoSrv Rudderstack backend', { error: toLogContextPart(error) });
   }
 
   try {
     await initAzureAppInsightsBackend();
   } catch (error) {
-    console.error('Error initializing EchoSrv AzureAppInsights backend', error);
+    structuredLog('error', 'Error initializing EchoSrv AzureAppInsights backend', { error: toLogContextPart(error) });
   }
 
   try {
     await initConsoleBackend();
   } catch (error) {
-    console.error('Error initializing EchoSrv Console backend', error);
+    structuredLog('error', 'Error initializing EchoSrv Console backend', { error: toLogContextPart(error) });
   }
 }
 

--- a/public/app/core/trustedTypePolicies.ts
+++ b/public/app/core/trustedTypePolicies.ts
@@ -1,4 +1,7 @@
-import { textUtil } from '@grafana/data';
+import {
+  textUtil,
+  structuredLog
+} from '@grafana/data';
 import { config } from '@grafana/runtime';
 
 const CSP_REPORT_ONLY_ENABLED = config.cspReportOnlyEnabled;
@@ -8,7 +11,7 @@ export const defaultTrustedTypesPolicy = {
     if (!CSP_REPORT_ONLY_ENABLED) {
       return string.replace(/<script/gi, '&lt;script');
     }
-    console.error('[HTML not sanitized with Trusted Types]', string, source, sink);
+    structuredLog('error', '[HTML not sanitized with Trusted Types]', { details: string, source, sink });
     return string;
   },
   createScript: (string: string) => string,
@@ -16,7 +19,7 @@ export const defaultTrustedTypesPolicy = {
     if (!CSP_REPORT_ONLY_ENABLED) {
       return textUtil.sanitizeUrl(string);
     }
-    console.error('[ScriptURL not sanitized with Trusted Types]', string, source, sink);
+    structuredLog('error', '[ScriptURL not sanitized with Trusted Types]', { details: string, source, sink });
     return string;
   },
 };

--- a/public/app/core/utils/dag.ts
+++ b/public/app/core/utils/dag.ts
@@ -1,3 +1,4 @@
+import { structuredLog, toLogContextPart } from '@grafana/data';
 export class Edge {
   inputNode?: Node;
   outputNode?: Node;
@@ -268,7 +269,7 @@ export const printGraph = (g: Graph) => {
     if (!inputEdges) {
       inputEdges = '<none>';
     }
-    console.log(`${n.name}:\n - links to:   ${outputEdges}\n - links from: ${inputEdges}`);
+    structuredLog('info', `${n.name}:\n - links to:   ${outputEdges}\n - links from: ${inputEdges}`);
   });
 };
 

--- a/public/app/core/utils/debugLog.ts
+++ b/public/app/core/utils/debugLog.ts
@@ -1,4 +1,4 @@
-import { store } from '@grafana/data';
+import { store, structuredLog, toLogContextPart } from '@grafana/data';
 
 /**
  * Creates a debug logger gated by a localStorage key.
@@ -11,7 +11,7 @@ export function createDebugLog(key: string, prefix: string) {
 
   return function debugLog(message: string, ...args: unknown[]) {
     if (store.get(storageKey) === 'true') {
-      console.log(`[${prefix}] ${message}`, ...args);
+      structuredLog('info', `[${prefix}] ${message}`, { extras: args.map((a) => toLogContextPart(a)) });
     }
   };
 }

--- a/public/app/core/utils/explore.ts
+++ b/public/app/core/utils/explore.ts
@@ -1,4 +1,5 @@
-import { customAlphabet } from 'nanoid';
+import {
+  customAlphabet } from 'nanoid';
 import { type Unsubscribable } from 'rxjs';
 import { v4 as uuidv4 } from 'uuid';
 
@@ -23,6 +24,8 @@ import {
   type TimeZone,
   toURLRange,
   urlUtil,
+  structuredLog,
+  toLogContextPart
 } from '@grafana/data';
 import { getDataSourceSrv } from '@grafana/runtime';
 import { RefreshPicker } from '@grafana/ui';
@@ -159,7 +162,7 @@ export const safeStringifyValue = (value: unknown, space?: number) => {
   try {
     return JSON.stringify(value, null, space);
   } catch (error) {
-    console.error(error);
+    structuredLog('error', 'Error', { error: toLogContextPart(error) });
   }
 
   return '';
@@ -232,7 +235,7 @@ export async function ensureQueries(
         try {
           await getDataSourceSrv().get(query.datasource.uid);
         } catch {
-          console.error(`One of the queries has a datasource that is no longer available and was removed.`);
+          structuredLog('error', `One of the queries has a datasource that is no longer available and was removed.`);
           validDS = false;
         }
       }

--- a/public/app/core/utils/fetch.ts
+++ b/public/app/core/utils/fetch.ts
@@ -1,7 +1,10 @@
-import { omitBy } from 'lodash';
+import {
+  omitBy } from 'lodash';
 import { type Observable, of, throwError } from 'rxjs';
 
-import { deprecationWarning, validatePath } from '@grafana/data';
+import { deprecationWarning, validatePath,
+  structuredLog
+} from '@grafana/data';
 import { type BackendSrvRequest } from '@grafana/runtime';
 
 export const parseInitFromOptions = (options: BackendSrvRequest): RequestInit => {
@@ -139,7 +142,7 @@ export async function parseResponseBody<T>(
         // An empty string is not a valid JSON.
         // Sometimes (unfortunately) our APIs declare their Content-Type as JSON, however they return an empty body.
         if (response.headers.get('Content-Length') === '0') {
-          console.warn(`${response.url} returned an invalid JSON`);
+          structuredLog('warn', `${response.url} returned an invalid JSON`);
           return {} as T;
         }
         return await response.json();

--- a/public/app/core/utils/metrics.ts
+++ b/public/app/core/utils/metrics.ts
@@ -1,3 +1,4 @@
+import { structuredLog, toLogContextPart } from '@grafana/data';
 import { reportPerformance } from '../services/echo/EchoSrv';
 
 export function startMeasure(eventName: string) {
@@ -8,7 +9,7 @@ export function startMeasure(eventName: string) {
   try {
     performance.mark(`${eventName}_started`);
   } catch (error) {
-    console.error(`[Metrics] Failed to startMeasure ${eventName}`, error);
+    structuredLog('error', `[Metrics] Failed to startMeasure ${eventName}`, { error: toLogContextPart(error) });
   }
 }
 
@@ -31,7 +32,7 @@ export function stopMeasure(eventName: string) {
     performance.clearMeasures(measured);
     return measure;
   } catch (error) {
-    console.error(`[Metrics] Failed to stopMeasure ${eventName}`, error);
+    structuredLog('error', `[Metrics] Failed to stopMeasure ${eventName}`, { error: toLogContextPart(error) });
     return;
   }
 }

--- a/public/app/core/utils/shortLinks.ts
+++ b/public/app/core/utils/shortLinks.ts
@@ -1,6 +1,10 @@
 import memoizeOne from 'memoize-one';
 
-import { type AbsoluteTimeRange, type LogRowModel, type UrlQueryMap } from '@grafana/data';
+import {
+  type AbsoluteTimeRange, type LogRowModel, type UrlQueryMap,
+  structuredLog,
+  toLogContextPart
+} from '@grafana/data';
 import { t } from '@grafana/i18n';
 import { getBackendSrv, config, locationService } from '@grafana/runtime';
 import { sceneGraph, type SceneTimeRangeLike, type VizPanel } from '@grafana/scenes';
@@ -73,7 +77,7 @@ export const createShortLink = memoizeOne(async (path: string): Promise<string> 
       return await createShortLinkLegacy(path);
     }
   } catch (err) {
-    console.error('Error when creating shortened link: ', err);
+    structuredLog('error', 'Error when creating shortened link: ', { error: toLogContextPart(err) });
     dispatch(notifyApp(createErrorNotification('Error generating shortened link')));
     createShortLink.clear();
     throw err; // Re-throw so callers know it failed
@@ -104,7 +108,7 @@ export const createAndCopyShortLink = async (path: string) => {
     }
   } catch (error) {
     // createShortLink already handles error notifications, just log
-    console.error('Error in createAndCopyShortLink:', error);
+    structuredLog('error', 'Error in createAndCopyShortLink:', { error: toLogContextPart(error) });
   }
 };
 

--- a/public/app/core/utils/timeRegions.ts
+++ b/public/app/core/utils/timeRegions.ts
@@ -1,6 +1,10 @@
-import { Cron } from 'croner';
+import {
+  Cron } from 'croner';
 
-import { type AbsoluteTimeRange, type TimeRange, durationToMilliseconds, parseDuration } from '@grafana/data';
+import { type AbsoluteTimeRange, type TimeRange, durationToMilliseconds, parseDuration,
+  structuredLog,
+  toLogContextPart
+} from '@grafana/data';
 
 export type TimeRegionMode = null | 'cron';
 export interface TimeRegionConfig {
@@ -160,7 +164,7 @@ export function calculateTimesWithin(cfg: TimeRegionConfig, tRange: TimeRange): 
     }
   } catch (e) {
     // invalid expression
-    console.error(e);
+    structuredLog('error', 'Error', { error: toLogContextPart(e) });
   }
 
   return ranges;

--- a/public/app/features/actions/ConnectionPicker.tsx
+++ b/public/app/features/actions/ConnectionPicker.tsx
@@ -1,6 +1,10 @@
-import { useMemo } from 'react';
+import {
+  useMemo } from 'react';
 
-import { ActionType, type DataSourceInstanceSettings } from '@grafana/data';
+import { ActionType, type DataSourceInstanceSettings,
+  structuredLog,
+  toLogContextPart
+} from '@grafana/data';
 import { t } from '@grafana/i18n';
 import { config, getDataSourceSrv } from '@grafana/runtime';
 import { Select } from '@grafana/ui';
@@ -78,7 +82,7 @@ export const ConnectionPicker = ({ actionType, datasourceUid, onChange }: Connec
       if (selectedDatasource) {
         onChange(selectedDatasource);
       } else {
-        console.error('ConnectionPicker: Could not find datasource with UID:', selectedValue);
+        structuredLog('error', 'ConnectionPicker: Could not find datasource with UID:', { error: toLogContextPart(selectedValue) });
       }
     }
   };

--- a/public/app/features/actions/utils.ts
+++ b/public/app/features/actions/utils.ts
@@ -15,6 +15,8 @@ import {
   type ScopedVars,
   textUtil,
   type ValueLinkConfig,
+  structuredLog,
+  toLogContextPart
 } from '@grafana/data';
 import { type BackendSrvRequest, config as grafanaConfig, getBackendSrv } from '@grafana/runtime';
 import { appEvents } from 'app/core/app_events';
@@ -120,7 +122,7 @@ export const getActions = (
                   appEvents.emit(AppEvents.alertError, [
                     'An error has occurred. Check console output for more details.',
                   ]);
-                  console.error(error);
+                  structuredLog('error', 'Error', { error: toLogContextPart(error) });
                 },
                 complete: () => {
                   appEvents.emit(AppEvents.alertSuccess, ['API call was successful']);
@@ -128,7 +130,7 @@ export const getActions = (
               });
           } catch (error) {
             appEvents.emit(AppEvents.alertError, ['An error has occurred. Check console output for more details.']);
-            console.error(error);
+            structuredLog('error', 'Error', { error: toLogContextPart(error) });
             return;
           }
         },

--- a/public/app/features/admin/UserOrgs.tsx
+++ b/public/app/features/admin/UserOrgs.tsx
@@ -1,7 +1,11 @@
-import { css, cx } from '@emotion/css';
+import {
+  css, cx } from '@emotion/css';
 import { memo, type ReactElement, useEffect, useRef, useState } from 'react';
 
-import { type GrafanaTheme2, OrgRole } from '@grafana/data';
+import { type GrafanaTheme2, OrgRole,
+  structuredLog,
+  toLogContextPart
+} from '@grafana/data';
 import { Trans, t } from '@grafana/i18n';
 import { Button, ConfirmButton, Field, Icon, Modal, Tooltip, useStyles2, Stack, TextLink } from '@grafana/ui';
 import { UserRolePicker } from 'app/core/components/RolePicker/UserRolePicker';
@@ -128,7 +132,7 @@ const OrgRow = memo(({ user, org, isExternalUser, onOrgRemove, onOrgRoleChange }
       if (contextSrv.hasPermission(AccessControlAction.ActionRolesList)) {
         fetchRoleOptions(org.orgId)
           .then((roles) => setRoleOptions(roles))
-          .catch((e) => console.error(e));
+          .catch((e) => structuredLog('error', 'Error', { error: toLogContextPart(e) }));
       }
     }
   }, [org.orgId]);
@@ -266,7 +270,7 @@ export const AddToOrgModal = memo(({ isOpen, user, userOrgs, onOrgAdd, onDismiss
       if (contextSrv.hasPermission(AccessControlAction.ActionRolesList)) {
         fetchRoleOptions(org.value?.id)
           .then((roles) => setRoleOptions(roles))
-          .catch((e) => console.error(e));
+          .catch((e) => structuredLog('error', 'Error', { error: toLogContextPart(e) }));
       }
     }
   };

--- a/public/app/features/admin/Users/OrgUsersTable.tsx
+++ b/public/app/features/admin/Users/OrgUsersTable.tsx
@@ -1,6 +1,9 @@
-import { useEffect, useMemo, useState } from 'react';
+import {
+  useEffect, useMemo, useState } from 'react';
 
-import { type OrgRole } from '@grafana/data';
+import { type OrgRole,
+  structuredLog
+} from '@grafana/data';
 import { selectors as e2eSelectors } from '@grafana/e2e-selectors';
 import { Trans, t } from '@grafana/i18n';
 import { config } from '@grafana/runtime';
@@ -79,7 +82,7 @@ export const OrgUsersTable = ({
           setRoleOptions(options);
         }
       } catch (e) {
-        console.error('Error loading options');
+        structuredLog('error', 'Error loading options');
       }
     }
     if (contextSrv.licensedAccessControlEnabled()) {

--- a/public/app/features/admin/state/actions.ts
+++ b/public/app/features/admin/state/actions.ts
@@ -1,6 +1,10 @@
-import { debounce } from 'lodash';
+import {
+  debounce } from 'lodash';
 
-import { dateTimeFormatTimeAgo } from '@grafana/data';
+import { dateTimeFormatTimeAgo,
+  structuredLog,
+  toLogContextPart
+} from '@grafana/data';
 import { featureEnabled, getBackendSrv, isFetchError, locationService } from '@grafana/runtime';
 import { type FetchDataArgs } from '@grafana/ui';
 import config from 'app/core/config';
@@ -50,7 +54,7 @@ export function loadAdminUserPage(userUid: string): ThunkResult<void> {
       }
       dispatch(userAdminPageLoadedAction(true));
     } catch (error) {
-      console.error(error);
+      structuredLog('error', 'Error', { error: toLogContextPart(error) });
 
       if (isFetchError(error)) {
         const userError = {
@@ -300,7 +304,7 @@ export function fetchUsers(): ThunkResult<void> {
       dispatch(usersFetched(result));
     } catch (error) {
       usersFetchEnd();
-      console.error(error);
+      structuredLog('error', 'Error', { error: toLogContextPart(error) });
     }
   };
 }
@@ -366,7 +370,7 @@ export function fetchUsersAnonymousDevices(): ThunkResult<void> {
       const result = await getBackendSrv().get(url);
       dispatch(usersAnonymousDevicesFetched(result));
     } catch (error) {
-      console.error(error);
+      structuredLog('error', 'Error', { error: toLogContextPart(error) });
     }
   };
 }
@@ -409,7 +413,7 @@ export function changeAnonPage(page: number): ThunkResult<void> {
 //       dispatch(usersAnonymousDevicesFetched({ devices: result }));
 //     } catch (error) {
 //       usersFetchEnd();
-//       console.error(error);
+//       structuredLog('error', 'Error', { error: toLogContextPart(error) });
 //     }
 //   };
 // }

--- a/public/app/features/admin/state/apis.tsx
+++ b/public/app/features/admin/state/apis.tsx
@@ -1,3 +1,4 @@
+import { structuredLog, toLogContextPart } from '@grafana/data';
 import { getBackendSrv } from '@grafana/runtime';
 
 interface AnonServerStat {
@@ -28,7 +29,7 @@ export const getServerStats = async (): Promise<ServerStat | null> => {
   return getBackendSrv()
     .get('api/admin/stats')
     .catch((err) => {
-      console.error(err);
+      structuredLog('error', 'Error', { error: toLogContextPart(err) });
       return null;
     });
 };

--- a/public/app/features/alerting/unified/components/receivers/form/fields/OptionField.tsx
+++ b/public/app/features/alerting/unified/components/receivers/form/fields/OptionField.tsx
@@ -1,8 +1,11 @@
-import { css } from '@emotion/css';
+import {
+  css } from '@emotion/css';
 import { type FC } from 'react';
 import { Controller, type DeepMap, type FieldError, useFormContext } from 'react-hook-form';
 
-import { type GrafanaTheme2 } from '@grafana/data';
+import { type GrafanaTheme2,
+  structuredLog
+} from '@grafana/data';
 import { t } from '@grafana/i18n';
 import {
   Checkbox,
@@ -318,7 +321,7 @@ const OptionInput: FC<Props & { id: string }> = ({
       );
 
     default:
-      console.error('Element not supported', option.element);
+      structuredLog('error', 'Element not supported', { details: option.element });
       return null;
   }
 };

--- a/public/app/features/alerting/unified/components/rule-editor/labels/LabelsField.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/labels/LabelsField.tsx
@@ -1,9 +1,12 @@
-import { css, cx } from '@emotion/css';
+import {
+  css, cx } from '@emotion/css';
 import { type FC, useCallback, useMemo } from 'react';
 import { Controller, FormProvider, useFieldArray, useForm, useFormContext } from 'react-hook-form';
 
 import { AlertLabels } from '@grafana/alerting/unstable';
-import { type GrafanaTheme2, type SelectableValue } from '@grafana/data';
+import { type GrafanaTheme2, type SelectableValue,
+  structuredLog
+} from '@grafana/data';
 import { Trans, t } from '@grafana/i18n';
 import { Button, type ComboboxOption, Field, InlineLabel, Input, Space, Stack, Text, useStyles2 } from '@grafana/ui';
 
@@ -183,7 +186,7 @@ export function useCombinedLabels(
               opsValues = result.values.map((value) => value.name);
             }
           } catch (error) {
-            console.error('Failed to fetch label values for key:', key, error);
+            structuredLog('error', 'Failed to fetch label values for key:', { details: key, error });
           }
         }
 

--- a/public/app/features/alerting/unified/components/rule-editor/useDashboardQuery.ts
+++ b/public/app/features/alerting/unified/components/rule-editor/useDashboardQuery.ts
@@ -1,3 +1,6 @@
+import {
+  structuredLog, toLogContextPart
+} from '@grafana/data';
 import memoizeOne from 'memoize-one';
 import { useEffect, useState } from 'react';
 
@@ -36,11 +39,11 @@ export function useDashboardQuery(dashboardUid?: string) {
           } else if (isDashboardV2Resource(dashboardDTO)) {
             setDashboard(dashboardDTO);
           } else {
-            console.error('Something went wrong, unexpected dashboard format');
+            structuredLog('error', 'Something went wrong, unexpected dashboard format');
           }
         })
         .catch((error) => {
-          console.error('Failed to fetch dashboard', error);
+          structuredLog('error', 'Failed to fetch dashboard', { error: toLogContextPart(error) });
         })
         .finally(() => {
           setIsFetching(false);

--- a/public/app/features/alerting/unified/components/rule-editor/util.ts
+++ b/public/app/features/alerting/unified/components/rule-editor/util.ts
@@ -1,4 +1,5 @@
-import { xor } from 'lodash';
+import {
+  xor } from 'lodash';
 
 import {
   type DataFrame,
@@ -7,6 +8,8 @@ import {
   type ThresholdsConfig,
   ThresholdsMode,
   isTimeSeriesFrames,
+  structuredLog,
+  toLogContextPart
 } from '@grafana/data';
 import { config } from '@grafana/runtime';
 import { GraphThresholdsStyleMode } from '@grafana/schema';
@@ -210,7 +213,7 @@ export function getThresholdsForQueries(queries: AlertQuery[], condition: string
           }
         });
       } catch (err) {
-        console.error('Failed to parse thresholds', err);
+        structuredLog('error', 'Failed to parse thresholds', { error: toLogContextPart(err) });
         return;
       }
     });

--- a/public/app/features/alerting/unified/components/rules/Filter/useRuleFilterAutocomplete.ts
+++ b/public/app/features/alerting/unified/components/rules/Filter/useRuleFilterAutocomplete.ts
@@ -1,7 +1,11 @@
-import { chain } from 'lodash';
+import {
+  chain } from 'lodash';
 import { useCallback } from 'react';
 
-import { type DataSourceInstanceSettings } from '@grafana/data';
+import { type DataSourceInstanceSettings,
+  structuredLog,
+  toLogContextPart
+} from '@grafana/data';
 import { t } from '@grafana/i18n';
 import { getDataSourceSrv } from '@grafana/runtime';
 import { type ComboboxOption } from '@grafana/ui';
@@ -161,7 +165,7 @@ export function useNamespaceAndGroupOptions(): {
 
         return options;
       } catch (error) {
-        console.error('Error fetching groups:', error);
+        structuredLog('error', 'Error fetching groups:', { error: toLogContextPart(error) });
         return [createInfoOption(t('alerting.rules-filter.group-search-error', 'Error searching groups'))];
       }
     },

--- a/public/app/features/alerting/unified/rule-list/hooks/grafanaFilter.ts
+++ b/public/app/features/alerting/unified/rule-list/hooks/grafanaFilter.ts
@@ -1,3 +1,4 @@
+import { structuredLog, toLogContextPart } from '@grafana/data';
 import { attempt, isError } from 'lodash';
 
 import { type PromRuleDTO, type PromRuleGroupDTO } from 'app/types/unified-alerting-dto';
@@ -154,7 +155,7 @@ function labelMatchersToBackendFormat(labels: string[]): string[] {
     const result = attempt(() => JSON.stringify(parseMatcher(label)));
 
     if (isError(result)) {
-      console.warn('Failed to parse label matcher:', label, result);
+      structuredLog('warn', 'Failed to parse label matcher:', { details: label, result });
     } else {
       acc.push(result);
     }

--- a/public/app/features/alerting/unified/settings/extensions.ts
+++ b/public/app/features/alerting/unified/settings/extensions.ts
@@ -1,6 +1,9 @@
-import { useLocation } from 'react-router-dom-v5-compat';
+import {
+  useLocation } from 'react-router-dom-v5-compat';
 
-import { type NavModelItem } from '@grafana/data';
+import { type NavModelItem,
+  structuredLog
+} from '@grafana/data';
 import { useSelector } from 'app/types/store';
 
 type SettingsSectionUrl = `/alerting/admin/${string}`;
@@ -16,7 +19,7 @@ const settingsExtensions: Map<SettingsSectionUrl, { nav: SettingsSectionNav }> =
  */
 export function addSettingsSection(pageNav: SettingsSectionNav) {
   if (settingsExtensions.has(pageNav.url)) {
-    console.warn('Unable to add settings page, PageNav must have an unique url');
+    structuredLog('warn', 'Unable to add settings page, PageNav must have an unique url');
     return;
   }
   settingsExtensions.set(pageNav.url, { nav: pageNav });

--- a/public/app/features/alerting/unified/state/AlertingQueryRunner.ts
+++ b/public/app/features/alerting/unified/state/AlertingQueryRunner.ts
@@ -1,4 +1,5 @@
-import { reject } from 'lodash';
+import {
+  reject } from 'lodash';
 import { type Observable, type OperatorFunction, ReplaySubject, type Unsubscribable, of } from 'rxjs';
 import { catchError, map, share } from 'rxjs/operators';
 import { v4 as uuidv4 } from 'uuid';
@@ -13,6 +14,7 @@ import {
   preProcessPanelData,
   rangeUtil,
   withLoadingIndicator,
+  structuredLog
 } from '@grafana/data';
 import { t } from '@grafana/i18n';
 import { DataSourceWithBackend, type FetchResponse, getDataSourceSrv, toDataQueryError } from '@grafana/runtime';
@@ -210,7 +212,7 @@ const getTimeRange = (query: AlertQuery, queries: AlertQuery[]): TimeRange => {
   }
 
   if (!query.relativeTimeRange) {
-    console.warn(`Query with refId: ${query.refId} did not have any relative time range, using default.`);
+    structuredLog('warn', `Query with refId: ${query.refId} did not have any relative time range, using default.`);
     return getDefaultTimeRange();
   }
 

--- a/public/app/features/annotations/components/StandardAnnotationQueryEditor.tsx
+++ b/public/app/features/annotations/components/StandardAnnotationQueryEditor.tsx
@@ -1,4 +1,5 @@
-import { PureComponent, type ReactElement } from 'react';
+import {
+  PureComponent, type ReactElement } from 'react';
 import { lastValueFrom } from 'rxjs';
 
 import {
@@ -8,6 +9,8 @@ import {
   type DataSourceInstanceSettings,
   DataSourcePluginContextProvider,
   LoadingState,
+  structuredLog,
+  toLogContextPart
 } from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';
 import { Trans, t } from '@grafana/i18n';
@@ -261,7 +264,7 @@ export default class StandardAnnotationQueryEditor extends PureComponent<Props, 
       this.setState({ skipNextVerification: true });
       onChange(preparedAnnotation);
     } catch (error) {
-      console.error('Failed to replace annotation query:', error);
+      structuredLog('error', 'Failed to replace annotation query:', { error: toLogContextPart(error) });
       // On error, reset the replacing state but don't change the annotation
     }
   };

--- a/public/app/features/annotations/standardAnnotationSupport.ts
+++ b/public/app/features/annotations/standardAnnotationSupport.ts
@@ -1,4 +1,5 @@
-import { isString } from 'lodash';
+import {
+  isString } from 'lodash';
 import { type Observable, of, type OperatorFunction } from 'rxjs';
 import { map, mergeMap } from 'rxjs/operators';
 
@@ -16,6 +17,7 @@ import {
   getFieldDisplayName,
   type KeyValue,
   standardTransformers,
+  structuredLog
 } from '@grafana/data';
 import { t } from '@grafana/i18n';
 import { config } from '@grafana/runtime';
@@ -227,7 +229,7 @@ export function getAnnotationsFromData(
       }
 
       if (!hasTime || !hasText) {
-        console.error('Cannot process annotation fields. No time or text present.');
+        structuredLog('error', 'Cannot process annotation fields. No time or text present.');
         return [];
       }
 

--- a/public/app/features/annotations/utils/savedQueryUtils.ts
+++ b/public/app/features/annotations/utils/savedQueryUtils.ts
@@ -4,6 +4,7 @@ import {
   type DataSourceApi,
   hasQueryExportSupport,
   hasQueryImportSupport,
+  structuredLog
 } from '@grafana/data';
 import { getDataSourceSrv } from '@grafana/runtime';
 import { type DataQuery } from '@grafana/schema';
@@ -128,7 +129,7 @@ export async function updateAnnotationFromSavedQuery(
 
     return preparedAnnotation;
   } catch (error) {
-    console.warn('Could not prepare annotation with new datasource:', error);
+    structuredLog('warn', 'Could not prepare annotation with new datasource:', { details: error });
     // Return structurally correct annotation even if preparation fails
     const { datasource, ...queryFields } = replacedQuery;
     return { ...cleanAnnotation, target: queryFields };

--- a/public/app/features/apiserver/client.ts
+++ b/public/app/features/apiserver/client.ts
@@ -1,6 +1,10 @@
-import { Observable, from, retry, catchError, filter, map, mergeMap } from 'rxjs';
+import {
+  Observable, from, retry, catchError, filter, map, mergeMap } from 'rxjs';
 
-import { isLiveChannelMessageEvent, isLiveChannelStatusEvent, LiveChannelScope } from '@grafana/data';
+import { isLiveChannelMessageEvent, isLiveChannelStatusEvent, LiveChannelScope,
+  structuredLog,
+  toLogContextPart
+} from '@grafana/data';
 import { config, getBackendSrv, getGrafanaLiveSrv } from '@grafana/runtime';
 import { contextSrv } from 'app/core/services/context_srv';
 
@@ -69,7 +73,7 @@ export class ScopedResourceClient<T = object, S = object, K = string> implements
           filter((event) => isLiveChannelMessageEvent(event)),
           map((event) => event.message),
           catchError((error) => {
-            console.warn('Live channel watch failed, falling back to polling:', error);
+            structuredLog('warn', 'Live channel watch failed, falling back to polling:', { details: error });
             return this.createPollingFallback(params, error);
           })
         );
@@ -100,14 +104,14 @@ export class ScopedResourceClient<T = object, S = object, K = string> implements
           try {
             return JSON.parse(line);
           } catch (e) {
-            console.warn('Invalid JSON in watch stream:', e, line);
+            structuredLog('warn', 'Invalid JSON in watch stream:', { details: e, line });
             return null;
           }
         }),
         filter((event): event is ResourceEvent<T, S, K> => event !== null),
         retry({ count: 3, delay: 1000 }),
         catchError((error) => {
-          console.error('Watch stream error:', error);
+          structuredLog('error', 'Watch stream error:', { error: toLogContextPart(error) });
           throw error;
         })
       );
@@ -250,10 +254,8 @@ export class ScopedResourceClient<T = object, S = object, K = string> implements
             return;
           }
           // Transient failure: log and retry next cycle.
-          console.warn(
-            `Polling fallback error (${consecutiveFailures}/${ScopedResourceClient.MAX_CONSECUTIVE_POLL_FAILURES}):`,
-            pollError
-          );
+          structuredLog('warn', `Polling fallback error (${consecutiveFailures}/${ScopedResourceClient.MAX_CONSECUTIVE_POLL_FAILURES}):`, { details: pollError
+           });
         }
 
         if (active) {

--- a/public/app/features/auth-config/FieldRenderer.tsx
+++ b/public/app/features/auth-config/FieldRenderer.tsx
@@ -1,8 +1,11 @@
-import { css } from '@emotion/css';
+import {
+  css } from '@emotion/css';
 import { useEffect, useState } from 'react';
 import { type UseFormReturn, Controller } from 'react-hook-form';
 
-import { type SelectableValue } from '@grafana/data';
+import { type SelectableValue,
+  structuredLog
+} from '@grafana/data';
 import { Checkbox, Field, Input, SecretInput, Select, Switch, useTheme2 } from '@grafana/ui';
 
 import { fieldMap } from './fields';
@@ -78,7 +81,7 @@ export const FieldRenderer = ({
   }, [isDisabled, disabledWhen?.disabledValue, name, setValue]);
 
   if (!field) {
-    console.log('missing field:', name);
+    structuredLog('info', 'missing field:', { details: name });
     return null;
   }
 
@@ -190,7 +193,7 @@ export const FieldRenderer = ({
         </Field>
       );
     default:
-      console.error(`Unknown field type: ${fieldData.type}`);
+      structuredLog('error', `Unknown field type: ${fieldData.type}`);
       return null;
   }
 };

--- a/public/app/features/auth-config/state/actions.ts
+++ b/public/app/features/auth-config/state/actions.ts
@@ -1,3 +1,4 @@
+import { structuredLog, toLogContextPart } from '@grafana/data';
 import { lastValueFrom } from 'rxjs';
 
 import { getBackendSrv, isFetchError } from '@grafana/runtime';
@@ -78,7 +79,7 @@ export function saveSettings(data: UpdateSettingsQuery): ThunkResult<Promise<boo
         dispatch(resetError());
         return true;
       } catch (error) {
-        console.log(error);
+        structuredLog('info', 'console.log', { value: toLogContextPart(error) });
         if (isFetchError(error)) {
           error.isHandled = true;
           const updateErr: SettingsError = {

--- a/public/app/features/browse-dashboards/api/browseDashboardsAPI.ts
+++ b/public/app/features/browse-dashboards/api/browseDashboardsAPI.ts
@@ -1,10 +1,14 @@
-import { createApi } from '@reduxjs/toolkit/query/react';
+import {
+  createApi } from '@reduxjs/toolkit/query/react';
 
 import { handleRequestError } from '@grafana/api-clients';
 import { generatedAPI as legacyUserAPI } from '@grafana/api-clients/internal/rtkq/legacy/user';
 import { createBaseQuery } from '@grafana/api-clients/rtkq';
 import { invalidateQuotaUsage } from '@grafana/api-clients/rtkq/quotas/v0alpha1';
-import { AppEvents, locationUtil } from '@grafana/data';
+import { AppEvents, locationUtil,
+  structuredLog,
+  toLogContextPart
+} from '@grafana/data';
 import { t } from '@grafana/i18n';
 import { config, getBackendSrv, isFetchError, locationService } from '@grafana/runtime';
 import { type Dashboard } from '@grafana/schema';
@@ -521,7 +525,7 @@ export const browseDashboardsAPI = createApi({
           } catch (error) {
             if (isFetchError(error)) {
               if (error.status !== 404) {
-                console.error('Error fetching dashboard', error);
+                structuredLog('error', 'Error fetching dashboard', { error: toLogContextPart(error) });
               } else {
                 // Do not show the error alert if the dashboard does not exist
                 // this is expected when importing a new dashboard

--- a/public/app/features/browse-dashboards/api/recentlyViewed.ts
+++ b/public/app/features/browse-dashboards/api/recentlyViewed.ts
@@ -1,3 +1,4 @@
+import { structuredLog, toLogContextPart } from '@grafana/data';
 import impressionSrv from 'app/core/services/impression_srv';
 import { getGrafanaSearcher } from 'app/features/search/service/searcher';
 import { type DashboardQueryResult } from 'app/features/search/service/types';
@@ -30,7 +31,7 @@ export async function getRecentlyViewedDashboards(maxItems = 5): Promise<Dashboa
     dashboards.sort((a, b) => order(a.uid) - order(b.uid));
     return dashboards;
   } catch (error) {
-    console.error('Failed to load recently viewed dashboards', error);
+    structuredLog('error', 'Failed to load recently viewed dashboards', { error: toLogContextPart(error) });
     return [];
   }
 }

--- a/public/app/features/browse-dashboards/api/services.ts
+++ b/public/app/features/browse-dashboards/api/services.ts
@@ -1,3 +1,4 @@
+import { structuredLog, toLogContextPart } from '@grafana/data';
 import { t } from '@grafana/i18n';
 import { config, getBackendSrv } from '@grafana/runtime';
 import { dashboardAPIv0alpha1 } from 'app/api/clients/dashboard/v0alpha1';
@@ -78,7 +79,7 @@ async function searchNewAPI(parentUID?: string, page = 1, pageSize = PAGE_SIZE) 
         });
       }
     } catch (error) {
-      console.error('Failed to load team folders', error);
+      structuredLog('error', 'Failed to load team folders', { error: toLogContextPart(error) });
     }
   }
 

--- a/public/app/features/browse-dashboards/api/useRecentlyDeletedStateManager.ts
+++ b/public/app/features/browse-dashboards/api/useRecentlyDeletedStateManager.ts
@@ -1,4 +1,8 @@
-import { type SelectableValue, store } from '@grafana/data';
+import {
+  type SelectableValue, store,
+  structuredLog,
+  toLogContextPart
+} from '@grafana/data';
 import { t } from '@grafana/i18n';
 import { type TermCount } from 'app/core/components/TagFilter/TagFilter';
 import { SEARCH_SELECTED_SORT } from 'app/features/search/constants';
@@ -65,7 +69,7 @@ export class TrashStateManager extends SearchStateManager {
 
       return termCounts.sort((a, b) => b.count - a.count);
     } catch (error) {
-      console.error('Failed to get tags from deleted dashboards:', error);
+      structuredLog('error', 'Failed to get tags from deleted dashboards:', { error: toLogContextPart(error) });
       return [];
     }
   };

--- a/public/app/features/browse-dashboards/components/RecentlyDeletedActions.tsx
+++ b/public/app/features/browse-dashboards/components/RecentlyDeletedActions.tsx
@@ -1,3 +1,4 @@
+import { structuredLog, toLogContextPart } from '@grafana/data';
 import { useMemo, useState } from 'react';
 
 import { Trans } from '@grafana/i18n';
@@ -81,7 +82,7 @@ export function RecentlyDeletedActions() {
       const deletedDashboards = await deletedDashboardsCache.getAsResourceList();
       const dashboard = deletedDashboards?.items.find((d) => d.metadata.name === uid);
       if (!dashboard) {
-        console.warn(`Dashboard ${uid} not found in deleted items`);
+        structuredLog('warn', `Dashboard ${uid} not found in deleted items`);
         return { uid, error: 'not_found' };
       }
       // Clone the dashboard to be able to edit the immutable data from the store

--- a/public/app/features/browse-dashboards/state/actions.ts
+++ b/public/app/features/browse-dashboards/state/actions.ts
@@ -1,3 +1,4 @@
+import { structuredLog, toLogContextPart } from '@grafana/data';
 import { GENERAL_FOLDER_UID, TEAM_FOLDERS_UID } from 'app/features/search/constants';
 import { type DashboardViewItem, type DashboardViewItemKind } from 'app/features/search/types';
 import { createAsyncThunk } from 'app/types/store';
@@ -12,7 +13,7 @@ async function listTeamFoldersSafe() {
   try {
     return await listTeamFolders();
   } catch (error) {
-    console.error('Failed to load team folders', error);
+    structuredLog('error', 'Failed to load team folders', { error: toLogContextPart(error) });
     return [];
   }
 }
@@ -151,7 +152,7 @@ export const fetchNextChildrenPage = createAsyncThunk(
       fetchKind = 'folder';
     } else if (collection.lastFetchedKind === 'dashboard' && !collection.lastKindHasMoreItems) {
       // There's nothing to load at all
-      console.warn(`fetchNextChildrenPage called for ${uid} but that collection is fully loaded`);
+      structuredLog('warn', `fetchNextChildrenPage called for ${uid} but that collection is fully loaded`);
       // return;
     } else if (collection.lastFetchedKind === 'folder' && collection.lastKindHasMoreItems) {
       // Load additional pages of folders

--- a/public/app/features/canvas/runtime/frame.tsx
+++ b/public/app/features/canvas/runtime/frame.tsx
@@ -1,3 +1,4 @@
+import { structuredLog, toLogContextPart } from '@grafana/data';
 import { cloneDeep } from 'lodash';
 
 import { notFoundItem } from 'app/features/canvas/elements/notFound';
@@ -129,7 +130,7 @@ export class FrameState extends ElementState {
         break;
       case LayerActionID.Duplicate:
         if (element.item.id === 'frame') {
-          console.log('Can not duplicate frames (yet)', action, element);
+          structuredLog('info', 'Can not duplicate frames (yet)', { details: action, element });
           return;
         }
         const opts = cloneDeep(element.options);
@@ -239,7 +240,7 @@ export class FrameState extends ElementState {
         break;
 
       default:
-        console.log('DO action', action, element);
+        structuredLog('info', 'DO action', { details: action, element });
         return;
     }
   };

--- a/public/app/features/commandPalette/actions/useActions.tsx
+++ b/public/app/features/commandPalette/actions/useActions.tsx
@@ -1,3 +1,4 @@
+import { structuredLog, toLogContextPart } from '@grafana/data';
 import { useRegisterActions } from 'kbar';
 import { useEffect, useMemo, useState } from 'react';
 
@@ -27,7 +28,7 @@ export function useRegisterRecentDashboardsActions() {
     getRecentDashboardActions()
       .then((recentDashboardActions) => setRecentDashboardActions(recentDashboardActions))
       .catch((err) => {
-        console.error('Error loading recent dashboard actions', err);
+        structuredLog('error', 'Error loading recent dashboard actions', { error: toLogContextPart(err) });
       });
   }, []);
 

--- a/public/app/features/dashboard-scene/behaviors/DashboardAnalyticsInitializerBehavior.ts
+++ b/public/app/features/dashboard-scene/behaviors/DashboardAnalyticsInitializerBehavior.ts
@@ -1,3 +1,4 @@
+import { structuredLog, toLogContextPart } from '@grafana/data';
 import { writePerformanceLog } from '@grafana/scenes';
 
 import { getDashboardAnalyticsAggregator } from '../../dashboard/services/DashboardAnalyticsAggregator';
@@ -15,7 +16,7 @@ export function dashboardAnalyticsInitializer(dashboard: DashboardScene) {
   const { uid, title } = dashboard.state;
 
   if (!uid) {
-    console.warn('dashboardAnalyticsInitializer: Dashboard UID is missing');
+    structuredLog('warn', 'dashboardAnalyticsInitializer: Dashboard UID is missing');
     return;
   }
 

--- a/public/app/features/dashboard-scene/behaviors/DefaultControlsBehavior.ts
+++ b/public/app/features/dashboard-scene/behaviors/DefaultControlsBehavior.ts
@@ -1,3 +1,4 @@
+import { structuredLog, toLogContextPart } from '@grafana/data';
 import { type Subscription } from 'rxjs';
 
 import { SceneObjectBase, type SceneObjectState } from '@grafana/scenes';
@@ -32,7 +33,7 @@ export class DefaultControlsBehavior extends SceneObjectBase<SceneObjectState> {
     this._variablesSub = loadDefaultVariables$(shared$).subscribe({
       next: (vars) => dashboard.setDefaultVariables(vars),
       error: (err) => {
-        console.warn('Failed to load default variables', err);
+        structuredLog('warn', 'Failed to load default variables', { details: err });
         dashboard.setState({ defaultVariablesLoading: false });
       },
       complete: () => dashboard.setState({ defaultVariablesLoading: false }),
@@ -41,7 +42,7 @@ export class DefaultControlsBehavior extends SceneObjectBase<SceneObjectState> {
     this._linksSub = loadDefaultLinks$(shared$).subscribe({
       next: (links) => dashboard.setDefaultLinks(links),
       error: (err) => {
-        console.warn('Failed to load default links', err);
+        structuredLog('warn', 'Failed to load default links', { details: err });
         dashboard.setState({ defaultLinksLoading: false });
       },
       complete: () => dashboard.setState({ defaultLinksLoading: false }),

--- a/public/app/features/dashboard-scene/edit-pane/DashboardEditPane.tsx
+++ b/public/app/features/dashboard-scene/edit-pane/DashboardEditPane.tsx
@@ -1,3 +1,4 @@
+import { structuredLog, toLogContextPart } from '@grafana/data';
 import { type SceneObject, SceneObjectBase, type SceneObjectState, sceneGraph } from '@grafana/scenes';
 import {
   type ElementSelectionContextItem,
@@ -237,7 +238,7 @@ export class DashboardEditPane extends SceneObjectBase<DashboardEditPaneState> i
   private selectElement(element: ElementSelectionContextItem, options: ElementSelectionOnSelectOptions) {
     let obj = sceneGraph.findByKey(this, element.id);
     if (!obj) {
-      console.warn('Cannot find element by key="%s"!', element.id);
+      structuredLog('warn', 'Cannot find element by key="%s"!', { details: element.id });
       return;
     }
 
@@ -245,7 +246,7 @@ export class DashboardEditPane extends SceneObjectBase<DashboardEditPaneState> i
     if (sourceKey) {
       obj = sceneGraph.findByKey(this, sourceKey);
       if (!obj) {
-        console.warn('Cannot find element by source key="%s"!', sourceKey);
+        structuredLog('warn', 'Cannot find element by source key="%s"!', { details: sourceKey });
         return;
       }
     }

--- a/public/app/features/dashboard-scene/inspect/HelpWizard/SupportSnapshotService.ts
+++ b/public/app/features/dashboard-scene/inspect/HelpWizard/SupportSnapshotService.ts
@@ -1,6 +1,9 @@
 import saveAs from 'file-saver';
 
-import { dateTimeFormat, formattedValueToString, getValueFormat, type SelectableValue } from '@grafana/data';
+import {
+  dateTimeFormat, formattedValueToString, getValueFormat, type SelectableValue,
+  structuredLog
+} from '@grafana/data';
 import { t } from '@grafana/i18n';
 import { sceneGraph, type SceneObject, type VizPanel } from '@grafana/scenes';
 import { StateManagerBase } from 'app/core/services/StateManagerBase';
@@ -84,7 +87,7 @@ export class SupportSnapshotService extends StateManagerBase<SupportSnapshotStat
         const dash = transformSaveModelToScene({ dashboard: snapshot, meta: { isEmbedded: true } });
         scene = dash.state.body; // skip the wrappers
       } catch (ex) {
-        console.log('Error creating scene:', ex);
+        structuredLog('info', 'Error creating scene:', { details: ex });
       }
     }
 

--- a/public/app/features/dashboard-scene/inspect/InspectJsonTab.tsx
+++ b/public/app/features/dashboard-scene/inspect/InspectJsonTab.tsx
@@ -1,7 +1,10 @@
-import { isEqual } from 'lodash';
+import {
+  isEqual } from 'lodash';
 import AutoSizer from 'react-virtualized-auto-sizer';
 
-import { type SelectableValue } from '@grafana/data';
+import { type SelectableValue,
+  structuredLog
+} from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';
 import { Trans, t } from '@grafana/i18n';
 import {
@@ -165,7 +168,7 @@ export class InspectJsonTab extends SceneObjectBase<InspectJsonTabState> {
     const gridItem = panel.parent;
 
     if (!(gridItem instanceof DashboardGridItem)) {
-      console.error('Cannot update layout: panel parent is not a DashboardGridItem');
+      structuredLog('error', 'Cannot update layout: panel parent is not a DashboardGridItem');
       return;
     }
 
@@ -259,7 +262,7 @@ export class InspectJsonTab extends SceneObjectBase<InspectJsonTabState> {
     const newState = sceneUtils.cloneSceneObjectState(gridItem.state);
 
     if (!(panel.parent instanceof DashboardGridItem)) {
-      console.error('Cannot update state of panel', panel, gridItem);
+      structuredLog('error', 'Cannot update state of panel', { details: panel, gridItem });
       return;
     }
 

--- a/public/app/features/dashboard-scene/pages/DashboardScenePage.tsx
+++ b/public/app/features/dashboard-scene/pages/DashboardScenePage.tsx
@@ -1,8 +1,11 @@
-import { useEffect, useRef } from 'react';
+import {
+  useEffect, useRef } from 'react';
 import { type Params, useParams } from 'react-router-dom-v5-compat';
 import { usePrevious } from 'react-use';
 
-import { PageLayoutType } from '@grafana/data';
+import { PageLayoutType,
+  structuredLog
+} from '@grafana/data';
 import { locationService } from '@grafana/runtime';
 import { UrlSyncContextProvider } from '@grafana/scenes';
 import { Box } from '@grafana/ui';
@@ -126,7 +129,7 @@ export function DashboardScenePage({ route, queryParams, location }: Props) {
   // A bit tricky for transition to or from Home dashboard that does not have a uid in the url (but could have it in the dashboard model)
   // if prevMatch is undefined we are going from normal route to home route or vice versa
   if (type !== 'snapshot' && (!prevMatch || uid !== prevMatch?.params.uid)) {
-    console.log('skipping rendering');
+    structuredLog('info', 'skipping rendering');
     return null;
   }
 

--- a/public/app/features/dashboard-scene/pages/DashboardScenePageStateManager.ts
+++ b/public/app/features/dashboard-scene/pages/DashboardScenePageStateManager.ts
@@ -1,4 +1,8 @@
-import { locationUtil, type UrlQueryMap } from '@grafana/data';
+import {
+  locationUtil, type UrlQueryMap,
+  structuredLog,
+  toLogContextPart
+} from '@grafana/data';
 import { t } from '@grafana/i18n';
 import { config, getBackendSrv, getDataSourceSrv, isFetchError, locationService } from '@grafana/runtime';
 import { UserStorage } from '@grafana/runtime/internal';
@@ -436,7 +440,7 @@ abstract class DashboardScenePageStateManagerBase<T>
       });
 
       if (!isFetchError(err)) {
-        console.error('Error loading dashboard:', err);
+        structuredLog('error', 'Error loading dashboard:', { error: toLogContextPart(err) });
       }
 
       // If the error is a DashboardVersionError, we want to throw it so that the error boundary is triggered
@@ -797,7 +801,7 @@ export class DashboardScenePageStateManager extends DashboardScenePageStateManag
             ...locationService.getLocation(),
             pathname: dashboardUrl,
           });
-          console.log('not correct url correcting', dashboardUrl, currentPath);
+          structuredLog('info', 'not correct url correcting', { details: dashboardUrl, currentPath });
         }
       }
 
@@ -1017,7 +1021,7 @@ export class DashboardScenePageStateManagerV2 extends DashboardScenePageStateMan
             ...locationService.getLocation(),
             pathname: dashboardUrl,
           });
-          console.log('not correct url correcting', dashboardUrl, currentPath);
+          structuredLog('info', 'not correct url correcting', { details: dashboardUrl, currentPath });
         }
       }
       // Populate nav model in global store according to the folder

--- a/public/app/features/dashboard-scene/pages/utils.ts
+++ b/public/app/features/dashboard-scene/pages/utils.ts
@@ -1,4 +1,7 @@
-import { type UrlQueryMap, getTimeZone, getDefaultTimeRange, dateMath } from '@grafana/data';
+import {
+  type UrlQueryMap, getTimeZone, getDefaultTimeRange, dateMath,
+  structuredLog
+} from '@grafana/data';
 import { locationService } from '@grafana/runtime';
 import { getFolderByUidFacade } from 'app/api/clients/folder/v1beta1/hooks';
 import { updateNavIndex } from 'app/core/reducers/navModel';
@@ -10,7 +13,7 @@ export async function updateNavModel(folderUid: string) {
     const folder = await getFolderByUidFacade(folderUid);
     store.dispatch(updateNavIndex(buildNavModel(folder)));
   } catch (err) {
-    console.warn('Error fetching parent folder', folderUid, 'for dashboard', err);
+    structuredLog('warn', 'Error fetching parent folder', { details: folderUid, 'for dashboard', err });
   }
 }
 

--- a/public/app/features/dashboard-scene/panel-edit/PanelDataPane/PanelDataQueriesTab.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelDataPane/PanelDataQueriesTab.tsx
@@ -1,6 +1,10 @@
-import { useCallback, useMemo } from 'react';
+import {
+  useCallback, useMemo } from 'react';
 
-import { CoreApp, type DataSourceApi, type DataSourceInstanceSettings, getDataSourceRef } from '@grafana/data';
+import { CoreApp, type DataSourceApi, type DataSourceInstanceSettings, getDataSourceRef,
+  structuredLog,
+  toLogContextPart
+} from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';
 import { t, Trans } from '@grafana/i18n';
 import { config, getDataSourceSrv, reportInteraction } from '@grafana/runtime';
@@ -163,7 +167,7 @@ export class PanelDataQueriesTab extends SceneObjectBase<PanelDataQueriesTabStat
         });
       }
 
-      console.error(err);
+      structuredLog('error', 'Error', { error: toLogContextPart(err) });
     }
   }
 

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/PanelDataPaneNext.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/PanelDataPaneNext.tsx
@@ -1,4 +1,5 @@
-import { throttle } from 'lodash';
+import {
+  throttle } from 'lodash';
 
 import {
   CoreApp,
@@ -7,6 +8,8 @@ import {
   type DataTransformerConfig,
   getDataSourceRef,
   getNextRefId,
+  structuredLog,
+  toLogContextPart
 } from '@grafana/data';
 import { config, getDataSourceSrv, isExpressionReference, reportInteraction } from '@grafana/runtime';
 import {
@@ -204,7 +207,7 @@ export class PanelDataPaneNext extends SceneObjectBase<PanelDataPaneNextState> {
       this.setState({ datasource, dsSettings, dsError: undefined });
       storeLastUsedDataSourceInLocalStorage(getDataSourceRef(dsSettings) || { default: true });
     } catch (err) {
-      console.error('Failed to load datasource:', err);
+      structuredLog('error', 'Failed to load datasource:', { error: toLogContextPart(err) });
 
       // Fallback to default datasource (parity with PanelDataQueriesTab)
       try {
@@ -218,7 +221,7 @@ export class PanelDataPaneNext extends SceneObjectBase<PanelDataPaneNextState> {
           // resolveDatasourceRef() handles the stale-ref case on the next activation.
         }
       } catch (fallbackErr) {
-        console.error('Failed to load default datasource:', fallbackErr);
+        structuredLog('error', 'Failed to load default datasource:', { error: toLogContextPart(fallbackErr) });
         this.setState({
           datasource: undefined,
           dsSettings: undefined,

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Header/PluginActions.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Header/PluginActions.tsx
@@ -1,9 +1,12 @@
-import { useMemo } from 'react';
+import {
+  useMemo } from 'react';
 
 import {
   type CoreApp,
   PluginExtensionPoints,
   type PluginExtensionQueryEditorRowAdaptiveTelemetryV1Context,
+  structuredLog,
+  toLogContextPart
 } from '@grafana/data';
 import { renderLimitedComponents, usePluginComponents } from '@grafana/runtime';
 import { type DataQuery } from '@grafana/schema';
@@ -94,7 +97,7 @@ function useAdaptiveTelemetryComponents(query: DataQuery | null) {
       pluginId: /grafana-adaptive.*/,
     });
   } catch (error) {
-    console.error('Failed to render adaptive telemetry components:', error);
+    structuredLog('error', 'Failed to render adaptive telemetry components:', { error: toLogContextPart(error) });
     return null;
   }
 }

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/hooks/useSelectedQueryDatasource.ts
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/hooks/useSelectedQueryDatasource.ts
@@ -1,6 +1,10 @@
-import { useAsync } from 'react-use';
+import {
+  useAsync } from 'react-use';
 
-import { type DataSourceInstanceSettings, getDataSourceRef } from '@grafana/data';
+import { type DataSourceInstanceSettings, getDataSourceRef,
+  structuredLog,
+  toLogContextPart
+} from '@grafana/data';
 import { config, getDataSourceSrv } from '@grafana/runtime';
 import { type DataQuery } from '@grafana/schema';
 
@@ -41,14 +45,14 @@ export function useSelectedQueryDatasource(
 
       const queryDsSettings = getDataSourceSrv().getInstanceSettings(dsRef);
       if (!queryDsSettings) {
-        console.error('Datasource settings not found for', dsRef);
+        structuredLog('error', 'Datasource settings not found for', { error: toLogContextPart(dsRef) });
         return undefined;
       }
 
       const queryDatasource = await getDataSourceSrv().get(dsRef);
       return { datasource: queryDatasource, dsSettings: queryDsSettings };
     } catch (err) {
-      console.error('Failed to load datasource for selected query:', err);
+      structuredLog('error', 'Failed to load datasource for selected query:', { error: toLogContextPart(err) });
       return undefined;
     }
   }, [

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/localStorageWithTTL.ts
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/localStorageWithTTL.ts
@@ -1,4 +1,8 @@
-import { store } from '@grafana/data';
+import {
+  store,
+  structuredLog,
+  toLogContextPart
+} from '@grafana/data';
 
 interface StoredValueWithTTL<T> {
   value: T;
@@ -20,7 +24,7 @@ export const setLocalStorageWithTTL = <T>(key: string, value: T) => {
   try {
     store.setObject(key, item);
   } catch (error) {
-    console.error('Failed to persist value with TTL', error);
+    structuredLog('error', 'Failed to persist value with TTL', { error: toLogContextPart(error) });
   }
 };
 

--- a/public/app/features/dashboard-scene/saving/getDashboardChanges.ts
+++ b/public/app/features/dashboard-scene/saving/getDashboardChanges.ts
@@ -1,3 +1,4 @@
+import { structuredLog, toLogContextPart } from '@grafana/data';
 import type { AdHocVariableModel, TextBoxVariableModel, TypedVariableModel } from '@grafana/data';
 import { config } from '@grafana/runtime';
 import { type Dashboard, type VariableOption } from '@grafana/schema';
@@ -136,12 +137,12 @@ export function getHasTimeChanged(
 
 export function adHocVariableFiltersEqual(filtersA?: AdHocFilterWithLabels[], filtersB?: AdHocFilterWithLabels[]) {
   if (filtersA === undefined && filtersB === undefined) {
-    console.warn('Adhoc variable filter property is undefined');
+    structuredLog('warn', 'Adhoc variable filter property is undefined');
     return true;
   }
 
   if ((filtersA === undefined && filtersB !== undefined) || (filtersB === undefined && filtersA !== undefined)) {
-    console.warn('Adhoc variable filter property is undefined');
+    structuredLog('warn', 'Adhoc variable filter property is undefined');
     return false;
   }
 

--- a/public/app/features/dashboard-scene/scene/DashboardLayoutOrchestrator.tsx
+++ b/public/app/features/dashboard-scene/scene/DashboardLayoutOrchestrator.tsx
@@ -1,8 +1,11 @@
-import { css } from '@emotion/css';
+import {
+  css } from '@emotion/css';
 import { type PointerEvent as ReactPointerEvent } from 'react';
 import { createPortal } from 'react-dom';
 
-import { type GrafanaTheme2 } from '@grafana/data';
+import { type GrafanaTheme2,
+  structuredLog
+} from '@grafana/data';
 import { logWarning } from '@grafana/runtime';
 import {
   sceneGraph,
@@ -241,7 +244,7 @@ export class DashboardLayoutOrchestrator extends SceneObjectBase<DashboardLayout
             }
           } else {
             const warningMessage = 'No grid item to drag';
-            console.warn(warningMessage);
+            structuredLog('warn', String(warningMessage));
             logWarning(warningMessage);
           }
         });

--- a/public/app/features/dashboard-scene/scene/DashboardMacro.ts
+++ b/public/app/features/dashboard-scene/scene/DashboardMacro.ts
@@ -1,3 +1,4 @@
+import { structuredLog, toLogContextPart } from '@grafana/data';
 import { type FormatVariable, type SceneObject, sceneUtils } from '@grafana/scenes';
 
 import { getDashboardSceneFor } from '../utils/utils';
@@ -39,7 +40,7 @@ export function registerDashboardMacro() {
 
     return () => unregister();
   } catch (e) {
-    console.error('Error registering dashboard macro', e);
+    structuredLog('error', 'Error registering dashboard macro', { error: toLogContextPart(e) });
     return () => {};
   }
 }

--- a/public/app/features/dashboard-scene/scene/DashboardMutationClientSetter.ts
+++ b/public/app/features/dashboard-scene/scene/DashboardMutationClientSetter.ts
@@ -1,3 +1,4 @@
+import { structuredLog, toLogContextPart } from '@grafana/data';
 /**
  * Bridge between DashboardScene and the mutation-api module.
  *
@@ -19,9 +20,7 @@ export function provideMutationClientFactory(create: CreateMutationClient): void
 
 export function createMutationClient(scene: unknown): () => void {
   if (!_create) {
-    console.warn(
-      'createMutationClient called before provideMutationClientFactory. Mutation API will not be available.'
-    );
+    structuredLog('warn', 'createMutationClient called before provideMutationClientFactory. Mutation API will not be available.');
     return () => {};
   }
   const teardown = _create(scene);

--- a/public/app/features/dashboard-scene/scene/DashboardScene.tsx
+++ b/public/app/features/dashboard-scene/scene/DashboardScene.tsx
@@ -11,6 +11,8 @@ import {
   type NavIndex,
   type NavModelItem,
   store,
+  structuredLog,
+  toLogContextPart
 } from '@grafana/data';
 import { t } from '@grafana/i18n';
 import { config, locationService, RefreshEvent } from '@grafana/runtime';
@@ -342,7 +344,7 @@ export class DashboardScene extends SceneObjectBase<DashboardSceneState> impleme
         try {
           return createSceneVariableFromVariableModelV2(v);
         } catch (err) {
-          console.error(err);
+          structuredLog('error', 'Error', { error: toLogContextPart(err) });
           return null;
         }
       })
@@ -409,7 +411,7 @@ export class DashboardScene extends SceneObjectBase<DashboardSceneState> impleme
 
   public exitEditMode({ skipConfirm, restoreInitialState }: { skipConfirm: boolean; restoreInitialState?: boolean }) {
     if (!this.canDiscard()) {
-      console.error('Trying to discard back to a state that does not exist, initialState undefined');
+      structuredLog('error', 'Trying to discard back to a state that does not exist, initialState undefined');
       return;
     }
 
@@ -514,7 +516,7 @@ export class DashboardScene extends SceneObjectBase<DashboardSceneState> impleme
    */
   public discardChangesAndKeepEditing() {
     if (!this.canDiscard()) {
-      console.error('Trying to discard back to a state that does not exist, initialState undefined');
+      structuredLog('error', 'Trying to discard back to a state that does not exist, initialState undefined');
       return;
     }
 
@@ -708,7 +710,7 @@ export class DashboardScene extends SceneObjectBase<DashboardSceneState> impleme
         clearClipboard();
         store.set(LS_PANEL_COPY_KEY, JSON.stringify({ elements, gridItem: gridItemKind }));
       } else {
-        console.error('Trying to copy a panel that is not DashboardGridItem child');
+        structuredLog('error', 'Trying to copy a panel that is not DashboardGridItem child');
         throw new Error('Trying to copy a panel that is not DashboardGridItem child');
       }
       return;
@@ -721,7 +723,7 @@ export class DashboardScene extends SceneObjectBase<DashboardSceneState> impleme
     let gridItem = vizPanel.parent;
 
     if (!(gridItem instanceof DashboardGridItem)) {
-      console.error('Trying to copy a panel that is not DashboardGridItem child');
+      structuredLog('error', 'Trying to copy a panel that is not DashboardGridItem child');
       throw new Error('Trying to copy a panel that is not DashboardGridItem child');
     }
 
@@ -876,7 +878,7 @@ export class DashboardScene extends SceneObjectBase<DashboardSceneState> impleme
 
       appEvents.emit('alert-success', ['Panel styles applied.']);
     } catch (e) {
-      console.error('Error pasting panel styles:', e);
+      structuredLog('error', 'Error pasting panel styles:', { error: toLogContextPart(e) });
       appEvents.emit('alert-error', ['Error pasting panel styles.']);
       DashboardInteractions.panelStylesMenuClicked(
         'paste',
@@ -960,7 +962,7 @@ export class DashboardScene extends SceneObjectBase<DashboardSceneState> impleme
       return;
     }
 
-    console.error('Trying to unlink a lib panel in a layout that is not DashboardGridItem or AutoGridItem');
+    structuredLog('error', 'Trying to unlink a lib panel in a layout that is not DashboardGridItem or AutoGridItem');
   }
 
   public showModal(modal: SceneObject) {

--- a/public/app/features/dashboard-scene/scene/DashboardSceneUrlSync.ts
+++ b/public/app/features/dashboard-scene/scene/DashboardSceneUrlSync.ts
@@ -1,3 +1,4 @@
+import { structuredLog, toLogContextPart } from '@grafana/data';
 import { type SceneObjectUrlSyncHandler, type SceneObjectUrlValues, type VizPanel } from '@grafana/scenes';
 import { contextSrv } from 'app/core/services/context_srv';
 
@@ -72,7 +73,7 @@ export class DashboardSceneUrlSync implements SceneObjectUrlSyncHandler {
       const panel = findEditPanel(this._scene, values.editPanel);
 
       if (!panel) {
-        console.warn(`Panel ${values.editPanel} not found`);
+        structuredLog('warn', `Panel ${values.editPanel} not found`);
         return;
       }
 

--- a/public/app/features/dashboard-scene/scene/GoToSnapshotOriginButton.tsx
+++ b/public/app/features/dashboard-scene/scene/GoToSnapshotOriginButton.tsx
@@ -1,6 +1,10 @@
-import { css } from '@emotion/css';
+import {
+  css } from '@emotion/css';
 
-import { textUtil } from '@grafana/data';
+import { textUtil,
+  structuredLog,
+  toLogContextPart
+} from '@grafana/data';
 import { t } from '@grafana/i18n';
 import { config, locationService } from '@grafana/runtime';
 import { ConfirmModal, ToolbarButton } from '@grafana/ui';
@@ -59,6 +63,6 @@ export const onOpenSnapshotOriginalDashboard = (originalUrl: string) => {
       locationService.push(sanitizedRelativeURL);
     }
   } catch (err) {
-    console.error('Failed to open original dashboard', err);
+    structuredLog('error', 'Failed to open original dashboard', { error: toLogContextPart(err) });
   }
 };

--- a/public/app/features/dashboard-scene/scene/export/exporters.ts
+++ b/public/app/features/dashboard-scene/scene/export/exporters.ts
@@ -1,6 +1,10 @@
-import { defaults, each, sortBy } from 'lodash';
+import {
+  defaults, each, sortBy } from 'lodash';
 
-import { type DataSourceRef, type VariableOption, VariableRefresh } from '@grafana/data';
+import { type DataSourceRef, type VariableOption, VariableRefresh,
+  structuredLog,
+  toLogContextPart
+} from '@grafana/data';
 import { getDataSourceSrv } from '@grafana/runtime';
 import { getPanelPluginMeta } from '@grafana/runtime/internal';
 import { type Panel } from '@grafana/schema';
@@ -352,7 +356,7 @@ export async function makeExportableV1(dashboard: DashboardModel) {
 
     return newObj;
   } catch (err) {
-    console.error('Export failed:', err);
+    structuredLog('error', 'Export failed:', { error: toLogContextPart(err) });
     return {
       error: err,
     };
@@ -374,7 +378,7 @@ async function convertLibraryPanelToInlinePanel(libraryPanelElement: LibraryPane
     inlinePanel.spec.id = id;
     return inlinePanel;
   } catch (error) {
-    console.error(`Failed to load library panel ${libraryPanel.uid}:`, error);
+    structuredLog('error', `Failed to load library panel ${libraryPanel.uid}:`, { error: toLogContextPart(error) });
 
     const errorMessage = error instanceof Error ? error.message : 'Unknown error';
     dispatch(
@@ -544,7 +548,7 @@ export async function makeExportableV2(dashboard: DashboardV2Spec, isSharingExte
 
     return dashboard;
   } catch (err) {
-    console.error('Export failed:', err);
+    structuredLog('error', 'Export failed:', { error: toLogContextPart(err) });
     return {
       error: err,
     };

--- a/public/app/features/dashboard-scene/scene/layout-auto-grid/AutoGridItem.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-auto-grid/AutoGridItem.tsx
@@ -1,3 +1,4 @@
+import { structuredLog, toLogContextPart } from '@grafana/data';
 import { isEqual } from 'lodash';
 import React from 'react';
 
@@ -91,7 +92,7 @@ export class AutoGridItem extends SceneObjectBase<AutoGridItemState> implements 
       });
 
     if (!(variable instanceof MultiValueVariable)) {
-      console.error('DashboardGridItem: Variable is not a MultiValueVariable');
+      structuredLog('error', 'DashboardGridItem: Variable is not a MultiValueVariable');
       return;
     }
 

--- a/public/app/features/dashboard-scene/scene/layout-auto-grid/AutoGridLayoutManager.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-auto-grid/AutoGridLayoutManager.tsx
@@ -1,4 +1,7 @@
-import { AppEvents } from '@grafana/data';
+import {
+  AppEvents,
+  structuredLog
+} from '@grafana/data';
 import { t } from '@grafana/i18n';
 import { config, getAppEvents } from '@grafana/runtime';
 import {
@@ -248,7 +251,7 @@ export class AutoGridLayoutManager
   public duplicatePanel(panel: VizPanel) {
     const gridItem = panel.parent;
     if (!(gridItem instanceof AutoGridItem)) {
-      console.error('Trying to duplicate a panel that is not inside a DashboardGridItem');
+      structuredLog('error', 'Trying to duplicate a panel that is not inside a DashboardGridItem');
       return;
     }
 

--- a/public/app/features/dashboard-scene/scene/layout-default/DashboardGridItem.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-default/DashboardGridItem.tsx
@@ -1,3 +1,4 @@
+import { structuredLog, toLogContextPart } from '@grafana/data';
 import { isEqual } from 'lodash';
 import React from 'react';
 import { type Unsubscribable } from 'rxjs';
@@ -150,7 +151,7 @@ export class DashboardGridItem
       });
 
     if (!(variable instanceof MultiValueVariable)) {
-      console.error('DashboardGridItem: Variable is not a MultiValueVariable');
+      structuredLog('error', 'DashboardGridItem: Variable is not a MultiValueVariable');
       return;
     }
 

--- a/public/app/features/dashboard-scene/scene/layout-default/DefaultGridLayoutManager.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-default/DefaultGridLayoutManager.tsx
@@ -1,6 +1,9 @@
-import { css, cx } from '@emotion/css';
+import {
+  css, cx } from '@emotion/css';
 
-import { AppEvents, type GrafanaTheme2 } from '@grafana/data';
+import { AppEvents, type GrafanaTheme2,
+  structuredLog
+} from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';
 import { t } from '@grafana/i18n';
 import { config, getAppEvents } from '@grafana/runtime';
@@ -260,7 +263,7 @@ export class DefaultGridLayoutManager
   public duplicatePanel(vizPanel: VizPanel) {
     const gridItem = vizPanel.parent;
     if (!(gridItem instanceof DashboardGridItem)) {
-      console.error('Trying to duplicate a panel that is not inside a DashboardGridItem');
+      structuredLog('error', 'Trying to duplicate a panel that is not inside a DashboardGridItem');
       return;
     }
 

--- a/public/app/features/dashboard-scene/scene/layout-default/RowRepeaterBehavior.ts
+++ b/public/app/features/dashboard-scene/scene/layout-default/RowRepeaterBehavior.ts
@@ -1,3 +1,4 @@
+import { structuredLog, toLogContextPart } from '@grafana/data';
 import { isEqual } from 'lodash';
 
 import {
@@ -91,12 +92,12 @@ export class RowRepeaterBehavior extends SceneObjectBase<RowRepeaterBehaviorStat
     const variable = sceneGraph.lookupVariable(this.state.variableName, this.parent?.parent!);
 
     if (!variable) {
-      console.error('RepeatedRowBehavior: Variable not found');
+      structuredLog('error', 'RepeatedRowBehavior: Variable not found');
       return;
     }
 
     if (!(variable instanceof MultiValueVariable)) {
-      console.error('RepeatedRowBehavior: Variable is not a MultiValueVariable');
+      structuredLog('error', 'RepeatedRowBehavior: Variable is not a MultiValueVariable');
       return;
     }
 

--- a/public/app/features/dashboard-scene/scene/layout-rows/RowItem.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-rows/RowItem.tsx
@@ -1,6 +1,9 @@
 import React from 'react';
 
-import { store } from '@grafana/data';
+import {
+  store,
+  structuredLog
+} from '@grafana/data';
 import { t } from '@grafana/i18n';
 import { logWarning } from '@grafana/runtime';
 import { getFeatureFlagClient } from '@grafana/runtime/internal';
@@ -227,7 +230,7 @@ export class RowItem
         layout.setState({ children: newChildren });
       } else {
         const warningMessage = 'Grid item has unexpected parent type';
-        console.warn(warningMessage);
+        structuredLog('warn', String(warningMessage));
         logWarning(warningMessage);
       }
     }
@@ -242,7 +245,7 @@ export class RowItem
       layout.addGridItem(gridItem);
     } else {
       const warningMessage = 'Layout manager does not support addGridItem';
-      console.warn(warningMessage);
+      structuredLog('warn', String(warningMessage));
       logWarning(warningMessage);
     }
     this.setIsDropTarget(false);

--- a/public/app/features/dashboard-scene/scene/layout-tabs/TabItem.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-tabs/TabItem.tsx
@@ -1,6 +1,9 @@
 import React from 'react';
 
-import { store } from '@grafana/data';
+import {
+  store,
+  structuredLog
+} from '@grafana/data';
 import { t } from '@grafana/i18n';
 import { logWarning } from '@grafana/runtime';
 import { getFeatureFlagClient } from '@grafana/runtime/internal';
@@ -234,7 +237,7 @@ export class TabItem
         layout.setState({ children: newChildren });
       } else {
         const warningMessage = 'Grid item has unexpected parent type';
-        console.warn(warningMessage);
+        structuredLog('warn', String(warningMessage));
         logWarning(warningMessage);
       }
     }
@@ -256,13 +259,13 @@ export class TabItem
           rowLayout.addGridItem(gridItem);
         } else {
           const warningMessage = 'First row layout does not support addGridItem';
-          console.warn(warningMessage);
+          structuredLog('warn', String(warningMessage));
           logWarning(warningMessage);
         }
       }
     } else {
       const warningMessage = 'Layout manager does not support addGridItem';
-      console.warn(warningMessage);
+      structuredLog('warn', String(warningMessage));
       logWarning(warningMessage);
     }
     this.setIsDropTarget(false);

--- a/public/app/features/dashboard-scene/serialization/DashboardSceneSerializer.ts
+++ b/public/app/features/dashboard-scene/serialization/DashboardSceneSerializer.ts
@@ -353,7 +353,6 @@ export class V2DashboardSerializer
           }
         } else {
           const warningMsg = 'Dashboard serializer: Undefined variable found in dashboard save model, ignoring it';
-          console.warn(warningMsg);
           logWarning(warningMsg);
         }
       }

--- a/public/app/features/dashboard-scene/serialization/angularMigration.ts
+++ b/public/app/features/dashboard-scene/serialization/angularMigration.ts
@@ -1,6 +1,9 @@
-import { defaults, cloneDeep } from 'lodash';
+import {
+  defaults, cloneDeep } from 'lodash';
 
-import { type PanelModel as PanelModelFromData, type PanelPlugin } from '@grafana/data';
+import { type PanelModel as PanelModelFromData, type PanelPlugin,
+  structuredLog
+} from '@grafana/data';
 import { autoMigrateAngular, type PanelModel } from 'app/features/dashboard/state/PanelModel';
 
 /**
@@ -42,9 +45,7 @@ export function getAngularPanelMigrationHandler(oldModel: PanelModel) {
       const targetClone = cloneDeep(oldModel.targets);
       Object.defineProperty(panel, 'targets', {
         get: function () {
-          console.warn(
-            'Accessing the targets property when migrating a panel plugin is deprecated. Changes to this property will be ignored.'
-          );
+          structuredLog('warn', 'Accessing the targets property when migrating a panel plugin is deprecated. Changes to this property will be ignored.');
           return targetClone;
         },
       });
@@ -108,9 +109,7 @@ export function getV2AngularMigrationHandler(migrationData: AngularMigrationData
     const targetClone = cloneDeep(panel.targets);
     Object.defineProperty(panel, 'targets', {
       get: function () {
-        console.warn(
-          'Accessing the targets property when migrating a panel plugin is deprecated. Changes to this property will be ignored.'
-        );
+        structuredLog('warn', 'Accessing the targets property when migrating a panel plugin is deprecated. Changes to this property will be ignored.');
         return targetClone;
       },
     });

--- a/public/app/features/dashboard-scene/serialization/layoutSerializers/utils.ts
+++ b/public/app/features/dashboard-scene/serialization/layoutSerializers/utils.ts
@@ -1,4 +1,7 @@
-import { getNextRefId } from '@grafana/data';
+import {
+  getNextRefId,
+  structuredLog
+} from '@grafana/data';
 import { config } from '@grafana/runtime';
 import { getPanelPluginMetasMapSync, type PanelPluginMetas } from '@grafana/runtime/internal';
 import {
@@ -372,9 +375,7 @@ export function getDataSourceForQuery(querySpecDS: DataSourceRef | undefined | n
     // In the datasource list from bootData "id" is the type and the uid could be uid or the name
     // in cases like grafana, dashboard or mixed datasource
 
-    console.warn(
-      `Could not find datasource for query kind ${queryKind}, defaulting to ${dsList[defaultDatasource].meta.id}`
-    );
+    structuredLog('warn', `Could not find datasource for query kind ${queryKind}, defaulting to ${dsList[defaultDatasource].meta.id}`);
     return {
       uid: dsList[defaultDatasource].uid || dsList[defaultDatasource].name,
       type: dsList[defaultDatasource].meta.id,

--- a/public/app/features/dashboard-scene/serialization/transformSaveModelSchemaV2ToScene.ts
+++ b/public/app/features/dashboard-scene/serialization/transformSaveModelSchemaV2ToScene.ts
@@ -1,3 +1,4 @@
+import { structuredLog, toLogContextPart } from '@grafana/data';
 import { uniqueId } from 'lodash';
 
 import { config, getDataSourceSrv } from '@grafana/runtime';
@@ -309,7 +310,7 @@ function createVariablesForDashboard(dashboard: DashboardV2Spec, defaultVariable
       try {
         return createSceneVariableFromVariableModel(v);
       } catch (err) {
-        console.error(err);
+        structuredLog('error', 'Error', { error: toLogContextPart(err) });
         return null;
       }
     })
@@ -322,7 +323,7 @@ function createVariablesForDashboard(dashboard: DashboardV2Spec, defaultVariable
       try {
         return createSceneVariableFromVariableModel(v);
       } catch (err) {
-        console.error(err);
+        structuredLog('error', 'Error', { error: toLogContextPart(err) });
         return null;
       }
     })
@@ -616,7 +617,7 @@ export function createVariablesForSnapshot(dashboard: DashboardV2Spec): SceneVar
         // for other variable types we are using the SnapshotVariable
         return createSnapshotVariable(v);
       } catch (err) {
-        console.error(err);
+        structuredLog('error', 'Error', { error: toLogContextPart(err) });
         return null;
       }
     })

--- a/public/app/features/dashboard-scene/serialization/transformSceneToSaveModelSchemaV2.ts
+++ b/public/app/features/dashboard-scene/serialization/transformSceneToSaveModelSchemaV2.ts
@@ -1,6 +1,7 @@
-import { omit } from 'lodash';
+import {
+  omit } from 'lodash';
 
-import { type AnnotationQuery, isEmptyObject, type TimeRange } from '@grafana/data';
+import { type AnnotationQuery, isEmptyObject, type TimeRange, structuredLog, toLogContextPart } from '@grafana/data';
 import { config } from '@grafana/runtime';
 import { ExpressionDatasourceRef } from '@grafana/runtime/internal';
 import {
@@ -172,7 +173,9 @@ export function transformSceneToSaveModelSchemaV2(scene: DashboardScene, isSnaps
     // should never reach this point, validation should throw an error
     throw new Error('Error we could transform the dashboard to schema v2: ' + dashboardSchemaV2);
   } catch (reason) {
-    console.error('Error transforming dashboard to schema v2: ' + reason, dashboardSchemaV2);
+    structuredLog('error', 'Error transforming dashboard to schema v2: ' + String(reason), {
+      dashboard: toLogContextPart(dashboardSchemaV2),
+    });
     throw new Error('Error transforming dashboard to schema v2: ' + reason);
   }
 }
@@ -612,11 +615,9 @@ function getAnnotations(state: DashboardSceneState, dsReferencesMapping?: DSRefe
       // for layers created for v2 schema. See transform transformSaveModelSchemaV2ToScene.ts.
       // In this case we will resolve default data source
       layerDs = getDefaultDataSourceRef();
-      console.error(
-        'Misconfigured AnnotationsDataLayer: Data source is required for annotations. Resolving default data source',
-        layer,
+      structuredLog('error', 'Misconfigured AnnotationsDataLayer: Data source is required for annotations. Resolving default data source', { details: layer,
         layerDs
-      );
+       });
     }
 
     const result = transformV1ToV2AnnotationQuery(layer.state.query, layerDs.type!, layerDs.uid!, {

--- a/public/app/features/dashboard-scene/serialization/transformToV1TypesUtils.ts
+++ b/public/app/features/dashboard-scene/serialization/transformToV1TypesUtils.ts
@@ -1,4 +1,7 @@
-import { type FieldConfigSource as FieldConfigSourceV1, SpecialValueMatch as SpecialValueMatchV1 } from '@grafana/data';
+import {
+  type FieldConfigSource as FieldConfigSourceV1, SpecialValueMatch as SpecialValueMatchV1,
+  structuredLog
+} from '@grafana/data';
 import {
   VariableHide as VariableHideV1,
   VariableRefresh as VariableRefreshV1,
@@ -98,7 +101,7 @@ function transformSpecialValueMatchToV1(match: SpecialValueMatch): SpecialValueM
     case 'empty':
       return SpecialValueMatchV1.Empty;
     default:
-      console.warn(`Skipping special value mapping with unknown match type: "${match}"`);
+      structuredLog('warn', `Skipping special value mapping with unknown match type: "${match}"`);
       return undefined;
   }
 }

--- a/public/app/features/dashboard-scene/settings/AnnotationsEditView.tsx
+++ b/public/app/features/dashboard-scene/settings/AnnotationsEditView.tsx
@@ -4,6 +4,7 @@ import {
   type NavModel,
   type NavModelItem,
   PageLayoutType,
+  structuredLog
 } from '@grafana/data';
 import { getDataSourceSrv } from '@grafana/runtime';
 import { type SceneComponentProps, SceneObjectBase, type VizPanel, dataLayers } from '@grafana/scenes';
@@ -65,7 +66,7 @@ export class AnnotationsEditView extends SceneObjectBase<AnnotationsEditViewStat
     const defaultInstanceDS = getDataSourceSrv().getInstanceSettings(null);
     // check for an annotation flag in the plugin json to see if it supports annotations
     if (!defaultInstanceDS || !defaultInstanceDS.meta.annotations) {
-      console.error('Default datasource does not support annotations');
+      structuredLog('error', 'Default datasource does not support annotations');
       return undefined;
     }
     return getDataSourceRef(defaultInstanceDS);

--- a/public/app/features/dashboard-scene/settings/GeneralSettingsEditView.tsx
+++ b/public/app/features/dashboard-scene/settings/GeneralSettingsEditView.tsx
@@ -1,6 +1,10 @@
-import { type ChangeEvent } from 'react';
+import {
+  type ChangeEvent } from 'react';
 
-import { PageLayoutType } from '@grafana/data';
+import { PageLayoutType,
+  structuredLog,
+  toLogContextPart
+} from '@grafana/data';
 import { Trans, t } from '@grafana/i18n';
 import { config } from '@grafana/runtime';
 import { type SceneComponentProps, SceneObjectBase, behaviors, sceneGraph } from '@grafana/scenes';
@@ -159,7 +163,7 @@ export class GeneralSettingsEditView
       const liveNow = this.getLiveNowTimer();
       enable ? liveNow.enable() : liveNow.disable();
     } catch (err) {
-      console.error(err);
+      structuredLog('error', 'Error', { error: toLogContextPart(err) });
     }
   };
 

--- a/public/app/features/dashboard-scene/settings/VariablesEditView.tsx
+++ b/public/app/features/dashboard-scene/settings/VariablesEditView.tsx
@@ -1,7 +1,10 @@
-import { useMemo } from 'react';
+import {
+  useMemo } from 'react';
 import { v4 as uuidv4 } from 'uuid';
 
-import { type NavModel, type NavModelItem, PageLayoutType } from '@grafana/data';
+import { type NavModel, type NavModelItem, PageLayoutType,
+  structuredLog
+} from '@grafana/data';
 import {
   type SceneComponentProps,
   SceneObjectBase,
@@ -66,7 +69,7 @@ export class VariablesEditView extends SceneObjectBase<VariablesEditViewState> i
 
     if (!variable) {
       // Handle the case where the variable is not found
-      console.error('Variable not found');
+      structuredLog('error', 'Variable not found');
       return;
     }
 
@@ -82,7 +85,7 @@ export class VariablesEditView extends SceneObjectBase<VariablesEditViewState> i
     const { variables } = this.getVariableSet().state;
     if (variableIndex === -1) {
       // Handle the case where the variable is not found
-      console.error('Variable not found');
+      structuredLog('error', 'Variable not found');
       return;
     }
 
@@ -104,7 +107,7 @@ export class VariablesEditView extends SceneObjectBase<VariablesEditViewState> i
     const variables = this.getVariableSet().state.variables;
 
     if (variableIndex === -1) {
-      console.error('Variable not found');
+      structuredLog('error', 'Variable not found');
       return;
     }
 
@@ -137,7 +140,7 @@ export class VariablesEditView extends SceneObjectBase<VariablesEditViewState> i
     }
     // check the index are within the variables array
     if (fromIndex < 0 || fromIndex >= variables.length || toIndex < 0 || toIndex >= variables.length) {
-      console.error('Invalid index');
+      structuredLog('error', 'Invalid index');
       return;
     }
     const updatedVariables = [...variables];
@@ -151,7 +154,7 @@ export class VariablesEditView extends SceneObjectBase<VariablesEditViewState> i
   public onEdit = (identifier: string) => {
     const variableIndex = this.getVariableIndex(identifier);
     if (variableIndex === -1) {
-      console.error('Variable not found');
+      structuredLog('error', 'Variable not found');
       return;
     }
     this.setState({ editIndex: variableIndex });
@@ -175,7 +178,7 @@ export class VariablesEditView extends SceneObjectBase<VariablesEditViewState> i
 
     if (!variable) {
       // Handle the case where the variable is not found
-      console.error('Variable not found');
+      structuredLog('error', 'Variable not found');
       return;
     }
 

--- a/public/app/features/dashboard-scene/settings/VersionsEditView.tsx
+++ b/public/app/features/dashboard-scene/settings/VersionsEditView.tsx
@@ -2,7 +2,7 @@ import { skipToken } from '@reduxjs/toolkit/query/react';
 import * as React from 'react';
 import { useMemo } from 'react';
 
-import { PageLayoutType, dateTimeFormat, dateTimeFormatTimeAgo } from '@grafana/data';
+import { PageLayoutType, dateTimeFormat, dateTimeFormatTimeAgo, structuredLog, toLogContextPart } from '@grafana/data';
 import { Trans } from '@grafana/i18n';
 import { type SceneComponentProps, SceneObjectBase, sceneGraph } from '@grafana/scenes';
 import { Alert, Spinner, Stack } from '@grafana/ui';
@@ -118,7 +118,11 @@ export class VersionsEditView extends SceneObjectBase<VersionsEditViewState> imp
         // Update the continueToken for the next request, if available
         this._continueToken = result.metadata.continue ?? '';
       })
-      .catch((err) => console.log(err))
+      .catch((err) =>
+        structuredLog('error', 'Failed to fetch dashboard revision history', {
+          error: toLogContextPart(err),
+        })
+      )
       .finally(() => this.setState({ isAppending: false }));
   };
 

--- a/public/app/features/dashboard-scene/settings/annotations/AnnotationQueryOptions.tsx
+++ b/public/app/features/dashboard-scene/settings/annotations/AnnotationQueryOptions.tsx
@@ -1,7 +1,11 @@
-import { useCallback, useState } from 'react';
+import {
+  useCallback, useState } from 'react';
 import { useAsync } from 'react-use';
 
-import { AppEvents, CoreApp, type DataSourceInstanceSettings, getDataSourceRef } from '@grafana/data';
+import { AppEvents, CoreApp, type DataSourceInstanceSettings, getDataSourceRef,
+  structuredLog,
+  toLogContextPart
+} from '@grafana/data';
 import { t, Trans } from '@grafana/i18n';
 import { getAppEvents, getDataSourceSrv } from '@grafana/runtime';
 import { type DataQuery } from '@grafana/schema';
@@ -79,7 +83,7 @@ function QueryLibraryButton({ layer, onQuerySelected }: { layer: AnnotationLayer
           layer.setState({ query: updatedQuery });
           layer.runLayer();
         } catch (error) {
-          console.error('Failed to replace annotation query!', error);
+          structuredLog('error', 'Failed to replace annotation query!', { error: toLogContextPart(error) });
           getAppEvents().publish({
             type: AppEvents.alertError.name,
             payload: ['Failed to create annotation query!', error instanceof Error ? error.message : error],

--- a/public/app/features/dashboard-scene/settings/variables/editors/AdHocFiltersVariableEditor.tsx
+++ b/public/app/features/dashboard-scene/settings/variables/editors/AdHocFiltersVariableEditor.tsx
@@ -1,4 +1,5 @@
-import { noop } from 'lodash';
+import {
+  noop } from 'lodash';
 import { type FormEvent, useCallback, useMemo, useState } from 'react';
 import { useAsync } from 'react-use';
 
@@ -7,6 +8,7 @@ import {
   type MetricFindValue,
   type SelectableValue,
   getDataSourceRef,
+  structuredLog
 } from '@grafana/data';
 import { t } from '@grafana/i18n';
 import { config, getDataSourceSrv } from '@grafana/runtime';
@@ -169,7 +171,7 @@ export function AdHocFiltersVariableEditor(props: AdHocFiltersVariableEditorProp
 
 export function getAdHocFilterOptions(variable: SceneVariable): OptionsPaneItemDescriptor[] {
   if (!(variable instanceof AdHocFiltersVariable)) {
-    console.warn('getAdHocFilterOptions: variable is not an AdHocFiltersVariable');
+    structuredLog('warn', 'getAdHocFilterOptions: variable is not an AdHocFiltersVariable');
     return [];
   }
 

--- a/public/app/features/dashboard-scene/settings/variables/editors/ConstantVariableEditor.tsx
+++ b/public/app/features/dashboard-scene/settings/variables/editors/ConstantVariableEditor.tsx
@@ -1,3 +1,4 @@
+import { structuredLog, toLogContextPart } from '@grafana/data';
 import { type FormEvent } from 'react';
 import { lastValueFrom } from 'rxjs';
 
@@ -24,7 +25,7 @@ export function ConstantVariableEditor({ variable }: ConstantVariableEditorProps
 
 export function getConstantVariableOptions(variable: SceneVariable): OptionsPaneItemDescriptor[] {
   if (!(variable instanceof ConstantVariable)) {
-    console.warn('getConstantVariableOptions: variable is not a ConstantVariable');
+    structuredLog('warn', 'getConstantVariableOptions: variable is not a ConstantVariable');
     return [];
   }
 

--- a/public/app/features/dashboard-scene/settings/variables/editors/GroupByVariableEditor.tsx
+++ b/public/app/features/dashboard-scene/settings/variables/editors/GroupByVariableEditor.tsx
@@ -1,4 +1,5 @@
-import { noop } from 'lodash';
+import {
+  noop } from 'lodash';
 import { type FormEvent } from 'react';
 import { useAsync } from 'react-use';
 
@@ -7,6 +8,7 @@ import {
   type MetricFindValue,
   type SelectableValue,
   getDataSourceRef,
+  structuredLog
 } from '@grafana/data';
 import { getDataSourceSrv } from '@grafana/runtime';
 import { GroupByVariable, type SceneVariable } from '@grafana/scenes';
@@ -106,7 +108,7 @@ export function GroupByVariableEditor(props: GroupByVariableEditorProps) {
 
 export function getGroupByVariableOptions(variable: SceneVariable): OptionsPaneItemDescriptor[] {
   if (!(variable instanceof GroupByVariable)) {
-    console.warn('getAdHocFilterOptions: variable is not an AdHocFiltersVariable');
+    structuredLog('warn', 'getAdHocFilterOptions: variable is not an AdHocFiltersVariable');
     return [];
   }
 

--- a/public/app/features/dashboard-scene/settings/variables/editors/IntervalVariableEditor.tsx
+++ b/public/app/features/dashboard-scene/settings/variables/editors/IntervalVariableEditor.tsx
@@ -1,7 +1,10 @@
-import { noop } from 'lodash';
+import {
+  noop } from 'lodash';
 import { type ChangeEvent, type FormEvent } from 'react';
 
-import { type SelectableValue } from '@grafana/data';
+import { type SelectableValue,
+  structuredLog
+} from '@grafana/data';
 import { IntervalVariable, type SceneVariable } from '@grafana/scenes';
 import { OptionsPaneItemDescriptor } from 'app/features/dashboard/components/PanelEditor/OptionsPaneItemDescriptor';
 import {
@@ -65,7 +68,7 @@ export function IntervalVariableEditor({ variable, onRunQuery, inline }: Interva
 
 export function getIntervalVariableOptions(variable: SceneVariable): OptionsPaneItemDescriptor[] {
   if (!(variable instanceof IntervalVariable)) {
-    console.warn('getIntervalVariableOptions: variable is not an IntervalVariable');
+    structuredLog('warn', 'getIntervalVariableOptions: variable is not an IntervalVariable');
     return [];
   }
 

--- a/public/app/features/dashboard-scene/settings/variables/editors/QueryVariableEditor.tsx
+++ b/public/app/features/dashboard-scene/settings/variables/editors/QueryVariableEditor.tsx
@@ -1,4 +1,5 @@
-import { type FormEvent, useState } from 'react';
+import {
+  type FormEvent, useState } from 'react';
 import { useAsync } from 'react-use';
 
 import {
@@ -6,6 +7,7 @@ import {
   getDataSourceRef,
   type SelectableValue,
   type VariableRegexApplyTo,
+  structuredLog
 } from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';
 import { t, Trans } from '@grafana/i18n';
@@ -138,7 +140,7 @@ export function QueryVariableEditor({ variable, onRunQuery }: QueryVariableEdito
 
 export function getQueryVariableOptions(variable: SceneVariable): OptionsPaneItemDescriptor[] {
   if (!(variable instanceof QueryVariable)) {
-    console.warn('getQueryVariableOptions: variable is not a QueryVariable');
+    structuredLog('warn', 'getQueryVariableOptions: variable is not a QueryVariable');
     return [];
   }
 

--- a/public/app/features/dashboard-scene/settings/variables/editors/SwitchVariableEditor.tsx
+++ b/public/app/features/dashboard-scene/settings/variables/editors/SwitchVariableEditor.tsx
@@ -1,3 +1,4 @@
+import { structuredLog, toLogContextPart } from '@grafana/data';
 import { type SceneVariable, SwitchVariable } from '@grafana/scenes';
 import { OptionsPaneItemDescriptor } from 'app/features/dashboard/components/PanelEditor/OptionsPaneItemDescriptor';
 
@@ -44,7 +45,7 @@ export function SwitchVariableEditor({ variable, inline = false }: SwitchVariabl
 
 export function getSwitchVariableOptions(variable: SceneVariable): OptionsPaneItemDescriptor[] {
   if (!(variable instanceof SwitchVariable)) {
-    console.warn('getSwitchVariableOptions: variable is not a SwitchVariable');
+    structuredLog('warn', 'getSwitchVariableOptions: variable is not a SwitchVariable');
     return [];
   }
 

--- a/public/app/features/dashboard-scene/settings/variables/editors/TextBoxVariableEditor.tsx
+++ b/public/app/features/dashboard-scene/settings/variables/editors/TextBoxVariableEditor.tsx
@@ -1,3 +1,4 @@
+import { structuredLog, toLogContextPart } from '@grafana/data';
 import { noop } from 'lodash';
 import { type FormEvent } from 'react';
 
@@ -25,7 +26,7 @@ export function TextBoxVariableEditor({ variable, inline }: TextBoxVariableEdito
 
 export function getTextBoxVariableOptions(variable: SceneVariable): OptionsPaneItemDescriptor[] {
   if (!(variable instanceof TextBoxVariable)) {
-    console.warn('getTextBoxVariableOptions: variable is not a TextBoxVariable');
+    structuredLog('warn', 'getTextBoxVariableOptions: variable is not a TextBoxVariable');
     return [];
   }
 

--- a/public/app/features/dashboard-scene/sharing/ExportButton/ExportAsImage.tsx
+++ b/public/app/features/dashboard-scene/sharing/ExportButton/ExportAsImage.tsx
@@ -1,9 +1,13 @@
-import { css } from '@emotion/css';
+import {
+  css } from '@emotion/css';
 import { saveAs } from 'file-saver';
 import { useEffect } from 'react';
 import { useAsyncFn } from 'react-use';
 
-import { type GrafanaTheme2 } from '@grafana/data';
+import { type GrafanaTheme2,
+  structuredLog,
+  toLogContextPart
+} from '@grafana/data';
 import { Trans, t } from '@grafana/i18n';
 import { config } from '@grafana/runtime';
 import { type SceneComponentProps, SceneObjectBase } from '@grafana/scenes';
@@ -48,7 +52,7 @@ function ExportAsImageRenderer({ model }: SceneComponentProps<ExportAsImage>) {
 
       return result.blob;
     } catch (error) {
-      console.error('Error exporting image:', error);
+      structuredLog('error', 'Error exporting image:', { error: toLogContextPart(error) });
       DashboardInteractions.generateDashboardImageClicked({
         scale: config.rendererDefaultImageScale || 1,
         shareResource: 'dashboard',

--- a/public/app/features/dashboard-scene/utils/DashboardModelCompatibilityWrapper.ts
+++ b/public/app/features/dashboard-scene/utils/DashboardModelCompatibilityWrapper.ts
@@ -1,4 +1,5 @@
-import { Subscription } from 'rxjs';
+import {
+  Subscription } from 'rxjs';
 
 import {
   type AnnotationQuery,
@@ -6,6 +7,8 @@ import {
   dateTimeFormat,
   type DateTimeInput,
   EventBusSrv,
+  structuredLog,
+  toLogContextPart
 } from '@grafana/data';
 import { TimeRangeUpdatedEvent } from '@grafana/runtime';
 import { behaviors, sceneGraph, type SceneObject, VizPanel } from '@grafana/scenes';
@@ -165,7 +168,7 @@ export class DashboardModelCompatibilityWrapper {
   public removePanel(panel: PanelModelCompatibilityWrapper) {
     const vizPanel = findVizPanelByKey(this._scene, getVizPanelKeyForPanelId(panel.id));
     if (!vizPanel) {
-      console.error('Trying to remove a panel that was not found in scene', panel);
+      structuredLog('error', 'Trying to remove a panel that was not found in scene', { error: toLogContextPart(panel) });
       return;
     }
 

--- a/public/app/features/dashboard-scene/utils/PanelModelCompatibilityWrapper.ts
+++ b/public/app/features/dashboard-scene/utils/PanelModelCompatibilityWrapper.ts
@@ -1,4 +1,7 @@
-import { type PanelModel } from '@grafana/data';
+import {
+  type PanelModel,
+  structuredLog
+} from '@grafana/data';
 import { SceneDataTransformer, type VizPanel } from '@grafana/scenes';
 import { type DataSourceRef, type DataTransformerConfig } from '@grafana/schema';
 
@@ -11,7 +14,7 @@ export class PanelModelCompatibilityWrapper implements PanelModel {
     const id = getPanelIdForVizPanel(this._vizPanel);
 
     if (isNaN(id)) {
-      console.error('VizPanel key could not be translated to a legacy numeric panel id', this._vizPanel);
+      structuredLog('error', 'VizPanel key could not be translated to a legacy numeric panel id', { details: this._vizPanel });
       return 0;
     }
 

--- a/public/app/features/dashboard-scene/utils/dashboardControls.ts
+++ b/public/app/features/dashboard-scene/utils/dashboardControls.ts
@@ -1,7 +1,10 @@
-import { nanoid } from 'nanoid';
+import {
+  nanoid } from 'nanoid';
 import { filter, Observable, scan, share, type Subscriber } from 'rxjs';
 
-import { type DataSourceApi } from '@grafana/data';
+import { type DataSourceApi,
+  structuredLog
+} from '@grafana/data';
 import { getDataSourceSrv, reportInteraction } from '@grafana/runtime';
 import { type SceneVariable } from '@grafana/scenes';
 import { type DashboardLink, type DataSourceRef } from '@grafana/schema';
@@ -85,7 +88,7 @@ async function loadControlsFromRef(ref: DataSourceRef, traceId: string, subscrib
   try {
     ds = await getDataSourceSrv().get(ref);
   } catch (e) {
-    console.warn('Failed to load datasource', ref, e);
+    structuredLog('warn', 'Failed to load datasource', { details: ref, e });
     return;
   }
 
@@ -119,7 +122,7 @@ async function emitDefaultVariables(ds: DataSourceApi, traceId: string, subscrib
       subscriber.next({ type: 'variables', data });
     }
   } catch (e) {
-    console.warn('Failed to load default variables from datasource', ds.type, e);
+    structuredLog('warn', 'Failed to load default variables from datasource', { details: ds.type, e });
   }
 }
 
@@ -145,7 +148,7 @@ async function emitDefaultLinks(ds: DataSourceApi, traceId: string, subscriber: 
       });
     }
   } catch (e) {
-    console.warn('Failed to load default links from datasource', ds.type, e);
+    structuredLog('warn', 'Failed to load default links from datasource', { details: ds.type, e });
   }
 }
 

--- a/public/app/features/dashboard-scene/utils/variables.ts
+++ b/public/app/features/dashboard-scene/utils/variables.ts
@@ -1,4 +1,8 @@
-import { type AdHocVariableFilter, type TypedVariableModel } from '@grafana/data';
+import {
+  type AdHocVariableFilter, type TypedVariableModel,
+  structuredLog,
+  toLogContextPart
+} from '@grafana/data';
 import { config, getDataSourceSrv } from '@grafana/runtime';
 import {
   AdHocFiltersVariable,
@@ -32,7 +36,7 @@ export function createVariablesForDashboard(oldModel: DashboardModel, defaultVar
       try {
         return createSceneVariableFromVariableModel(v);
       } catch (err) {
-        console.error(err);
+        structuredLog('error', 'Error', { error: toLogContextPart(err) });
         return null;
       }
     })
@@ -45,7 +49,7 @@ export function createVariablesForDashboard(oldModel: DashboardModel, defaultVar
       try {
         return createSceneVariableFromVariableModelV2(v);
       } catch (err) {
-        console.error(err);
+        structuredLog('error', 'Error', { error: toLogContextPart(err) });
         return null;
       }
     })
@@ -91,7 +95,7 @@ export function createVariablesForSnapshot(oldModel: DashboardModel) {
         // for other variable types we are using the SnapshotVariable
         return createSnapshotVariable(v);
       } catch (err) {
-        console.error(err);
+        structuredLog('error', 'Error', { error: toLogContextPart(err) });
         return null;
       }
     })

--- a/public/app/features/dashboard/api/ResponseTransformers.ts
+++ b/public/app/features/dashboard/api/ResponseTransformers.ts
@@ -1,4 +1,7 @@
-import { type MetricFindValue, type TypedVariableModel, type AnnotationQuery } from '@grafana/data';
+import {
+  type MetricFindValue, type TypedVariableModel, type AnnotationQuery,
+  structuredLog
+} from '@grafana/data';
 import { config } from '@grafana/runtime';
 import {
   type DataQuery,
@@ -712,9 +715,7 @@ function getVariables(vars: TypedVariableModel[]): DashboardV2Spec['variables'] 
         let query = v.query || {};
 
         if (typeof query === 'string') {
-          console.warn(
-            'Query variable query is a string which is deprecated in the schema v2. It should extend DataQuery'
-          );
+          structuredLog('warn', 'Query variable query is a string which is deprecated in the schema v2. It should extend DataQuery');
           query = {
             [LEGACY_STRING_VALUE_KEY]: query,
           };
@@ -925,7 +926,7 @@ function getVariables(vars: TypedVariableModel[]): DashboardV2Spec['variables'] 
         break;
       default:
         // do not throw error, just log it
-        console.error(`Variable transformation not implemented: ${v.type}`);
+        structuredLog('error', `Variable transformation not implemented: ${v.type}`);
     }
   }
   return variables;
@@ -1138,7 +1139,7 @@ function getVariablesV1(vars: DashboardV2Spec['variables']): VariableModel[] {
         break;
       default:
         // do not throw error, just log it
-        console.error(`Variable transformation not implemented: ${v}`);
+        structuredLog('error', `Variable transformation not implemented: ${v}`);
     }
   }
   return variables;
@@ -1391,7 +1392,7 @@ function transformSpecialValueMatchToV1(match: SpecialValueMatch): SpecialValueM
     case 'empty':
       return SpecialValueMatchV1.Empty;
     default:
-      console.warn(`Skipping special value mapping with unknown match type: "${match}"`);
+      structuredLog('warn', `Skipping special value mapping with unknown match type: "${match}"`);
       return undefined;
   }
 }

--- a/public/app/features/dashboard/api/utils.ts
+++ b/public/app/features/dashboard/api/utils.ts
@@ -1,3 +1,4 @@
+import { structuredLog, toLogContextPart } from '@grafana/data';
 import { config, locationService } from '@grafana/runtime';
 import { type Dashboard } from '@grafana/schema';
 import { type Status, type Spec as DashboardV2Spec } from '@grafana/schema/apis/dashboard.grafana.app/v2';
@@ -23,7 +24,7 @@ export function getDashboardsApiVersion(responseFormat?: 'v1' | 'v2') {
 
   const forcingOldDashboardArch = locationService.getSearch().get('scenes') === 'false';
 
-  // console.log(forcingOldDashboardArch);
+  // structuredLog('info', 'console.log', { value: toLogContextPart(forcingOldDashboardArch) });
   // Force legacy API when dashboard scene is force disabled
   if (forcingOldDashboardArch) {
     if (responseFormat === 'v2') {

--- a/public/app/features/dashboard/components/DashExportModal/DashboardExporter.ts
+++ b/public/app/features/dashboard/components/DashExportModal/DashboardExporter.ts
@@ -1,6 +1,10 @@
-import { defaults, each, sortBy } from 'lodash';
+import {
+  defaults, each, sortBy } from 'lodash';
 
-import { type DataSourceRef, type VariableOption, VariableRefresh } from '@grafana/data';
+import { type DataSourceRef, type VariableOption, VariableRefresh,
+  structuredLog,
+  toLogContextPart
+} from '@grafana/data';
 import { getDataSourceSrv } from '@grafana/runtime';
 import { getPanelPluginMeta } from '@grafana/runtime/internal';
 import config from 'app/core/config';
@@ -318,7 +322,7 @@ export class DashboardExporter {
 
       return newObj;
     } catch (err) {
-      console.error('Export failed:', err);
+      structuredLog('error', 'Export failed:', { error: toLogContextPart(err) });
       return {
         error: err,
       };

--- a/public/app/features/dashboard/components/DashboardSettings/VersionsSettings.tsx
+++ b/public/app/features/dashboard/components/DashboardSettings/VersionsSettings.tsx
@@ -1,6 +1,7 @@
 import { PureComponent } from 'react';
 import * as React from 'react';
 
+import { structuredLog, toLogContextPart } from '@grafana/data';
 import { Spinner, Stack } from '@grafana/ui';
 import { Page } from 'app/core/components/Page/Page';
 import { type Resource } from 'app/features/apiserver/types';
@@ -69,7 +70,11 @@ export class VersionsSettings extends PureComponent<Props, State> {
         // Update the continueToken for the next request, if available
         this.continueToken = result.metadata.continue ?? '';
       })
-      .catch((err) => console.log(err))
+      .catch((err) =>
+        structuredLog('error', 'Failed to fetch dashboard revision history', {
+          error: toLogContextPart(err),
+        })
+      )
       .finally(() => this.setState({ isAppending: false }));
   };
 

--- a/public/app/features/dashboard/components/GenAI/hooks.ts
+++ b/public/app/features/dashboard/components/GenAI/hooks.ts
@@ -1,3 +1,4 @@
+import { structuredLog, toLogContextPart } from '@grafana/data';
 import { type Dispatch, type SetStateAction, useCallback, useEffect, useState } from 'react';
 import { useAsync } from 'react-use';
 import { type Subscription } from 'rxjs';
@@ -71,7 +72,7 @@ export function useLLMStream(options: Options = defaultOptions): UseLLMStreamRes
         'Failed to generate content using LLM',
         'Please try again or if the problem persists, contact your organization admin.'
       );
-      console.error(e);
+      structuredLog('error', 'Error', { error: toLogContextPart(e) });
       genAILogger.logError(e, { messages: JSON.stringify(messages), model, temperature: String(temperature) });
     },
     [messages, model, temperature, notifyError]

--- a/public/app/features/dashboard/components/HelpWizard/SupportSnapshotService.ts
+++ b/public/app/features/dashboard/components/HelpWizard/SupportSnapshotService.ts
@@ -1,6 +1,9 @@
 import saveAs from 'file-saver';
 
-import { dateTimeFormat, formattedValueToString, getValueFormat, type SelectableValue } from '@grafana/data';
+import {
+  dateTimeFormat, formattedValueToString, getValueFormat, type SelectableValue,
+  structuredLog
+} from '@grafana/data';
 import { t } from '@grafana/i18n';
 import { type SceneObject } from '@grafana/scenes';
 import { StateManagerBase } from 'app/core/services/StateManagerBase';
@@ -88,7 +91,7 @@ export class SupportSnapshotService extends StateManagerBase<SupportSnapshotStat
       const dash = createDashboardSceneFromDashboardModel(oldModel, snapshot);
       scene = dash.state.body; // skip the wrappers
     } catch (ex) {
-      console.log('Error creating scene:', ex);
+      structuredLog('info', 'Error creating scene:', { details: ex });
     }
 
     this.setState({ snapshot, snapshotText, markdownText, snapshotSize, snapshotUpdate: snapshotUpdate + 1, scene });

--- a/public/app/features/dashboard/components/PanelEditor/state/actions.ts
+++ b/public/app/features/dashboard/components/PanelEditor/state/actions.ts
@@ -1,6 +1,10 @@
-import { pick } from 'lodash';
+import {
+  pick } from 'lodash';
 
-import { store } from '@grafana/data';
+import { store,
+  structuredLog,
+  toLogContextPart
+} from '@grafana/data';
 import { removePanel } from 'app/features/dashboard/utils/panel';
 import { cleanUpPanelState } from 'app/features/panel/state/actions';
 import { panelModelAndPluginReady } from 'app/features/panel/state/reducers';
@@ -171,7 +175,7 @@ export function updatePanelEditorUIState(uiState: Partial<PanelEditorUIState>): 
     try {
       store.setObject(PANEL_EDITOR_UI_STATE_STORAGE_KEY, nextState);
     } catch (error) {
-      console.error(error);
+      structuredLog('error', 'Error', { error: toLogContextPart(error) });
     }
   };
 }

--- a/public/app/features/dashboard/dashgrid/DashboardGrid.tsx
+++ b/public/app/features/dashboard/dashgrid/DashboardGrid.tsx
@@ -1,3 +1,4 @@
+import { structuredLog, toLogContextPart } from '@grafana/data';
 import classNames from 'classnames';
 import { PureComponent, type CSSProperties } from 'react';
 import * as React from 'react';
@@ -115,7 +116,7 @@ export class DashboardGrid extends PureComponent<Props, State> {
       this.panelMap[panel.key] = panel;
 
       if (!panel.gridPos) {
-        console.log('panel without gridpos');
+        structuredLog('info', 'panel without gridpos');
         continue;
       }
 

--- a/public/app/features/dashboard/dashgrid/DashboardLibrary/DashboardCard.tsx
+++ b/public/app/features/dashboard/dashgrid/DashboardLibrary/DashboardCard.tsx
@@ -1,9 +1,12 @@
-import { css, cx } from '@emotion/css';
+import {
+  css, cx } from '@emotion/css';
 import { useMemo } from 'react';
 import Skeleton from 'react-loading-skeleton';
 
 import { createAssistantContextItem, useAssistant } from '@grafana/assistant';
-import { type GrafanaTheme2 } from '@grafana/data';
+import { type GrafanaTheme2,
+  structuredLog
+} from '@grafana/data';
 import { t, Trans } from '@grafana/i18n';
 import { config } from '@grafana/runtime';
 import { Badge, Box, Button, Card, IconButton, Text, TextLink, Tooltip, useStyles2 } from '@grafana/ui';
@@ -120,7 +123,7 @@ function DashboardCardComponent({
               kind === 'suggested_dashboard' ? styles.thumbnailCoverImage : styles.thumbnailContainImage
             )}
             onError={(e) => {
-              console.error('Failed to load image for:', title, 'URL:', imageUrl);
+              structuredLog('error', 'Failed to load image for:', { details: title, 'URL:', imageUrl });
               e.currentTarget.style.display = 'none';
             }}
           />

--- a/public/app/features/dashboard/dashgrid/DashboardLibrary/SuggestedDashboardsList/SuggestedDashboardsList.tsx
+++ b/public/app/features/dashboard/dashgrid/DashboardLibrary/SuggestedDashboardsList/SuggestedDashboardsList.tsx
@@ -1,9 +1,13 @@
-import { css } from '@emotion/css';
+import {
+  css } from '@emotion/css';
 import { useBooleanFlagValue } from '@openfeature/react-sdk';
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { useAsyncFn, useDebounce } from 'react-use';
 
-import { type GrafanaTheme2 } from '@grafana/data';
+import { type GrafanaTheme2,
+  structuredLog,
+  toLogContextPart
+} from '@grafana/data';
 import { t } from '@grafana/i18n';
 import { config, getDataSourceSrv, isFetchError, locationService } from '@grafana/runtime';
 import { FilterInput, Grid, Pagination, Stack, useStyles2 } from '@grafana/ui';
@@ -252,7 +256,7 @@ export const SuggestedDashboardsList = ({
           });
         }
       } catch (err) {
-        console.error('Error loading community dashboards', err);
+        structuredLog('error', 'Error loading community dashboards', { error: toLogContextPart(err) });
       } finally {
         setIsCommunityLoading(false);
       }
@@ -422,7 +426,7 @@ export const SuggestedDashboardsList = ({
         sourceEntryPoint,
       });
     } catch (err) {
-      console.error('Error checking dashboard compatibility:', err);
+      structuredLog('error', 'Error checking dashboard compatibility:', { error: toLogContextPart(err) });
 
       const errorMessage = isFetchError(err) ? err.data?.message : 'Failed to check compatibility';
       const errorCode = isFetchError(err) ? err.data?.code : undefined;

--- a/public/app/features/dashboard/dashgrid/DashboardLibrary/TemplateDashboardModal.tsx
+++ b/public/app/features/dashboard/dashgrid/DashboardLibrary/TemplateDashboardModal.tsx
@@ -1,10 +1,14 @@
-import { css } from '@emotion/css';
+import {
+  css } from '@emotion/css';
 import { useBooleanFlagValue } from '@openfeature/react-sdk';
 import { useEffect } from 'react';
 import { useSearchParams } from 'react-router-dom-v5-compat';
 import { useAsync } from 'react-use';
 
-import { type GrafanaTheme2 } from '@grafana/data';
+import { type GrafanaTheme2,
+  structuredLog,
+  toLogContextPart
+} from '@grafana/data';
 import { t, Trans } from '@grafana/i18n';
 import { getBackendSrv, getDataSourceSrv, locationService } from '@grafana/runtime';
 import { Box, Grid, Modal, Text, useStyles2 } from '@grafana/ui';
@@ -97,7 +101,7 @@ export const TemplateDashboardModal = () => {
 
       return response.items;
     } catch (error) {
-      console.error('Error loading template dashboards ', error);
+      structuredLog('error', 'Error loading template dashboards ', { error: toLogContextPart(error) });
       return [];
     }
   }, [isOpen]);

--- a/public/app/features/dashboard/dashgrid/DashboardLibrary/api/compatibilityApi.ts
+++ b/public/app/features/dashboard/dashgrid/DashboardLibrary/api/compatibilityApi.ts
@@ -1,3 +1,4 @@
+import { structuredLog, toLogContextPart } from '@grafana/data';
 import { getAPINamespace } from '@grafana/api-clients';
 import { getBackendSrv } from '@grafana/runtime';
 import { type DashboardJson } from 'app/features/manage-dashboards/types';
@@ -105,8 +106,8 @@ export interface CompatibilityCheckResult {
  *   [{ uid: "prometheus-uid", type: "prometheus" }]
  * );
  *
- * console.log(`Compatibility: ${result.compatibilityScore}%`);
- * console.log(`Missing metrics: ${result.datasourceResults[0].missingMetrics}`);
+ * structuredLog('info', `Compatibility: ${result.compatibilityScore}%`);
+ * structuredLog('info', `Missing metrics: ${result.datasourceResults[0].missingMetrics}`);
  * ```
  */
 export async function checkDashboardCompatibility(
@@ -138,7 +139,7 @@ export async function checkDashboardCompatibility(
     return response;
   } catch (error) {
     // Log error for debugging
-    console.error('Dashboard compatibility check failed:', error);
+    structuredLog('error', 'Dashboard compatibility check failed:', { error: toLogContextPart(error) });
 
     // Re-throw original error for caller to handle
     throw error;

--- a/public/app/features/dashboard/dashgrid/DashboardLibrary/api/dashboardLibraryApi.ts
+++ b/public/app/features/dashboard/dashgrid/DashboardLibrary/api/dashboardLibraryApi.ts
@@ -1,3 +1,4 @@
+import { structuredLog, toLogContextPart } from '@grafana/data';
 import { getBackendSrv, logInfo, logWarning } from '@grafana/runtime';
 import { type DashboardJson } from 'app/features/manage-dashboards/types';
 import { type PluginDashboard } from 'app/types/plugins';
@@ -102,7 +103,7 @@ export async function fetchCommunityDashboards(
   }
 
   // Fallback for unexpected response format
-  console.warn('Unexpected API response format from Grafana.com:', result);
+  structuredLog('warn', 'Unexpected API response format from Grafana.com:', { details: result });
   return {
     page: params.page,
     pages: 1,
@@ -127,7 +128,7 @@ export async function fetchProvisionedDashboards(datasourceType: string): Promis
     });
     return Array.isArray(dashboards) ? dashboards.filter((dashboard) => !dashboard.removed) : [];
   } catch (error) {
-    console.error('Error loading provisioned dashboards', error);
+    structuredLog('error', 'Error loading provisioned dashboards', { error: toLogContextPart(error) });
     return [];
   }
 }
@@ -144,9 +145,7 @@ const filterNonSafeDashboards = (dashboards: GnetDashboard[], dataSourceType?: s
     if (unsafePanelTypes.length > 0) {
       unsafeDashboardsCount++;
 
-      console.warn(
-        `Community dashboard ${item.id} ${item.name} filtered out due to panel types ${item.panelTypeSlugs?.join(', ')} that can embed JavaScript`
-      );
+      structuredLog('warn', `Community dashboard ${item.id} ${item.name} filtered out due to panel types ${item.panelTypeSlugs?.join(', ')} that can embed JavaScript`);
 
       logWarning('Community dashboard filtered out due to unsafe panel types', {
         dashboardId: item.id.toString(),

--- a/public/app/features/dashboard/dashgrid/DashboardLibrary/utils/communityDashboardHelpers.ts
+++ b/public/app/features/dashboard/dashgrid/DashboardLibrary/utils/communityDashboardHelpers.ts
@@ -1,4 +1,8 @@
-import { type PanelModel } from '@grafana/data';
+import {
+  type PanelModel,
+  structuredLog,
+  toLogContextPart
+} from '@grafana/data';
 import { t } from '@grafana/i18n';
 import { getBackendSrv, locationService } from '@grafana/runtime';
 import { createErrorNotification } from 'app/core/copy/appNotification';
@@ -165,7 +169,7 @@ function canPanelContainJS(panel: PanelModel): boolean {
   try {
     panelJson = JSON.stringify(panelWithoutSanitizedFields);
   } catch (e) {
-    console.warn('Failed to stringify panel', e);
+    structuredLog('warn', 'Failed to stringify panel', { details: e });
     return true;
   }
 
@@ -196,7 +200,7 @@ function canPanelContainJS(panel: PanelModel): boolean {
 
   const hasSuspiciousValue = valuePatterns.some((pattern) => {
     if (pattern.test(panelJson)) {
-      console.warn('Panel contains JavaScript code in value');
+      structuredLog('warn', 'Panel contains JavaScript code in value');
       return true;
     }
     return false;
@@ -204,7 +208,7 @@ function canPanelContainJS(panel: PanelModel): boolean {
 
   const hasSuspiciousKey = keyPatterns.some((pattern) => {
     if (pattern.test(panelJson)) {
-      console.warn('Panel contains JavaScript code in key');
+      structuredLog('warn', 'Panel contains JavaScript code in key');
       return true;
     }
     return false;
@@ -320,7 +324,7 @@ export async function onUseCommunityDashboard({
       }
     }
   } catch (err) {
-    console.error('Error loading community dashboard:', err);
+    structuredLog('error', 'Error loading community dashboard:', { error: toLogContextPart(err) });
     dispatch(
       notifyApp(
         createErrorNotification(t('dashboard-library.community-error-title', 'Error loading community dashboard'))

--- a/public/app/features/dashboard/dashgrid/PanelStateWrapper.tsx
+++ b/public/app/features/dashboard/dashgrid/PanelStateWrapper.tsx
@@ -1,4 +1,5 @@
-import { debounce } from 'lodash';
+import {
+  debounce } from 'lodash';
 import { PureComponent } from 'react';
 import { Subscription } from 'rxjs';
 
@@ -22,6 +23,7 @@ import {
   type TimeRange,
   toDataFrameDTO,
   toUtc,
+  structuredLog
 } from '@grafana/data';
 import { RefreshEvent } from '@grafana/runtime';
 import { type VizLegendOptions } from '@grafana/schema';
@@ -257,7 +259,7 @@ export class PanelStateWrapper extends PureComponent<Props, State> {
       const delta = liveTime.to.valueOf() - data.timeRange.to.valueOf();
       if (delta < 100) {
         // 10hz
-        console.log('Skip tick render', this.props.panel.title, delta);
+        structuredLog('info', 'Skip tick render', { details: this.props.panel.title, delta });
         return;
       }
     }

--- a/public/app/features/dashboard/services/DashboardAnalyticsAggregator.ts
+++ b/public/app/features/dashboard/services/DashboardAnalyticsAggregator.ts
@@ -1,3 +1,4 @@
+import { structuredLog, toLogContextPart } from '@grafana/data';
 import { logMeasurement, reportInteraction } from '@grafana/runtime';
 import { type performanceUtils } from '@grafana/scenes';
 
@@ -108,7 +109,7 @@ export class DashboardAnalyticsAggregator implements performanceUtils.ScenePerfo
     // Aggregate panel metrics without verbose logging (handled by ScenePerformanceLogger)
     const panel = this.panelMetrics.get(data.panelKey);
     if (!panel) {
-      console.warn('Panel not found for operation completion:', data.panelKey);
+      structuredLog('warn', 'Panel not found for operation completion:', { details: data.panelKey });
       return;
     }
 

--- a/public/app/features/dashboard/services/DashboardLoaderSrv.ts
+++ b/public/app/features/dashboard/services/DashboardLoaderSrv.ts
@@ -2,7 +2,11 @@ import $ from 'jquery';
 import _, { isFunction } from 'lodash'; // eslint-disable-line lodash/import-scope
 import moment from 'moment'; // eslint-disable-line no-restricted-imports
 
-import { AppEvents, dateMath, type UrlQueryMap, type UrlQueryValue } from '@grafana/data';
+import {
+  AppEvents, dateMath, type UrlQueryMap, type UrlQueryValue,
+  structuredLog,
+  toLogContextPart
+} from '@grafana/data';
 import { getBackendSrv, isFetchError, locationService } from '@grafana/runtime';
 import { type Spec as DashboardV2Spec } from '@grafana/schema/apis/dashboard.grafana.app/v2';
 import { backendSrv } from 'app/core/services/backend_srv';
@@ -58,7 +62,7 @@ abstract class DashboardLoaderSrvBase<T> implements DashboardLoaderSrvLike<T> {
           };
         },
         (err) => {
-          console.error('Script dashboard error ' + err);
+          structuredLog('error', 'Script dashboard error', { error: toLogContextPart(err) });
           appEvents.emit(AppEvents.alertError, [
             'Script Error',
             'Please make sure it exists and returns a valid dashboard',
@@ -143,7 +147,7 @@ export class DashboardLoaderSrv extends DashboardLoaderSrvBase<DashboardDTO> {
           return await api.getDashboardDTO(uid, params);
         } catch (e) {
           if (isFetchError(e) && !(e instanceof DashboardVersionError)) {
-            console.error('Failed to load dashboard', e);
+            structuredLog('error', 'Failed to load dashboard', { error: toLogContextPart(e) });
             e.isHandled = true;
             if (e.status === 404) {
               appEvents.emit(AppEvents.alertError, ['Dashboard not found']);
@@ -208,7 +212,7 @@ export class DashboardLoaderSrvV2 extends DashboardLoaderSrvBase<DashboardWithAc
           return await api.getDashboardDTO(uid, params);
         } catch (e) {
           if (isFetchError(e) && !(e instanceof DashboardVersionError)) {
-            console.error('Failed to load dashboard', e);
+            structuredLog('error', 'Failed to load dashboard', { error: toLogContextPart(e) });
             e.isHandled = true;
             if (e.status === 404) {
               appEvents.emit(AppEvents.alertError, ['Dashboard not found']);

--- a/public/app/features/dashboard/services/performanceUtils.ts
+++ b/public/app/features/dashboard/services/performanceUtils.ts
@@ -1,4 +1,8 @@
-import { store } from '@grafana/data';
+import {
+  store,
+  structuredLog,
+  toLogContextPart
+} from '@grafana/data';
 import { performanceUtils, writePerformanceLog } from '@grafana/scenes';
 
 /**
@@ -84,12 +88,10 @@ export function writePerformanceGroupStart(logger: string, message: string): voi
  */
 export function writePerformanceGroupLog(logger: string, message: string, data?: unknown): void {
   if (isPerformanceLoggingEnabled()) {
-    if (data) {
-      // eslint-disable-next-line no-console
-      console.log(message, data);
+    if (data !== undefined && data !== null) {
+      structuredLog('info', `${logger}: ${message}`, { payload: toLogContextPart(data) });
     } else {
-      // eslint-disable-next-line no-console
-      console.log(message);
+      structuredLog('info', `${logger}: ${message}`);
     }
   }
 }
@@ -117,7 +119,7 @@ export function createPerformanceMark(name: string, timestamp?: number): void {
       }
     }
   } catch (error) {
-    console.error(`❌ Failed to create performance mark: ${name}`, { timestamp, error });
+    structuredLog('error', `❌ Failed to create performance mark: ${name}`, { details: { timestamp, error } });
   }
 }
 
@@ -134,6 +136,6 @@ export function createPerformanceMeasure(name: string, startMark: string, endMar
       }
     }
   } catch (error) {
-    console.error(`❌ Failed to create performance measure: ${name}`, { startMark, endMark, error });
+    structuredLog('error', `❌ Failed to create performance measure: ${name}`, { details: { startMark, endMark, error } });
   }
 }

--- a/public/app/features/dashboard/state/DashboardModel.ts
+++ b/public/app/features/dashboard/state/DashboardModel.ts
@@ -1,4 +1,5 @@
-import { cloneDeep, defaults as _defaults, filter, indexOf, isEqual, map, maxBy, pull } from 'lodash';
+import {
+  cloneDeep, defaults as _defaults, filter, indexOf, isEqual, map, maxBy, pull } from 'lodash';
 import { Subscription } from 'rxjs';
 
 import {
@@ -16,6 +17,7 @@ import {
   type TimeZone,
   type TypedVariableModel,
   type UrlQueryValue,
+  structuredLog
 } from '@grafana/data';
 import { type PromQuery } from '@grafana/prometheus';
 import { RefreshEvent, TimeRangeUpdatedEvent } from '@grafana/runtime';
@@ -1115,13 +1117,13 @@ export class DashboardModel implements TimeModel {
 
   /** @deprecated */
   on<T>(event: AppEvent<T>, callback: (payload?: T) => void) {
-    console.log('DashboardModel.on is deprecated use events.subscribe');
+    structuredLog('info', 'DashboardModel.on is deprecated use events.subscribe');
     this.events.on(event, callback);
   }
 
   /** @deprecated */
   off<T>(event: AppEvent<T>, callback: (payload?: T) => void) {
-    console.log('DashboardModel.off is deprecated');
+    structuredLog('info', 'DashboardModel.off is deprecated');
     this.events.off(event, callback);
   }
 

--- a/public/app/features/dashboard/state/initDashboard.ts
+++ b/public/app/features/dashboard/state/initDashboard.ts
@@ -1,4 +1,8 @@
-import { type DataQuery, locationUtil, setWeekStart, DashboardLoadedEvent, store } from '@grafana/data';
+import {
+  type DataQuery, locationUtil, setWeekStart, DashboardLoadedEvent, store,
+  structuredLog,
+  toLogContextPart
+} from '@grafana/data';
 import { t } from '@grafana/i18n';
 import { config, isFetchError, locationService } from '@grafana/runtime';
 import { appEvents } from 'app/core/app_events';
@@ -109,7 +113,7 @@ async function fetchDashboard(
               ...locationService.getLocation(),
               pathname: dashboardUrl,
             });
-            console.log('not correct url correcting', dashboardUrl, currentPath);
+            structuredLog('info', 'not correct url correcting', { details: dashboardUrl, currentPath });
           }
         }
         return dashDTO;
@@ -138,7 +142,7 @@ async function fetchDashboard(
         error: err,
       })
     );
-    console.error(err);
+    structuredLog('error', 'Error', { error: toLogContextPart(err) });
     return null;
   }
 }
@@ -206,7 +210,7 @@ export function initDashboard(args: InitDashboardArgs): ThunkResult<void> {
           error: err,
         })
       );
-      console.error(err);
+      structuredLog('error', 'Error', { error: toLogContextPart(err) });
       return;
     }
 
@@ -264,7 +268,7 @@ export function initDashboard(args: InitDashboardArgs): ThunkResult<void> {
       if (err instanceof Error) {
         dispatch(notifyApp(createErrorNotification('Dashboard init failed', err)));
       }
-      console.error(err);
+      structuredLog('error', 'Error', { error: toLogContextPart(err) });
     }
 
     // send open dashboard event

--- a/public/app/features/dimensions/editors/FileUploader.tsx
+++ b/public/app/features/dimensions/editors/FileUploader.tsx
@@ -1,7 +1,11 @@
-import { css } from '@emotion/css';
+import {
+  css } from '@emotion/css';
 import { type Dispatch, type SetStateAction, useState } from 'react';
 
-import { type GrafanaTheme2 } from '@grafana/data';
+import { type GrafanaTheme2,
+  structuredLog,
+  toLogContextPart
+} from '@grafana/data';
 import { Trans, t } from '@grafana/i18n';
 import { FileDropzone, useStyles2, Button, type DropzoneFile, Field } from '@grafana/ui';
 import { SanitizedSVG } from 'app/core/components/SVG/SanitizedSVG';
@@ -47,7 +51,7 @@ export const FileUploader = ({ mediaType, setFormData, setUpload, error }: Props
   const onFileRemove = (file: DropzoneFile) => {
     fetch(`/api/storage/delete/upload/${file.file.name}`, {
       method: 'DELETE',
-    }).catch((error) => console.error('cannot delete file', error));
+    }).catch((error) => structuredLog('error', 'cannot delete file', { error: toLogContextPart(error) }));
   };
 
   const acceptableFiles =

--- a/public/app/features/dimensions/editors/ResourcePickerPopover.tsx
+++ b/public/app/features/dimensions/editors/ResourcePickerPopover.tsx
@@ -1,10 +1,14 @@
-import { css } from '@emotion/css';
+import {
+  css } from '@emotion/css';
 import { useDialog } from '@react-aria/dialog';
 import { FocusScope } from '@react-aria/focus';
 import { useOverlay } from '@react-aria/overlays';
 import { useRef, useState } from 'react';
 
-import { type GrafanaTheme2 } from '@grafana/data';
+import { type GrafanaTheme2,
+  structuredLog,
+  toLogContextPart
+} from '@grafana/data';
 import { Trans } from '@grafana/i18n';
 import { config, getBackendSrv } from '@grafana/runtime';
 import { Button, useStyles2 } from '@grafana/ui';
@@ -129,7 +133,7 @@ export const ResourcePickerPopover = (props: Props) => {
                           .then(() => onChange(`${config.appUrl}api/storage/read/${data.path}`))
                           .then(() => hidePopper?.());
                       })
-                      .catch((err) => console.error(err));
+                      .catch((err) => structuredLog('error', 'Error', { error: toLogContextPart(err) }));
                   } else {
                     onChange(newValue);
                     hidePopper?.();

--- a/public/app/features/explore/Logs/LogsMetaRow.tsx
+++ b/public/app/features/explore/Logs/LogsMetaRow.tsx
@@ -1,4 +1,5 @@
-import { css } from '@emotion/css';
+import {
+  css } from '@emotion/css';
 import { useBooleanFlagValue } from '@openfeature/react-sdk';
 import { memo } from 'react';
 
@@ -11,6 +12,7 @@ import {
   type Labels,
   store,
   shallowCompare,
+  structuredLog
 } from '@grafana/data';
 import { Trans, t } from '@grafana/i18n';
 import { config, reportInteraction } from '@grafana/runtime';
@@ -162,6 +164,6 @@ function renderMetaItem(value: string | number | Labels, kind: LogsMetaKind, log
   if (kind === LogsMetaKind.Error) {
     return <span className="logs-meta-item__error">{value.toString()}</span>;
   }
-  console.error(`Meta type ${typeof value} ${value} not recognized.`);
+  structuredLog('error', `Meta type ${typeof value} ${value} not recognized.`);
   return <></>;
 }

--- a/public/app/features/explore/Logs/LogsTableWrap.tsx
+++ b/public/app/features/explore/Logs/LogsTableWrap.tsx
@@ -1,4 +1,5 @@
-import { css } from '@emotion/css';
+import {
+  css } from '@emotion/css';
 import { Resizable, type ResizeCallback } from 're-resizable';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 
@@ -14,6 +15,7 @@ import {
   type SplitOpen,
   store,
   type TimeRange,
+  structuredLog
 } from '@grafana/data';
 import { t } from '@grafana/i18n';
 import { reportInteraction } from '@grafana/runtime';
@@ -385,7 +387,7 @@ export function LogsTableWrap(props: Props) {
   // Toggle a column on or off when the user interacts with an element in the multi-select sidebar
   const toggleColumn = (columnName: FieldName) => {
     if (!columnsWithMeta || !(columnName in columnsWithMeta)) {
-      console.warn('failed to get column', columnsWithMeta);
+      structuredLog('warn', 'failed to get column', { details: columnsWithMeta });
       return;
     }
 

--- a/public/app/features/explore/Logs/utils/table/logsTable.ts
+++ b/public/app/features/explore/Logs/utils/table/logsTable.ts
@@ -1,4 +1,8 @@
-import { type DataFrame, FieldType, getFieldDisplayName, LogsSortOrder } from '@grafana/data';
+import {
+  type DataFrame, FieldType, getFieldDisplayName, LogsSortOrder,
+  structuredLog,
+  toLogContextPart
+} from '@grafana/data';
 import { type TableSortByFieldState } from '@grafana/schema/dist/esm/common/common.gen';
 import { LOGS_DATAPLANE_TIMESTAMP_NAME } from 'app/features/logs/logsFrame';
 
@@ -34,7 +38,7 @@ export const getDefaultTableSortBy = (
         return parsed;
       }
     } catch (e) {
-      console.error('failed to parse table sort from local storage!', e);
+      structuredLog('error', 'failed to parse table sort from local storage!', { error: toLogContextPart(e) });
     }
   }
 

--- a/public/app/features/explore/PrometheusListView/utils/getRawPrometheusListItemsFromDataFrame.ts
+++ b/public/app/features/explore/PrometheusListView/utils/getRawPrometheusListItemsFromDataFrame.ts
@@ -1,4 +1,7 @@
-import { type DataFrame, formattedValueToString } from '@grafana/data';
+import {
+  type DataFrame, formattedValueToString,
+  structuredLog
+} from '@grafana/data';
 
 import { type instantQueryRawVirtualizedListData } from '../RawListContainer';
 
@@ -51,7 +54,7 @@ export const getRawPrometheusListItemsFromDataFrame = (dataFrame: DataFrame): in
             }
           }
         } else {
-          console.warn('Field display method is missing!');
+          structuredLog('warn', 'Field display method is missing!');
         }
       }
     }

--- a/public/app/features/explore/QueryLibrary/OpenQueryLibraryExposedComponent.tsx
+++ b/public/app/features/explore/QueryLibrary/OpenQueryLibraryExposedComponent.tsx
@@ -1,3 +1,4 @@
+import { structuredLog, toLogContextPart } from '@grafana/data';
 import { useCallback } from 'react';
 
 import { t } from '@grafana/i18n';
@@ -81,9 +82,7 @@ export const OpenQueryLibraryExposedComponent = ({
   }, [context, datasourceFilters, onSelectQuery, openDrawer, query]);
 
   if (!queryLibraryEnabled) {
-    console.warn(
-      '[OpenQueryLibraryExposedComponent]: Attempted to use unsupported exposed component. Query library is not enabled.'
-    );
+    structuredLog('warn', '[OpenQueryLibraryExposedComponent]: Attempted to use unsupported exposed component. Query library is not enabled.');
     return null;
   }
 

--- a/public/app/features/explore/TraceView/components/CriticalPath/index.tsx
+++ b/public/app/features/explore/TraceView/components/CriticalPath/index.tsx
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import { structuredLog, toLogContextPart } from '@grafana/data';
 import memoizeOne from 'memoize-one';
 
 import { type TraceSpan, type CriticalPathSection, type Trace } from '../types/trace';
@@ -104,7 +105,7 @@ function criticalPathForTrace(trace: Trace) {
       criticalPath = computeCriticalPath(sanitizedSpanMap, rootSpanId, criticalPath);
     } catch (error) {
       /* eslint-disable no-console */
-      console.log('error while computing critical path for a trace', error);
+      structuredLog('info', 'error while computing critical path for a trace', { details: error });
     }
   }
   return criticalPath;

--- a/public/app/features/explore/TraceView/components/ScrollManager.tsx
+++ b/public/app/features/explore/TraceView/components/ScrollManager.tsx
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import { structuredLog, toLogContextPart } from '@grafana/data';
 import type TNil from './types/TNil';
 import { type TraceSpan, type TraceSpanReference, type Trace } from './types/trace';
 
@@ -106,7 +107,7 @@ export default class ScrollManager {
     const position = xrs.getRowPosition(rowIndex);
     if (!position) {
       // eslint-disable-next-line no-console
-      console.warn('Invalid row index');
+      structuredLog('warn', 'Invalid row index');
       return;
     }
     let { y } = position;

--- a/public/app/features/explore/TraceView/components/TraceTimelineViewer/ListView/index.tsx
+++ b/public/app/features/explore/TraceView/components/TraceTimelineViewer/ListView/index.tsx
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import { structuredLog, toLogContextPart } from '@grafana/data';
 import * as React from 'react';
 
 import type TNil from '../../types/TNil';
@@ -388,7 +389,7 @@ export default class ListView extends React.Component<TListViewProps> {
         const itemKey = node.getAttribute('data-item-key');
         if (!itemKey) {
           // eslint-disable-next-line no-console
-          console.warn('itemKey not found');
+          structuredLog('warn', 'itemKey not found');
           continue;
         }
         // measure the first child, if it's available, otherwise the node itself

--- a/public/app/features/explore/TraceView/components/model/link-patterns.tsx
+++ b/public/app/features/explore/TraceView/components/model/link-patterns.tsx
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import { structuredLog, toLogContextPart } from '@grafana/data';
 import { uniq as _uniq } from 'lodash';
 import memoize from 'lru-memoize';
 
@@ -112,7 +113,7 @@ export function processLinkPattern(pattern: any): ProcessedLinkPattern | null {
     };
   } catch (error) {
     // eslint-disable-next-line no-console
-    console.error(`Ignoring invalid link pattern: ${error}`, pattern);
+    structuredLog('error', `Ignoring invalid link pattern: ${error}`, { error: toLogContextPart(pattern) });
     return null;
   }
 }

--- a/public/app/features/explore/TraceView/components/model/transform-trace-data.tsx
+++ b/public/app/features/explore/TraceView/components/model/transform-trace-data.tsx
@@ -12,10 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { isEqual as _isEqual } from 'lodash';
+import {
+  isEqual as _isEqual } from 'lodash';
 
 // @ts-ignore
-import { type TraceKeyValuePair } from '@grafana/data';
+import { type TraceKeyValuePair,
+  structuredLog
+} from '@grafana/data';
 
 import { getTraceSpanIdsAsTree } from '../selectors/trace';
 import { type TraceResponse, type Trace, type TraceSpan, type TraceProcess } from '../types/trace';
@@ -121,10 +124,10 @@ export default function transformTraceData(data: TraceResponse | undefined): Tra
     const idCount = spanIdCounts.get(spanID);
     if (idCount != null) {
       // eslint-disable-next-line no-console
-      console.warn(`Dupe spanID, ${idCount + 1} x ${spanID}`, span, spanMap.get(spanID));
+      structuredLog('warn', `Dupe spanID, ${idCount + 1} x ${spanID}`, { details: span, spanMap.get(spanID }));
       if (_isEqual(span, spanMap.get(spanID))) {
         // eslint-disable-next-line no-console
-        console.warn('\t two spans with same ID have `isEqual(...) === true`');
+        structuredLog('warn', '\t two spans with same ID have `isEqual(...) === true`');
       }
       spanIdCounts.set(spanID, idCount + 1);
       spanID = `${spanID}_${idCount}`;

--- a/public/app/features/explore/TraceView/createSpanLink.tsx
+++ b/public/app/features/explore/TraceView/createSpanLink.tsx
@@ -12,6 +12,8 @@ import {
   type ScopedVars,
   type SplitOpen,
   type TimeRange,
+  structuredLog,
+  toLogContextPart
 } from '@grafana/data';
 import { t } from '@grafana/i18n';
 import {
@@ -123,7 +125,7 @@ export function createSpanLinkFactory({
         spanLinks.push.apply(spanLinks, newSpanLinks);
       } catch (error) {
         // It's fairly easy to crash here for example if data source defines wrong interpolation in the data link
-        console.error(error);
+        structuredLog('error', 'Error', { error: toLogContextPart(error) });
         return spanLinks;
       }
     }

--- a/public/app/features/explore/hooks/useExplorePageContext.ts
+++ b/public/app/features/explore/hooks/useExplorePageContext.ts
@@ -1,7 +1,11 @@
-import { useEffect } from 'react';
+import {
+  useEffect } from 'react';
 
 import { createAssistantContextItem, type ChatContextItem, useProvidePageContext } from '@grafana/assistant';
-import { type DataSourceApi } from '@grafana/data';
+import { type DataSourceApi,
+  structuredLog,
+  toLogContextPart
+} from '@grafana/data';
 import { getDataSourceSrv } from '@grafana/runtime';
 import { type DataQuery } from '@grafana/schema';
 import { type ExploreItemState } from 'app/types/explore';
@@ -99,7 +103,7 @@ function getDisplayText(query: DataQuery, ds?: DataSourceApi): string | undefine
   try {
     return ds?.getQueryDisplayText?.(query);
   } catch (error) {
-    console.error(error);
+    structuredLog('error', 'Error', { error: toLogContextPart(error) });
     return undefined;
   }
 }

--- a/public/app/features/explore/state/correlations.ts
+++ b/public/app/features/explore/state/correlations.ts
@@ -1,6 +1,10 @@
-import { Observable } from 'rxjs';
+import {
+  Observable } from 'rxjs';
 
-import { type DataLinkTransformationConfig } from '@grafana/data';
+import { type DataLinkTransformationConfig,
+  structuredLog,
+  toLogContextPart
+} from '@grafana/data';
 import { type CorrelationData, getDataSourceSrv, reportInteraction } from '@grafana/runtime';
 import { createErrorNotification } from 'app/core/copy/appNotification';
 import { notifyApp } from 'app/core/reducers/appNotification';
@@ -95,7 +99,7 @@ export function saveCurrentCorrelation(
         })
         .catch((err) => {
           dispatch(notifyApp(createErrorNotification('Error creating correlation', err)));
-          console.error(err);
+          structuredLog('error', 'Error', { error: toLogContextPart(err) });
         });
     }
   };

--- a/public/app/features/explore/state/query.ts
+++ b/public/app/features/explore/state/query.ts
@@ -1,4 +1,5 @@
-import { type AnyAction, createAction, type PayloadAction } from '@reduxjs/toolkit';
+import {
+  type AnyAction, createAction, type PayloadAction } from '@reduxjs/toolkit';
 import deepEqual from 'fast-deep-equal';
 import { findLast, flatten, groupBy, head, map, mapValues, snakeCase, zipObject } from 'lodash';
 import { combineLatest, identity, type Observable, of, type SubscriptionLike, type Unsubscribable } from 'rxjs';
@@ -18,6 +19,8 @@ import {
   type QueryFixAction,
   type ScopedVars,
   type SupplementaryQueryType,
+  structuredLog,
+  toLogContextPart
 } from '@grafana/data';
 import { combinePanelData } from '@grafana/o11y-ds-frontend';
 import { config, getDataSourceSrv } from '@grafana/runtime';
@@ -657,7 +660,9 @@ export const runQueries = createAsyncThunk<void, RunQueriesOptions>(
 
           // Keep scanning for results if this was the last scanning transaction
           if (exploreState!.scanning) {
-            console.log(data.series);
+            structuredLog('info', 'Explore scanning query response', {
+              series: toLogContextPart(data.series),
+            });
             if (data.state === LoadingState.Done && data.series.length === 0) {
               const range = getShiftedTimeRange(-1, exploreState!.range);
               dispatch(updateTime({ exploreId, absoluteRange: range }));
@@ -671,7 +676,7 @@ export const runQueries = createAsyncThunk<void, RunQueriesOptions>(
         error(error) {
           dispatch(notifyApp(createErrorNotification('Query processing error', error)));
           dispatch(changeLoadingStateAction({ exploreId, loadingState: LoadingState.Error }));
-          console.error(error);
+          structuredLog('error', 'Error', { error: toLogContextPart(error) });
         },
         complete() {
           // In case we don't get any response at all but the observable completed, make sure we stop loading state.
@@ -793,7 +798,7 @@ export const runLoadMoreLogsQueries = createAsyncThunk<void, RunLoadMoreLogsQuer
       error(error) {
         dispatch(notifyApp(createErrorNotification('Query processing error', error)));
         dispatch(changeLoadingStateAction({ exploreId, loadingState: LoadingState.Error }));
-        console.error(error);
+        structuredLog('error', 'Error', { error: toLogContextPart(error) });
       },
       complete() {
         dispatch(changeLoadingStateAction({ exploreId, loadingState: LoadingState.Done }));

--- a/public/app/features/explore/state/utils.ts
+++ b/public/app/features/explore/state/utils.ts
@@ -1,4 +1,5 @@
-import { uniq } from 'lodash';
+import {
+  uniq } from 'lodash';
 
 import {
   type AbsoluteTimeRange,
@@ -20,6 +21,8 @@ import {
   toUtc,
   type URLRange,
   type URLRangeValue,
+  structuredLog,
+  toLogContextPart
 } from '@grafana/data';
 import { getDataSourceSrv } from '@grafana/runtime';
 import { type DataQuery, type DataSourceJsonData, type DataSourceRef, type TimeZone } from '@grafana/schema';
@@ -118,7 +121,7 @@ export async function loadAndInitDatasource(
       instance.init();
     } catch (err) {
       // TODO: should probably be handled better
-      console.error(err);
+      structuredLog('error', 'Error', { error: toLogContextPart(err) });
     }
   }
 

--- a/public/app/features/expressions/components/QueryToolbox.tsx
+++ b/public/app/features/expressions/components/QueryToolbox.tsx
@@ -1,7 +1,11 @@
-import { css } from '@emotion/css';
+import {
+  css } from '@emotion/css';
 import { useCallback, useEffect, useRef, useState, type JSX } from 'react';
 
-import { type GrafanaTheme2 } from '@grafana/data';
+import { type GrafanaTheme2,
+  structuredLog,
+  toLogContextPart
+} from '@grafana/data';
 import { t } from '@grafana/i18n';
 import { IconButton, useStyles2, Stack, InlineToast, Tooltip, Icon } from '@grafana/ui';
 
@@ -39,7 +43,7 @@ export const QueryToolbox = ({ onFormatCode, onExpand, isExpanded, query }: Quer
       await navigator.clipboard.writeText(query.expression ?? '');
       setShowCopySuccess(true);
     } catch (e) {
-      console.error(e);
+      structuredLog('error', 'Error', { error: toLogContextPart(e) });
     }
   }, [query.expression]);
 

--- a/public/app/features/geo/gazetteer/gazetteer.ts
+++ b/public/app/features/geo/gazetteer/gazetteer.ts
@@ -1,7 +1,10 @@
-import { getCenter } from 'ol/extent';
+import {
+  getCenter } from 'ol/extent';
 import { type Geometry, Point } from 'ol/geom';
 
-import { type DataFrame, type Field, FieldType, type KeyValue, toDataFrame } from '@grafana/data';
+import { type DataFrame, type Field, FieldType, type KeyValue, toDataFrame,
+  structuredLog
+} from '@grafana/data';
 
 import { frameFromGeoJSON } from '../format/geojson';
 import { pointFieldFromLonLat, pointFieldFromGeohash } from '../format/utils';
@@ -199,7 +202,7 @@ export async function getGazetteer(path?: string): Promise<Gazetteer> {
       const data = await response.json();
       lookup = loadGazetteer(path, data);
     } catch (err) {
-      console.warn('Error loading placename lookup', path, err);
+      structuredLog('warn', 'Error loading placename lookup', { details: path, err });
       lookup = {
         path,
         error: 'Error loading URL',

--- a/public/app/features/inspector/InspectJSONTab.tsx
+++ b/public/app/features/inspector/InspectJSONTab.tsx
@@ -1,10 +1,14 @@
-import { isEqual } from 'lodash';
+import {
+  isEqual } from 'lodash';
 import { useState, useCallback, useMemo } from 'react';
 import { useAsync } from 'react-use';
 import AutoSizer from 'react-virtualized-auto-sizer';
 import { firstValueFrom } from 'rxjs';
 
-import { AppEvents, type PanelData, type SelectableValue, LoadingState } from '@grafana/data';
+import { AppEvents, type PanelData, type SelectableValue, LoadingState,
+  structuredLog,
+  toLogContextPart
+} from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';
 import { Trans, t } from '@grafana/i18n';
 import { locationService } from '@grafana/runtime';
@@ -104,7 +108,7 @@ export function InspectJSONTab({ panel, dashboard, data, onClose }: Props) {
           appEvents.emit(AppEvents.alertSuccess, ['Panel model updated']);
         }
       } catch (err) {
-        console.error('Error applying updates', err);
+        structuredLog('error', 'Error applying updates', { error: toLogContextPart(err) });
         appEvents.emit(AppEvents.alertError, ['Invalid JSON text']);
       }
 

--- a/public/app/features/library-panels/components/LibraryPanelsView/actions.ts
+++ b/public/app/features/library-panels/components/LibraryPanelsView/actions.ts
@@ -1,3 +1,4 @@
+import { structuredLog, toLogContextPart } from '@grafana/data';
 import { type Action } from '@reduxjs/toolkit';
 import { type Dispatch } from 'react';
 import { from, merge, of, Subscription, timer } from 'rxjs';
@@ -54,7 +55,7 @@ export function searchForLibraryPanels(args: SearchArgs): SearchDispatchResult {
         }
 
         // For real errors, log and show error to user
-        console.error('Error fetching library panels:', err);
+        structuredLog('error', 'Error fetching library panels:', { error: toLogContextPart(err) });
 
         // Update state to show empty results
         return of(searchCompleted({ ...initialLibraryPanelsViewState, page: args.page, perPage: args.perPage }));
@@ -78,7 +79,7 @@ export function deleteLibraryPanel(uid: string, args: SearchArgs) {
       await apiDeleteLibraryPanel(uid);
       searchForLibraryPanels(args)(dispatch);
     } catch (e) {
-      console.error(e);
+      structuredLog('error', 'Error', { error: toLogContextPart(e) });
     }
   };
 }

--- a/public/app/features/live/centrifuge/LiveDataStream.ts
+++ b/public/app/features/live/centrifuge/LiveDataStream.ts
@@ -1,4 +1,5 @@
-import { map, Observable, ReplaySubject, type Subject, type Subscriber, type Subscription } from 'rxjs';
+import {
+  map, Observable, ReplaySubject, type Subject, type Subscriber, type Subscription } from 'rxjs';
 
 import {
   type DataFrameJSON,
@@ -11,6 +12,7 @@ import {
   type LiveChannelId,
   LoadingState,
   StreamingDataFrame,
+  structuredLog
 } from '@grafana/data';
 import { getStreamingFrameOptions } from '@grafana/data/internal';
 import {
@@ -154,7 +156,7 @@ export class LiveDataStream<T = unknown> {
   };
 
   private onError = (err: unknown) => {
-    console.log('LiveQuery [error]', { err }, this.deps.channelId);
+    structuredLog('info', 'LiveQuery [error]', { details: { err }, this.deps.channelId });
     this.stream.next({
       type: InternalStreamMessageType.Error,
       error: toDataQueryError(err),
@@ -163,7 +165,7 @@ export class LiveDataStream<T = unknown> {
   };
 
   private onComplete = () => {
-    console.log('LiveQuery [complete]', this.deps.channelId);
+    structuredLog('info', 'LiveQuery [complete]', { details: this.deps.channelId });
     this.shutdown();
   };
 
@@ -280,7 +282,7 @@ export class LiveDataStream<T = unknown> {
       }
 
       if (!messages.length) {
-        console.warn(`expected to find at least one non error message ${messages.map(({ type }) => type)}`);
+        structuredLog('warn', `expected to find at least one non error message ${messages.map(({ type }) => type)}`);
         // send empty frame
         return {
           key: subKey,
@@ -358,7 +360,7 @@ export class LiveDataStream<T = unknown> {
 
         const newValueSameSchemaMessages = filterMessages(messages, InternalStreamMessageType.NewValuesSameSchema);
         if (newValueSameSchemaMessages.length !== messages.length) {
-          console.warn(`unsupported message type ${messages.map(({ type }) => type)}`);
+          structuredLog('warn', `unsupported message type ${messages.map(({ type }) => type)}`);
         }
 
         return getNewValuesSameSchemaResponseData(newValueSameSchemaMessages);

--- a/public/app/features/live/centrifuge/channel.ts
+++ b/public/app/features/live/centrifuge/channel.ts
@@ -18,6 +18,7 @@ import {
   type LiveChannelAddress,
   type DataFrameJSON,
   isValidLiveChannelAddress,
+  structuredLog
 } from '@grafana/data';
 
 /**
@@ -81,7 +82,7 @@ export class CentrifugeLiveChannel<T = any> {
           this.sendStatus();
         }
       } catch (err) {
-        console.log('publish error', this.addr, err);
+        structuredLog('info', 'publish error', { details: this.addr, err });
         this.currentStatus.error = err;
         this.currentStatus.timestamp = Date.now();
         this.sendStatus();

--- a/public/app/features/live/centrifuge/service.ts
+++ b/public/app/features/live/centrifuge/service.ts
@@ -16,6 +16,7 @@ import {
   LiveChannelConnectionState,
   type LiveChannelId,
   toLiveChannelId,
+  structuredLog
 } from '@grafana/data';
 import {
   type FetchResponse,
@@ -126,7 +127,7 @@ export class CentrifugeService implements CentrifugeSrv {
   };
 
   private onServerSideMessage = (context: ServerPublicationContext) => {
-    console.log('Publication from server-side channel', context);
+    structuredLog('info', 'Publication from server-side channel', { details: context });
   };
 
   private onError = (context: ErrorContext) => {

--- a/public/app/features/live/dashboard/dashboardWatcher.ts
+++ b/public/app/features/live/dashboard/dashboardWatcher.ts
@@ -1,4 +1,5 @@
-import { type Unsubscribable } from 'rxjs';
+import {
+  type Unsubscribable } from 'rxjs';
 import { v4 as uuidv4 } from 'uuid';
 
 import {
@@ -9,6 +10,7 @@ import {
   LiveChannelConnectionState,
   type LiveChannelEvent,
   LiveChannelScope,
+  structuredLog
 } from '@grafana/data';
 import { getGrafanaLiveSrv, locationService } from '@grafana/runtime';
 import { appEvents } from 'app/core/app_events';
@@ -127,7 +129,7 @@ class DashboardWatcher {
 
             const dash = getDashboardSrv().getCurrent();
             if (dash?.uid !== event.message.uid) {
-              console.log('dashboard event for different dashboard?', event, dash);
+              structuredLog('info', 'dashboard event for different dashboard?', { details: event, dash });
               return;
             }
 

--- a/public/app/features/live/live.ts
+++ b/public/app/features/live/live.ts
@@ -1,6 +1,9 @@
-import { map } from 'rxjs';
+import {
+  map } from 'rxjs';
 
-import { toLiveChannelId, StreamingDataFrame } from '@grafana/data';
+import { toLiveChannelId, StreamingDataFrame,
+  structuredLog
+} from '@grafana/data';
 import { type BackendSrv, type GrafanaLiveSrv } from '@grafana/runtime';
 
 import { type CentrifugeSrv, type StreamingDataQueryResponse } from './centrifuge/service';
@@ -30,7 +33,7 @@ export class GrafanaLiveService implements GrafanaLiveSrv {
     const updateBuffer = (next: StreamingDataQueryResponse): void => {
       const data = next.data[0];
       if (!buffer && !isStreamingResponseData(data, StreamingResponseDataType.FullFrame)) {
-        console.warn(`expected first packet to contain a full frame, received ${data?.type}`);
+        structuredLog('warn', `expected first packet to contain a full frame, received ${data?.type}`);
         return;
       }
 

--- a/public/app/features/logs/components/ControlledLogsTable.tsx
+++ b/public/app/features/logs/components/ControlledLogsTable.tsx
@@ -1,7 +1,10 @@
-import { css } from '@emotion/css';
+import {
+  css } from '@emotion/css';
 import { useMemo, useRef } from 'react';
 
-import { EventBusSrv, type GrafanaTheme2 } from '@grafana/data';
+import { EventBusSrv, type GrafanaTheme2,
+  structuredLog
+} from '@grafana/data';
 import { useStyles2 } from '@grafana/ui';
 
 import { LogsTableWrap } from '../../explore/Logs/LogsTableWrap';
@@ -38,7 +41,7 @@ export const ControlledLogsTable = ({
   const styles = useStyles2(getStyles);
 
   if (!splitOpen || !width || !updatePanelState) {
-    console.error('<ControlledLogsTable>: Missing required props.');
+    structuredLog('error', '<ControlledLogsTable>: Missing required props.');
     return;
   }
 

--- a/public/app/features/logs/components/fieldSelector/LogListFieldSelector.tsx
+++ b/public/app/features/logs/components/fieldSelector/LogListFieldSelector.tsx
@@ -1,8 +1,11 @@
-import { useBooleanFlagValue } from '@openfeature/react-sdk';
+import {
+  useBooleanFlagValue } from '@openfeature/react-sdk';
 import { Resizable, type ResizeCallback } from 're-resizable';
 import { useCallback, useLayoutEffect, useMemo, useState } from 'react';
 
-import { type DataFrame, store } from '@grafana/data';
+import { type DataFrame, store,
+  structuredLog
+} from '@grafana/data';
 import { t } from '@grafana/i18n';
 import { reportInteraction } from '@grafana/runtime';
 import { getDragStyles, IconButton, useStyles2 } from '@grafana/ui';
@@ -116,9 +119,7 @@ export const LogListFieldSelector = ({ containerElement, dataFrames, logs }: Log
   const fields = useMemo(() => getFieldsWithStats(dataFrames), [dataFrames]);
 
   if (!onClickShowField || !onClickHideField || !setDisplayedFields) {
-    console.warn(
-      'LogListFieldSelector: Missing required props: onClickShowField, onClickHideField, setDisplayedFields'
-    );
+    structuredLog('warn', 'LogListFieldSelector: Missing required props: onClickShowField, onClickHideField, setDisplayedFields');
     return null;
   }
   if (sidebarHeight === 0) {

--- a/public/app/features/logs/components/panel/grammar.ts
+++ b/public/app/features/logs/components/panel/grammar.ts
@@ -1,6 +1,10 @@
-import { type Grammar } from 'prismjs';
+import {
+  type Grammar } from 'prismjs';
 
-import { escapeRegex, parseFlags } from '@grafana/data';
+import { escapeRegex, parseFlags,
+  structuredLog,
+  toLogContextPart
+} from '@grafana/data';
 
 import { type LogListModel } from './processing';
 
@@ -64,7 +68,7 @@ export const generateTextMatchGrammar = (highlightWords: string[] | undefined = 
       try {
         return new RegExp(`(?:${cleaned})`, flags);
       } catch (e) {
-        console.error(`generateTextMatchGrammar: cannot generate regular expression from /${cleaned}/${flags}`, e);
+        structuredLog('error', `generateTextMatchGrammar: cannot generate regular expression from /${cleaned}/${flags}`, { error: toLogContextPart(e) });
       }
       return undefined;
     })
@@ -74,7 +78,7 @@ export const generateTextMatchGrammar = (highlightWords: string[] | undefined = 
     try {
       expressions.push(new RegExp(escapeRegex(search), 'gi'));
     } catch (e) {
-      console.error(`generateTextMatchGrammar: cannot generate regular expression from /${search}/gi`, e);
+      structuredLog('error', `generateTextMatchGrammar: cannot generate regular expression from /${search}/gi`, { error: toLogContextPart(e) });
     }
   }
   if (!expressions.length) {

--- a/public/app/features/logs/components/panel/panelState/getLogsPanelState.ts
+++ b/public/app/features/logs/components/panel/panelState/getLogsPanelState.ts
@@ -1,4 +1,8 @@
-import { urlUtil } from '@grafana/data';
+import {
+  urlUtil,
+  structuredLog,
+  toLogContextPart
+} from '@grafana/data';
 
 interface LogsPermalinkUrlState {
   logs?: {
@@ -18,7 +22,7 @@ export function getLogsPanelState(): LogsPermalinkUrlState | undefined {
     try {
       return JSON.parse(panelStateEncoded[0]);
     } catch (e) {
-      console.error('error parsing logsPanelState', e);
+      structuredLog('error', 'error parsing logsPanelState', { error: toLogContextPart(e) });
     }
   }
 

--- a/public/app/features/logs/components/panel/virtualization.ts
+++ b/public/app/features/logs/components/panel/virtualization.ts
@@ -1,6 +1,9 @@
 import ansicolor from 'ansicolor';
 
-import { BusEventWithPayload, type GrafanaTheme2 } from '@grafana/data';
+import {
+  BusEventWithPayload, type GrafanaTheme2,
+  structuredLog
+} from '@grafana/data';
 
 import { type LogLineTimestampResolution } from './LogLine';
 import { type LogListFontSize } from './LogList';
@@ -73,7 +76,7 @@ export class LogLineVirtualization {
     const domCharWidth = this.measureTextWidthWithDOM('e');
     const diff = domCharWidth - canvasCharWidth;
     if (diff >= 0.1) {
-      console.warn('Virtualized log list: falling back to DOM for measurement');
+      structuredLog('warn', 'Virtualized log list: falling back to DOM for measurement');
       this.measurementMode = 'dom';
     }
   };

--- a/public/app/features/logs/utils.ts
+++ b/public/app/features/logs/utils.ts
@@ -1,5 +1,6 @@
 import saveAs from 'file-saver';
-import { countBy, chain } from 'lodash';
+import {
+  countBy, chain } from 'lodash';
 import { type MouseEvent } from 'react';
 import { lastValueFrom, map, type Observable } from 'rxjs';
 
@@ -30,6 +31,7 @@ import {
   type Field,
   type LogsMetaItem,
   store,
+  structuredLog
 } from '@grafana/data';
 import { t } from '@grafana/i18n';
 import { getConfig } from 'app/core/config';
@@ -368,10 +370,10 @@ export function getLogLevelInfo(dataFrame: DataFrame, allDataFrames: DataFrame[]
   const valueField = fieldCache.getFirstFieldOfType(FieldType.number);
 
   if (!timeField) {
-    console.error('Time field missing in data frame');
+    structuredLog('error', 'Time field missing in data frame');
   }
   if (!valueField) {
-    console.error('Value field missing in data frame');
+    structuredLog('error', 'Value field missing in data frame');
   }
 
   const level = valueField ? getFieldDisplayName(valueField, dataFrame, allDataFrames) : 'logs';

--- a/public/app/features/panel/panellinks/linkSuppliers.ts
+++ b/public/app/features/panel/panellinks/linkSuppliers.ts
@@ -10,6 +10,7 @@ import {
   type LinkModelSupplier,
   type ScopedVar,
   type ScopedVars,
+  structuredLog
 } from '@grafana/data';
 import { t } from '@grafana/i18n';
 import { type VizPanel } from '@grafana/scenes';
@@ -124,7 +125,7 @@ export const getFieldLinksSupplier = (value: FieldDisplay): LinkModelSupplier<Fi
           };
         }
       } else {
-        console.log('VALUE', value);
+        structuredLog('info', 'VALUE', { details: value });
       }
 
       const replace: InterpolateFunction = (value: string, vars: ScopedVars | undefined, fmt?: string | Function) => {

--- a/public/app/features/panel/state/actions.ts
+++ b/public/app/features/panel/state/actions.ts
@@ -1,4 +1,7 @@
-import { type DataTransformerConfig, type FieldConfigSource, getPanelOptionsWithDefaults } from '@grafana/data';
+import {
+  type DataTransformerConfig, type FieldConfigSource, getPanelOptionsWithDefaults,
+  structuredLog
+} from '@grafana/data';
 import { type PanelModel } from 'app/features/dashboard/state/PanelModel';
 import { getLibraryPanel } from 'app/features/library-panels/state/api';
 import { type LibraryElementDTO } from 'app/features/library-panels/types';
@@ -165,7 +168,7 @@ export function loadLibraryPanelAndUpdate(panel: PanelModel): ThunkResult<void> 
 
       await dispatch(initPanelState(panel));
     } catch (ex) {
-      console.log('ERROR: ', ex);
+      structuredLog('info', 'ERROR: ', { details: ex });
       dispatch(
         panelModelAndPluginReady({
           key: panel.key,

--- a/public/app/features/panel/suggestions/getAllSuggestions.ts
+++ b/public/app/features/panel/suggestions/getAllSuggestions.ts
@@ -7,6 +7,7 @@ import {
   type PanelPluginVisualizationSuggestion,
   type PreferredVisualisationType,
   VisualizationSuggestionScore,
+  structuredLog
 } from '@grafana/data';
 import { t } from '@grafana/i18n';
 import { config } from '@grafana/runtime';
@@ -58,7 +59,7 @@ export async function loadPlugins(pluginIds: string[]): Promise<PluginLoadResult
       plugins.push(settled.value);
     } else {
       const pluginId = pluginIds[i];
-      console.error(`Failed to load ${pluginId} for visualization suggestions:`, settled.reason);
+      structuredLog('error', `Failed to load ${pluginId} for visualization suggestions:`, { details: settled.reason });
 
       if (await isBuiltInPlugin(pluginId)) {
         hasErrors = true;
@@ -163,7 +164,7 @@ export async function getAllSuggestions(series?: DataFrame[]): Promise<Suggestio
         list.push(...suggestions);
       }
     } catch (e) {
-      console.warn(`error when loading suggestions from plugin "${plugin.meta.id}"`, e);
+      structuredLog('warn', `error when loading suggestions from plugin "${plugin.meta.id}"`, { details: e });
       pluginSuggestionsError = true;
     }
   }

--- a/public/app/features/plugins/admin/api.ts
+++ b/public/app/features/plugins/admin/api.ts
@@ -1,4 +1,7 @@
-import { type PluginError, type PluginMeta, renderMarkdown } from '@grafana/data';
+import {
+  type PluginError, type PluginMeta, renderMarkdown,
+  structuredLog
+} from '@grafana/data';
 import { getBackendSrv, isFetchError } from '@grafana/runtime';
 import { installPluginMeta, logPluginMetaError, uninstallPluginMeta } from '@grafana/runtime/internal';
 import { accessControlQueryParam } from 'app/core/utils/accessControl';
@@ -92,7 +95,7 @@ export async function getRemotePlugins(): Promise<RemotePlugin[]> {
     if (isFetchError(error)) {
       // It can happen that GCOM is not available, in that case we show a limited set of information to the user.
       error.isHandled = true;
-      console.error('Failed to fetch plugins from catalog (default https://grafana.com/api/plugins)');
+      structuredLog('error', 'Failed to fetch plugins from catalog (default https://grafana.com/api/plugins)');
       return [];
     }
 

--- a/public/app/features/plugins/admin/components/GetStartedWithPlugin/GetStartedWithApp.tsx
+++ b/public/app/features/plugins/admin/components/GetStartedWithPlugin/GetStartedWithApp.tsx
@@ -1,6 +1,10 @@
 import * as React from 'react';
 
-import { type PluginMeta } from '@grafana/data';
+import {
+  type PluginMeta,
+  structuredLog,
+  toLogContextPart
+} from '@grafana/data';
 import { Trans } from '@grafana/i18n';
 import { reportInteraction } from '@grafana/runtime';
 import { Button } from '@grafana/ui';
@@ -80,6 +84,6 @@ const updatePluginSettingsAndReload = async (id: string, data: Partial<PluginMet
     // Reloading the page as the plugin meta changes made here wouldn't be propagated throughout the app.
     window.location.reload();
   } catch (e) {
-    console.error('Error while updating the plugin', e);
+    structuredLog('error', 'Error while updating the plugin', { error: toLogContextPart(e) });
   }
 };

--- a/public/app/features/plugins/admin/pages/Browse.tsx
+++ b/public/app/features/plugins/admin/pages/Browse.tsx
@@ -2,7 +2,7 @@ import { css } from '@emotion/css';
 import { useState } from 'react';
 import { useLocation } from 'react-router-dom-v5-compat';
 
-import { type SelectableValue, type GrafanaTheme2, type PluginType } from '@grafana/data';
+import { type SelectableValue, type GrafanaTheme2, type PluginType, structuredLog, toLogContextPart } from '@grafana/data';
 import { Trans, t } from '@grafana/i18n';
 import { locationSearchToObject } from '@grafana/runtime';
 import { Select, RadioButtonGroup, useStyles2, Tooltip, Field, TextLink } from '@grafana/ui';
@@ -72,7 +72,10 @@ export default function Browse() {
 
   // How should we handle errors?
   if (error) {
-    console.error(error.message);
+    structuredLog('error', 'Failed to load plugins list', {
+      message: error instanceof Error ? error.message : String(error),
+      error: toLogContextPart(error),
+    });
     return null;
   }
 

--- a/public/app/features/plugins/admin/state/actions.ts
+++ b/public/app/features/plugins/admin/state/actions.ts
@@ -1,7 +1,11 @@
-import { createAction, createAsyncThunk, type Update } from '@reduxjs/toolkit';
+import {
+  createAction, createAsyncThunk, type Update } from '@reduxjs/toolkit';
 import { from, forkJoin, timeout, lastValueFrom, catchError, of } from 'rxjs';
 
-import { type PanelPlugin, type PluginError } from '@grafana/data';
+import { type PanelPlugin, type PluginError,
+  structuredLog,
+  toLogContextPart
+} from '@grafana/data';
 import { config, getBackendSrv, isFetchError } from '@grafana/runtime';
 import { refetchPanelPluginMetas } from '@grafana/runtime/internal';
 import { importPanelPlugin } from 'app/features/plugins/importPanelPlugin';
@@ -46,7 +50,7 @@ export const fetchAll = createAsyncThunk(`${STATE_PREFIX}/fetchAll`, async (_, t
     const remote$ = from(getRemotePlugins()).pipe(
       catchError((err) => {
         thunkApi.dispatch({ type: `${STATE_PREFIX}/fetchRemote/rejected` });
-        console.error(err);
+        structuredLog('error', 'Error', { error: toLogContextPart(err) });
         return of([]);
       })
     );
@@ -121,7 +125,7 @@ export const fetchAll = createAsyncThunk(`${STATE_PREFIX}/fetchAll`, async (_, t
           }
         },
         (error) => {
-          console.log(error);
+          structuredLog('info', 'console.log', { value: toLogContextPart(error) });
           thunkApi.dispatch({ type: `${STATE_PREFIX}/fetchLocal/rejected` });
           thunkApi.dispatch({ type: `${STATE_PREFIX}/fetchRemote/rejected` });
           return thunkApi.rejectWithValue('Unknown error.');
@@ -235,7 +239,7 @@ export const install = createAsyncThunk<
 
     return { id, changes };
   } catch (e) {
-    console.error(e);
+    structuredLog('error', 'Error', { error: toLogContextPart(e) });
     if (isFetchError(e)) {
       // add id to identify errors in multiple requests
       e.data.id = id;
@@ -262,7 +266,7 @@ export const uninstall = createAsyncThunk<Update<CatalogPlugin, string>, string>
         changes: { isInstalled: false, installedVersion: undefined, isFullyInstalled: false },
       };
     } catch (e) {
-      console.error(e);
+      structuredLog('error', 'Error', { error: toLogContextPart(e) });
 
       return thunkApi.rejectWithValue('Unknown error.');
     }

--- a/public/app/features/plugins/components/AppRootPage.tsx
+++ b/public/app/features/plugins/components/AppRootPage.tsx
@@ -1,5 +1,6 @@
 // Libraries
-import { type AnyAction, createSlice, type PayloadAction } from '@reduxjs/toolkit';
+import {
+  type AnyAction, createSlice, type PayloadAction } from '@reduxjs/toolkit';
 import { useCallback, useEffect, useMemo, useReducer } from 'react';
 import * as React from 'react';
 import { useLocation, useParams } from 'react-router-dom-v5-compat';
@@ -13,6 +14,8 @@ import {
   OrgRole,
   PluginType,
   PluginContextProvider,
+  structuredLog,
+  toLogContextPart
 } from '@grafana/data';
 import { Trans, t } from '@grafana/i18n';
 import { config, locationSearchToObject } from '@grafana/runtime';
@@ -249,7 +252,7 @@ async function loadAppPlugin(pluginId: string, dispatch: React.Dispatch<AnyActio
     );
     const error = err instanceof Error ? err : new Error(getMessageFromError(err));
     pluginsLogger.logError(error);
-    console.error(error);
+    structuredLog('error', 'Error', { error: toLogContextPart(error) });
   }
 }
 

--- a/public/app/features/plugins/components/PluginErrorBoundary.tsx
+++ b/public/app/features/plugins/components/PluginErrorBoundary.tsx
@@ -1,6 +1,9 @@
 import * as React from 'react';
 
-import { PluginContext } from '@grafana/data';
+import {
+  PluginContext,
+  structuredLog
+} from '@grafana/data';
 
 interface PluginErrorBoundaryProps {
   children: React.ReactNode;
@@ -32,7 +35,7 @@ export class PluginErrorBoundary extends React.Component<PluginErrorBoundaryProp
     if (this.props.onError) {
       this.props.onError(error, info);
     } else {
-      console.error(`Plugin "${this.context?.meta.id}" failed to load:`, error, info);
+      structuredLog('error', `Plugin "${this.context?.meta.id}" failed to load:`, { details: error, info });
     }
 
     this.setState({ error, errorInfo: info });

--- a/public/app/features/plugins/components/restrictedGrafanaApis/dashboardMutation/dashboardMutationApi.ts
+++ b/public/app/features/plugins/components/restrictedGrafanaApis/dashboardMutation/dashboardMutationApi.ts
@@ -10,6 +10,7 @@
  * import this module directly because it lives inside the core bundle.
  */
 
+import { structuredLog, toLogContextPart } from '@grafana/data';
 import type { DashboardMutationAPI } from '@grafana/data';
 import { ALL_COMMANDS } from 'app/features/dashboard-scene/mutation-api';
 import { DashboardMutationClient } from 'app/features/dashboard-scene/mutation-api/DashboardMutationClient';
@@ -26,7 +27,7 @@ provideMutationClientFactory((sceneObject) => {
   try {
     _client = new DashboardMutationClient(scene);
   } catch (error) {
-    console.error('Failed to register Dashboard Mutation API:', error);
+    structuredLog('error', 'Failed to register Dashboard Mutation API:', { error: toLogContextPart(error) });
   }
 
   return () => {

--- a/public/app/features/plugins/extensions/logs/LogViewFilters.tsx
+++ b/public/app/features/plugins/extensions/logs/LogViewFilters.tsx
@@ -1,7 +1,10 @@
-import { isEmpty } from 'lodash';
+import {
+  isEmpty } from 'lodash';
 import { type ReactElement, useMemo } from 'react';
 
-import { type DataFrame, type MatcherConfig, type SelectableValue } from '@grafana/data';
+import { type DataFrame, type MatcherConfig, type SelectableValue,
+  structuredLog
+} from '@grafana/data';
 import { t } from '@grafana/i18n';
 import { type SceneDataProvider } from '@grafana/scenes';
 import { InlineField, InlineFieldRow, MultiSelect } from '@grafana/ui';
@@ -98,7 +101,7 @@ function useLogFilters(
 
   return useMemo(() => {
     if (data && data?.series.length > 1) {
-      console.warn('LogViewFilter does not support multiple series in query result.');
+      structuredLog('warn', 'LogViewFilter does not support multiple series in query result.');
     }
 
     const frame = data?.series[0];

--- a/public/app/features/plugins/extensions/logs/log.ts
+++ b/public/app/features/plugins/extensions/logs/log.ts
@@ -1,8 +1,9 @@
-import { isString } from 'lodash';
+import {
+  isString } from 'lodash';
 import { nanoid } from 'nanoid';
 import { type Observable, ReplaySubject } from 'rxjs';
 
-import { type Labels, LogLevel } from '@grafana/data';
+import { type Labels, LogLevel, structuredLog, toLogContextPart } from '@grafana/data';
 import { config, createMonitoringLogger } from '@grafana/runtime';
 
 export type ExtensionsLogItem = {
@@ -41,7 +42,9 @@ export class ExtensionsLog {
 
   warning(message: string, labels?: Labels): void {
     monitoringLogger.logWarning(message, { ...this.baseLabels, ...labels });
-    config.buildInfo.env === 'development' && console.warn(message, { ...this.baseLabels, ...labels });
+    if (config.buildInfo.env === 'development') {
+      structuredLog('warn', message, { labels: { ...this.baseLabels, ...labels } });
+    }
     this.log(LogLevel.warning, message, labels);
   }
 
@@ -49,7 +52,7 @@ export class ExtensionsLog {
     // TODO: If Faro has console instrumentation, then the following will track the same error message twice
     // (first: `monitoringLogger.logError()`, second: `console.error()` which gets picked up by Faro)
     monitoringLogger.logError(new Error(message), { ...this.baseLabels, ...labels });
-    console.error(message, { ...this.baseLabels, ...labels });
+    structuredLog('error', 'Error', { error: toLogContextPart(message), context: { ...this.baseLabels, ...labels } });
     this.log(LogLevel.error, message, labels);
   }
 

--- a/public/app/features/plugins/extensions/utils.tsx
+++ b/public/app/features/plugins/extensions/utils.tsx
@@ -1,4 +1,5 @@
-import { css } from '@emotion/css';
+import {
+  css } from '@emotion/css';
 import { cloneDeep, isArray, isObject, isString } from 'lodash';
 import * as React from 'react';
 import { useAsync } from 'react-use';
@@ -14,6 +15,7 @@ import {
   type PluginExtensionLink,
   PluginExtensionTypes,
   urlUtil,
+  structuredLog
 } from '@grafana/data';
 import { reportInteraction, config } from '@grafana/runtime';
 import { getAppPluginMetas } from '@grafana/runtime/internal';
@@ -49,7 +51,7 @@ export function handleErrorsInFn(fn: Function, errorMessagePrefix = '') {
       return fn(...args);
     } catch (e) {
       if (e instanceof Error) {
-        console.warn(`${errorMessagePrefix}${e.message}`);
+        structuredLog('warn', `${errorMessagePrefix}${e.message}`);
       }
     }
   };

--- a/public/app/features/plugins/importer/addTranslationsToI18n.ts
+++ b/public/app/features/plugins/importer/addTranslationsToI18n.ts
@@ -1,3 +1,4 @@
+import { structuredLog, toLogContextPart } from '@grafana/data';
 import { addResourceBundle } from '@grafana/i18n/internal';
 
 import { SystemJS } from '../loader/systemjs';
@@ -21,29 +22,29 @@ export async function addTranslationsToI18n({
   const path = resolvedPath ?? fallbackPath;
 
   if (!path) {
-    console.warn(`Could not find any translation for plugin ${pluginId}`, { resolvedLanguage, fallbackLanguage });
+    structuredLog('warn', `Could not find any translation for plugin ${pluginId}`, { details: { resolvedLanguage, fallbackLanguage } });
     return;
   }
 
   try {
     const module = await SystemJS.import(resolveModulePath(path));
     if (!module.default) {
-      console.warn(`Could not find default export for plugin ${pluginId}`, {
+      structuredLog('warn', `Could not find default export for plugin ${pluginId}`, { details: {
         resolvedLanguage,
         fallbackLanguage,
         path,
-      });
+      } });
       return;
     }
 
     const language = resolvedPath ? resolvedLanguage : fallbackLanguage;
     addResourceBundle(language, pluginId, module.default);
   } catch (error) {
-    console.warn(`Could not load translation for plugin ${pluginId}`, {
+    structuredLog('warn', `Could not load translation for plugin ${pluginId}`, { details: {
       resolvedLanguage,
       fallbackLanguage,
       error,
       path,
-    });
+    } });
   }
 }

--- a/public/app/features/plugins/importer/importPluginModule.ts
+++ b/public/app/features/plugins/importer/importPluginModule.ts
@@ -1,3 +1,4 @@
+import { structuredLog, toLogContextPart } from '@grafana/data';
 import { DEFAULT_LANGUAGE } from '@grafana/i18n';
 import { getResolvedLanguage } from '@grafana/i18n/internal';
 import { config } from '@grafana/runtime';
@@ -68,7 +69,7 @@ export async function importPluginModule({
 
   return SystemJS.import(modulePath).catch((e) => {
     let error = new Error('Could not load plugin', { cause: e });
-    console.error(error);
+    structuredLog('error', 'Error', { error: toLogContextPart(error) });
     pluginsLogger.logError(error, {
       path,
       pluginId,

--- a/public/app/features/plugins/importer/pluginImporter.ts
+++ b/public/app/features/plugins/importer/pluginImporter.ts
@@ -11,6 +11,8 @@ import {
   PluginLoadingStrategy,
   type PluginMeta,
   throwIfAngular,
+  structuredLog,
+  toLogContextPart,
 } from '@grafana/data';
 import { config } from '@grafana/runtime';
 import { type GenericDataSourcePlugin } from 'app/features/datasources/types';
@@ -54,7 +56,10 @@ const panelPluginPostImport: PostImportStrategy<PanelPlugin, PanelPluginMeta> = 
     throw new Error('missing export: plugin');
   } catch (error) {
     // TODO, maybe a different error plugin
-    console.warn('Error loading panel plugin: ' + meta.id, error);
+    structuredLog('warn', 'Error loading panel plugin: ' + meta.id, {
+      pluginId: meta.id,
+      error: toLogContextPart(error),
+    });
     return getPanelPluginLoadError(meta, error);
   }
 };

--- a/public/app/features/plugins/loader/pluginLoader.mock.ts
+++ b/public/app/features/plugins/loader/pluginLoader.mock.ts
@@ -1,3 +1,4 @@
+import { structuredLog, toLogContextPart } from '@grafana/data';
 import { http, HttpResponse } from 'msw';
 import { setupServer } from 'msw/node';
 
@@ -17,7 +18,7 @@ export const mockSystemModule = `System.register(['./dependencyA'], function (_e
 
 export const mockAmdModule = `define([], function() {
   return function() {
-    console.log('AMD module loaded');
+    structuredLog('info', 'AMD module loaded');
     var pluginPath = "/public/plugins/";
   }
 });`;

--- a/public/app/features/plugins/loader/systemjsHooks.ts
+++ b/public/app/features/plugins/loader/systemjsHooks.ts
@@ -1,4 +1,7 @@
-import { PluginLoadingStrategy } from '@grafana/data';
+import {
+  PluginLoadingStrategy,
+  structuredLog
+} from '@grafana/data';
 import { config } from '@grafana/runtime';
 
 import { transformPluginSourceForCDN } from '../cdn/utils';
@@ -102,7 +105,7 @@ export function decorateSystemJSResolve(
       const url = originalResolve.apply(this, [resolvedUrl, parentUrl]);
       return resolvePluginUrlWithCache(url);
     }
-    console.warn(`SystemJS: failed to resolve '${id}'`);
+    structuredLog('warn', `SystemJS: failed to resolve '${id}'`);
     return id;
   }
 }

--- a/public/app/features/plugins/loader/utils.ts
+++ b/public/app/features/plugins/loader/utils.ts
@@ -1,3 +1,4 @@
+import { structuredLog, toLogContextPart } from '@grafana/data';
 import { config } from '@grafana/runtime';
 
 import { sandboxPluginDependencies } from '../sandbox/pluginDependencies';
@@ -29,7 +30,7 @@ function addPreload(id: string, preload: (() => Promise<System.Module>) | System
   try {
     resolvedId = SystemJS.resolve(id);
   } catch (e) {
-    console.log(e);
+    structuredLog('info', 'console.log', { value: toLogContextPart(e) });
   }
 
   if (resolvedId && SystemJS.has(resolvedId)) {

--- a/public/app/features/plugins/pluginPreloader.ts
+++ b/public/app/features/plugins/pluginPreloader.ts
@@ -1,3 +1,4 @@
+import { structuredLog, toLogContextPart } from '@grafana/data';
 import type {
   AppPluginConfig,
   PluginExtensionAddedLinkConfig,
@@ -46,6 +47,6 @@ async function preload(config: AppPluginConfig): Promise<void> {
       return;
     }
 
-    console.error(`[Plugins] Failed to preload plugin: ${config.path} (version: ${config.version})`, error);
+    structuredLog('error', `[Plugins] Failed to preload plugin: ${config.path} (version: ${config.version})`, { error: toLogContextPart(error) });
   }
 }

--- a/public/app/features/plugins/sandbox/distortions.ts
+++ b/public/app/features/plugins/sandbox/distortions.ts
@@ -1,3 +1,4 @@
+import { structuredLog, toLogContextPart } from '@grafana/data';
 import { type ProxyTarget } from '@locker/near-membrane-shared';
 import DOMPurify from 'dompurify';
 import { cloneDeep, isFunction } from 'lodash';
@@ -140,7 +141,7 @@ function distortConsole(distortions: DistortionMap) {
       const pluginId = meta.id;
 
       function sandboxLog(...args: unknown[]) {
-        console.log(`[plugin ${pluginId}]`, ...args);
+        structuredLog('info', `[plugin ${pluginId}]`, { details: ...args });
       }
       return {
         log: sandboxLog,
@@ -170,7 +171,7 @@ function distortAlert(distortions: DistortionMap) {
     });
 
     return function (...args: unknown[]) {
-      console.log(`[plugin ${pluginId}]`, ...args);
+      structuredLog('info', `[plugin ${pluginId}]`, { details: ...args });
     };
   }
   const descriptor = Object.getOwnPropertyDescriptor(window, 'alert');

--- a/public/app/features/plugins/sandbox/sandboxPluginLoader.ts
+++ b/public/app/features/plugins/sandbox/sandboxPluginLoader.ts
@@ -1,7 +1,10 @@
 import createVirtualEnvironment from '@locker/near-membrane-dom';
-import { type ProxyTarget } from '@locker/near-membrane-shared';
+import {
+  type ProxyTarget } from '@locker/near-membrane-shared';
 
-import { type BootData } from '@grafana/data';
+import { type BootData,
+  structuredLog
+} from '@grafana/data';
 import { config } from '@grafana/runtime';
 import { defaultTrustedTypesPolicy } from 'app/core/trustedTypePolicies';
 
@@ -139,9 +142,7 @@ async function doImportPluginModuleInSandbox(meta: SandboxPluginMeta): Promise<S
               `Error in ${meta.id}: Plugins should not use window.grafanaBootData. Use "config" from "@grafana/runtime" instead.`
             );
           } else {
-            console.error(
-              `${meta.id.toUpperCase()}: Plugins should not use window.grafanaBootData. Use "config" from "@grafana/runtime" instead.`
-            );
+            structuredLog('error', `${meta.id.toUpperCase()}: Plugins should not use window.grafanaBootData. Use "config" from "@grafana/runtime" instead.`);
           }
           return config.bootData;
         },

--- a/public/app/features/profile/api.ts
+++ b/public/app/features/profile/api.ts
@@ -1,3 +1,4 @@
+import { structuredLog, toLogContextPart } from '@grafana/data';
 import { getBackendSrv } from '@grafana/runtime';
 import { type Team } from 'app/types/teams';
 import { type UserDTO, type UserOrg, type UserSession } from 'app/types/user';
@@ -8,7 +9,7 @@ async function changePassword(payload: ChangePasswordFields): Promise<void> {
   try {
     await getBackendSrv().put('/api/user/password', payload);
   } catch (err) {
-    console.error(err);
+    structuredLog('error', 'Error', { error: toLogContextPart(err) });
   }
 }
 
@@ -42,7 +43,7 @@ async function updateUserProfile(payload: ProfileUpdateFields): Promise<void> {
   try {
     await getBackendSrv().put('/api/user', payload);
   } catch (err) {
-    console.error(err);
+    structuredLog('error', 'Error', { error: toLogContextPart(err) });
   }
 }
 

--- a/public/app/features/provisioning/utils/sourceLink.ts
+++ b/public/app/features/provisioning/utils/sourceLink.ts
@@ -1,3 +1,4 @@
+import { structuredLog, toLogContextPart } from '@grafana/data';
 import { t } from '@grafana/i18n';
 import { config } from '@grafana/runtime';
 import { type DashboardLink } from '@grafana/schema';
@@ -83,7 +84,7 @@ export async function buildSourceLink(annotations: ObjectMeta['annotations']): P
       keepTime: false,
     };
   } catch (e) {
-    console.warn('Failed to fetch repository info for source link:', e);
+    structuredLog('warn', 'Failed to fetch repository info for source link:', { details: e });
     return undefined;
   }
 }

--- a/public/app/features/query/components/QueryGroup.tsx
+++ b/public/app/features/query/components/QueryGroup.tsx
@@ -1,4 +1,5 @@
-import { css } from '@emotion/css';
+import {
+  css } from '@emotion/css';
 import { PureComponent, useEffect, useState } from 'react';
 import * as React from 'react';
 import { type Unsubscribable } from 'rxjs';
@@ -12,6 +13,8 @@ import {
   getDefaultTimeRange,
   LoadingState,
   type PanelData,
+  structuredLog,
+  toLogContextPart
 } from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';
 import { Trans, t } from '@grafana/i18n';
@@ -123,7 +126,7 @@ export class QueryGroup extends PureComponent<Props, State> {
         defaultDataSource,
       });
     } catch (error) {
-      console.error('failed to load data source', error);
+      structuredLog('error', 'failed to load data source', { error: toLogContextPart(error) });
     }
   }
 

--- a/public/app/features/query/state/DashboardQueryRunner/DashboardQueryRunner.ts
+++ b/public/app/features/query/state/DashboardQueryRunner/DashboardQueryRunner.ts
@@ -73,7 +73,7 @@ class DashboardQueryRunnerImpl implements DashboardQueryRunner {
       takeUntil(this.runs.asObservable()),
       mergeAll(),
       reduce((acc: DashboardQueryRunnerWorkerResult, value: DashboardQueryRunnerWorkerResult) => {
-        // console.log({ acc: acc.annotations.length, value: value.annotations.length });
+        // Previously: debug annotations merge counts
         // should we use scan or reduce here
         // reduce will only emit when all observables are completed
         // scan will emit when any observable is completed

--- a/public/app/features/query/state/DashboardQueryRunner/LegacyAnnotationQueryRunner.ts
+++ b/public/app/features/query/state/DashboardQueryRunner/LegacyAnnotationQueryRunner.ts
@@ -1,7 +1,10 @@
-import { from, type Observable, of } from 'rxjs';
+import {
+  from, type Observable, of } from 'rxjs';
 import { catchError } from 'rxjs/operators';
 
-import { type AnnotationEvent, type DataSourceApi } from '@grafana/data';
+import { type AnnotationEvent, type DataSourceApi,
+  structuredLog
+} from '@grafana/data';
 import { shouldUseLegacyRunner } from 'app/features/annotations/standardAnnotationSupport';
 
 import { type AnnotationQueryRunner, type AnnotationQueryRunnerOptions } from './types';
@@ -26,13 +29,13 @@ export class LegacyAnnotationQueryRunner implements AnnotationQueryRunner {
     }
 
     if (datasource?.annotationQuery === undefined) {
-      console.warn('datasource does not have an annotation query');
+      structuredLog('warn', 'datasource does not have an annotation query');
       return of([]);
     }
 
     const annotationQuery = datasource.annotationQuery({ range, rangeRaw: range.raw, annotation, dashboard });
     if (annotationQuery === undefined) {
-      console.warn('datasource does not have an annotation query');
+      structuredLog('warn', 'datasource does not have an annotation query');
       return of([]);
     }
 

--- a/public/app/features/query/state/DashboardQueryRunner/utils.ts
+++ b/public/app/features/query/state/DashboardQueryRunner/utils.ts
@@ -1,4 +1,5 @@
-import { cloneDeep } from 'lodash';
+import {
+  cloneDeep } from 'lodash';
 import { type Observable, of } from 'rxjs';
 
 import {
@@ -7,6 +8,8 @@ import {
   type DataFrame,
   DataFrameView,
   type DataSourceApi,
+  structuredLog,
+  toLogContextPart
 } from '@grafana/data';
 import { config, toDataQueryError } from '@grafana/runtime';
 import { dispatch } from 'app/store/store';
@@ -44,7 +47,7 @@ export function handleDashboardQueryRunnerWorkerError(err: any): Observable<Dash
 
 function notifyWithError(title: string, err: any) {
   const error = toDataQueryError(err);
-  console.error('handleAnnotationQueryRunnerError', error);
+  structuredLog('error', 'handleAnnotationQueryRunnerError', { error: toLogContextPart(error) });
   const notification = createErrorNotification(title, error.message);
   dispatch(notifyApp(notification));
 }

--- a/public/app/features/query/state/PanelQueryRunner.ts
+++ b/public/app/features/query/state/PanelQueryRunner.ts
@@ -1,4 +1,5 @@
-import { cloneDeep, isEqual } from 'lodash';
+import {
+  cloneDeep, isEqual } from 'lodash';
 import { forkJoin, type Observable, of, ReplaySubject, type Unsubscribable } from 'rxjs';
 import { map, mergeMap, catchError } from 'rxjs/operators';
 
@@ -29,6 +30,7 @@ import {
   type ApplyFieldOverrideOptions,
   type StreamingDataFrame,
   DataTopic,
+  structuredLog
 } from '@grafana/data';
 import { toDataQueryError } from '@grafana/runtime';
 import { ExpressionDatasourceRef } from '@grafana/runtime/internal';
@@ -257,7 +259,7 @@ export class PanelQueryRunner {
         return { ...data, series, annotations };
       }),
       catchError((err) => {
-        console.warn('Error running transformation:', err);
+        structuredLog('warn', 'Error running transformation:', { details: err });
         return of({
           ...data,
           state: LoadingState.Error,

--- a/public/app/features/query/state/QueryRunner.ts
+++ b/public/app/features/query/state/QueryRunner.ts
@@ -1,4 +1,5 @@
-import { cloneDeep } from 'lodash';
+import {
+  cloneDeep } from 'lodash';
 import { from, type Observable, ReplaySubject, type Unsubscribable } from 'rxjs';
 import { first } from 'rxjs/operators';
 
@@ -14,6 +15,8 @@ import {
   LoadingState,
   type DataSourceRef,
   preProcessPanelData,
+  structuredLog,
+  toLogContextPart
 } from '@grafana/data';
 import { getTemplateSrv } from '@grafana/runtime';
 import { getDatasourceSrv } from 'app/features/plugins/datasource_srv';
@@ -113,7 +116,7 @@ export class QueryRunner implements QueryRunnerSrv {
             },
           });
         },
-        error: (error) => console.error('PanelQueryRunner Error', error),
+        error: (error) => structuredLog('error', 'PanelQueryRunner Error', { error: toLogContextPart(error) }),
       });
   }
 

--- a/public/app/features/query/state/runRequest.ts
+++ b/public/app/features/query/state/runRequest.ts
@@ -1,5 +1,6 @@
 // Libraries
-import { isString, map as isArray } from 'lodash';
+import {
+  isString, map as isArray } from 'lodash';
 import { from, merge, type Observable, of, timer } from 'rxjs';
 import { catchError, map, mapTo, mergeMap, share, takeUntil, tap } from 'rxjs/operators';
 
@@ -17,6 +18,8 @@ import {
   LoadingState,
   type PanelData,
   type TimeRange,
+  structuredLog,
+  toLogContextPart
 } from '@grafana/data';
 import { config, isMigrationHandler, migrateRequest, toDataQueryError, isExpressionReference } from '@grafana/runtime';
 import { backendSrv } from 'app/core/services/backend_srv';
@@ -161,7 +164,7 @@ export function runRequest(
     }),
     // handle errors
     catchError((err) => {
-      console.error('runRequest.catchError', err);
+      structuredLog('error', 'runRequest.catchError', { error: toLogContextPart(err) });
       return of({
         ...state.panelData,
         state: LoadingState.Error,

--- a/public/app/features/scopes/ScopesApiClient.ts
+++ b/public/app/features/scopes/ScopesApiClient.ts
@@ -1,4 +1,7 @@
-import { type Scope, type ScopeDashboardBinding, type ScopeNode } from '@grafana/data';
+import {
+  type Scope, type ScopeDashboardBinding, type ScopeNode,
+  structuredLog
+} from '@grafana/data';
 import { config } from '@grafana/runtime';
 import { scopeAPIv0alpha1 } from 'app/api/clients/scope/v0alpha1';
 import { getMessageFromError } from 'app/core/utils/errors';
@@ -34,7 +37,7 @@ export class ScopesApiClient {
       // Check if the data is actually an error response (Kubernetes Status object)
       if (this.isStatusError(result.data)) {
         const errorMessage = getMessageFromError(result.data);
-        console.error(`Failed to fetch %s:`, context, errorMessage);
+        structuredLog('error', `Failed to fetch %s:`, { details: context, errorMessage });
         return undefined;
       }
       return result.data;
@@ -42,7 +45,7 @@ export class ScopesApiClient {
 
     if ('error' in result) {
       const errorMessage = getMessageFromError(result.error);
-      console.error(`Failed to fetch %s:`, context, errorMessage);
+      structuredLog('error', `Failed to fetch %s:`, { details: context, errorMessage });
     }
 
     return undefined;
@@ -54,7 +57,7 @@ export class ScopesApiClient {
       return this.extractDataOrHandleError(result, `scope: ${name}`);
     } catch (err) {
       const errorMessage = getMessageFromError(err);
-      console.error('Failed to fetch scope:', name, errorMessage);
+      structuredLog('error', 'Failed to fetch scope:', { details: name, errorMessage });
       return undefined;
     } finally {
       // Unsubscribe for extra safety, even though with subscribe: false and awaiting,
@@ -74,12 +77,10 @@ export class ScopesApiClient {
 
       if (successfulScopes.length < scopesIds.length) {
         const failedCount = scopesIds.length - successfulScopes.length;
-        console.warn(
-          'Failed to fetch',
-          failedCount,
+        structuredLog('warn', 'Failed to fetch', { details: failedCount,
           'of',
           scopesIds.length,
-          'scope(s). Requested IDs:',
+          'scope(s }). Requested IDs:',
           scopesIds.join(', ')
         );
       }
@@ -87,7 +88,7 @@ export class ScopesApiClient {
       return successfulScopes;
     } catch (err) {
       const errorMessage = getMessageFromError(err);
-      console.error('Failed to fetch multiple scopes:', scopesIds, errorMessage);
+      structuredLog('error', 'Failed to fetch multiple scopes:', { details: scopesIds, errorMessage });
       return [];
     }
   }
@@ -110,13 +111,13 @@ export class ScopesApiClient {
 
       if ('error' in result) {
         const errorMessage = getMessageFromError(result.error);
-        console.error('Failed to fetch multiple scope nodes:', names, errorMessage);
+        structuredLog('error', 'Failed to fetch multiple scope nodes:', { details: names, errorMessage });
       }
 
       return [];
     } catch (err) {
       const errorMessage = getMessageFromError(err);
-      console.error('Failed to fetch multiple scope nodes:', names, errorMessage);
+      structuredLog('error', 'Failed to fetch multiple scope nodes:', { details: names, errorMessage });
       return [];
     } finally {
       // Unsubscribe for extra safety, even though with subscribe: false and awaiting,
@@ -170,7 +171,7 @@ export class ScopesApiClient {
         }
         contextParts.push('limit=' + limit);
         const context = contextParts.join(', ');
-        console.error('Failed to fetch scope nodes:', context, errorMessage);
+        structuredLog('error', 'Failed to fetch scope nodes:', { details: context, errorMessage });
       }
 
       return [];
@@ -185,7 +186,7 @@ export class ScopesApiClient {
       }
       contextParts.push('limit=' + limit);
       const context = contextParts.join(', ');
-      console.error('Failed to fetch scope nodes:', context, errorMessage);
+      structuredLog('error', 'Failed to fetch scope nodes:', { details: context, errorMessage });
       return [];
     } finally {
       // Unsubscribe for extra safety, even though with subscribe: false and awaiting,
@@ -213,13 +214,13 @@ export class ScopesApiClient {
 
       if ('error' in result) {
         const errorMessage = getMessageFromError(result.error);
-        console.error('Failed to fetch dashboards for scopes:', scopeNames, errorMessage);
+        structuredLog('error', 'Failed to fetch dashboards for scopes:', { details: scopeNames, errorMessage });
       }
 
       return [];
     } catch (err) {
       const errorMessage = getMessageFromError(err);
-      console.error('Failed to fetch dashboards for scopes:', scopeNames, errorMessage);
+      structuredLog('error', 'Failed to fetch dashboards for scopes:', { details: scopeNames, errorMessage });
       return [];
     } finally {
       // Unsubscribe for extra safety, even though with subscribe: false and awaiting,
@@ -252,13 +253,13 @@ export class ScopesApiClient {
 
       if ('error' in result) {
         const errorMessage = getMessageFromError(result.error);
-        console.error('Failed to fetch scope navigations for scopes:', scopeNames, errorMessage);
+        structuredLog('error', 'Failed to fetch scope navigations for scopes:', { details: scopeNames, errorMessage });
       }
 
       return [];
     } catch (err) {
       const errorMessage = getMessageFromError(err);
-      console.error('Failed to fetch scope navigations for scopes:', scopeNames, errorMessage);
+      structuredLog('error', 'Failed to fetch scope navigations for scopes:', { details: scopeNames, errorMessage });
       return [];
     } finally {
       // Unsubscribe for extra safety, even though with subscribe: false and awaiting,
@@ -280,7 +281,7 @@ export class ScopesApiClient {
       return this.extractDataOrHandleError(result, `scope node: ${scopeNodeId}`);
     } catch (err) {
       const errorMessage = getMessageFromError(err);
-      console.error('Failed to fetch scope node:', scopeNodeId, errorMessage);
+      structuredLog('error', 'Failed to fetch scope node:', { details: scopeNodeId, errorMessage });
       return undefined;
     } finally {
       // Unsubscribe for extra safety, even though with subscribe: false and awaiting,

--- a/public/app/features/scopes/ScopesService.ts
+++ b/public/app/features/scopes/ScopesService.ts
@@ -1,3 +1,4 @@
+import { structuredLog, toLogContextPart } from '@grafana/data';
 import { isEqual } from 'lodash';
 import { BehaviorSubject, type Observable, combineLatest, type Subscription } from 'rxjs';
 import { map, distinctUntilChanged } from 'rxjs/operators';
@@ -93,7 +94,7 @@ export class ScopesService implements ScopesContextValue {
     const nodeToPreload = scopeNodeId;
     if (nodeToPreload) {
       this.selectorService.resolvePathToRoot(nodeToPreload, this.selectorService.state.tree!).catch((error) => {
-        console.error('Failed to pre-load node path', error);
+        structuredLog('error', 'Failed to pre-load node path', { error: toLogContextPart(error) });
       });
     }
 

--- a/public/app/features/scopes/selector/ScopesSelectorService.ts
+++ b/public/app/features/scopes/selector/ScopesSelectorService.ts
@@ -1,4 +1,8 @@
-import { type Scope, type ScopeNode, store as storeImpl } from '@grafana/data';
+import {
+  type Scope, type ScopeNode, store as storeImpl,
+  structuredLog,
+  toLogContextPart
+} from '@grafana/data';
 import { config, locationService } from '@grafana/runtime';
 import { type performanceUtils } from '@grafana/scenes';
 import { getDashboardSceneProfiler } from 'app/features/dashboard/services/DashboardProfiler';
@@ -111,7 +115,7 @@ export class ScopesSelectorService extends ScopesServiceBase<ScopesSelectorServi
       }
       return node;
     } catch (error) {
-      console.error('Failed to load node', error);
+      structuredLog('error', 'Failed to load node', { error: toLogContextPart(error) });
       return undefined;
     }
   };
@@ -119,7 +123,7 @@ export class ScopesSelectorService extends ScopesServiceBase<ScopesSelectorServi
   private getNodePath = async (scopeNodeId: string, visited: Set<string> = new Set()): Promise<ScopeNode[]> => {
     // Protect against circular references
     if (visited.has(scopeNodeId)) {
-      console.error('Circular reference detected in node path', scopeNodeId);
+      structuredLog('error', 'Circular reference detected in node path', { error: toLogContextPart(scopeNodeId) });
       return [];
     }
 
@@ -449,7 +453,7 @@ export class ScopesSelectorService extends ScopesServiceBase<ScopesSelectorServi
 
       // Validate API response is an array
       if (!Array.isArray(fetchedScopes)) {
-        console.error('Expected fetchedScopes to be an array, got:', typeof fetchedScopes);
+        structuredLog('error', 'Expected fetchedScopes to be an array, got:', { details: typeof fetchedScopes });
         this.updateState({ scopes: newScopesState, loading: false });
         return;
       }
@@ -664,7 +668,7 @@ export class ScopesSelectorService extends ScopesServiceBase<ScopesSelectorServi
           newTree = expandNodes(newTree, parentPath);
         }
       } catch (error) {
-        console.error('Failed to expand to selected scope', error);
+        structuredLog('error', 'Failed to expand to selected scope', { error: toLogContextPart(error) });
       }
     }
 
@@ -747,7 +751,7 @@ function parseScopesFromLocalStorage(content: string | undefined): RecentScope[]
   try {
     recentScopes = JSON.parse(content || '[]');
   } catch (e) {
-    console.error('Failed to parse recent scopes', e, content);
+    structuredLog('error', 'Failed to parse recent scopes', { details: e, content });
     return [];
   }
   if (!(Array.isArray(recentScopes) && Array.isArray(recentScopes[0]))) {

--- a/public/app/features/scopes/selector/scopesTreeUtils.ts
+++ b/public/app/features/scopes/selector/scopesTreeUtils.ts
@@ -1,4 +1,4 @@
-import { type ScopeNode } from '@grafana/data';
+import { type ScopeNode, structuredLog } from '@grafana/data';
 
 import { type NodesMap, type TreeNode } from './types';
 
@@ -125,7 +125,10 @@ export const insertPathNodesIntoTree = (tree: TreeNode, path: ScopeNode[]) => {
     newTree = modifyTreeNodeAtPath(newTree, pathSlice, (treeNode) => {
       treeNode.children = { ...treeNode.children };
       if (!childNodeName) {
-        console.warn('Failed to insert full path into tree. Did not find child to' + stringPath[index]);
+        structuredLog(
+          'warn',
+          `Failed to insert full path into tree. Did not find child for segment at index ${index}: ${stringPath[index]}`
+        );
         treeNode.childrenLoaded = treeNode.childrenLoaded ?? false;
         return;
       }

--- a/public/app/features/scopes/selector/useScopeNode.ts
+++ b/public/app/features/scopes/selector/useScopeNode.ts
@@ -1,6 +1,10 @@
-import { useEffect, useState } from 'react';
+import {
+  useEffect, useState } from 'react';
 
-import { type ScopeNode } from '@grafana/data';
+import { type ScopeNode,
+  structuredLog,
+  toLogContextPart
+} from '@grafana/data';
 
 import { useScopesServices } from '../ScopesContextProvider';
 
@@ -21,7 +25,7 @@ export function useScopeNode(scopeNodeId?: string) {
         const node = await scopesSelectorService.getScopeNode(scopeNodeId);
         setNode(node);
       } catch (error) {
-        console.error('Failed to load node', error);
+        structuredLog('error', 'Failed to load node', { error: toLogContextPart(error) });
       } finally {
         setIsLoading(false);
       }

--- a/public/app/features/search/service/deletedDashboardsCache.ts
+++ b/public/app/features/search/service/deletedDashboardsCache.ts
@@ -1,3 +1,4 @@
+import { structuredLog, toLogContextPart } from '@grafana/data';
 import { isResourceList } from 'app/features/apiserver/guards';
 import { type ResourceList } from 'app/features/apiserver/types';
 import { getDashboardAPI } from 'app/features/dashboard/api/dashboard_api';
@@ -79,7 +80,7 @@ class DeletedDashboardsCache {
         items: [],
       };
     } catch (error) {
-      console.error('Failed to fetch deleted dashboards:', error);
+      structuredLog('error', 'Failed to fetch deleted dashboards:', { error: toLogContextPart(error) });
       return {
         apiVersion: 'v1',
         kind: 'List',

--- a/public/app/features/search/service/unified.ts
+++ b/public/app/features/search/service/unified.ts
@@ -1,4 +1,5 @@
-import { isEmpty } from 'lodash';
+import {
+  isEmpty } from 'lodash';
 
 import { generatedAPI as legacyUserAPI } from '@grafana/api-clients/internal/rtkq/legacy/user';
 import {
@@ -12,6 +13,7 @@ import {
   DataFrameView,
   getDisplayProcessor,
   type SelectableValue,
+  structuredLog
 } from '@grafana/data';
 import { t } from '@grafana/i18n';
 import { config, getBackendSrv } from '@grafana/runtime';
@@ -209,7 +211,7 @@ export class UnifiedSearcher implements GrafanaSearcher {
         const resp = await this.fetchResponse(nextPageUrl);
         const frame = toDashboardResults(resp, query.sort ?? '');
         if (!frame) {
-          console.log('no results', frame);
+          structuredLog('info', 'no results', { details: frame });
           return;
         }
 

--- a/public/app/features/search/service/utils.ts
+++ b/public/app/features/search/service/utils.ts
@@ -1,5 +1,9 @@
-import { type ManagedBy } from '@grafana/api-clients/rtkq/dashboard/v0alpha1';
-import { type DataFrame, type DataFrameView, type IconName, fuzzySearch } from '@grafana/data';
+import {
+  type ManagedBy } from '@grafana/api-clients/rtkq/dashboard/v0alpha1';
+import { type DataFrame, type DataFrameView, type IconName, fuzzySearch,
+  structuredLog,
+  toLogContextPart
+} from '@grafana/data';
 import { type DashboardViewItemWithUIItems } from 'app/features/browse-dashboards/types';
 import { isSharedWithMe, isVirtualTeamFolder } from 'app/features/browse-dashboards/utils/dashboards';
 import { getDashboardSrv } from 'app/features/dashboard/services/DashboardSrv';
@@ -40,7 +44,7 @@ async function getCurrentFolderUID(): Promise<string | undefined> {
     }
     return Promise.resolve(dash?.meta?.folderUid);
   } catch (e) {
-    console.error(e);
+    structuredLog('error', 'Error', { error: toLogContextPart(e) });
   }
   return undefined;
 }

--- a/public/app/features/serviceaccounts/ServiceAccountCreatePage.tsx
+++ b/public/app/features/serviceaccounts/ServiceAccountCreatePage.tsx
@@ -1,7 +1,11 @@
-import { useCallback, useEffect, useState, type JSX } from 'react';
+import {
+  useCallback, useEffect, useState, type JSX } from 'react';
 import { FormProvider, useForm } from 'react-hook-form';
 
-import { OrgRole } from '@grafana/data';
+import { OrgRole,
+  structuredLog,
+  toLogContextPart
+} from '@grafana/data';
 import { Trans, t } from '@grafana/i18n';
 import { config, getBackendSrv, locationService } from '@grafana/runtime';
 import { Button, Input, Field, FieldSet } from '@grafana/ui';
@@ -68,7 +72,7 @@ export const ServiceAccountCreatePage = ({}: Props): JSX.Element => {
           setRoleOptions(options);
         }
       } catch (e) {
-        console.error('Error loading options', e); // TODO: handle error
+        structuredLog('error', 'Error loading options', { error: toLogContextPart(e) }); // TODO: handle error
       }
     }
     if (contextSrv.licensedAccessControlEnabled()) {
@@ -101,7 +105,7 @@ export const ServiceAccountCreatePage = ({}: Props): JSX.Element => {
           await updateUserRoles(pendingRoles, newAccount.id, newAccount.orgId);
         }
       } catch (e) {
-        console.error(e); // TODO: handle error
+        structuredLog('error', 'Error', { error: toLogContextPart(e) }); // TODO: handle error
       }
       locationService.push(`/org/serviceaccounts/${response.uid}`);
     },

--- a/public/app/features/serviceaccounts/components/ServiceAccountProfile.tsx
+++ b/public/app/features/serviceaccounts/components/ServiceAccountProfile.tsx
@@ -1,7 +1,10 @@
-import { css } from '@emotion/css';
+import {
+  css } from '@emotion/css';
 import { useEffect, useState, type JSX } from 'react';
 
-import { type GrafanaTheme2, type OrgRole, type TimeZone, dateTimeFormat } from '@grafana/data';
+import { type GrafanaTheme2, type OrgRole, type TimeZone, dateTimeFormat,
+  structuredLog
+} from '@grafana/data';
 import { Trans, t } from '@grafana/i18n';
 import { Label, TextLink, useStyles2 } from '@grafana/ui';
 import { fetchRoleOptions } from 'app/core/components/RolePicker/api';
@@ -39,7 +42,7 @@ export function ServiceAccountProfile({ serviceAccount, timeZone, onChange }: Pr
           setRoleOptions(options);
         }
       } catch (e) {
-        console.error('Error loading options for service account');
+        structuredLog('error', 'Error loading options for service account');
       }
     }
     if (contextSrv.licensedAccessControlEnabled()) {

--- a/public/app/features/serviceaccounts/state/actions.ts
+++ b/public/app/features/serviceaccounts/state/actions.ts
@@ -1,3 +1,4 @@
+import { structuredLog, toLogContextPart } from '@grafana/data';
 import { debounce } from 'lodash';
 
 import { getBackendSrv } from '@grafana/runtime';
@@ -31,7 +32,7 @@ export function fetchACOptions(): ThunkResult<void> {
         dispatch(acOptionsLoaded(options));
       }
     } catch (error) {
-      console.error(error);
+      structuredLog('error', 'Error', { error: toLogContextPart(error) });
     }
   };
 }
@@ -76,7 +77,7 @@ export function fetchServiceAccounts(
         dispatch(serviceAccountsFetched(result));
       }
     } catch (error) {
-      console.error(error);
+      structuredLog('error', 'Error', { error: toLogContextPart(error) });
     } finally {
       dispatch(serviceAccountsFetchEnd());
     }

--- a/public/app/features/serviceaccounts/state/actionsServiceAccountPage.ts
+++ b/public/app/features/serviceaccounts/state/actionsServiceAccountPage.ts
@@ -1,3 +1,4 @@
+import { structuredLog, toLogContextPart } from '@grafana/data';
 import { getBackendSrv, locationService } from '@grafana/runtime';
 import { accessControlQueryParam } from 'app/core/utils/accessControl';
 import { type ServiceAccountDTO } from 'app/types/serviceaccount';
@@ -21,7 +22,7 @@ export function loadServiceAccount(saUid: string): ThunkResult<void> {
       const response = await getBackendSrv().get(`${BASE_URL}/${saUid}`, accessControlQueryParam());
       dispatch(serviceAccountLoaded(response));
     } catch (error) {
-      console.error(error);
+      structuredLog('error', 'Error', { error: toLogContextPart(error) });
     } finally {
       dispatch(serviceAccountFetchEnd());
     }
@@ -69,7 +70,7 @@ export function loadServiceAccountTokens(saUid: string): ThunkResult<void> {
       const response = await getBackendSrv().get(`${BASE_URL}/${saUid}/tokens`);
       dispatch(serviceAccountTokensLoaded(response));
     } catch (error) {
-      console.error(error);
+      structuredLog('error', 'Error', { error: toLogContextPart(error) });
     }
   };
 }

--- a/public/app/features/teams/TeamList.tsx
+++ b/public/app/features/teams/TeamList.tsx
@@ -1,3 +1,4 @@
+import { structuredLog, toLogContextPart } from '@grafana/data';
 import { css } from '@emotion/css';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import Skeleton from 'react-loading-skeleton';
@@ -235,7 +236,7 @@ const TeamList = () => {
                     'Failed to check if the team owns folders. Please try again.'
                   )
                 );
-                console.error(error);
+                structuredLog('error', 'Error', { error: toLogContextPart(error) });
                 return;
               }
 

--- a/public/app/features/templating/LegacyVariableWrapper.ts
+++ b/public/app/features/templating/LegacyVariableWrapper.ts
@@ -1,3 +1,4 @@
+import { structuredLog, toLogContextPart } from '@grafana/data';
 import { type VariableValue, type FormatVariable } from '@grafana/scenes';
 import { type VariableModel, type VariableType } from '@grafana/schema';
 
@@ -31,7 +32,7 @@ export class LegacyVariableWrapper implements FormatVariable {
       return text.join(' + ');
     }
 
-    console.log('value', text);
+    structuredLog('info', 'value', { details: text });
     return String(text);
   }
 }

--- a/public/app/features/templating/formatVariableValue.ts
+++ b/public/app/features/templating/formatVariableValue.ts
@@ -1,3 +1,4 @@
+import { structuredLog, toLogContextPart } from '@grafana/data';
 import { formatRegistry } from '@grafana/scenes';
 import { VariableFormatID } from '@grafana/schema';
 
@@ -42,7 +43,7 @@ export function formatVariableValue(value: any, format?: any, variable?: any, te
   let formatItem = formatRegistry.getIfExists(format);
 
   if (!formatItem) {
-    console.error(`Variable format ${format} not found. Using glob format as fallback.`);
+    structuredLog('error', `Variable format ${format} not found. Using glob format as fallback.`);
     formatItem = formatRegistry.get(VariableFormatID.Glob);
   }
 

--- a/public/app/features/theme-playground/ThemePlayground.tsx
+++ b/public/app/features/theme-playground/ThemePlayground.tsx
@@ -1,7 +1,10 @@
-import { css } from '@emotion/css';
+import {
+  css } from '@emotion/css';
 import { useId, useState } from 'react';
 
-import { createTheme, type GrafanaTheme2, type NewThemeOptions } from '@grafana/data';
+import { createTheme, type GrafanaTheme2, type NewThemeOptions,
+  structuredLog
+} from '@grafana/data';
 import { NewThemeOptionsSchema } from '@grafana/data/internal';
 import aubergine from '@grafana/data/themes/definitions/aubergine.json';
 import debug from '@grafana/data/themes/definitions/debug.json';
@@ -73,7 +76,7 @@ const experimentalDefinitions: Record<string, unknown> = {
 for (const [name, json] of Object.entries(experimentalDefinitions)) {
   const result = NewThemeOptionsSchema.safeParse(json);
   if (!result.success) {
-    console.error(`Invalid theme definition for theme ${name}: ${result.error.message}`);
+    structuredLog('error', `Invalid theme definition for theme ${name}: ${result.error.message}`);
   } else {
     themeMap[result.data.id] = result.data;
   }

--- a/public/app/features/transformers/editors/FilterByNameTransformerEditor.tsx
+++ b/public/app/features/transformers/editors/FilterByNameTransformerEditor.tsx
@@ -10,6 +10,8 @@ import {
   stringToJsRegex,
   TransformerCategory,
   type SelectableValue,
+  structuredLog,
+  toLogContextPart
 } from '@grafana/data';
 import { type FilterFieldsByNameTransformerOptions } from '@grafana/data/internal';
 import { t } from '@grafana/i18n';
@@ -101,7 +103,7 @@ export class FilterByNameTransformerEditor extends React.PureComponent<
           }
         }
       } catch (error) {
-        console.error(error);
+        structuredLog('error', 'Error', { error: toLogContextPart(error) });
       }
     }
 

--- a/public/app/features/transformers/extractFields/fieldExtractors.ts
+++ b/public/app/features/transformers/extractFields/fieldExtractors.ts
@@ -1,4 +1,7 @@
-import { escapeStringForRegex, Registry, type RegistryItem, stringStartsAsRegEx, stringToJsRegex } from '@grafana/data';
+import {
+  escapeStringForRegex, Registry, type RegistryItem, stringStartsAsRegEx, stringToJsRegex,
+  structuredLog
+} from '@grafana/data';
 
 import { type ExtractFieldsOptions, FieldExtractorID } from './types';
 
@@ -29,7 +32,7 @@ const extRegExp: FieldExtractor = {
         regex = stringToJsRegex(options.regExp!);
       } catch (error) {
         if (error instanceof Error) {
-          console.warn(error.message);
+          structuredLog('warn', String(error.message));
         }
       }
     }

--- a/public/app/features/transformers/spatial/SpatialTransformerEditor.tsx
+++ b/public/app/features/transformers/spatial/SpatialTransformerEditor.tsx
@@ -1,4 +1,5 @@
-import { css } from '@emotion/css';
+import {
+  css } from '@emotion/css';
 import { useEffect } from 'react';
 
 import {
@@ -10,6 +11,7 @@ import {
   type TransformerRegistryItem,
   type TransformerUIProps,
   TransformerCategory,
+  structuredLog
 } from '@grafana/data';
 import { t } from '@grafana/i18n';
 import { FrameGeometrySourceMode } from '@grafana/schema';
@@ -137,7 +139,7 @@ export const SetGeometryTransformerEditor = (props: Props) => {
     if (!props.options.source?.mode) {
       const opts = getDefaultOptions(supplier);
       props.onChange({ ...opts, ...props.options });
-      console.log('geometry useEffect', opts);
+      structuredLog('info', 'geometry useEffect', { details: opts });
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);

--- a/public/app/features/variables/adhoc/AdHocVariableEditor.tsx
+++ b/public/app/features/variables/adhoc/AdHocVariableEditor.tsx
@@ -1,6 +1,9 @@
-import { memo, useEffect } from 'react';
+import {
+  memo, useEffect } from 'react';
 
-import { type AdHocVariableModel, type DataSourceInstanceSettings, getDataSourceRef } from '@grafana/data';
+import { type AdHocVariableModel, type DataSourceInstanceSettings, getDataSourceRef,
+  structuredLog
+} from '@grafana/data';
 import { AdHocVariableForm } from 'app/features/dashboard-scene/settings/variables/components/AdHocVariableForm';
 import { type StoreState, useDispatch, useSelector } from 'app/types/store';
 
@@ -30,7 +33,7 @@ export const AdHocVariableEditor = memo(function AdHocVariableEditor({ variable 
 
   useEffect(() => {
     if (!variable.rootStateKey) {
-      console.error('AdHocVariableEditor: variable has no rootStateKey');
+      structuredLog('error', 'AdHocVariableEditor: variable has no rootStateKey');
     }
   }, [variable.rootStateKey]);
 

--- a/public/app/features/variables/datasource/DataSourceVariableEditor.tsx
+++ b/public/app/features/variables/datasource/DataSourceVariableEditor.tsx
@@ -1,6 +1,9 @@
-import { type FormEvent, memo, useEffect } from 'react';
+import {
+  type FormEvent, memo, useEffect } from 'react';
 
-import { type DataSourceVariableModel, type SelectableValue, type VariableWithMultiSupport } from '@grafana/data';
+import { type DataSourceVariableModel, type SelectableValue, type VariableWithMultiSupport,
+  structuredLog
+} from '@grafana/data';
 import { DataSourceVariableForm } from 'app/features/dashboard-scene/settings/variables/components/DataSourceVariableForm';
 import { type StoreState, useDispatch, useSelector } from 'app/types/store';
 
@@ -21,7 +24,7 @@ export const DataSourceVariableEditor = memo(function DataSourceVariableEditor({
   const extended = useSelector((state: StoreState) => {
     const { rootStateKey } = variable;
     if (!rootStateKey) {
-      console.error('DataSourceVariableEditor: variable has no rootStateKey');
+      structuredLog('error', 'DataSourceVariableEditor: variable has no rootStateKey');
       return getDatasourceVariableEditorState(initialVariableEditorState);
     }
 
@@ -32,7 +35,7 @@ export const DataSourceVariableEditor = memo(function DataSourceVariableEditor({
   useEffect(() => {
     const { rootStateKey } = variable;
     if (!rootStateKey) {
-      console.error('DataSourceVariableEditor: variable has no rootStateKey');
+      structuredLog('error', 'DataSourceVariableEditor: variable has no rootStateKey');
       return;
     }
 

--- a/public/app/features/variables/pickers/OptionsPicker/OptionsPicker.tsx
+++ b/public/app/features/variables/pickers/OptionsPicker/OptionsPicker.tsx
@@ -1,4 +1,5 @@
-import { css } from '@emotion/css';
+import {
+  css } from '@emotion/css';
 import { type ComponentType, PureComponent } from 'react';
 import { connect, type ConnectedProps } from 'react-redux';
 import { bindActionCreators } from 'redux';
@@ -8,6 +9,7 @@ import {
   type VariableOption,
   type VariableWithMultiSupport,
   type VariableWithOptions,
+  structuredLog
 } from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';
 import { ClickOutsideWrapper } from '@grafana/ui';
@@ -52,7 +54,7 @@ export const optionPickerFactory = <Model extends VariableWithOptions | Variable
   const mapStateToProps = (state: StoreState, ownProps: OwnProps) => {
     const { rootStateKey } = ownProps.variable;
     if (!rootStateKey) {
-      console.error('OptionPickerFactory: variable has no rootStateKey');
+      structuredLog('error', 'OptionPickerFactory: variable has no rootStateKey');
       return {
         picker: initialOptionPickerState,
       };
@@ -74,7 +76,7 @@ export const optionPickerFactory = <Model extends VariableWithOptions | Variable
       this.props.openOptions(toKeyedVariableIdentifier(this.props.variable), this.props.onVariableChange);
     onHideOptions = () => {
       if (!this.props.variable.rootStateKey) {
-        console.error('Variable has no rootStateKey');
+        structuredLog('error', 'Variable has no rootStateKey');
         return;
       }
 
@@ -108,7 +110,7 @@ export const optionPickerFactory = <Model extends VariableWithOptions | Variable
 
     onNavigate = (key: NavigationKey, clearOthers: boolean) => {
       if (!this.props.variable.rootStateKey) {
-        console.error('Variable has no rootStateKey');
+        structuredLog('error', 'Variable has no rootStateKey');
         return;
       }
 

--- a/public/app/features/variables/pickers/OptionsPicker/actions.ts
+++ b/public/app/features/variables/pickers/OptionsPicker/actions.ts
@@ -1,6 +1,10 @@
-import { debounce, trim } from 'lodash';
+import {
+  debounce, trim } from 'lodash';
 
-import { isEmptyObject, containsSearchFilter, type VariableWithOptions, type VariableOption } from '@grafana/data';
+import { isEmptyObject, containsSearchFilter, type VariableWithOptions, type VariableOption,
+  structuredLog,
+  toLogContextPart
+} from '@grafana/data';
 import { type StoreState, type ThunkDispatch, type ThunkResult } from 'app/types/store';
 
 import { variableAdapters } from '../../adapters';
@@ -180,7 +184,7 @@ const searchForOptions = async (
 
     dispatch(toKeyedAction(key, updateOptionsFromSearch(updated.options)));
   } catch (error) {
-    console.error(error);
+    structuredLog('error', 'Error', { error: toLogContextPart(error) });
   }
 };
 

--- a/public/app/features/variables/query/QueryVariableEditor.tsx
+++ b/public/app/features/variables/query/QueryVariableEditor.tsx
@@ -1,4 +1,5 @@
-import { type FormEvent, PureComponent } from 'react';
+import {
+  type FormEvent, PureComponent } from 'react';
 import { connect, type ConnectedProps } from 'react-redux';
 
 import {
@@ -8,6 +9,7 @@ import {
   type SelectableValue,
   type VariableRefresh,
   type VariableSort,
+  structuredLog
 } from '@grafana/data';
 import { QueryVariableEditorForm } from 'app/features/dashboard-scene/settings/variables/components/QueryVariableForm';
 import { type StoreState } from 'app/types/store';
@@ -25,7 +27,7 @@ import { changeQueryVariableDataSource, changeQueryVariableQuery, initQueryVaria
 const mapStateToProps = (state: StoreState, ownProps: OwnProps) => {
   const { rootStateKey } = ownProps.variable;
   if (!rootStateKey) {
-    console.error('QueryVariableEditor: variable has no rootStateKey');
+    structuredLog('error', 'QueryVariableEditor: variable has no rootStateKey');
     return {
       extended: getQueryVariableEditorState(initialVariableEditorState),
     };

--- a/public/app/features/variables/query/actions.ts
+++ b/public/app/features/variables/query/actions.ts
@@ -1,6 +1,10 @@
-import { Subscription } from 'rxjs';
+import {
+  Subscription } from 'rxjs';
 
-import { type DataSourceRef } from '@grafana/data';
+import { type DataSourceRef,
+  structuredLog,
+  toLogContextPart
+} from '@grafana/data';
 import { getDataSourceSrv, toDataQueryError } from '@grafana/runtime';
 import { type ThunkResult } from 'app/types/store';
 
@@ -109,7 +113,7 @@ export const changeQueryVariableDataSource = (
         )
       );
     } catch (err) {
-      console.error(err);
+      structuredLog('error', 'Error', { error: toLogContextPart(err) });
     }
   };
 };

--- a/public/app/features/variables/query/operators.ts
+++ b/public/app/features/variables/query/operators.ts
@@ -1,4 +1,5 @@
-import { from, of, type OperatorFunction } from 'rxjs';
+import {
+  from, of, type OperatorFunction } from 'rxjs';
 import { map, mergeMap } from 'rxjs/operators';
 
 import {
@@ -9,6 +10,7 @@ import {
   type MetricFindValue,
   type PanelData,
   type QueryVariableModel,
+  structuredLog
 } from '@grafana/data';
 import { type ThunkDispatch } from 'app/types/store';
 
@@ -110,7 +112,7 @@ export function updateOptionsState(args: {
       map((results) => {
         const { variable, dispatch, getTemplatedRegexFunc } = args;
         if (!variable.rootStateKey) {
-          console.error('updateOptionsState: variable.rootStateKey is not defined');
+          structuredLog('error', 'updateOptionsState: variable.rootStateKey is not defined');
           return;
         }
         const templatedRegex = getTemplatedRegexFunc(variable);

--- a/public/app/features/variables/state/actions.ts
+++ b/public/app/features/variables/state/actions.ts
@@ -1,4 +1,5 @@
-import { castArray, isEqual } from 'lodash';
+import {
+  castArray, isEqual } from 'lodash';
 
 import {
   type DataQuery,
@@ -19,6 +20,8 @@ import {
   type VariableOption,
   VariableRefresh,
   type VariableWithOptions,
+  structuredLog,
+  toLogContextPart
 } from '@grafana/data';
 import { config, locationService, logWarning, reportInteraction } from '@grafana/runtime';
 import { notifyApp } from 'app/core/reducers/appNotification';
@@ -779,7 +782,7 @@ export const onTimeRangeUpdated =
       await Promise.all(promises);
       dependencies.events.publish(new VariablesTimeRangeProcessDone({ variableIds }));
     } catch (error) {
-      console.error(error);
+      structuredLog('error', 'Error', { error: toLogContextPart(error) });
       dispatch(notifyApp(createVariableErrorNotification('Template variable service failed', error)));
     }
   };
@@ -933,7 +936,7 @@ export const initVariablesTransaction =
       dispatch(toKeyedAction(uid, variablesCompleteTransaction({ uid })));
     } catch (err) {
       dispatch(notifyApp(createVariableErrorNotification('Templating init failed', err)));
-      console.error(err);
+      structuredLog('error', 'Error', { error: toLogContextPart(err) });
     }
   };
 
@@ -1004,7 +1007,7 @@ export const updateOptions =
       dispatch(toKeyedAction(rootStateKey, variableStateFailed(toVariablePayload(identifier, { error }))));
 
       if (!rethrow) {
-        console.error(error);
+        structuredLog('error', 'Error', { error: toLogContextPart(error) });
         dispatch(notifyApp(createVariableErrorNotification('Error updating options:', error, identifier)));
       }
 
@@ -1084,7 +1087,7 @@ export function upgradeLegacyQueries(
       );
     } catch (err) {
       dispatch(notifyApp(createVariableErrorNotification('Failed to upgrade legacy queries', err)));
-      console.error(err);
+      structuredLog('error', 'Error', { error: toLogContextPart(err) });
     }
   };
 }

--- a/public/app/features/variables/switch/SwitchVariablePicker.tsx
+++ b/public/app/features/variables/switch/SwitchVariablePicker.tsx
@@ -1,6 +1,9 @@
-import { type ChangeEvent, type ReactElement, useCallback } from 'react';
+import {
+  type ChangeEvent, type ReactElement, useCallback } from 'react';
 
-import { type SwitchVariableModel } from '@grafana/data';
+import { type SwitchVariableModel,
+  structuredLog
+} from '@grafana/data';
 import { Switch } from '@grafana/ui';
 
 import { variableAdapters } from '../adapters';
@@ -12,7 +15,7 @@ export function SwitchVariablePicker({ variable, onVariableChange }: Props): Rea
   const updateVariable = useCallback(
     (event: ChangeEvent<HTMLInputElement>) => {
       if (!variable.rootStateKey) {
-        console.error('Cannot update variable without rootStateKey');
+        structuredLog('error', 'Cannot update variable without rootStateKey');
         return;
       }
 

--- a/public/app/features/variables/textbox/TextBoxVariablePicker.tsx
+++ b/public/app/features/variables/textbox/TextBoxVariablePicker.tsx
@@ -8,7 +8,9 @@ import {
   useState,
 } from 'react';
 
-import { type TextBoxVariableModel, isEmptyObject } from '@grafana/data';
+import { type TextBoxVariableModel, isEmptyObject,
+  structuredLog
+} from '@grafana/data';
 import { t } from '@grafana/i18n';
 import { Input } from '@grafana/ui';
 import { useDispatch } from 'app/types/store';
@@ -31,7 +33,7 @@ export function TextBoxVariablePicker({ variable, onVariableChange, readOnly }: 
 
   const updateVariable = useCallback(() => {
     if (!variable.rootStateKey) {
-      console.error('Cannot update variable without rootStateKey');
+      structuredLog('error', 'Cannot update variable without rootStateKey');
       return;
     }
 

--- a/public/app/index.ts
+++ b/public/app/index.ts
@@ -1,3 +1,4 @@
+import { structuredLog, toLogContextPart } from '@grafana/data';
 // The new index.html fetches window.grafanaBootData asynchronously.
 // Since much of Grafana depends on it in includes side effects at import time,
 // we delay loading the rest of the app using import() until the boot data is ready.
@@ -32,7 +33,7 @@ bootstrapWindowData().catch((error) => {
   const isRedirect = error && error.redirect && typeof error.redirect === 'string';
   // If a redirect was thrown, just ignore this. The index.html will handle the redirect
   if (!isRedirect) {
-    console.error('Error bootstrapping Grafana', error);
+    structuredLog('error', 'Error bootstrapping Grafana', { error: toLogContextPart(error) });
     window.__grafana_load_failed();
   }
 });

--- a/public/app/plugins/datasource/azuremonitor/azure_monitor/azure_monitor_datasource.ts
+++ b/public/app/plugins/datasource/azuremonitor/azure_monitor/azure_monitor_datasource.ts
@@ -1,7 +1,10 @@
-import { find } from 'lodash';
+import {
+  find } from 'lodash';
 
 import { type AzureCredentials } from '@grafana/azure-sdk';
-import { type ScopedVars } from '@grafana/data';
+import { type ScopedVars,
+  structuredLog
+} from '@grafana/data';
 import { DataSourceWithBackend, getTemplateSrv, type TemplateSrv } from '@grafana/runtime';
 
 import { getCredentials } from '../credentials';
@@ -218,7 +221,7 @@ export default class AzureMonitorDatasource extends DataSourceWithBackend<
         return result;
       })
       .catch((reason) => {
-        console.error(`Failed to get metric namespaces: ${reason}`);
+        structuredLog('error', `Failed to get metric namespaces: ${reason}`);
         return [];
       });
   }

--- a/public/app/plugins/datasource/azuremonitor/components/LogsQueryEditor/LogsQueryEditor.tsx
+++ b/public/app/plugins/datasource/azuremonitor/components/LogsQueryEditor/LogsQueryEditor.tsx
@@ -1,6 +1,10 @@
-import { useEffect, useState } from 'react';
+import {
+  useEffect, useState } from 'react';
 
-import { type PanelData, type TimeRange } from '@grafana/data';
+import { type PanelData, type TimeRange,
+  structuredLog,
+  toLogContextPart
+} from '@grafana/data';
 import { Trans } from '@grafana/i18n';
 import { EditorFieldGroup, EditorRow, EditorRows } from '@grafana/plugin-ui';
 import { config, getTemplateSrv } from '@grafana/runtime';
@@ -193,11 +197,11 @@ const LogsQueryEditor = ({
           setDataIngestedWarning(null);
         }
       } catch (err) {
-        console.error(err);
+        structuredLog('error', 'Error', { error: toLogContextPart(err) });
       }
     };
 
-    getBasicLogsUsage(query).catch((err) => console.error(err));
+    getBasicLogsUsage(query).catch((err) => structuredLog('error', 'Error', { error: toLogContextPart(err) }));
   }, [datasource.azureLogAnalyticsDatasource, query, showBasicLogsToggle, from, to]);
   let portalLinkButton = null;
 

--- a/public/app/plugins/datasource/azuremonitor/components/LogsQueryEditor/QueryField.tsx
+++ b/public/app/plugins/datasource/azuremonitor/components/LogsQueryEditor/QueryField.tsx
@@ -1,3 +1,4 @@
+import { structuredLog, toLogContextPart } from '@grafana/data';
 import { type EngineSchema, getKustoWorker } from '@kusto/monaco-kusto';
 import { useCallback, useEffect, useState } from 'react';
 
@@ -29,11 +30,11 @@ const QueryField = ({ query, onQueryChange, schema }: AzureQueryEditorFieldProps
           await kustoMode.setSchema(schema);
         }
       } catch (err) {
-        console.error(err);
+        structuredLog('error', 'Error', { error: toLogContextPart(err) });
       }
     };
 
-    setupEditor(monaco, schema).catch((err) => console.error(err));
+    setupEditor(monaco, schema).catch((err) => structuredLog('error', 'Error', { error: toLogContextPart(err) }));
   }, [schema, monaco]);
 
   const handleEditorMount = useCallback((editor: MonacoEditor, monaco: Monaco) => {

--- a/public/app/plugins/datasource/azuremonitor/credentials.ts
+++ b/public/app/plugins/datasource/azuremonitor/credentials.ts
@@ -1,3 +1,4 @@
+import { structuredLog, toLogContextPart } from '@grafana/data';
 import {
   type AzureCredentials,
   getDatasourceCredentials,
@@ -57,7 +58,7 @@ function getLegacyCredentials(
     return { authType: options.jsonData.azureAuthType };
   } catch (e) {
     if (e instanceof Error) {
-      console.error('Unable to restore legacy credentials: %s', e.message);
+      structuredLog('error', 'Unable to restore legacy credentials: %s', { details: e.message });
     }
     return undefined;
   }

--- a/public/app/plugins/datasource/cloud-monitoring/CloudMonitoringMetricFindQuery.ts
+++ b/public/app/plugins/datasource/cloud-monitoring/CloudMonitoringMetricFindQuery.ts
@@ -1,3 +1,4 @@
+import { structuredLog, toLogContextPart } from '@grafana/data';
 import { isString } from 'lodash';
 
 import { ALIGNMENT_PERIODS, SELECTORS } from './constants';
@@ -50,7 +51,7 @@ export default class CloudMonitoringMetricFindQuery {
           return [];
       }
     } catch (error) {
-      console.error(`Could not run CloudMonitoringMetricFindQuery ${query}`, error);
+      structuredLog('error', `Could not run CloudMonitoringMetricFindQuery ${query}`, { error: toLogContextPart(error) });
       return [];
     }
   }

--- a/public/app/plugins/datasource/cloudwatch/components/shared/LogGroups/LogGroupsField.tsx
+++ b/public/app/plugins/datasource/cloudwatch/components/shared/LogGroups/LogGroupsField.tsx
@@ -1,3 +1,4 @@
+import { structuredLog, toLogContextPart } from '@grafana/data';
 import { useEffect, useState } from 'react';
 
 import { EditorField, EditorRow } from '@grafana/plugin-ui';
@@ -92,7 +93,7 @@ export const LogGroupsField = ({
           onChange([...logGroups, ...variables.map((v) => ({ name: v, arn: v }))]);
         })
         .catch((err) => {
-          console.error(err);
+          structuredLog('error', 'Error', { error: toLogContextPart(err) });
         });
     }
   }, [datasource, legacyLogGroupNames, logGroups, onChange, region, loadingLogGroupsStarted]);

--- a/public/app/plugins/datasource/cloudwatch/tracking.ts
+++ b/public/app/plugins/datasource/cloudwatch/tracking.ts
@@ -1,4 +1,8 @@
-import { type DashboardLoadedEvent } from '@grafana/data';
+import {
+  type DashboardLoadedEvent,
+  structuredLog,
+  toLogContextPart
+} from '@grafana/data';
 import { config, reportInteraction } from '@grafana/runtime';
 
 import {
@@ -146,7 +150,7 @@ export const onDashboardLoadedHandler = ({
 
     reportInteraction('grafana_ds_cloudwatch_dashboard_loaded', e);
   } catch (error) {
-    console.error('error in cloudwatch tracking handler', error);
+    structuredLog('error', 'error in cloudwatch tracking handler', { error: toLogContextPart(error) });
   }
 };
 

--- a/public/app/plugins/datasource/cloudwatch/utils/datalinks.ts
+++ b/public/app/plugins/datasource/cloudwatch/utils/datalinks.ts
@@ -6,6 +6,8 @@ import {
   FieldType,
   type ScopedVars,
   type TimeRange,
+  structuredLog,
+  toLogContextPart
 } from '@grafana/data';
 import { getDataSourceSrv } from '@grafana/runtime';
 
@@ -66,7 +68,7 @@ async function createInternalXrayLink(datasourceUid: string, region: string): Pr
   try {
     ds = await getDataSourceSrv().get(datasourceUid);
   } catch (e) {
-    console.error('Could not load linked xray data source, it was probably deleted after it was linked', e);
+    structuredLog('error', 'Could not load linked xray data source, it was probably deleted after it was linked', { error: toLogContextPart(e) });
     return undefined;
   }
 

--- a/public/app/plugins/datasource/cloudwatch/variables.ts
+++ b/public/app/plugins/datasource/cloudwatch/variables.ts
@@ -1,4 +1,5 @@
-import { from, type Observable } from 'rxjs';
+import {
+  from, type Observable } from 'rxjs';
 import { map } from 'rxjs/operators';
 
 import {
@@ -7,6 +8,8 @@ import {
   type DataQueryResponse,
   type MetricFindValue,
   type SelectableValue,
+  structuredLog,
+  toLogContextPart
 } from '@grafana/data';
 
 import { VariableQueryEditor } from './components/VariableQueryEditor/VariableQueryEditor';
@@ -57,7 +60,7 @@ export class CloudWatchVariableSupport extends CustomVariableSupport<CloudWatchD
           return this.handleAccountsQuery(query);
       }
     } catch (error) {
-      console.error(`Could not run CloudWatchMetricFindQuery ${query}`, error);
+      structuredLog('error', `Could not run CloudWatchMetricFindQuery ${query}`, { error: toLogContextPart(error) });
       return [];
     }
   }

--- a/public/app/plugins/datasource/dashboard/datasource.ts
+++ b/public/app/plugins/datasource/dashboard/datasource.ts
@@ -1,4 +1,5 @@
-import { type Observable, debounce, debounceTime, defer, finalize, first, interval, map, of } from 'rxjs';
+import {
+  type Observable, debounce, debounceTime, defer, finalize, first, interval, map, of } from 'rxjs';
 
 import {
   DataSourceApi,
@@ -19,6 +20,7 @@ import {
   ValueMatcherID,
   type DataSourceGetDrilldownsApplicabilityOptions,
   type DrilldownsApplicability,
+  structuredLog
 } from '@grafana/data';
 import { isSceneObject, type SceneDataProvider, SceneDataTransformer, type SceneObject } from '@grafana/scenes';
 import {
@@ -270,7 +272,7 @@ export class DashboardDatasource extends DataSourceApi<DashboardQuery> {
         options: { value: filter.value },
       });
     } catch (error) {
-      console.warn('Failed to create value matcher for filter:', filter, error);
+      structuredLog('warn', 'Failed to create value matcher for filter:', { details: filter, error });
       return null;
     }
   }

--- a/public/app/plugins/datasource/grafana-testdata-datasource/components/RawFrameEditor.tsx
+++ b/public/app/plugins/datasource/grafana-testdata-datasource/components/RawFrameEditor.tsx
@@ -1,7 +1,10 @@
-import { isArray } from 'lodash';
+import {
+  isArray } from 'lodash';
 import { useState } from 'react';
 
-import { dataFrameToJSON, toDataFrame, toDataFrameDTO } from '@grafana/data';
+import { dataFrameToJSON, toDataFrame, toDataFrameDTO,
+  structuredLog
+} from '@grafana/data';
 import { toDataQueryResponse } from '@grafana/runtime';
 import { Alert, CodeEditor } from '@grafana/ui';
 
@@ -35,8 +38,8 @@ export const RawFrameEditor = ({ onChange, query }: EditorProps) => {
       }
 
       if (data) {
-        console.log('Original', json);
-        console.log('Save', data);
+        structuredLog('info', 'Original', { details: json });
+        structuredLog('info', 'Save', { details: data });
         setError(undefined);
         setWarning('Converted to direct frame result');
         onChange({ ...query, rawFrameContent: JSON.stringify(data, null, 2) });
@@ -45,7 +48,7 @@ export const RawFrameEditor = ({ onChange, query }: EditorProps) => {
 
       setError('Unable to read dataframes in text');
     } catch (e) {
-      console.log('Error parsing json', e);
+      structuredLog('info', 'Error parsing json', { details: e });
       setError('Enter JSON array of data frames (or raw query results body)');
       setWarning(undefined);
     }

--- a/public/app/plugins/datasource/grafana-testdata-datasource/runStreams.ts
+++ b/public/app/plugins/datasource/grafana-testdata-datasource/runStreams.ts
@@ -1,4 +1,5 @@
-import { defaults } from 'lodash';
+import {
+  defaults } from 'lodash';
 import { Observable, throwError } from 'rxjs';
 import { v4 as uuidv4 } from 'uuid';
 
@@ -17,6 +18,7 @@ import {
   addRow,
   getDisplayProcessor,
   createTheme,
+  structuredLog
 } from '@grafana/data';
 import { getBackendSrv } from '@grafana/runtime';
 
@@ -125,7 +127,7 @@ export function runSignalStream(
     setTimeout(pushNextEvent, 5);
 
     return () => {
-      console.log('unsubscribing to stream ' + streamId);
+      structuredLog('info', `unsubscribing to stream ${streamId}`);
       clearTimeout(timeoutId);
     };
   });
@@ -171,7 +173,7 @@ export function runLogsStream(
     setTimeout(pushNextEvent, 5);
 
     return () => {
-      console.log('unsubscribing to stream ' + streamId);
+      structuredLog('info', `unsubscribing to stream ${streamId}`);
       clearTimeout(timeoutId);
     };
   });
@@ -219,7 +221,7 @@ export function runWatchStream(
       .subscribe({
         next: (chunk) => {
           if (!chunk.data || !chunk.ok) {
-            console.info('chunk missing data', chunk);
+            structuredLog('info', 'chunk missing data', { details: chunk });
             return;
           }
           decoder
@@ -240,21 +242,21 @@ export function runWatchStream(
                     state: LoadingState.Streaming,
                   });
                 } catch (err) {
-                  console.warn('error parsing line', line, err);
+                  structuredLog('warn', 'error parsing line', { details: line, err });
                 }
               }
             });
         },
         error: (err) => {
-          console.warn('error in stream', streamId, err);
+          structuredLog('warn', 'error in stream', { details: streamId, err });
         },
         complete: () => {
-          console.info('complete stream', streamId);
+          structuredLog('info', 'complete stream', { details: streamId });
         },
       });
 
     return () => {
-      console.log('unsubscribing to stream', streamId);
+      structuredLog('info', 'unsubscribing to stream', { details: streamId });
       sub.unsubscribe();
     };
   });
@@ -314,7 +316,7 @@ export function runFetchStream(
       });
 
       if (value.done) {
-        console.log('Finished stream');
+        structuredLog('info', 'Finished stream');
         subscriber.complete(); // necessary?
         return;
       }
@@ -335,7 +337,7 @@ export function runFetchStream(
 
     return () => {
       // Cancel fetch?
-      console.log('unsubscribing to stream ' + streamId);
+      structuredLog('info', `unsubscribing to stream ${streamId}`);
     };
   });
 }
@@ -368,7 +370,7 @@ export function runTracesStream(
     setTimeout(pushNextEvent, 5);
 
     return () => {
-      console.log('unsubscribing to stream ' + streamId);
+      structuredLog('info', `unsubscribing to stream ${streamId}`);
       clearTimeout(timeoutId);
     };
   });

--- a/public/app/plugins/datasource/grafana/components/QueryEditor.tsx
+++ b/public/app/plugins/datasource/grafana/components/QueryEditor.tsx
@@ -7,6 +7,7 @@ import {
   rangeUtil,
   type DataQueryRequest,
   type Field,
+  structuredLog
 } from '@grafana/data';
 import { config, getDataSourceSrv } from '@grafana/runtime';
 import {
@@ -148,7 +149,7 @@ export class UnthemedQueryEditor extends React.PureComponent<Props, State> {
         try {
           buffer = rangeUtil.intervalToSeconds(txt) * 1000;
         } catch (err) {
-          console.warn('ERROR', err);
+          structuredLog('warn', 'ERROR', { details: err });
         }
       }
       onChange({

--- a/public/app/plugins/datasource/graphite/datasource.ts
+++ b/public/app/plugins/datasource/graphite/datasource.ts
@@ -1,4 +1,5 @@
-import { map as _map, each, indexOf, isArray, isString } from 'lodash';
+import {
+  map as _map, each, indexOf, isArray, isString } from 'lodash';
 import moment from 'moment';
 import { lastValueFrom, merge, Observable, of, type OperatorFunction, pipe, throwError } from 'rxjs';
 import { catchError, map } from 'rxjs/operators';
@@ -21,6 +22,8 @@ import {
   type ScopedVars,
   type TimeRange,
   toDataFrame,
+  structuredLog,
+  toLogContextPart
 } from '@grafana/data';
 import {
   type BackendSrvRequest,
@@ -555,7 +558,7 @@ export class GraphiteDatasource
       return this.events({ range: range, tags: tags }).then((results) => {
         const list = [];
         if (!isArray(results.data)) {
-          console.error(`Unable to get annotations.`);
+          structuredLog('error', `Unable to get annotations.`);
           return [];
         }
         for (let i = 0; i < results.data.length; i++) {
@@ -1047,7 +1050,7 @@ export class GraphiteDatasource
         this.funcDefs = gfunc.parseFuncDefs(functions);
         return this.funcDefs;
       } catch (error) {
-        console.error('Fetching graphite functions error', error);
+        structuredLog('error', 'Fetching graphite functions error', { error: toLogContextPart(error) });
         this.funcDefs = gfunc.getFuncDefs(this.graphiteVersion);
         return this.funcDefs;
       }
@@ -1066,7 +1069,7 @@ export class GraphiteDatasource
           return this.funcDefs;
         }),
         catchError((error) => {
-          console.error('Fetching graphite functions error', error);
+          structuredLog('error', 'Fetching graphite functions error', { error: toLogContextPart(error) });
           this.funcDefs = gfunc.getFuncDefs(this.graphiteVersion);
           return of(this.funcDefs);
         })

--- a/public/app/plugins/datasource/graphite/graphite_query.ts
+++ b/public/app/plugins/datasource/graphite/graphite_query.ts
@@ -1,6 +1,9 @@
-import { compact, each, findIndex, flatten, get, join, keyBy, last, map, reduce, without } from 'lodash';
+import {
+  compact, each, findIndex, flatten, get, join, keyBy, last, map, reduce, without } from 'lodash';
 
-import { type ScopedVars } from '@grafana/data';
+import { type ScopedVars,
+  structuredLog
+} from '@grafana/data';
 import { type TemplateSrv } from '@grafana/runtime';
 
 import { type GraphiteDatasource } from './datasource';
@@ -94,7 +97,7 @@ export default class GraphiteQuery {
       }
     } catch (err) {
       if (err instanceof Error) {
-        console.error('error parsing target:', err.message);
+        structuredLog('error', 'error parsing target:', { details: err.message });
         this.error = err.message;
       }
       this.target.textEditor = true;

--- a/public/app/plugins/datasource/influxdb/components/editor/config-v2/UrlAndAuthenticationSection.tsx
+++ b/public/app/plugins/datasource/influxdb/components/editor/config-v2/UrlAndAuthenticationSection.tsx
@@ -1,7 +1,11 @@
-import { css } from '@emotion/css';
+import {
+  css } from '@emotion/css';
 import { firstValueFrom } from 'rxjs';
 
-import { onUpdateDatasourceJsonDataOptionSelect, onUpdateDatasourceOption } from '@grafana/data';
+import { onUpdateDatasourceJsonDataOptionSelect, onUpdateDatasourceOption,
+  structuredLog,
+  toLogContextPart
+} from '@grafana/data';
 import { getBackendSrv } from '@grafana/runtime';
 import {
   Box,
@@ -104,7 +108,7 @@ export const UrlAndAuthenticationSection = (props: Props) => {
         }
       }
     } catch (err) {
-      console.error('Failed to get InfluxDB version:', err);
+      structuredLog('error', 'Failed to get InfluxDB version:', { error: toLogContextPart(err) });
     }
 
     return { product: undefined, version: undefined };

--- a/public/app/plugins/datasource/influxdb/components/editor/query/influxql/visual/TagsSection.tsx
+++ b/public/app/plugins/datasource/influxdb/components/editor/query/influxql/visual/TagsSection.tsx
@@ -1,6 +1,10 @@
 import type { JSX } from 'react';
 
-import { type SelectableValue } from '@grafana/data';
+import {
+  type SelectableValue,
+  structuredLog,
+  toLogContextPart
+} from '@grafana/data';
 import { AccessoryButton } from '@grafana/plugin-ui';
 
 import { type InfluxQueryTag } from '../../../../../types';
@@ -54,7 +58,7 @@ const Tag = ({ tag, isFirst, onRemove, onChange, getTagKeyOptions, getTagValueOp
         // to avoid it, we catch any potential errors coming from `getTagKeyOptions`,
         // log the error, and pretend that the list of options is an empty list.
         // this way the remove-item option can always be added to the list.
-        console.error(err);
+        structuredLog('error', 'Error', { error: toLogContextPart(err) });
         return [];
       })
       .then((tags) => tags.map(toSelectableValue));

--- a/public/app/plugins/datasource/influxdb/datasource.ts
+++ b/public/app/plugins/datasource/influxdb/datasource.ts
@@ -1,4 +1,5 @@
-import { map as _map, cloneDeep, extend, has, isString, omit, pick, reduce } from 'lodash';
+import {
+  map as _map, cloneDeep, extend, has, isString, omit, pick, reduce } from 'lodash';
 import { lastValueFrom, merge, Observable, of, throwError } from 'rxjs';
 import { catchError, map } from 'rxjs/operators';
 
@@ -25,6 +26,7 @@ import {
   TIME_SERIES_VALUE_FIELD_NAME,
   type TimeSeries,
   toDataFrame,
+  structuredLog
 } from '@grafana/data';
 import {
   type BackendDataSourceResponse,
@@ -388,7 +390,7 @@ export default class InfluxDatasource extends DataSourceWithBackend<InfluxQuery,
         // then put inside parenthesis.
         return typeof value === 'string' ? escapeRegex(value) : `(${value.map((v) => escapeRegex(v)).join('|')})`;
       } catch (e) {
-        console.warn(`Supplied match is not valid regex: ${match}`);
+        structuredLog('warn', `Supplied match is not valid regex: ${match}`);
       }
     }
 

--- a/public/app/plugins/datasource/loki/LanguageProvider.ts
+++ b/public/app/plugins/datasource/loki/LanguageProvider.ts
@@ -1,4 +1,5 @@
-import { flatten } from 'lodash';
+import {
+  flatten } from 'lodash';
 import { LRUCache } from 'lru-cache';
 
 import {
@@ -8,6 +9,8 @@ import {
   LanguageProvider,
   type ScopedVars,
   type TimeRange,
+  structuredLog,
+  toLogContextPart
 } from '@grafana/data';
 import { type BackendSrvRequest, config } from '@grafana/runtime';
 
@@ -63,7 +66,7 @@ export default class LokiLanguageProvider extends LanguageProvider {
       if (throwError) {
         throw error;
       } else {
-        console.error(error);
+        structuredLog('error', 'Error', { error: toLogContextPart(error) });
       }
     }
 
@@ -293,7 +296,7 @@ export default class LokiLanguageProvider extends LanguageProvider {
         const data = await this.request(url, params, true, requestOptions);
         resolve(data);
       } catch (error) {
-        console.error('error', error);
+        structuredLog('error', 'error', { error: toLogContextPart(error) });
         reject(error);
       }
     });
@@ -374,7 +377,7 @@ export default class LokiLanguageProvider extends LanguageProvider {
         if (queryOptions?.throwError) {
           reject(error);
         } else {
-          console.error(error);
+          structuredLog('error', 'Error', { error: toLogContextPart(error) });
           resolve([]);
         }
       }
@@ -444,7 +447,7 @@ export default class LokiLanguageProvider extends LanguageProvider {
           resolve(labelValues);
         }
       } catch (error) {
-        console.error(error);
+        structuredLog('error', 'Error', { error: toLogContextPart(error) });
         resolve([]);
       }
     });

--- a/public/app/plugins/datasource/loki/LiveStreams.ts
+++ b/public/app/plugins/datasource/loki/LiveStreams.ts
@@ -1,8 +1,11 @@
-import { type Observable, throwError, timer } from 'rxjs';
+import {
+  type Observable, throwError, timer } from 'rxjs';
 import { finalize, map, retryWhen, mergeMap } from 'rxjs/operators';
 import { webSocket } from 'rxjs/webSocket';
 
-import { type DataFrame, FieldType, type KeyValue, CircularDataFrame } from '@grafana/data';
+import { type DataFrame, FieldType, type KeyValue, CircularDataFrame,
+  structuredLog
+} from '@grafana/data';
 
 import { appendResponseToBufferedData } from './liveStreamsResultTransformer';
 import { type LokiTailResponse } from './types';
@@ -53,9 +56,7 @@ export class LiveStreams {
             if (error.code === 1006 && retryAttempt < 30) {
               if (retryAttempt > 10) {
                 // If more than 10 times retried, consol.warn, but keep reconnecting
-                console.warn(
-                  `Websocket connection is being disrupted. We keep reconnecting but consider starting new live tailing again. Error: ${error.reason}`
-                );
+                structuredLog('warn', `Websocket connection is being disrupted. We keep reconnecting but consider starting new live tailing again. Error: ${error.reason}`);
               }
               // Retry every 5s
               return timer(retryInterval);

--- a/public/app/plugins/datasource/loki/components/LokiLabelBrowser.tsx
+++ b/public/app/plugins/datasource/loki/components/LokiLabelBrowser.tsx
@@ -1,10 +1,14 @@
-import { css, cx } from '@emotion/css';
+import {
+  css, cx } from '@emotion/css';
 import { sortBy } from 'lodash';
 import { type ChangeEvent } from 'react';
 import * as React from 'react';
 import { FixedSizeList } from 'react-window';
 
-import { type CoreApp, type GrafanaTheme2, type TimeRange } from '@grafana/data';
+import { type CoreApp, type GrafanaTheme2, type TimeRange,
+  structuredLog,
+  toLogContextPart
+} from '@grafana/data';
 import { reportInteraction } from '@grafana/runtime';
 import {
   Button,
@@ -376,7 +380,7 @@ export class UnthemedLokiLabelBrowser extends React.Component<BrowserProps, Brow
       const values: FacettableValue[] = rawValues.map((value) => ({ name: value }));
       this.updateLabelState(name, { values, loading: false });
     } catch (error) {
-      console.error(error);
+      structuredLog('error', 'Error', { error: toLogContextPart(error) });
     }
   }
 
@@ -404,7 +408,7 @@ export class UnthemedLokiLabelBrowser extends React.Component<BrowserProps, Brow
         this.updateLabelState(lastFacetted, { loading: false });
       }
     } catch (error) {
-      console.error(error);
+      structuredLog('error', 'Error', { error: toLogContextPart(error) });
     }
   }
 

--- a/public/app/plugins/datasource/loki/components/monaco-query-field/getOverrideServices.ts
+++ b/public/app/plugins/datasource/loki/components/monaco-query-field/getOverrideServices.ts
@@ -1,3 +1,4 @@
+import { structuredLog, toLogContextPart } from '@grafana/data';
 import { type monacoTypes } from '@grafana/ui';
 
 // this thing here is a workaround in a way.
@@ -81,7 +82,7 @@ function makeStorageService() {
     },
 
     logStorage: (): void => {
-      console.log('logStorage: not implemented');
+      structuredLog('info', 'logStorage: not implemented');
     },
 
     migrate: (): Promise<void> => {

--- a/public/app/plugins/datasource/loki/mergeResponses.ts
+++ b/public/app/plugins/datasource/loki/mergeResponses.ts
@@ -10,6 +10,7 @@ import {
   type QueryResultMetaNotice,
   type QueryResultMetaStat,
   shallowCompare,
+  structuredLog,
 } from '@grafana/data';
 
 import { LOADING_FRAME_NAME } from './querySplitting';
@@ -142,7 +143,7 @@ export function mergeFrames(dest: DataFrame, source: DataFrame) {
   const sourceIdField = source.fields.find((field) => field.type === FieldType.string && field.name === 'id');
 
   if (!destTimeField || !sourceTimeField) {
-    console.error(new Error(`Time fields not found in the data frames`));
+    structuredLog('error', 'Time fields not found in the data frames');
     return;
   }
 

--- a/public/app/plugins/datasource/loki/querySplitting.ts
+++ b/public/app/plugins/datasource/loki/querySplitting.ts
@@ -1,4 +1,5 @@
-import { groupBy, partition } from 'lodash';
+import {
+  groupBy, partition } from 'lodash';
 import { Observable, type Subscriber, type Subscription, tap } from 'rxjs';
 import { v4 as uuidv4 } from 'uuid';
 
@@ -12,6 +13,8 @@ import {
   rangeUtil,
   store,
   type TimeRange,
+  structuredLog,
+  toLogContextPart
 } from '@grafana/data';
 import { config } from '@grafana/runtime';
 
@@ -187,7 +190,7 @@ export function runSplitGroupedQueries(
           return false;
         }
       } catch (e) {
-        console.error(e);
+        structuredLog('error', 'Error', { error: toLogContextPart(e) });
         shouldStop = true;
         return false;
       }

--- a/public/app/plugins/datasource/loki/querybuilder/LokiQueryModeller.ts
+++ b/public/app/plugins/datasource/loki/querybuilder/LokiQueryModeller.ts
@@ -1,3 +1,4 @@
+import { structuredLog, toLogContextPart } from '@grafana/data';
 import {
   QueryModellerBase,
   type QueryBuilderLabelFilter,
@@ -35,7 +36,7 @@ export class LokiQueryModeller extends QueryModellerBase {
       }
       const def = this.operationsRegistry.getIfExists(operation.id);
       if (!def) {
-        console.error(`Could not find operation ${operation.id} in the registry`);
+        structuredLog('error', `Could not find operation ${operation.id} in the registry`);
         continue;
       }
       queryString = def.renderer(operation, def, queryString);

--- a/public/app/plugins/datasource/loki/querybuilder/parsing.ts
+++ b/public/app/plugins/datasource/loki/querybuilder/parsing.ts
@@ -1,3 +1,4 @@
+import { structuredLog, toLogContextPart } from '@grafana/data';
 import { type SyntaxNode } from '@lezer/common';
 
 import {
@@ -109,7 +110,7 @@ export function buildVisualQueryFromString(expr: string): Context {
     handleExpression(replacedExpr, node, context);
   } catch (err) {
     // Not ideal to log it here, but otherwise we would lose the stack trace.
-    console.error(err);
+    structuredLog('error', 'Error', { error: toLogContextPart(err) });
     if (err instanceof Error) {
       context.errors.push({
         text: err.message,

--- a/public/app/plugins/datasource/loki/shardQuerySplitting.ts
+++ b/public/app/plugins/datasource/loki/shardQuerySplitting.ts
@@ -1,8 +1,12 @@
-import { groupBy, partition } from 'lodash';
+import {
+  groupBy, partition } from 'lodash';
 import { Observable, type Subscriber, type Subscription } from 'rxjs';
 import { v4 as uuidv4 } from 'uuid';
 
-import { type DataQueryRequest, type DataQueryResponse, LoadingState, type QueryResultMetaStat } from '@grafana/data';
+import { type DataQueryRequest, type DataQueryResponse, LoadingState, type QueryResultMetaStat,
+  structuredLog,
+  toLogContextPart
+} from '@grafana/data';
 import { config } from '@grafana/runtime';
 
 import { type LokiDatasource } from './datasource';
@@ -130,7 +134,7 @@ function splitQueriesByStreamShard(
           return false;
         }
       } catch (e) {
-        console.error(e);
+        structuredLog('error', 'Error', { error: toLogContextPart(e) });
         shouldStop = true;
         return false;
       }
@@ -155,7 +159,7 @@ function splitQueriesByStreamShard(
 
       retryTimer = setTimeout(
         () => {
-          console.warn(`Retrying ${group} ${cycle} (${retries + 1})`);
+          structuredLog('warn', `Retrying ${group} ${cycle} (${retries + 1})`);
           runNextRequest(subscriber, group, groups);
           retryTimer = null;
         },
@@ -224,7 +228,7 @@ function splitQueriesByStreamShard(
         nextRequest();
       },
       error: (error: unknown) => {
-        console.error(error, { msg: 'failed to shard' });
+        structuredLog('error', 'Error', { error: toLogContextPart(error), context: { msg: 'failed to shard' } });
         subscriber.next(mergedResponse);
         if (retry()) {
           return;
@@ -293,7 +297,7 @@ async function groupTargetsByQueryType(
         cycle: 0,
       });
     } catch (error) {
-      console.error(error, { msg: 'failed to fetch label values for __stream_shard__' });
+      structuredLog('error', 'Error', { error: toLogContextPart(error), context: { msg: 'failed to fetch label values for __stream_shard__' } });
       groups.push({
         targets: selectorPartition[selector],
       });
@@ -375,5 +379,5 @@ function debug(message: string) {
   if (!DEBUG_ENABLED) {
     return;
   }
-  console.log(message);
+  structuredLog('info', 'console.log', { value: toLogContextPart(message) });
 }

--- a/public/app/plugins/datasource/loki/tracking.ts
+++ b/public/app/plugins/datasource/loki/tracking.ts
@@ -1,4 +1,8 @@
-import { CoreApp, type DashboardLoadedEvent, type DataQueryRequest, type DataQueryResponse } from '@grafana/data';
+import {
+  CoreApp, type DashboardLoadedEvent, type DataQueryRequest, type DataQueryResponse,
+  structuredLog,
+  toLogContextPart
+} from '@grafana/data';
 import { QueryEditorMode } from '@grafana/plugin-ui';
 import { reportInteraction, config } from '@grafana/runtime';
 
@@ -97,7 +101,7 @@ export const onDashboardLoadedHandler = ({
 
     reportInteraction('grafana_loki_dashboard_loaded', event);
   } catch (error) {
-    console.error('error in loki tracking handler', error);
+    structuredLog('error', 'error in loki tracking handler', { error: toLogContextPart(error) });
   }
 };
 

--- a/public/app/plugins/datasource/tempo/datasource.ts
+++ b/public/app/plugins/datasource/tempo/datasource.ts
@@ -1,4 +1,5 @@
-import { groupBy } from 'lodash';
+import {
+  groupBy } from 'lodash';
 import { EMPTY, from, merge, type Observable, of } from 'rxjs';
 import { catchError, concatMap, finalize, map, mergeMap, toArray } from 'rxjs/operators';
 
@@ -23,6 +24,7 @@ import {
   type SelectableValue,
   type TestDataSourceResponse,
   type TimeRange,
+  structuredLog
 } from '@grafana/data';
 import { type NodeGraphOptions, type SpanBarOptions, type TraceToLogsOptions } from '@grafana/o11y-ds-frontend';
 import {
@@ -295,7 +297,7 @@ export class TempoDatasource extends DataSourceWithBackend<TempoQuery, TempoJson
 
       return false;
     } catch (error) {
-      console.warn('Failed to check for native histograms:', error);
+      structuredLog('warn', 'Failed to check for native histograms:', { details: error });
       return false;
     }
   }

--- a/public/app/plugins/datasource/tempo/resultTransformer.ts
+++ b/public/app/plugins/datasource/tempo/resultTransformer.ts
@@ -1,4 +1,5 @@
-import { type SpanStatus } from '@opentelemetry/api';
+import {
+  type SpanStatus } from '@opentelemetry/api';
 import { type collectorTypes } from '@opentelemetry/exporter-collector';
 import { SemanticResourceAttributes } from '@opentelemetry/semantic-conventions';
 import { isEqual } from 'lodash';
@@ -22,6 +23,8 @@ import {
   type TraceLog,
   type TraceSpanReference,
   type TraceSpanRow,
+  structuredLog,
+  toLogContextPart
 } from '@grafana/data';
 import { createNodeGraphFrames, type TraceToProfilesData } from '@grafana/o11y-ds-frontend';
 import { getDataSourceSrv } from '@grafana/runtime';
@@ -196,7 +199,7 @@ export function transformFromOTLP(
       }
     }
   } catch (error) {
-    console.error(error);
+    structuredLog('error', 'Error', { error: toLogContextPart(error) });
     return { error: { message: 'JSON is not valid OpenTelemetry format: ' + error }, data: [] };
   }
 

--- a/public/app/plugins/datasource/tempo/traceql/TraceQLEditor.tsx
+++ b/public/app/plugins/datasource/tempo/traceql/TraceQLEditor.tsx
@@ -1,7 +1,10 @@
-import { css } from '@emotion/css';
+import {
+  css } from '@emotion/css';
 import { useEffect, useRef, useState } from 'react';
 
-import { type GrafanaTheme2, type TimeRange } from '@grafana/data';
+import { type GrafanaTheme2, type TimeRange,
+  structuredLog
+} from '@grafana/data';
 import { TemporaryAlert } from '@grafana/o11y-ds-frontend';
 import { reportInteraction } from '@grafana/runtime';
 import { CodeEditor, type Monaco, type monacoTypes, useTheme2 } from '@grafana/ui';
@@ -94,7 +97,7 @@ export function TraceQLEditor(props: Props) {
               const errorNodes = getErrorNodes(model.getValue());
               setMarkers(monaco, model, errorNodes);
             } catch (err) {
-              console.warn('TraceQL editor: failed to update syntax error markers', err);
+              structuredLog('warn', 'TraceQL editor: failed to update syntax error markers', { details: err });
             }
           }
 
@@ -127,11 +130,11 @@ export function TraceQLEditor(props: Props) {
                 try {
                   setMarkers(monaco, model, errorNodes);
                 } catch (err) {
-                  console.warn('TraceQL editor: failed to update syntax error markers', err);
+                  structuredLog('warn', 'TraceQL editor: failed to update syntax error markers', { details: err });
                 }
               }, 500);
             } catch (err) {
-              console.warn('TraceQL editor: failed to parse query for error highlighting', err);
+              structuredLog('warn', 'TraceQL editor: failed to parse query for error highlighting', { details: err });
             }
           });
         }}

--- a/public/app/plugins/datasource/tempo/traceql/situation.ts
+++ b/public/app/plugins/datasource/tempo/traceql/situation.ts
@@ -1,3 +1,4 @@
+import { structuredLog, toLogContextPart } from '@grafana/data';
 import { type SyntaxNode, type Tree } from '@lezer/common';
 
 import {
@@ -444,7 +445,7 @@ function resolveNewSpansetExpression(node: SyntaxNode, text: string, offset: num
       previousNode = previousNode!.nextSibling;
     }
   } catch (error) {
-    console.error('Unexpected error while searching for previous node', error);
+    structuredLog('error', 'Unexpected error while searching for previous node', { error: toLogContextPart(error) });
   }
 
   if (previousNode?.type.id === And || previousNode?.type.id === Or) {

--- a/public/app/plugins/datasource/tempo/tracking.ts
+++ b/public/app/plugins/datasource/tempo/tracking.ts
@@ -1,4 +1,8 @@
-import { type DashboardLoadedEvent } from '@grafana/data';
+import {
+  type DashboardLoadedEvent,
+  structuredLog,
+  toLogContextPart
+} from '@grafana/data';
 import { getTemplateSrv, reportInteraction } from '@grafana/runtime';
 
 import pluginJson from './plugin.json';
@@ -58,7 +62,7 @@ export const onDashboardLoadedHandler = ({
 
     reportInteraction('grafana_tempo_dashboard_loaded', stats);
   } catch (error) {
-    console.error('error in tempo tracking handler', error);
+    structuredLog('error', 'error in tempo tracking handler', { error: toLogContextPart(error) });
   }
 };
 

--- a/public/app/plugins/datasource/tempo/utils.ts
+++ b/public/app/plugins/datasource/tempo/utils.ts
@@ -1,4 +1,8 @@
-import { type DataSourceApi, parseDuration } from '@grafana/data';
+import {
+  type DataSourceApi, parseDuration,
+  structuredLog,
+  toLogContextPart
+} from '@grafana/data';
 import { getDataSourceSrv } from '@grafana/runtime';
 
 import { generateId } from './SearchTraceQLEditor/TagsInput';
@@ -32,7 +36,7 @@ export async function getDS(uid?: string): Promise<DataSourceApi | undefined> {
   try {
     return await dsSrv.get(uid);
   } catch (error) {
-    console.error('Failed to load data source', error);
+    structuredLog('error', 'Failed to load data source', { error: toLogContextPart(error) });
     return undefined;
   }
 }

--- a/public/app/plugins/panel/canvas/components/connections/Connections.tsx
+++ b/public/app/plugins/panel/canvas/components/connections/Connections.tsx
@@ -1,3 +1,4 @@
+import { structuredLog, toLogContextPart } from '@grafana/data';
 import * as React from 'react';
 import { BehaviorSubject } from 'rxjs';
 
@@ -131,7 +132,7 @@ export class Connections {
     let element: ElementState | undefined = this.findElementTarget(event.target);
 
     if (!element) {
-      console.log('no element');
+      structuredLog('info', 'no element');
       return;
     }
 
@@ -140,7 +141,7 @@ export class Connections {
     } else {
       this.connectionSource = element;
       if (!this.connectionSource) {
-        console.log('no connection source');
+        structuredLog('info', 'no connection source');
         return;
       }
     }

--- a/public/app/plugins/panel/canvas/components/connections/Connections2.tsx
+++ b/public/app/plugins/panel/canvas/components/connections/Connections2.tsx
@@ -1,3 +1,4 @@
+import { structuredLog, toLogContextPart } from '@grafana/data';
 import * as React from 'react';
 import { BehaviorSubject } from 'rxjs';
 
@@ -126,7 +127,7 @@ export class Connections2 {
     let element: ElementState | undefined = this.findElementTarget(event.target);
 
     if (!element) {
-      console.log('no element');
+      structuredLog('info', 'no element');
       return;
     }
 
@@ -135,7 +136,7 @@ export class Connections2 {
     } else {
       this.connectionSource = element;
       if (!this.connectionSource) {
-        console.log('no connection source');
+        structuredLog('info', 'no connection source');
         return;
       }
     }

--- a/public/app/plugins/panel/canvas/editor/element/elementEditor.tsx
+++ b/public/app/plugins/panel/canvas/editor/element/elementEditor.tsx
@@ -1,3 +1,4 @@
+import { structuredLog, toLogContextPart } from '@grafana/data';
 import { get as lodashGet } from 'lodash';
 
 import { type NestedPanelOptions, type NestedValueAccess } from '@grafana/data/internal';
@@ -45,7 +46,7 @@ export function getElementEditor(opts: CanvasEditorOptions): NestedPanelOptions<
         if (path === 'type' && value) {
           const layer = canvasElementRegistry.getIfExists(value);
           if (!layer) {
-            console.warn('layer does not exist', value);
+            structuredLog('warn', 'layer does not exist', { details: value });
             return;
           }
           options = {

--- a/public/app/plugins/panel/canvas/editor/element/utils.ts
+++ b/public/app/plugins/panel/canvas/editor/element/utils.ts
@@ -1,4 +1,8 @@
-import { AppEvents, textUtil } from '@grafana/data';
+import {
+  AppEvents, textUtil,
+  structuredLog,
+  toLogContextPart
+} from '@grafana/data';
 import { type BackendSrvRequest, getBackendSrv, getTemplateSrv } from '@grafana/runtime';
 import { appEvents } from 'app/core/app_events';
 import { createAbsoluteUrl, type RelativeUrl } from 'app/features/alerting/unified/utils/url';
@@ -23,7 +27,7 @@ export const callApi = (api: APIEditorConfig, updateLoadingStateCallback?: IsLoa
     .subscribe({
       error: (error) => {
         appEvents.emit(AppEvents.alertError, ['An error has occurred. Check console output for more details.']);
-        console.error('API call error: ', error);
+        structuredLog('error', 'API call error: ', { error: toLogContextPart(error) });
         updateLoadingStateCallback && updateLoadingStateCallback(false);
       },
       complete: () => {

--- a/public/app/plugins/panel/canvas/editor/layer/TreeNavigationEditor.tsx
+++ b/public/app/plugins/panel/canvas/editor/layer/TreeNavigationEditor.tsx
@@ -1,9 +1,12 @@
-import { css } from '@emotion/css';
+import {
+  css } from '@emotion/css';
 import { Global } from '@emotion/react';
 import Tree, { type TreeNodeProps } from '@rc-component/tree';
 import { type Key, useEffect, useMemo, useState } from 'react';
 
-import { type GrafanaTheme2, type StandardEditorProps } from '@grafana/data';
+import { type GrafanaTheme2, type StandardEditorProps,
+  structuredLog
+} from '@grafana/data';
 import { Trans, t } from '@grafana/i18n';
 import { config } from '@grafana/runtime';
 import { Button, Icon, Stack, useStyles2, useTheme2 } from '@grafana/ui';
@@ -130,7 +133,7 @@ export const TreeNavigationEditor = ({ item }: StandardEditorProps<unknown, Tree
     if (layer.scene) {
       frameSelection(layer.scene);
     } else {
-      console.warn('no scene!');
+      structuredLog('warn', 'no scene!');
     }
   };
 

--- a/public/app/plugins/panel/canvas/editor/layer/layerEditor.tsx
+++ b/public/app/plugins/panel/canvas/editor/layer/layerEditor.tsx
@@ -1,3 +1,4 @@
+import { structuredLog, toLogContextPart } from '@grafana/data';
 import { get as lodashGet } from 'lodash';
 
 import { type NestedPanelOptions, type NestedValueAccess } from '@grafana/data/internal';
@@ -53,7 +54,7 @@ export function getLayerEditor(opts: InstanceState): NestedPanelOptions<LayerEdi
       },
       onChange: (path, value) => {
         if (path === 'type' && value) {
-          console.warn('unable to change layer type');
+          structuredLog('warn', 'unable to change layer type');
           return;
         }
         const c = setOptionImmutably(options, path, value);

--- a/public/app/plugins/panel/dashlist/migrations.ts
+++ b/public/app/plugins/panel/dashlist/migrations.ts
@@ -1,4 +1,7 @@
-import { type PanelModel } from '@grafana/data';
+import {
+  type PanelModel,
+  structuredLog
+} from '@grafana/data';
 import { getBackendSrv } from '@grafana/runtime';
 import { type FolderDTO } from 'app/types/folders';
 
@@ -67,7 +70,7 @@ export async function dashlistMigrationHandler(panel: PanelModel<Options> & Angu
       newOptions.folderUID = folderUID;
       delete newOptions.folderId;
     } catch (err) {
-      console.warn('Dashlist: Error migrating folder ID to UID', err);
+      structuredLog('warn', 'Dashlist: Error migrating folder ID to UID', { details: err });
     }
   }
 

--- a/public/app/plugins/panel/geomap/GeomapPanel.tsx
+++ b/public/app/plugins/panel/geomap/GeomapPanel.tsx
@@ -1,4 +1,5 @@
-import { css } from '@emotion/css';
+import {
+  css } from '@emotion/css';
 import { Global } from '@emotion/react';
 import type OpenLayersMap from 'ol/Map';
 import type MapBrowserEvent from 'ol/MapBrowserEvent';
@@ -15,7 +16,10 @@ import { Component, type ReactNode } from 'react';
 import * as React from 'react';
 import { Subscription } from 'rxjs';
 
-import { DataHoverEvent, type PanelData, type PanelProps } from '@grafana/data';
+import { DataHoverEvent, type PanelData, type PanelProps,
+  structuredLog,
+  toLogContextPart
+} from '@grafana/data';
 import { t } from '@grafana/i18n';
 import { config, locationService } from '@grafana/runtime';
 import { type PanelContext, PanelContextRoot } from '@grafana/ui';
@@ -323,7 +327,7 @@ export class GeomapPanel extends Component<Props, State> {
         layers.push(await initLayer(this, map, lyr, false));
       }
     } catch (ex) {
-      console.error('error loading layers', ex);
+      structuredLog('error', 'error loading layers', { error: toLogContextPart(ex) });
     }
 
     for (const lyr of layers) {

--- a/public/app/plugins/panel/geomap/layers/basemaps/maplibre.ts
+++ b/public/app/plugins/panel/geomap/layers/basemaps/maplibre.ts
@@ -1,8 +1,11 @@
 import type Map from 'ol/Map';
 import LayerGroup from 'ol/layer/Group';
-import { apply } from 'ol-mapbox-style';
+import {
+  apply } from 'ol-mapbox-style';
 
-import { type MapLayerRegistryItem, type MapLayerOptions, type GrafanaTheme2, type EventBus } from '@grafana/data';
+import { type MapLayerRegistryItem, type MapLayerOptions, type GrafanaTheme2, type EventBus,
+  structuredLog
+} from '@grafana/data';
 
 // MapLibre Style Specification constants
 const LAYER_TYPE_BACKGROUND = 'background';
@@ -63,13 +66,13 @@ export const maplibreLayer: MapLayerRegistryItem<MaplibreConfig> = {
       const loadStyle = async () => {
         try {
           if (!cfg.url) {
-            console.warn('No URL provided for MapLibre style, layer will be empty');
+            structuredLog('warn', 'No URL provided for MapLibre style, layer will be empty');
             return;
           }
 
           const res = await fetch(cfg.url);
           if (!res.ok) {
-            console.warn(`Failed to load MapLibre style from ${cfg.url}: ${res.status} ${res.statusText}`);
+            structuredLog('warn', `Failed to load MapLibre style from ${cfg.url}: ${res.status} ${res.statusText}`);
             // Try fallback approach
             await tryFallbackApply();
             return;
@@ -90,7 +93,7 @@ export const maplibreLayer: MapLayerRegistryItem<MaplibreConfig> = {
           await apply(layer, style, { styleUrl: cfg.url, accessToken: cfg.accessToken });
           applyNoRepeat();
         } catch (error) {
-          console.warn('Failed to parse or apply MapLibre style JSON:', error);
+          structuredLog('warn', 'Failed to parse or apply MapLibre style JSON:', { details: error });
           // Try fallback approach
           await tryFallbackApply();
         }
@@ -99,13 +102,13 @@ export const maplibreLayer: MapLayerRegistryItem<MaplibreConfig> = {
       const tryFallbackApply = async () => {
         try {
           if (!cfg.url) {
-            console.warn('No URL available for MapLibre fallback, layer will be empty');
+            structuredLog('warn', 'No URL available for MapLibre fallback, layer will be empty');
             return;
           }
           await apply(layer, cfg.url, { accessToken: cfg.accessToken });
           applyNoRepeat();
         } catch (fallbackError) {
-          console.warn('Failed to load MapLibre style from both JSON and direct URL approaches:', fallbackError);
+          structuredLog('warn', 'Failed to load MapLibre style from both JSON and direct URL approaches:', { details: fallbackError });
         }
       };
 

--- a/public/app/plugins/panel/geomap/style/markers.ts
+++ b/public/app/plugins/panel/geomap/style/markers.ts
@@ -1,8 +1,12 @@
-import { Fill, RegularShape, Stroke, Circle, Style, Icon, Text } from 'ol/style';
+import {
+  Fill, RegularShape, Stroke, Circle, Style, Icon, Text } from 'ol/style';
 import type { FlatStyle } from 'ol/style/flat';
 import tinycolor from 'tinycolor2';
 
-import { Registry, type RegistryItem, textUtil } from '@grafana/data';
+import { Registry, type RegistryItem, textUtil,
+  structuredLog,
+  toLogContextPart
+} from '@grafana/data';
 import { config } from '@grafana/runtime';
 import { getPublicOrAbsoluteUrl } from 'app/features/dimensions/resource';
 
@@ -297,7 +301,7 @@ async function prepareSVG(url: string, size?: number, backgroundOpacity?: number
       return `data:image/svg+xml,${svgURI}`;
     })
     .catch((error) => {
-      console.error(error); // eslint-disable-line no-console
+      structuredLog('error', 'Error', { error: toLogContextPart(error) }); // eslint-disable-line no-console
       return '';
     });
 }

--- a/public/app/plugins/panel/geomap/style/utils.ts
+++ b/public/app/plugins/panel/geomap/style/utils.ts
@@ -1,3 +1,4 @@
+import { structuredLog, toLogContextPart } from '@grafana/data';
 import { config } from '@grafana/runtime';
 import { TextDimensionMode } from '@grafana/schema';
 
@@ -106,7 +107,7 @@ export function getRGBValues(colorString: string): ColorValue | null {
 
   // Handle other color formats if needed
   else {
-    console.warn(`Unsupported color format: ${colorString}`);
+    structuredLog('warn', `Unsupported color format: ${colorString}`);
   }
   return null;
 }
@@ -142,10 +143,10 @@ function getRGBFromRGBString(rgbString: string): ColorValue | null {
         a: parseFloat(matches[3]), // Using parseFloat for alpha as it can be decimal (0-1)
       };
     } else {
-      console.warn(`Unsupported color format: ${rgbString}`);
+      structuredLog('warn', `Unsupported color format: ${rgbString}`);
     }
   } else {
-    console.warn(`Unsupported color format: ${rgbString}`);
+    structuredLog('warn', `Unsupported color format: ${rgbString}`);
   }
   return null;
 }

--- a/public/app/plugins/panel/geomap/utils/layers.ts
+++ b/public/app/plugins/panel/geomap/utils/layers.ts
@@ -1,11 +1,14 @@
-import { type FeatureLike } from 'ol/Feature';
+import {
+  type FeatureLike } from 'ol/Feature';
 import type OpenLayersMap from 'ol/Map';
 import type BaseLayer from 'ol/layer/Base';
 import LayerGroup from 'ol/layer/Group';
 import WebGLPointsLayer from 'ol/layer/WebGLPoints';
 import { Subject } from 'rxjs';
 
-import { getFrameMatchers, type MapLayerHandler, type MapLayerOptions, type PanelData, textUtil } from '@grafana/data';
+import { getFrameMatchers, type MapLayerHandler, type MapLayerOptions, type PanelData, textUtil,
+  structuredLog
+} from '@grafana/data';
 import { config } from '@grafana/runtime';
 
 import { type GeomapPanel } from '../GeomapPanel';
@@ -91,7 +94,7 @@ export async function updateLayer(panel: GeomapPanel, uid: string, newOptions: M
     // initialize with new data
     applyLayerFilter(info.handler, newOptions, panel.props.data);
   } catch (err) {
-    console.warn('ERROR', err); // eslint-disable-line no-console
+    structuredLog('warn', 'ERROR', { details: err }); // eslint-disable-line no-console
     return false;
   }
 

--- a/public/app/plugins/panel/heatmap/HeatmapPanel.tsx
+++ b/public/app/plugins/panel/heatmap/HeatmapPanel.tsx
@@ -1,7 +1,13 @@
 import { css } from '@emotion/css';
 import { useMemo, useRef, useState } from 'react';
 
-import { DashboardCursorSync, type PanelProps, type TimeRange } from '@grafana/data';
+import {
+  DashboardCursorSync,
+  type PanelProps,
+  type TimeRange,
+  structuredLog,
+  toLogContextPart,
+} from '@grafana/data';
 import { PanelDataErrorView } from '@grafana/runtime';
 import { type ScaleDistributionConfig } from '@grafana/schema';
 import {
@@ -54,7 +60,7 @@ export const HeatmapPanel = (props: HeatmapPanelProps) => {
         timeRange,
       });
     } catch (ex) {
-      console.error(ex);
+      structuredLog('error', 'Heatmap data preparation failed', { error: toLogContextPart(ex) });
       return { warning: `${ex}` };
     }
   }, [data.series, data.annotations, options, palette, theme, replaceVariables, timeRange]);

--- a/public/app/plugins/panel/live/LivePanel.tsx
+++ b/public/app/plugins/panel/live/LivePanel.tsx
@@ -1,4 +1,5 @@
-import { css, cx } from '@emotion/css';
+import {
+  css, cx } from '@emotion/css';
 import { isEqual } from 'lodash';
 import { PureComponent } from 'react';
 import { type Unsubscribable, type PartialObserver } from 'rxjs';
@@ -17,6 +18,7 @@ import {
   applyFieldOverrides,
   type LiveChannelAddress,
   StreamingDataFrame,
+  structuredLog
 } from '@grafana/data';
 import { Trans, t } from '@grafana/i18n';
 import { config, getGrafanaLiveSrv } from '@grafana/runtime';
@@ -72,7 +74,7 @@ export class LivePanel extends PureComponent<Props, State> {
       } else if (isLiveChannelMessageEvent(event)) {
         this.setState({ message: event.message, changed: Date.now() });
       } else {
-        console.log('ignore', event);
+        structuredLog('info', 'ignore', { details: event });
       }
     },
   };
@@ -87,7 +89,7 @@ export class LivePanel extends PureComponent<Props, State> {
   async loadChannel() {
     const addr = this.props.options?.channel;
     if (!isValidLiveChannelAddress(addr)) {
-      console.log('INVALID', addr);
+      structuredLog('info', 'INVALID', { details: addr });
       this.unsubscribe();
       this.setState({
         addr: undefined,
@@ -96,13 +98,13 @@ export class LivePanel extends PureComponent<Props, State> {
     }
 
     if (isEqual(addr, this.state.addr)) {
-      console.log('Same channel', this.state.addr);
+      structuredLog('info', 'Same channel', { details: this.state.addr });
       return;
     }
 
     const live = getGrafanaLiveSrv();
     if (!live) {
-      console.log('INVALID', addr);
+      structuredLog('info', 'INVALID', { details: addr });
       this.unsubscribe();
       this.setState({
         addr: undefined,
@@ -111,7 +113,7 @@ export class LivePanel extends PureComponent<Props, State> {
     }
     this.unsubscribe();
 
-    console.log('LOAD', addr);
+    structuredLog('info', 'LOAD', { details: addr });
 
     // Subscribe to new events
     try {

--- a/public/app/plugins/panel/live/LivePublish.tsx
+++ b/public/app/plugins/panel/live/LivePublish.tsx
@@ -1,6 +1,9 @@
-import { useMemo } from 'react';
+import {
+  useMemo } from 'react';
 
-import { type LiveChannelAddress, isValidLiveChannelAddress } from '@grafana/data';
+import { type LiveChannelAddress, isValidLiveChannelAddress,
+  structuredLog
+} from '@grafana/data';
 import { Trans } from '@grafana/i18n';
 import { getBackendSrv, getGrafanaLiveSrv } from '@grafana/runtime';
 import { CodeEditor, Button } from '@grafana/ui';
@@ -46,7 +49,7 @@ export function LivePublish({ height, mode, body, addr, onSave }: Props) {
     }
 
     const rsp = await getGrafanaLiveSrv().publish(addr, body);
-    console.log('onPublishClicked (response from publish)', rsp);
+    structuredLog('info', 'onPublishClicked (response from publish)', { details: rsp });
   };
 
   return (

--- a/public/app/plugins/panel/logs/LogsPanel.tsx
+++ b/public/app/plugins/panel/logs/LogsPanel.tsx
@@ -1,4 +1,5 @@
-import { css, cx } from '@emotion/css';
+import {
+  css, cx } from '@emotion/css';
 import { groupBy } from 'lodash';
 import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import * as React from 'react';
@@ -30,6 +31,8 @@ import {
   rangeUtil,
   transformDataFrame,
   store,
+  structuredLog,
+  toLogContextPart
 } from '@grafana/data';
 import { Trans } from '@grafana/i18n';
 import { config, getAppEvents } from '@grafana/runtime';
@@ -488,7 +491,7 @@ export const LogsPanel = ({ data, timeZone, fieldConfig, options, onOptionsChang
           newSeries = await lastValueFrom(transformDataFrame(panel?.transformations, newSeries));
         }
       } catch (e) {
-        console.error(e);
+        structuredLog('error', 'Error', { error: toLogContextPart(e) });
       } finally {
         setInfiniteScrolling(false);
         loadingRef.current = false;
@@ -851,7 +854,7 @@ export async function requestMoreLogs(
   for (const uid in targetGroups) {
     const dataSource = dataSourcesMap.get(panelData.request.targets[0].refId);
     if (!dataSource) {
-      console.warn(`Could not resolve data source for target ${panelData.request.targets[0].refId}`);
+      structuredLog('warn', `Could not resolve data source for target ${panelData.request.targets[0].refId}`);
       continue;
     }
     dataRequests.push(

--- a/public/app/plugins/panel/logstable/fieldSelector/buildColumnsWithMeta.ts
+++ b/public/app/plugins/panel/logstable/fieldSelector/buildColumnsWithMeta.ts
@@ -1,4 +1,7 @@
-import { type DataFrame, type FieldWithIndex, getFieldDisplayName } from '@grafana/data';
+import {
+  type DataFrame, type FieldWithIndex, getFieldDisplayName,
+  structuredLog
+} from '@grafana/data';
 import { type FieldNameMeta, type FieldNameMetaStore } from 'app/features/explore/Logs/LogsTableWrap';
 import { LOG_LINE_BODY_FIELD_NAME } from 'app/features/logs/components/fieldSelector/logFields';
 
@@ -104,7 +107,7 @@ export const buildColumnsWithMeta = (
       pendingLabelState[logsFrameFields.bodyField?.name].active = true;
       pendingLabelState[logsFrameFields.bodyField?.name].index = idx;
     } else {
-      console.error(`Unknown field ${fieldName}`, { pendingLabelState, displayedFields });
+      structuredLog('error', `Unknown field ${fieldName}`, { details: { pendingLabelState, displayedFields } });
     }
   });
 

--- a/public/app/plugins/panel/logstable/hooks/useExtractFields.ts
+++ b/public/app/plugins/panel/logstable/hooks/useExtractFields.ts
@@ -1,4 +1,5 @@
-import { useState, useEffect } from 'react';
+import {
+  useState, useEffect } from 'react';
 import useMountedState from 'react-use/lib/useMountedState';
 import { lastValueFrom } from 'rxjs';
 
@@ -9,6 +10,8 @@ import {
   type TimeZone,
   transformDataFrame,
   useDataLinksContext,
+  structuredLog,
+  toLogContextPart
 } from '@grafana/data';
 import { getTemplateSrv } from '@grafana/runtime';
 import { useTheme2 } from '@grafana/ui';
@@ -56,7 +59,7 @@ export function useExtractFields({ rawTableFrame, fieldConfig, timeZone }: Props
         }
       })
       .catch((err) => {
-        console.error('LogsTable: Extract fields transform error', err);
+        structuredLog('error', 'LogsTable: Extract fields transform error', { error: toLogContextPart(err) });
       });
     // @todo hook re-renders unexpectedly when data frame isn't changing if we add `rawTableFrame` as dependency, so we check for changes in the timestamps instead
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/public/app/plugins/panel/logstable/hooks/useOrganizeFields.tsx
+++ b/public/app/plugins/panel/logstable/hooks/useOrganizeFields.tsx
@@ -1,8 +1,12 @@
-import { useEffect, useState } from 'react';
+import {
+  useEffect, useState } from 'react';
 import useMountedState from 'react-use/lib/useMountedState';
 import { lastValueFrom } from 'rxjs';
 
-import { type DataFrame, type FieldConfigSource, transformDataFrame } from '@grafana/data';
+import { type DataFrame, type FieldConfigSource, transformDataFrame,
+  structuredLog,
+  toLogContextPart
+} from '@grafana/data';
 import { type CustomCellRendererProps, TableCellDisplayMode } from '@grafana/ui';
 import { type LogsFrame } from 'app/features/logs/logsFrame';
 
@@ -68,7 +72,7 @@ export function useOrganizeFields({
         }
       })
       .catch((err) => {
-        console.error('LogsTable: Organize fields transform error', err);
+        structuredLog('error', 'LogsTable: Organize fields transform error', { error: toLogContextPart(err) });
       });
   }, [
     bodyFieldName,

--- a/public/app/plugins/panel/logstable/rows/LogsTableRowActionButtons.tsx
+++ b/public/app/plugins/panel/logstable/rows/LogsTableRowActionButtons.tsx
@@ -1,7 +1,10 @@
-import { css } from '@emotion/css';
+import {
+  css } from '@emotion/css';
 import { useState } from 'react';
 
-import { type GrafanaTheme2 } from '@grafana/data';
+import { type GrafanaTheme2,
+  structuredLog
+} from '@grafana/data';
 import { t } from '@grafana/i18n';
 import {
   ClipboardButton,
@@ -71,7 +74,7 @@ export function LogsTableRowActionButtons(props: Props) {
                 if (logId) {
                   return buildLinkToLog(logId) ?? '';
                 } else {
-                  console.error('failed to copy log line link!');
+                  structuredLog('error', 'failed to copy log line link!');
                 }
                 return '';
               }}

--- a/public/app/plugins/panel/news/utils.ts
+++ b/public/app/plugins/panel/news/utils.ts
@@ -1,4 +1,7 @@
-import { FieldType, type DataFrame, dateTime } from '@grafana/data';
+import {
+  FieldType, type DataFrame, dateTime,
+  structuredLog
+} from '@grafana/data';
 
 import { type Feed } from './types';
 
@@ -23,7 +26,7 @@ export function feedToDataFrame(feed: Feed): DataFrame {
         content.push(body);
       }
     } catch (err) {
-      console.warn('Error reading news item:', err, item);
+      structuredLog('warn', 'Error reading news item:', { details: err, item });
     }
   }
 

--- a/public/app/plugins/panel/table/migrations.ts
+++ b/public/app/plugins/panel/table/migrations.ts
@@ -1,4 +1,5 @@
-import { omitBy, isNil, isNumber, defaultTo, groupBy, omit } from 'lodash';
+import {
+  omitBy, isNil, isNumber, defaultTo, groupBy, omit } from 'lodash';
 
 import {
   type PanelModel,
@@ -10,6 +11,7 @@ import {
   type DataFrame,
   FieldType,
   ByNamesMatcherMode,
+  structuredLog
 } from '@grafana/data';
 import { type ReduceTransformerOptions } from '@grafana/data/internal';
 
@@ -23,7 +25,7 @@ import { type Options } from './panelcfg.gen';
 export const tableMigrationHandler = (panel: PanelModel<Options>): Partial<Options> => {
   // Table was saved as an angular table, lets just swap to the 'table-old' panel
   if (!panel.pluginVersion && 'columns' in panel) {
-    console.log('Was angular table', panel);
+    structuredLog('info', 'Was angular table', { details: panel });
   }
 
   // ensure overrides array exists before applying rest of overrides

--- a/public/app/plugins/panel/timeseries/NullsThresholdInput.tsx
+++ b/public/app/plugins/panel/timeseries/NullsThresholdInput.tsx
@@ -1,6 +1,9 @@
 import * as React from 'react';
 
-import { rangeUtil } from '@grafana/data';
+import {
+  rangeUtil,
+  structuredLog
+} from '@grafana/data';
 import { t } from '@grafana/i18n';
 import { Input } from '@grafana/ui';
 
@@ -31,7 +34,7 @@ export const NullsThresholdInput = ({ value, onChange, inputPrefix, isTime }: Pr
           val = Number(txt);
         }
       } catch (err) {
-        console.warn('ERROR', err);
+        structuredLog('warn', 'ERROR', { details: err });
       }
     }
     onChange(val);

--- a/public/app/plugins/panel/timeseries/migrations.ts
+++ b/public/app/plugins/panel/timeseries/migrations.ts
@@ -1,4 +1,5 @@
-import { omitBy, pickBy, isNil, isNumber, isString } from 'lodash';
+import {
+  omitBy, pickBy, isNil, isNumber, isString } from 'lodash';
 
 import {
   type ConfigOverrideRule,
@@ -15,6 +16,7 @@ import {
   ReducerID,
   type Threshold,
   ThresholdsMode,
+  structuredLog
 } from '@grafana/data';
 import {
   LegendDisplayMode,
@@ -283,7 +285,7 @@ export function graphToTimeseriesOptions(angular: any): {
             });
             break;
           default:
-            console.log('Ignore override migration:', seriesOverride.alias, p, v);
+            structuredLog('info', 'Ignore override migration:', { details: seriesOverride.alias, p, v });
         }
       }
       if (dashOverride) {

--- a/public/app/plugins/panel/timeseries/plugins/annotations2-cluster/useAnnotationClustering.tsx
+++ b/public/app/plugins/panel/timeseries/plugins/annotations2-cluster/useAnnotationClustering.tsx
@@ -1,7 +1,10 @@
-import { useMemo } from 'react';
+import {
+  useMemo } from 'react';
 import uPlot from 'uplot';
 
-import { type DataFrame, FieldType } from '@grafana/data';
+import { type DataFrame, FieldType,
+  structuredLog
+} from '@grafana/data';
 import { maybeSortFrame } from '@grafana/data/internal';
 import { type TimeRange2 } from '@grafana/ui/internal';
 
@@ -120,7 +123,7 @@ export const useAnnotationClustering = ({ annotations, clusteringMode, plotWidth
       }
     } else if (clusteringMode === ClusteringMode.Hover) {
       // Have the tooltip be clustered, but not the annotations: https://github.com/grafana/grafana/issues/119436
-      console.warn('Hover mode not implemented');
+      structuredLog('warn', 'Hover mode not implemented');
     }
 
     // Sort clustered frames

--- a/public/swagger/K8sNameLookup.tsx
+++ b/public/swagger/K8sNameLookup.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 
-import { type SelectableValue } from '@grafana/data';
+import { type SelectableValue, structuredLog } from '@grafana/data';
 import { Select } from '@grafana/ui';
 
 import { NamespaceContext, ResourceContext } from './plugins';
@@ -41,12 +41,15 @@ export function K8sNameLookup(props: Props) {
           },
         });
         if (!response.ok) {
-          console.warn('error loading names');
+          structuredLog('warn', 'K8s name lookup failed to load list');
           setLoading(false);
           return;
         }
         const table = await response.json();
-        console.log('LIST', url, table);
+        structuredLog('info', 'K8s name lookup list loaded', {
+          url,
+          rowCount: table?.rows?.length ?? 0,
+        });
         const options: Array<SelectableValue<string>> = [];
         if (table.rows?.length) {
           for (const row of table.rows) {

--- a/public/swagger/SwaggerPage.tsx
+++ b/public/swagger/SwaggerPage.tsx
@@ -3,7 +3,7 @@ import { useState } from 'react';
 import { useAsync } from 'react-use';
 import SwaggerUI from 'swagger-ui-react';
 
-import { createTheme, monacoLanguageRegistry, type SelectableValue } from '@grafana/data';
+import { createTheme, monacoLanguageRegistry, type SelectableValue, structuredLog } from '@grafana/data';
 import { Trans } from '@grafana/i18n';
 import { Icon, Stack, Select, UserIcon, type UserView, Button } from '@grafana/ui';
 import { setMonacoEnv } from 'app/core/monacoEnv';
@@ -55,7 +55,7 @@ export const Page = () => {
   const namespace = useAsync(async () => {
     const response = await fetch('api/frontend/settings');
     if (!response.ok) {
-      console.warn('No settings found');
+      structuredLog('warn', 'Swagger page: settings request failed — using default namespace');
       return 'default';
     }
     const val = await response.json();
@@ -65,7 +65,7 @@ export const Page = () => {
   useAsync(async () => {
     const response = await fetch('api/user');
     if (!response.ok) {
-      console.warn('No user found, show login button');
+      structuredLog('warn', 'Swagger page: user request failed — show login UI');
       return;
     }
     const val = await response.json();

--- a/public/swagger/plugins.tsx
+++ b/public/swagger/plugins.tsx
@@ -1,5 +1,6 @@
 import { createContext } from 'react';
 
+import { structuredLog, toLogContextPart } from '@grafana/data';
 import { CodeEditor, type Monaco } from '@grafana/ui';
 
 import { K8sNameLookup } from './K8sNameLookup';
@@ -63,7 +64,11 @@ export const WrappedPlugins = function () {
           if (mime) {
             v = mime.get('schema').toJS();
           }
-          console.log('RequestBody', v, mime, props);
+          structuredLog('info', 'Swagger RequestBody render', {
+            mime,
+            value: toLogContextPart(v),
+            props: toLogContextPart(props),
+          });
         }
         // console.log('RequestBody PROPS', props);
         return (
@@ -75,7 +80,7 @@ export const WrappedPlugins = function () {
 
       modelExample: (Original: React.ElementType) => (props: UntypedProps) => {
         if (props.isExecute && props.schema) {
-          console.log('modelExample PROPS', props);
+          structuredLog('info', 'Swagger modelExample render', { props: toLogContextPart(props) });
           return (
             <SchemaContext.Provider value={props.schema.toJS()}>
               <Original {...props} />
@@ -128,7 +133,7 @@ export const WrappedPlugins = function () {
                     },
                   });
                 };
-                console.log('CodeEditor', schema);
+                structuredLog('info', 'Swagger CodeEditor schema', { schema: toLogContextPart(schema) });
 
                 return (
                   <CodeEditor

--- a/scripts/migrate-console-pass1.mjs
+++ b/scripts/migrate-console-pass1.mjs
@@ -1,0 +1,182 @@
+/**
+ * Migrates repetitive console patterns to structuredLog / toLogContextPart from @grafana/data.
+ * Run from repo root: node scripts/migrate-console-pass1.mjs
+ */
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const ROOT = path.join(__dirname, '..');
+
+const scanDirs = [
+  path.join(ROOT, 'public/app'),
+  path.join(ROOT, 'packages/grafana-prometheus'),
+  path.join(ROOT, 'packages/grafana-sql'),
+  path.join(ROOT, 'packages/grafana-flamegraph'),
+  path.join(ROOT, 'packages/grafana-openapi'),
+  path.join(ROOT, 'packages/grafana-ui/src'),
+  path.join(ROOT, 'packages/grafana-i18n/src'),
+];
+
+const pathBlocks = ['/node_modules/', '/dist/', 'BrowseConsoleBackend.ts'];
+const skipName = (n) =>
+  /\.(test|spec|story)\.(t|j)sx?$/.test(n) ||
+  /\.d\.ts$/.test(n);
+
+function shouldSkipFile(fp) {
+  if (pathBlocks.some((s) => fp.includes(s))) {
+    return true;
+  }
+  return skipName(path.basename(fp));
+}
+
+function walk(dir, acc = []) {
+  if (!fs.existsSync(dir)) {
+    return acc;
+  }
+  for (const e of fs.readdirSync(dir, { withFileTypes: true })) {
+    const p = path.join(dir, e.name);
+    if (e.isDirectory()) {
+      walk(p, acc);
+    } else if (/\.tsx?$/.test(e.name)) {
+      if (!shouldSkipFile(p)) {
+        acc.push(p);
+      }
+    }
+  }
+  return acc;
+}
+
+function ensureImport(original) {
+  const needsStructured = /\bstructuredLog\s*\(/.test(original);
+  const needsPart = /\btoLogContextPart\s*\(/.test(original);
+  if (!needsStructured && !needsPart) {
+    return original;
+  }
+
+  const dataImportRe = /^import\s*\{([\s\S]*?)\}\s*from\s*['"]@grafana\/data['"];/m;
+  const m = original.match(dataImportRe);
+  if (!m) {
+    const line = `import { structuredLog, toLogContextPart } from '@grafana/data';\n`;
+    const pos = original.search(/^import\s/m);
+    return pos === -1 ? line + original : original.slice(0, pos) + line + original.slice(pos);
+  }
+
+  let inner = m[1].trim().replace(/,\s*$/, '');
+
+  const ensureSym = (sym) => {
+    if (!new RegExp(`(^|[,\\s])${sym}\\b`).test(inner)) {
+      inner = inner.length ? `${inner},\n  ${sym}` : sym;
+    }
+  };
+
+  if (needsStructured) {
+    ensureSym('structuredLog');
+  }
+  if (needsPart) {
+    ensureSym('toLogContextPart');
+  }
+
+  const replacement = `import {\n  ${inner.replace(/^,\s*/, '').replace(/,\s*$/, '')}\n} from '@grafana/data';`;
+  return original.replace(dataImportRe, replacement);
+}
+
+const strOrTpl =
+  '(?:`(?:\\\\`|[^`])*`|\'(?:\\\\\'|[^\'])*\'|"(?:\\\\"|[^"])*")';
+
+function replaceConsole(content) {
+  let s = content;
+
+  s = s.replace(
+    /console\.error\(\s*error\s*\)/g,
+    `structuredLog('error', 'Error', { error: toLogContextPart(error) })`
+  );
+  s = s.replace(
+    /console\.error\(\s*err\s*\)/g,
+    `structuredLog('error', 'Error', { error: toLogContextPart(err) })`
+  );
+  s = s.replace(/console\.error\(\s*e\s*\)/g, `structuredLog('error', 'Error', { error: toLogContextPart(e) })`);
+
+  s = s.replace(/console\.warn\(\s*warningMessage\s*\)/g, `structuredLog('warn', String(warningMessage))`);
+
+  /** console.error(string|template, errVar) — errVar identifier only */
+  s = s.replace(
+    new RegExp(
+      `console\\.error\\(\\s*(${strOrTpl})\\s*,\\s*([a-zA-Z_$][a-zA-Z0-9_$]*)\\s*\\)`,
+      'g'
+    ),
+    `structuredLog('error', $1, { error: toLogContextPart($2) })`
+  );
+
+  /** console.warn(string|template, expr) */
+  s = s.replace(
+    new RegExp(`console\\.warn\\(\\s*(${strOrTpl})\\s*,\\s*((?:[^)]|\\([^)]*\\))+)\\s*\\)`, 'g'),
+    `structuredLog('warn', $1, { details: $2 })`
+  );
+
+  /** console.error(string|template, expr) — non-identifier tails */
+  s = s.replace(
+    new RegExp(`console\\.error\\(\\s*(${strOrTpl})\\s*,\\s*((?:[^)]|\\([^)]*\\))+)\\s*\\)`, 'g'),
+    `structuredLog('error', $1, { details: $2 })`
+  );
+
+  /** Single-arg string / template logs */
+  s = s.replace(new RegExp(`console\\.log\\(\\s*(${strOrTpl})\\s*\\)`, 'g'), `structuredLog('info', $1)`);
+  s = s.replace(
+    new RegExp(`console\\.log\\(\\s*(${strOrTpl})\\s*,\\s*((?:[^)]|\\([^)]*\\))+)\\)`, 'g'),
+    `structuredLog('info', $1, { details: $2 })`
+  );
+  s = s.replace(new RegExp(`console\\.debug\\(\\s*(${strOrTpl})\\s*\\)`, 'g'), `structuredLog('debug', $1)`);
+  s = s.replace(new RegExp(`console\\.warn\\(\\s*(${strOrTpl})\\s*\\)`, 'g'), `structuredLog('warn', $1)`);
+
+  /** console.error(ident, plain object literal) */
+  s = s.replace(
+    /console\.error\(\s*([a-zA-Z_$][a-zA-Z0-9_$]*)\s*,\s*(\{[^}]*\})\s*\)/g,
+    `structuredLog('error', 'Error', { error: toLogContextPart($1), context: $2 })`
+  );
+
+  /** console.info */
+  s = s.replace(
+    new RegExp(`console\\.info\\(\\s*(${strOrTpl})\\s*,\\s*((?:[^)]|\\([^)]*\\))+?)\\)`, 'g'),
+    `structuredLog('info', $1, { details: $2 })`
+  );
+  s = s.replace(new RegExp(`console\\.info\\(\\s*(${strOrTpl})\\s*\\)`, 'g'), `structuredLog('info', $1)`);
+
+  /** console.log(singleIdentifier); */
+  s = s.replace(
+    /console\.log\(\s*([a-zA-Z_$][a-zA-Z0-9_$]*)\s*\)\s*;/g,
+    `structuredLog('info', 'console.log', { value: toLogContextPart($1) });`
+  );
+
+  /** Single-arg console.error string */
+  s = s.replace(new RegExp(`console\\.error\\(\\s*(${strOrTpl})\\s*\\)`, 'g'), `structuredLog('error', $1)`);
+
+  /** console.warn(property chain) */
+  s = s.replace(
+    /console\.warn\(\s*([a-zA-Z_$][a-zA-Z0-9_$]*(?:\.[a-zA-Z_$][a-zA-Z0-9_$]*)+)\s*\)/g,
+    `structuredLog('warn', String($1))`
+  );
+
+  return s;
+}
+
+let updated = 0;
+for (const base of scanDirs) {
+  for (const fp of walk(base)) {
+    const txt = fs.readFileSync(fp, 'utf8');
+    if (!/console\.(log|warn|error|debug|info)\(/.test(txt)) {
+      continue;
+    }
+    let next = replaceConsole(txt);
+    if (next === txt) {
+      continue;
+    }
+    next = ensureImport(next);
+    fs.writeFileSync(fp, next);
+    updated++;
+  }
+}
+
+// eslint-disable-next-line no-console -- migration utility
+console.log(JSON.stringify({ updatedFiles: updated }));


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Introduces a canonical **single-line JSON** logging path via `structuredLog` / `toLogContextPart` on `@grafana/data`, wires `@grafana/runtime` monitoring helpers to emit the same format when the Grafana JavaScript Agent is disabled, and migrates the Grafana web app, Swagger UI, datasource packages, `@grafana/ui` (including Storybook stories), and related code off raw `console.*` calls.

`@grafana/i18n` keeps a tiny local duplicate of the JSON logger so we do not add a heavyweight `@grafana/data` dependency there (that package uses a narrower TS/browser surface).

## Notes

- The implementation at `structuredConsole.ts` intentionally remains the single place under libraries that calls `console.log` / `console.warn` / `console.error` with structured payloads.
- `scripts/migrate-console-pass1.mjs` documents repeatable regex-based replacements; rerun only if extending patterns intentionally.
- **Not migrated:** built plugin `dist/*` bundles, Node maintenance scripts under `scripts/` (they still print to stdout for CLI UX), and MDX/docs examples that mention `console` in prose.

## Testing

- `yarn jest packages/grafana-data/src/utils/structuredConsole.test.ts packages/grafana-data/src/utils/deprecationWarning.test.ts --no-watch --watchAll=false`
- `yarn workspace @grafana/runtime exec tsc --noEmit -p tsconfig.build.json`
- `cd packages/grafana-ui && yarn typecheck`
- `cd packages/grafana-i18n && yarn typecheck`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-004ade68-465d-4913-9c18-abb527783e2d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-004ade68-465d-4913-9c18-abb527783e2d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

