### PR TITLE
Time Series: Add derived series overlays

### DIFF
--- a/packages/grafana-schema/src/raw/composable/timeseries/panelcfg/x/types.gen.ts
+++ b/packages/grafana-schema/src/raw/composable/timeseries/panelcfg/x/types.gen.ts
@@ -22,10 +22,23 @@ export const defaultTimeSeriesLegendOptions: Partial<TimeSeriesLegendOptions> = 
   enableFacetedFilter: true,
 };
 
+export interface TimeSeriesOverlayOptions {
+  enabled?: boolean;
+  type?: ('movingAverage' | 'linearRegression');
+  window?: number;
+}
+
+export const defaultTimeSeriesOverlayOptions: Partial<TimeSeriesOverlayOptions> = {
+  enabled: false,
+  type: 'movingAverage',
+  window: 10,
+};
+
 export interface Options extends common.OptionsWithTimezones, common.OptionsWithAnnotations {
   disableKeyboardEvents?: boolean;
   legend: TimeSeriesLegendOptions;
   orientation?: common.VizOrientation;
+  overlay?: TimeSeriesOverlayOptions;
   timeCompare?: common.TimeCompareOptions;
   tooltip: common.VizTooltipOptions;
 }

--- a/public/app/plugins/panel/timeseries/TimeSeriesPanel.tsx
+++ b/public/app/plugins/panel/timeseries/TimeSeriesPanel.tsx
@@ -30,7 +30,7 @@ import { OutsideRangePlugin } from './plugins/OutsideRangePlugin';
 import { ThresholdControlsPlugin } from './plugins/ThresholdControlsPlugin';
 import { getXAnnotationFrames } from './plugins/utils';
 import { getPrepareTimeseriesSuggestion } from './suggestions';
-import { getGroupedFilters, getTimezones, prepareGraphableFields } from './utils';
+import { getGroupedFilters, getTimezones, prepareGraphableFields, prepareTimeSeriesOverlayFields } from './utils';
 
 interface TimeSeriesPanelProps extends PanelProps<Options> {}
 
@@ -67,6 +67,7 @@ export const TimeSeriesPanel = ({
   const isVerticallyOriented = options.orientation === VizOrientation.Vertical;
   const { frames, compareDiffMs } = useMemo(() => {
     let frames = prepareGraphableFields(data.series, config.theme2, timeRange);
+    frames = prepareTimeSeriesOverlayFields(frames, options.overlay, config.theme2);
     if (frames != null) {
       let compareDiffMs: number[] = [0];
 
@@ -94,7 +95,7 @@ export const TimeSeriesPanel = ({
     }
 
     return { frames };
-  }, [data.series, timeRange]);
+  }, [data.series, options.overlay, timeRange]);
 
   const timezones = useMemo(() => getTimezones(options.timezone, timeZone), [options.timezone, timeZone]);
   const suggestions = useMemo(() => {

--- a/public/app/plugins/panel/timeseries/module.tsx
+++ b/public/app/plugins/panel/timeseries/module.tsx
@@ -21,6 +21,7 @@ export const plugin = new PanelPlugin<Options, FieldConfig>(TimeSeriesPanel)
     commonOptionsBuilder.addLegendOptions(builder, true, true);
 
     const legendCategory = [t('timeseries.legend.category', 'Legend')];
+    const overlayCategory = [t('timeseries.overlay.category', 'Overlay')];
 
     if (config.featureToggles.vizLegendFacetedFilter) {
       builder.addBooleanSwitch({
@@ -32,6 +33,40 @@ export const plugin = new PanelPlugin<Options, FieldConfig>(TimeSeriesPanel)
         showIf: (c) => c.legend.showLegend,
       });
     }
+
+    builder
+      .addBooleanSwitch({
+        path: 'overlay.enabled',
+        name: t('timeseries.overlay.name-enable', 'Show overlay'),
+        category: overlayCategory,
+        description: t('timeseries.overlay.description-enable', 'Render a derived series for each numeric time series'),
+        defaultValue: false,
+      })
+      .addRadio({
+        path: 'overlay.type',
+        name: t('timeseries.overlay.name-type', 'Overlay type'),
+        category: overlayCategory,
+        defaultValue: 'movingAverage',
+        settings: {
+          options: [
+            { value: 'movingAverage', label: t('timeseries.overlay.type-moving-average', 'Moving average') },
+            { value: 'linearRegression', label: t('timeseries.overlay.type-linear-regression', 'Linear regression') },
+          ],
+        },
+        showIf: (c) => Boolean(c.overlay?.enabled),
+      })
+      .addNumberInput({
+        path: 'overlay.window',
+        name: t('timeseries.overlay.name-window', 'Window size'),
+        category: overlayCategory,
+        description: t('timeseries.overlay.description-window', 'Number of trailing points used for moving average'),
+        defaultValue: 10,
+        settings: {
+          min: 2,
+          integer: true,
+        },
+        showIf: (c) => Boolean(c.overlay?.enabled) && c.overlay?.type !== 'linearRegression',
+      });
 
     builder.addCustomEditor({
       id: 'timezone',

--- a/public/app/plugins/panel/timeseries/panelcfg.cue
+++ b/public/app/plugins/panel/timeseries/panelcfg.cue
@@ -26,6 +26,11 @@ composableKinds: PanelCfg: lineage: {
 				common.VizLegendOptions
 				enableFacetedFilter?: bool | *true
 			} @cuetsy(kind="interface")
+			TimeSeriesOverlayOptions: {
+				enabled?: bool | *false
+				type?:    "movingAverage" | "linearRegression" | *"movingAverage"
+				window?:  int | *10
+			} @cuetsy(kind="interface")
 			Options: {
 				common.OptionsWithTimezones
 				common.OptionsWithAnnotations
@@ -36,6 +41,7 @@ composableKinds: PanelCfg: lineage: {
 				orientation?:           common.VizOrientation
 				annotations?:           common.VizAnnotations
 				disableKeyboardEvents?: bool
+				overlay?:               TimeSeriesOverlayOptions
 			} @cuetsy(kind="interface")
 
 			FieldConfig: common.GraphFieldConfig & {} @cuetsy(kind="interface")

--- a/public/app/plugins/panel/timeseries/panelcfg.gen.ts
+++ b/public/app/plugins/panel/timeseries/panelcfg.gen.ts
@@ -20,10 +20,23 @@ export const defaultTimeSeriesLegendOptions: Partial<TimeSeriesLegendOptions> = 
   enableFacetedFilter: true,
 };
 
+export interface TimeSeriesOverlayOptions {
+  enabled?: boolean;
+  type?: ('movingAverage' | 'linearRegression');
+  window?: number;
+}
+
+export const defaultTimeSeriesOverlayOptions: Partial<TimeSeriesOverlayOptions> = {
+  enabled: false,
+  type: 'movingAverage',
+  window: 10,
+};
+
 export interface Options extends common.OptionsWithTimezones, common.OptionsWithAnnotations {
   disableKeyboardEvents?: boolean;
   legend: TimeSeriesLegendOptions;
   orientation?: common.VizOrientation;
+  overlay?: TimeSeriesOverlayOptions;
   timeCompare?: common.TimeCompareOptions;
   tooltip: common.VizTooltipOptions;
 }

--- a/public/app/plugins/panel/timeseries/utils.test.ts
+++ b/public/app/plugins/panel/timeseries/utils.test.ts
@@ -9,6 +9,7 @@ import {
   getTimezones,
   isTooltipScrollable,
   prepareGraphableFields,
+  prepareTimeSeriesOverlayFields,
   setClassicPaletteIdxs,
 } from './utils';
 
@@ -167,6 +168,113 @@ describe('prepare timeseries graph', () => {
       ]
     `);
     expect(frames![0].length).toEqual(6);
+  });
+
+  describe('prepareTimeSeriesOverlayFields', () => {
+    it('returns the original frames when overlay is disabled', () => {
+      const frames = prepareGraphableFields(
+        [
+          createDataFrame({
+            fields: [
+              { name: 'time', type: FieldType.time, values: [1, 2, 3] },
+              { name: 'a', type: FieldType.number, values: [1, 2, 3] },
+            ],
+          }),
+        ],
+        createTheme()
+      );
+
+      expect(prepareTimeSeriesOverlayFields(frames, { enabled: false }, createTheme())).toBe(frames);
+    });
+
+    it('adds a trailing moving average overlay for numeric time series', () => {
+      const frames = prepareGraphableFields(
+        [
+          createDataFrame({
+            fields: [
+              { name: 'time', type: FieldType.time, values: [1, 2, 3, 4] },
+              { name: 'a', type: FieldType.number, values: [2, null, 6, 10] },
+            ],
+          }),
+        ],
+        createTheme()
+      );
+
+      const result = prepareTimeSeriesOverlayFields(
+        frames,
+        { enabled: true, type: 'movingAverage', window: 2 },
+        createTheme()
+      );
+
+      expect(result![0].fields.map((field) => field.name)).toEqual(['time', 'a', 'a (moving average, 2)']);
+      expect(result![0].fields[2].values).toEqual([2, 2, 6, 8]);
+      expect(result![0].fields[2].config.custom.drawStyle).toEqual('line');
+    });
+
+    it('clamps moving average window size to a minimum of two', () => {
+      const frames = prepareGraphableFields(
+        [
+          createDataFrame({
+            fields: [
+              { name: 'time', type: FieldType.time, values: [1, 2, 3] },
+              { name: 'a', type: FieldType.number, values: [2, 4, 10] },
+            ],
+          }),
+        ],
+        createTheme()
+      );
+
+      const result = prepareTimeSeriesOverlayFields(
+        frames,
+        { enabled: true, type: 'movingAverage', window: 1 },
+        createTheme()
+      );
+
+      expect(result![0].fields[2].name).toBe('a (moving average, 2)');
+      expect(result![0].fields[2].values).toEqual([2, 3, 7]);
+    });
+
+    it('adds a linear regression overlay across the source time domain', () => {
+      const frames = prepareGraphableFields(
+        [
+          createDataFrame({
+            fields: [
+              { name: 'time', type: FieldType.time, values: [0, 1, 2, 3] },
+              { name: 'a', type: FieldType.number, values: [1, 3, null, 7] },
+            ],
+          }),
+        ],
+        createTheme()
+      );
+
+      const result = prepareTimeSeriesOverlayFields(frames, { enabled: true, type: 'linearRegression' }, createTheme());
+
+      expect(result![0].fields.map((field) => field.name)).toEqual(['time', 'a', 'a (trendline)']);
+      expect(result![0].fields[2].values).toEqual([1, 3, 5, 7]);
+    });
+
+    it('ignores non-numeric fields when building overlays', () => {
+      const frames = prepareGraphableFields(
+        [
+          createDataFrame({
+            fields: [
+              { name: 'time', type: FieldType.time, values: [1, 2, 3] },
+              { name: 'label', type: FieldType.string, values: ['a', 'b', 'c'] },
+              { name: 'a', type: FieldType.number, values: [1, 2, 3] },
+            ],
+          }),
+        ],
+        createTheme()
+      );
+
+      const result = prepareTimeSeriesOverlayFields(
+        frames,
+        { enabled: true, type: 'movingAverage', window: 3 },
+        createTheme()
+      );
+
+      expect(result![0].fields.map((field) => field.name)).toEqual(['time', 'label', 'a', 'a (moving average, 3)']);
+    });
   });
 
   describe('boolean fields', () => {

--- a/public/app/plugins/panel/timeseries/utils.test.ts
+++ b/public/app/plugins/panel/timeseries/utils.test.ts
@@ -1,4 +1,4 @@
-import { createTheme, FieldType, createDataFrame, toDataFrame } from '@grafana/data';
+import { createTheme, FieldType, createDataFrame, getFieldDisplayName, toDataFrame } from '@grafana/data';
 import { TooltipDisplayMode } from '@grafana/schema';
 import { LineInterpolation } from '@grafana/ui';
 
@@ -209,6 +209,7 @@ describe('prepare timeseries graph', () => {
       expect(result![0].fields.map((field) => field.name)).toEqual(['time', 'a', 'a (moving average, 2)']);
       expect(result![0].fields[2].values).toEqual([2, 2, 6, 8]);
       expect(result![0].fields[2].config.custom.drawStyle).toEqual('line');
+      expect(getFieldDisplayName(result![0].fields[2], result![0], result!)).toBe('a (moving average, 2)');
     });
 
     it('clamps moving average window size to a minimum of two', () => {

--- a/public/app/plugins/panel/timeseries/utils.ts
+++ b/public/app/plugins/panel/timeseries/utils.ts
@@ -392,9 +392,11 @@ function getOverlayField(
   return {
     ...sourceField,
     name: label,
+    state: sourceField.state ? { ...sourceField.state, displayName: undefined, multipleFrames: undefined } : undefined,
     config: {
       ...sourceField.config,
       displayName: label,
+      displayNameFromDS: undefined,
       links: [],
       custom: {
         ...sourceCustom,

--- a/public/app/plugins/panel/timeseries/utils.ts
+++ b/public/app/plugins/panel/timeseries/utils.ts
@@ -12,11 +12,21 @@ import {
   nullToValue,
 } from '@grafana/data';
 import { convertFieldType } from '@grafana/data/internal';
-import { type GraphFieldConfig, LineInterpolation, TooltipDisplayMode, type VizTooltipOptions } from '@grafana/schema';
+import {
+  GraphDrawStyle,
+  type GraphFieldConfig,
+  GraphGradientMode,
+  LineInterpolation,
+  StackingMode,
+  TooltipDisplayMode,
+  type VizTooltipOptions,
+} from '@grafana/schema';
 import { type AdHocFilterItem } from '@grafana/ui';
 import { buildScaleKey, FILTER_FOR_OPERATOR } from '@grafana/ui/internal';
 
 import { type HeatmapTooltip } from '../heatmap/panelcfg.gen';
+
+import { type TimeSeriesOverlayOptions } from './panelcfg.gen';
 
 type ScaleKey = string;
 
@@ -237,6 +247,172 @@ export function prepareGraphableFields(
   }
 
   return null;
+}
+
+export function prepareTimeSeriesOverlayFields(
+  frames: DataFrame[] | null,
+  overlay: TimeSeriesOverlayOptions | undefined,
+  theme: GrafanaTheme2
+): DataFrame[] | null {
+  if (!frames || !overlay?.enabled) {
+    return frames;
+  }
+
+  const overlayType = overlay.type ?? 'movingAverage';
+  const windowSize = Math.max(2, Math.floor(overlay.window ?? 10));
+  let hasOverlay = false;
+
+  const framesWithOverlays = frames.map((frame) => {
+    const timeField = frame.fields.find((field) => field.type === FieldType.time);
+    if (!timeField) {
+      return frame;
+    }
+
+    const overlayFields: Field[] = [];
+
+    for (const field of frame.fields) {
+      if (field === timeField || field.type !== FieldType.number) {
+        continue;
+      }
+
+      const values =
+        overlayType === 'linearRegression'
+          ? getLinearRegressionValues(timeField.values, field.values)
+          : getMovingAverageValues(field.values, windowSize);
+
+      if (values.every((value) => value == null)) {
+        continue;
+      }
+
+      overlayFields.push(getOverlayField(field, values, overlayType, windowSize));
+    }
+
+    if (overlayFields.length === 0) {
+      return frame;
+    }
+
+    hasOverlay = true;
+    return {
+      ...frame,
+      fields: [...frame.fields, ...overlayFields],
+    };
+  });
+
+  if (!hasOverlay) {
+    return frames;
+  }
+
+  setClassicPaletteIdxs(framesWithOverlays, theme, 0);
+  return framesWithOverlays;
+}
+
+function getMovingAverageValues(values: unknown[], windowSize: number): Array<number | null> {
+  return values.map((_, index) => {
+    const start = Math.max(0, index - windowSize + 1);
+    let sum = 0;
+    let count = 0;
+
+    for (let i = start; i <= index; i++) {
+      const value = values[i];
+      if (isFiniteNumber(value)) {
+        sum += value;
+        count++;
+      }
+    }
+
+    return count > 0 ? sum / count : null;
+  });
+}
+
+function getLinearRegressionValues(xValues: unknown[], yValues: unknown[]): Array<number | null> {
+  const points: Array<[number, number]> = [];
+  const xOffset = xValues.find(isFiniteNumber);
+
+  if (xOffset == null) {
+    return yValues.map(() => null);
+  }
+
+  for (let i = 0; i < yValues.length; i++) {
+    const x = xValues[i];
+    const y = yValues[i];
+
+    if (isFiniteNumber(x) && isFiniteNumber(y)) {
+      points.push([x - xOffset, y]);
+    }
+  }
+
+  if (points.length < 2) {
+    return yValues.map(() => null);
+  }
+
+  let sumX = 0;
+  let sumY = 0;
+  let sumXX = 0;
+  let sumXY = 0;
+
+  for (const [x, y] of points) {
+    sumX += x;
+    sumY += y;
+    sumXX += x * x;
+    sumXY += x * y;
+  }
+
+  const n = points.length;
+  const denominator = n * sumXX - sumX * sumX;
+
+  if (denominator === 0) {
+    return yValues.map(() => null);
+  }
+
+  const slope = (n * sumXY - sumX * sumY) / denominator;
+  const intercept = (sumY - slope * sumX) / n;
+
+  return yValues.map((_, index) => {
+    const x = xValues[index];
+    return isFiniteNumber(x) ? intercept + slope * (x - xOffset) : null;
+  });
+}
+
+function isFiniteNumber(value: unknown): value is number {
+  return typeof value === 'number' && Number.isFinite(value);
+}
+
+function getOverlayField(
+  sourceField: Field,
+  values: Array<number | null>,
+  overlayType: TimeSeriesOverlayOptions['type'],
+  windowSize: number
+): Field {
+  const sourceCustom: GraphFieldConfig = sourceField.config.custom ?? {};
+  const label =
+    overlayType === 'linearRegression'
+      ? `${sourceField.name} (trendline)`
+      : `${sourceField.name} (moving average, ${windowSize})`;
+
+  return {
+    ...sourceField,
+    name: label,
+    config: {
+      ...sourceField.config,
+      displayName: label,
+      links: [],
+      custom: {
+        ...sourceCustom,
+        drawStyle: GraphDrawStyle.Line,
+        fillOpacity: 0,
+        gradientMode: GraphGradientMode.None,
+        lineInterpolation: LineInterpolation.Linear,
+        lineStyle: { fill: 'dash' },
+        lineWidth: Math.max(sourceCustom.lineWidth ?? 1, 2),
+        stacking: {
+          mode: StackingMode.None,
+          group: sourceCustom.stacking?.group ?? 'A',
+        },
+      },
+    },
+    values,
+    getLinks: undefined,
+  };
 }
 
 const matchEnumColorToSeriesColor = (frames: DataFrame[], theme: GrafanaTheme2) => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
**What is this feature?**

Adds a Time Series panel overlay option that renders derived client-side series for each numeric time series: trailing moving average or simple linear regression trendline.

<a href="https://cursor.com/agents/bc-5f92cc1c-d6a2-4ff9-82bc-640ba408e336/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ftimeseries_overlay_e2e_walkthrough.mp4"><img src="https://cursor.com/artifacts/c/art-d5969758-f564-4bd5-8c88-5f91cb140a02" alt="timeseries_overlay_e2e_walkthrough.mp4" /></a>

![Moving average overlay legend](https://cursor.com/artifacts/c/art-1bd3a1e9-02d3-403b-b21f-65080c2be084)

![Overlay editor settings](https://cursor.com/artifacts/c/art-6cd2862f-9c73-45e9-bdbc-0b2b661615c0)

![Trendline overlay legend](https://cursor.com/artifacts/c/art-bd42bb86-bffb-496e-874f-484240256094)

**Why do we need this feature?**

Users can inspect smoothed values or trend direction directly in the Time Series panel without changing queries, datasources, or backend APIs.

**Who is this feature for?**

Grafana users analyzing numeric time series in dashboards.

**Which issue(s) does this PR fix?**:

Fixes #

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle. Not applicable; this is a panel option disabled by default.
- [ ] The docs are updated, and if this is a notable improvement, it's added to What's New.

Testing:
- `make gen-cue`
- `yarn prettier:write public/app/plugins/panel/timeseries/TimeSeriesPanel.tsx public/app/plugins/panel/timeseries/module.tsx public/app/plugins/panel/timeseries/utils.ts public/app/plugins/panel/timeseries/utils.test.ts public/app/plugins/panel/timeseries/panelcfg.gen.ts packages/grafana-schema/src/raw/composable/timeseries/panelcfg/x/types.gen.ts`
- `yarn eslint public/app/plugins/panel/timeseries/TimeSeriesPanel.tsx public/app/plugins/panel/timeseries/module.tsx public/app/plugins/panel/timeseries/utils.ts public/app/plugins/panel/timeseries/utils.test.ts`
- `yarn jest --no-watch public/app/plugins/panel/timeseries/utils.test.ts`
- `yarn typecheck`
- Manual UI walkthrough on `http://localhost:3000/d/timeseries-overlay-demo/time-series-overlay-demo?orgId=1`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5f92cc1c-d6a2-4ff9-82bc-640ba408e336"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5f92cc1c-d6a2-4ff9-82bc-640ba408e336"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

