### PR TITLE
feat(labs): Labs page with registered feature flags

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -152,6 +152,8 @@ func (hs *HTTPServer) registerRoutes() {
 
 	r.Get("/styleguide", reqSignedIn, hs.Index)
 
+	r.Get("/labs", reqSignedIn, hs.Index)
+
 	r.Get("/live", reqGrafanaAdmin, hs.Index)
 	r.Get("/live/pipeline", reqGrafanaAdmin, hs.Index)
 	r.Get("/live/cloud", reqGrafanaAdmin, hs.Index)
@@ -286,6 +288,8 @@ func (hs *HTTPServer) registerRoutes() {
 
 	// authed api
 	r.Group("/api", func(apiRoute routing.RouteRegister) {
+		apiRoute.Get("/featuremgmt/registered-flags", reqSignedIn, routing.Wrap(hs.GetRegisteredFeatureFlags))
+
 		// user (signed in)
 		apiRoute.Group("/user", func(userRoute routing.RouteRegister) {
 			userRoute.Get("/", routing.Wrap(hs.GetSignedInUser))

--- a/pkg/api/featuremgmt_labs.go
+++ b/pkg/api/featuremgmt_labs.go
@@ -1,0 +1,23 @@
+package api
+
+import (
+	"net/http"
+
+	"github.com/grafana/grafana/pkg/api/response"
+	contextmodel "github.com/grafana/grafana/pkg/services/contexthandler/model"
+	"github.com/grafana/grafana/pkg/services/featuremgmt"
+)
+
+// GET /api/featuremgmt/registered-flags
+func (hs *HTTPServer) GetRegisteredFeatureFlags(c *contextmodel.ReqContext) response.Response {
+	if !c.IsSignedIn {
+		return response.Error(http.StatusUnauthorized, "Unauthorized", nil)
+	}
+
+	provider, ok := hs.Features.(featuremgmt.RegisteredFeatureFlagsProvider)
+	if !ok {
+		return response.JSON(http.StatusOK, []featuremgmt.RegisteredFeatureFlag{})
+	}
+
+	return response.JSON(http.StatusOK, provider.GetRegisteredFeatureFlags(c.Req.Context()))
+}

--- a/pkg/services/featuremgmt/manager.go
+++ b/pkg/services/featuremgmt/manager.go
@@ -1,15 +1,18 @@
 package featuremgmt
 
 import (
+	"cmp"
 	"context"
 	"fmt"
 	"reflect"
+	"slices"
 
 	"github.com/grafana/grafana/pkg/infra/log"
 )
 
 var (
-	_ FeatureToggles = (*FeatureManager)(nil)
+	_ FeatureToggles                 = (*FeatureManager)(nil)
+	_ RegisteredFeatureFlagsProvider = (*FeatureManager)(nil)
 )
 
 type FeatureManager struct {
@@ -116,6 +119,27 @@ func (fm *FeatureManager) GetEnabled(ctx context.Context) map[string]bool {
 		}
 	}
 	return enabled
+}
+
+// GetRegisteredFeatureFlags returns every registered flag with its current enabled state.
+func (fm *FeatureManager) GetRegisteredFeatureFlags(ctx context.Context) []RegisteredFeatureFlag {
+	defs := fm.GetFlags()
+	slices.SortFunc(defs, func(a, b FeatureFlag) int {
+		return cmp.Compare(a.Name, b.Name)
+	})
+	out := make([]RegisteredFeatureFlag, 0, len(defs))
+	for _, f := range defs {
+		out = append(out, RegisteredFeatureFlag{
+			Name:            f.Name,
+			Description:     f.Description,
+			Stage:           f.Stage.String(),
+			Enabled:         fm.IsEnabled(ctx, f.Name),
+			Expression:      f.Expression,
+			RequiresDevMode: f.RequiresDevMode,
+			FrontendOnly:    f.FrontendOnly,
+		})
+	}
+	return out
 }
 
 // GetFlags returns all flag definitions

--- a/pkg/services/featuremgmt/manager_test.go
+++ b/pkg/services/featuremgmt/manager_test.go
@@ -24,6 +24,16 @@ func TestFeatureManager(t *testing.T) {
 		require.Equal(t, map[string]bool{"a": true}, ft.GetEnabled(context.Background()))
 	})
 
+	t.Run("registered flags sorted by name", func(t *testing.T) {
+		ft := WithManager("zebra", true, "alpha", false)
+		flags := ft.GetRegisteredFeatureFlags(context.Background())
+		require.Len(t, flags, 2)
+		require.Equal(t, "alpha", flags[0].Name)
+		require.False(t, flags[0].Enabled)
+		require.Equal(t, "zebra", flags[1].Name)
+		require.True(t, flags[1].Enabled)
+	})
+
 	t.Run("check description and stage configs", func(t *testing.T) {
 		ft := FeatureManager{
 			flags: map[string]*FeatureFlag{},

--- a/pkg/services/featuremgmt/models.go
+++ b/pkg/services/featuremgmt/models.go
@@ -31,6 +31,22 @@ type FeatureToggles interface {
 	GetEnabled(ctx context.Context) map[string]bool
 }
 
+// RegisteredFeatureFlag describes a feature toggle for display in the Labs UI.
+type RegisteredFeatureFlag struct {
+	Name            string `json:"name"`
+	Description     string `json:"description"`
+	Stage           string `json:"stage"`
+	Enabled         bool   `json:"enabled"`
+	Expression      string `json:"expression,omitempty"`
+	RequiresDevMode bool   `json:"requiresDevMode,omitempty"`
+	FrontendOnly    bool   `json:"frontendOnly,omitempty"`
+}
+
+// RegisteredFeatureFlagsProvider exposes full registry metadata for the Labs page.
+type RegisteredFeatureFlagsProvider interface {
+	GetRegisteredFeatureFlags(ctx context.Context) []RegisteredFeatureFlag
+}
+
 func AnyEnabled(f FeatureToggles, flags ...string) bool {
 	for _, flag := range flags {
 		if f.IsEnabledGlobally(flag) {

--- a/pkg/services/navtree/models.go
+++ b/pkg/services/navtree/models.go
@@ -38,6 +38,9 @@ const (
 	WeightHelp
 )
 
+// WeightLabs places Labs immediately after Administration (WeightConfig) in the sidebar.
+const WeightLabs = WeightConfig + 50
+
 const (
 	NavIDRoot                 = "root"
 	NavIDDashboards           = "dashboards/browse"
@@ -56,6 +59,7 @@ const (
 	NavIDCfgPlugins           = "cfg/plugins"
 	NavIDCfgAccess            = "cfg/access"
 	NavIDBookmarks            = "bookmarks"
+	NavIDLabs                 = "labs"
 )
 
 type NavLink struct {

--- a/pkg/services/navtree/navtreeimpl/navtree.go
+++ b/pkg/services/navtree/navtreeimpl/navtree.go
@@ -172,6 +172,18 @@ func (s *ServiceImpl) GetNavTree(c *contextmodel.ReqContext, prefs *pref.Prefere
 		return nil, err
 	}
 
+	if c.IsSignedIn {
+		treeRoot.AddSection(&navtree.NavLink{
+			Text:       "Labs",
+			Id:         navtree.NavIDLabs,
+			SubTitle:   "Feature flags registered in this Grafana build",
+			Icon:       "rocket",
+			SortWeight: navtree.WeightLabs,
+			Url:        s.cfg.AppSubURL + "/labs",
+			IsNew:      true,
+		})
+	}
+
 	s.addHelpLinks(treeRoot, c)
 
 	if err := s.addAppLinks(treeRoot, c); err != nil {

--- a/public/app/core/utils/navBarItem-translations.ts
+++ b/public/app/core/utils/navBarItem-translations.ts
@@ -93,6 +93,8 @@ export function getNavTitle(navId: string | undefined) {
       return t('nav.alerts-recently-deleted.title', 'Recently deleted');
     case 'cfg':
       return t('nav.config.title', 'Administration');
+    case 'labs':
+      return t('nav.labs.title', 'Labs');
     case 'cfg/general':
       return t('nav.config-general.title', 'General');
     case 'cfg/plugins':
@@ -319,6 +321,8 @@ export function getNavSubTitle(navId: string | undefined) {
       );
     case 'plugin-page-grafana-ml-app':
       return t('nav.machine-learning.subtitle', 'Explore AI and machine learning features');
+    case 'labs':
+      return t('nav.labs.subtitle', 'Feature flags registered in this Grafana build');
     default:
       return undefined;
   }

--- a/public/app/features/labs/LabsPage.tsx
+++ b/public/app/features/labs/LabsPage.tsx
@@ -1,0 +1,89 @@
+import { useEffect, useMemo, useState } from 'react';
+
+import { t, Trans } from '@grafana/i18n';
+import { getBackendSrv } from '@grafana/runtime';
+import {
+  Alert,
+  Badge,
+  type CellProps,
+  type Column,
+  InteractiveTable,
+  Spinner,
+  Stack,
+  Text,
+} from '@grafana/ui';
+import { Page } from 'app/core/components/Page/Page';
+
+export interface RegisteredFeatureFlagDTO {
+  name: string;
+  description: string;
+  stage: string;
+  enabled: boolean;
+  expression?: string;
+  requiresDevMode?: boolean;
+  frontendOnly?: boolean;
+}
+
+export default function LabsPage() {
+  const [flags, setFlags] = useState<RegisteredFeatureFlagDTO[] | undefined>();
+  const [error, setError] = useState<string>();
+
+  useEffect(() => {
+    getBackendSrv()
+      .get<RegisteredFeatureFlagDTO[]>('/api/featuremgmt/registered-flags')
+      .then((data) => setFlags(data))
+      .catch(() => setError(t('labs-page.load-error', 'Could not load feature flags')));
+  }, []);
+
+  const columns = useMemo<Array<Column<RegisteredFeatureFlagDTO>>>(
+    () => [
+      {
+        id: 'name',
+        header: t('labs-page.column-name', 'Flag'),
+      },
+      {
+        id: 'enabled',
+        header: t('labs-page.column-enabled', 'Enabled'),
+        cell: ({ row }: CellProps<RegisteredFeatureFlagDTO>) => (
+          <Badge
+            color={row.original.enabled ? 'green' : 'red'}
+            text={row.original.enabled ? t('labs-page.enabled-yes', 'On') : t('labs-page.enabled-no', 'Off')}
+          />
+        ),
+      },
+      {
+        id: 'stage',
+        header: t('labs-page.column-stage', 'Stage'),
+      },
+      {
+        id: 'description',
+        header: t('labs-page.column-description', 'Description'),
+      },
+      {
+        id: 'expression',
+        header: t('labs-page.column-expression', 'Default expression'),
+      },
+    ],
+    []
+  );
+
+  return (
+    <Page navId="labs">
+      <Page.Contents>
+        <Stack direction="column" gap={2}>
+          <Text element="p">
+            <Trans i18nKey="labs-page.intro">
+              All feature toggles registered in this Grafana build and whether they are enabled for your session.
+            </Trans>
+          </Text>
+          {error && <Alert title={error} severity="error" />}
+          {flags === undefined ? (
+            <Spinner />
+          ) : (
+            <InteractiveTable columns={columns} data={flags} getRowId={(row) => row.name} />
+          )}
+        </Stack>
+      </Page.Contents>
+    </Page>
+  );
+}

--- a/public/app/features/labs/LabsPage.tsx
+++ b/public/app/features/labs/LabsPage.tsx
@@ -2,16 +2,7 @@ import { useEffect, useMemo, useState } from 'react';
 
 import { t, Trans } from '@grafana/i18n';
 import { getBackendSrv } from '@grafana/runtime';
-import {
-  Alert,
-  Badge,
-  type CellProps,
-  type Column,
-  InteractiveTable,
-  Spinner,
-  Stack,
-  Text,
-} from '@grafana/ui';
+import { Alert, Badge, type CellProps, type Column, InteractiveTable, Spinner, Stack, Text } from '@grafana/ui';
 import { Page } from 'app/core/components/Page/Page';
 
 export interface RegisteredFeatureFlagDTO {

--- a/public/app/routes/routes.tsx
+++ b/public/app/routes/routes.tsx
@@ -539,6 +539,10 @@ export function getAppRoutes(): RouteDescriptor[] {
       ),
     },
     {
+      path: '/labs',
+      component: SafeDynamicImport(() => import(/* webpackChunkName: "LabsPage"*/ 'app/features/labs/LabsPage')),
+    },
+    {
       path: '/theme-playground',
       component: SafeDynamicImport(
         () => import(/* webpackChunkName: "ThemePlayground"*/ 'app/features/theme-playground/ThemePlayground')


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a **Labs** entry in the left navigation (directly after **Administration**) with a **New** badge. The `/labs` page lists every feature toggle registered in the Grafana build (name, enabled state, stage, description, default expression) for any signed-in user.

## Backend

- New `GET /api/featuremgmt/registered-flags` (requires signed-in session).
- `FeatureManager` implements `RegisteredFeatureFlagsProvider` with sorted `GetRegisteredFeatureFlags`.

## Frontend

- `LabsPage` loads data via `getBackendSrv` and renders an `InteractiveTable`.

## Verification

- `go test ./pkg/services/featuremgmt/...`
- Local dev: `make run` + `yarn start`; API smoke: `curl -u admin:admin http://localhost:3000/api/featuremgmt/registered-flags`

## Artifacts

Sample API response saved during verification: `/opt/cursor/artifacts/labs-registered-flags-sample.json`

Screenshot (headless `/labs` navigation): ![Labs route screenshot](https://cursor.com/artifacts/c/art-56fbe86b-e1a9-4bc0-b2af-6904d47d62bf)

Target repo: **fieldsphere/grafana**
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7c6bf546-329b-4ee4-bcd6-94f8eb418eb2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7c6bf546-329b-4ee4-bcd6-94f8eb418eb2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

