### PR TITLE
Frontend: structured logging for console output

### DIFF
--- a/packages/grafana-alerting/src/grafana/notificationPolicies/components/RoutingTreeSelector/RoutingTreeSelector.tsx
+++ b/packages/grafana-alerting/src/grafana/notificationPolicies/components/RoutingTreeSelector/RoutingTreeSelector.tsx
@@ -8,6 +8,7 @@ import { type CustomComboBoxProps } from '../../../common/ComboBox.types';
 import { USER_DEFINED_TREE_NAME } from '../../consts';
 import { useListRoutingTrees } from '../../hooks/useRoutingTrees';
 
+import { grafanaStructuredLogger } from '@grafana/runtime';
 const collator = new Intl.Collator('en', { sensitivity: 'accent' });
 
 type SingleSelectProps = CustomComboBoxProps<RoutingTree> & { multi?: false };
@@ -130,7 +131,7 @@ function RoutingTreeSelector(props: RoutingTreeSelectorProps) {
     if (selectedOption) {
       const tree = treeLookup.get(selectedOption.value);
       if (!tree) {
-        console.warn(`RoutingTreeSelector: could not find routing tree for value "${selectedOption.value}"`);
+        grafanaStructuredLogger.logWarning(String(`RoutingTreeSelector: could not find routing tree for value "${selectedOption.value}"`));
         return;
       }
 

--- a/packages/grafana-data/src/dataframe/FieldCache.ts
+++ b/packages/grafana-data/src/dataframe/FieldCache.ts
@@ -1,4 +1,5 @@
 import { type DataFrame, type Field, FieldType } from '../types/dataFrame';
+import { emitStructuredBrowserLog } from '../utils/structuredBrowserLog';
 
 import { guessFieldTypeForField } from './processDataFrame';
 
@@ -36,7 +37,7 @@ export class FieldCache {
       });
 
       if (this.fieldByName[field.name]) {
-        console.warn('Duplicate field names in DataFrame: ', field.name);
+        emitStructuredBrowserLog('warn', 'Duplicate field names in DataFrame', { fieldName: field.name });
       } else {
         this.fieldByName[field.name] = { ...field, index: i };
       }

--- a/packages/grafana-data/src/dataframe/processDataFrame.ts
+++ b/packages/grafana-data/src/dataframe/processDataFrame.ts
@@ -1,6 +1,7 @@
 // Libraries
 import { isArray, isBoolean, isNumber, isString } from 'lodash';
 
+import { emitStructuredBrowserLog } from '../utils/structuredBrowserLog';
 import { isDateTime } from '../datetime/moment_wrapper';
 import { fieldIndexComparer } from '../field/fieldComparers';
 import { getFieldDisplayName } from '../field/fieldState';
@@ -340,7 +341,7 @@ export function toDataFrame(data: any): DataFrame {
     return arrayToDataFrame(data);
   }
 
-  console.warn('Can not convert', data);
+  emitStructuredBrowserLog('warn', 'Can not convert', { data });
   throw new Error('Unsupported data format');
 }
 

--- a/packages/grafana-data/src/index.ts
+++ b/packages/grafana-data/src/index.ts
@@ -243,6 +243,11 @@ export {
 } from './utils/datasource';
 export { deprecationWarning } from './utils/deprecationWarning';
 export {
+  emitStructuredBrowserLog,
+  emitStructuredBrowserError,
+  type StructuredLogRecord,
+} from './utils/structuredBrowserLog';
+export {
   CSVHeaderStyle,
   type CSVConfig,
   type CSVParseCallbacks,

--- a/packages/grafana-data/src/text/sanitize.ts
+++ b/packages/grafana-data/src/text/sanitize.ts
@@ -2,6 +2,8 @@ import { sanitizeUrl as braintreeSanitizeUrl } from '@braintree/sanitize-url';
 import DOMPurify from 'dompurify';
 import * as xss from 'xss';
 
+import { emitStructuredBrowserLog } from '../utils/structuredBrowserLog';
+
 const XSSWL = Object.keys(xss.whiteList).reduce<xss.IWhiteList>((acc, element) => {
   acc[element] = xss.whiteList[element]?.concat(['class', 'style']);
   return acc;
@@ -68,7 +70,7 @@ export function sanitize(unsanitizedString: string): string {
       ADD_ATTR: ['target'],
     });
   } catch (error) {
-    console.error('String could not be sanitized', unsanitizedString);
+    emitStructuredBrowserLog('error', 'String could not be sanitized', { sample: unsanitizedString });
     return escapeHtml(unsanitizedString);
   } finally {
     DOMPurify.removeHook('afterSanitizeAttributes');
@@ -99,7 +101,7 @@ export function sanitizeTextPanelContent(unsanitizedString: string): string {
   try {
     return sanitizeTextPanelWhitelist.process(unsanitizedString);
   } catch (error) {
-    console.error('String could not be sanitized', unsanitizedString);
+    emitStructuredBrowserLog('error', 'String could not be sanitized', { sample: unsanitizedString });
     return 'Text string could not be sanitized';
   }
 }

--- a/packages/grafana-data/src/themes/colorManipulator.ts
+++ b/packages/grafana-data/src/themes/colorManipulator.ts
@@ -4,6 +4,8 @@
 
 import tinycolor from 'tinycolor2';
 
+import { emitStructuredBrowserLog } from '../utils/structuredBrowserLog';
+
 /**
  * Returns a number whose value is limited to the given range.
  * @param value The value to be clamped
@@ -15,7 +17,7 @@ import tinycolor from 'tinycolor2';
 function clamp(value: number, min = 0, max = 1) {
   if (process.env.NODE_ENV !== 'production') {
     if (value < min || value > max) {
-      console.error(`The value provided ${value} is out of range [${min}, ${max}].`);
+      emitStructuredBrowserLog('error', `The value provided ${value} is out of range [${min}, ${max}].`);
     }
   }
 

--- a/packages/grafana-data/src/themes/createSpacing.ts
+++ b/packages/grafana-data/src/themes/createSpacing.ts
@@ -3,6 +3,8 @@
 // Copyright (c) 2014 Call-Em-All
 import { z } from 'zod';
 
+import { emitStructuredBrowserLog } from '../utils/structuredBrowserLog';
+
 /** @internal */
 export const ThemeSpacingOptionsSchema = z.object({
   gridSize: z.int().positive().optional(),
@@ -52,7 +54,7 @@ export function createSpacing(options: ThemeSpacingOptions = {}): ThemeSpacing {
 
     if (process.env.NODE_ENV !== 'production') {
       if (typeof value !== 'number') {
-        console.error(`Expected spacing argument to be a number or a string, got ${value}.`);
+        emitStructuredBrowserLog('error', `Expected spacing argument to be a number or a string, got ${value}.`);
       }
     }
     return value * gridSize;
@@ -61,7 +63,7 @@ export function createSpacing(options: ThemeSpacingOptions = {}): ThemeSpacing {
   const spacing = (...args: Array<number | string>): string => {
     if (process.env.NODE_ENV !== 'production') {
       if (!(args.length <= 4)) {
-        console.error(`Too many arguments provided, expected between 0 and 4, got ${args.length}`);
+        emitStructuredBrowserLog('error', `Too many arguments provided, expected between 0 and 4, got ${args.length}`);
       }
     }
 

--- a/packages/grafana-data/src/themes/createTypography.ts
+++ b/packages/grafana-data/src/themes/createTypography.ts
@@ -3,6 +3,8 @@
 // Copyright (c) 2014 Call-Em-All
 import { z } from 'zod';
 
+import { emitStructuredBrowserLog } from '../utils/structuredBrowserLog';
+
 import { type ThemeColors } from './createColors';
 
 /** @beta */
@@ -76,11 +78,11 @@ export function createTypography(colors: ThemeColors, typographyInput: ThemeTypo
 
   if (process.env.NODE_ENV !== 'production') {
     if (typeof fontSize !== 'number') {
-      console.error('Grafana-UI: `fontSize` is required to be a number.');
+      emitStructuredBrowserLog('error', 'Grafana-UI: `fontSize` is required to be a number.');
     }
 
     if (typeof htmlFontSize !== 'number') {
-      console.error('Grafana-UI: `htmlFontSize` is required to be a number.');
+      emitStructuredBrowserLog('error', 'Grafana-UI: `htmlFontSize` is required to be a number.');
     }
   }
 

--- a/packages/grafana-data/src/themes/registry.ts
+++ b/packages/grafana-data/src/themes/registry.ts
@@ -1,4 +1,5 @@
 import { Registry, type RegistryItem } from '../utils/Registry';
+import { emitStructuredBrowserLog } from '../utils/structuredBrowserLog';
 
 import { createTheme, NewThemeOptionsSchema } from './createTheme';
 import aubergine from './themeDefinitions/aubergine.json';
@@ -87,7 +88,7 @@ const themeRegistry = new Registry<ThemeRegistryItem>(() => {
 for (const [name, json] of Object.entries(extraThemes)) {
   const result = NewThemeOptionsSchema.safeParse(json);
   if (!result.success) {
-    console.error(`Invalid theme definition for theme ${name}: ${result.error.message}`);
+    emitStructuredBrowserLog('error', `Invalid theme definition for theme ${name}: ${result.error.message}`);
   } else {
     const theme = result.data;
     themeRegistry.register({

--- a/packages/grafana-data/src/transformations/matchers/nameMatcher.ts
+++ b/packages/grafana-data/src/transformations/matchers/nameMatcher.ts
@@ -2,6 +2,7 @@ import { getFieldDisplayName } from '../../field/fieldState';
 import { stringToJsRegex } from '../../text/string';
 import { type DataFrame, type Field, FieldType, TIME_SERIES_VALUE_FIELD_NAME } from '../../types/dataFrame';
 import { type FieldMatcher, type FieldMatcherInfo, type FrameMatcherInfo } from '../../types/transformations';
+import { emitStructuredBrowserError } from '../../utils/structuredBrowserLog';
 
 import { FieldMatcherID, FrameMatcherID } from './ids';
 
@@ -201,7 +202,7 @@ const patternToRegex = (pattern?: string): RegExp | undefined => {
   try {
     return stringToJsRegex(pattern);
   } catch (error) {
-    console.error(error);
+    emitStructuredBrowserError(error instanceof Error ? error : new Error(String(error)));
     return undefined;
   }
 };

--- a/packages/grafana-data/src/transformations/matchers/refIdMatcher.ts
+++ b/packages/grafana-data/src/transformations/matchers/refIdMatcher.ts
@@ -1,6 +1,7 @@
 import { escapeStringForRegex, stringStartsAsRegEx, stringToJsRegex } from '../../text/string';
 import { type DataFrame } from '../../types/dataFrame';
 import { type FrameMatcherInfo } from '../../types/transformations';
+import { emitStructuredBrowserLog } from '../../utils/structuredBrowserLog';
 
 import { FrameMatcherID } from './ids';
 
@@ -19,7 +20,7 @@ const refIdMatcher: FrameMatcherInfo<string> = {
         regex = stringToJsRegex(pattern);
       } catch (error) {
         if (error instanceof Error) {
-          console.warn(error.message);
+          emitStructuredBrowserLog('warn', error.message);
         }
       }
     }

--- a/packages/grafana-data/src/transformations/transformers/filterByValue.ts
+++ b/packages/grafana-data/src/transformations/transformers/filterByValue.ts
@@ -3,6 +3,7 @@ import { map } from 'rxjs/operators';
 import { getFieldDisplayName } from '../../field/fieldState';
 import { type DataFrame, type Field } from '../../types/dataFrame';
 import { type DataTransformerInfo, type MatcherConfig } from '../../types/transformations';
+import { emitStructuredBrowserLog } from '../../utils/structuredBrowserLog';
 import { getValueMatcher } from '../matchers';
 
 import { DataTransformerID } from './ids';
@@ -139,7 +140,7 @@ const createFilterValueMatchers = (
     const fieldIndex = fieldIndexByName[filter.fieldName] ?? -1;
 
     if (fieldIndex < 0) {
-      console.warn(`[FilterByValue] Could not find index for field name: ${filter.fieldName}`);
+      emitStructuredBrowserLog('warn', `[FilterByValue] Could not find index for field name: ${filter.fieldName}`);
       return noop;
     }
 

--- a/packages/grafana-data/src/types/app.ts
+++ b/packages/grafana-data/src/types/app.ts
@@ -1,6 +1,7 @@
 import { type ComponentType } from 'react';
 
 import { throwIfAngular } from '../utils/throwIfAngular';
+import { emitStructuredBrowserLog } from '../utils/structuredBrowserLog';
 
 import { type KeyValue } from './data';
 import { type NavModel } from './navModel';
@@ -93,7 +94,10 @@ export class AppPlugin<T extends KeyValue = KeyValue> extends GrafanaPlugin<AppP
           const exp = pluginExports[include.component];
 
           if (!exp) {
-            console.warn('App Page uses unknown component: ', include.component, this.meta);
+            emitStructuredBrowserLog('warn', 'App Page uses unknown component', {
+              component: include.component,
+              meta: this.meta,
+            });
             continue;
           }
         }

--- a/packages/grafana-data/src/types/plugin.ts
+++ b/packages/grafana-data/src/types/plugin.ts
@@ -1,5 +1,7 @@
 import { type ComponentType } from 'react';
 
+import { emitStructuredBrowserLog } from '../utils/structuredBrowserLog';
+
 import { type KeyValue } from './data';
 import { type IconName } from './icon';
 
@@ -260,7 +262,9 @@ export class GrafanaPlugin<T extends PluginMeta = PluginMeta> {
    * @deprecated -- this is no longer necessary and will be removed
    */
   setChannelSupport() {
-    console.warn('[deprecation] plugin is using ignored option: setChannelSupport', this.meta);
+    emitStructuredBrowserLog('warn', '[deprecation] plugin is using ignored option: setChannelSupport', {
+      meta: this.meta,
+    });
     return this;
   }
 

--- a/packages/grafana-data/src/utils/LocalStorageValueProvider.tsx
+++ b/packages/grafana-data/src/utils/LocalStorageValueProvider.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react';
 import * as React from 'react';
 
+import { emitStructuredBrowserError } from './structuredBrowserLog';
 import { store } from './store';
 
 export interface Props<T> {
@@ -32,7 +33,7 @@ export const LocalStorageValueProvider = <T,>(props: Props<T>) => {
     try {
       store.setObject(storageKey, value);
     } catch (error) {
-      console.error(error);
+      emitStructuredBrowserError(error instanceof Error ? error : new Error(String(error)), { storageKey });
     }
     setState({ value });
   };
@@ -41,7 +42,10 @@ export const LocalStorageValueProvider = <T,>(props: Props<T>) => {
     try {
       store.delete(storageKey);
     } catch (error) {
-      console.log(error);
+      emitStructuredBrowserError(error instanceof Error ? error : new Error(String(error)), {
+        operation: 'delete',
+        storageKey,
+      });
     }
     setState({ value: defaultValue });
   };

--- a/packages/grafana-data/src/utils/deprecationWarning.ts
+++ b/packages/grafana-data/src/utils/deprecationWarning.ts
@@ -1,5 +1,7 @@
 import { type KeyValue } from '../types/data';
 
+import { emitStructuredBrowserLog } from './structuredBrowserLog';
+
 // Avoid writing the warning message more than once every 10s
 const history: KeyValue<number> = {};
 
@@ -11,7 +13,7 @@ export const deprecationWarning = (file: string, oldName: string, newName?: stri
   const now = Date.now();
   const last = history[message];
   if (!last || now - last > 10000) {
-    console.warn(message);
+    emitStructuredBrowserLog('warn', message);
     history[message] = now;
   }
 };

--- a/packages/grafana-data/src/utils/store.ts
+++ b/packages/grafana-data/src/utils/store.ts
@@ -1,3 +1,5 @@
+import { emitStructuredBrowserLog } from './structuredBrowserLog';
+
 type StoreValue = string | number | boolean | null;
 type StoreSubscriber = () => void;
 
@@ -65,7 +67,7 @@ export class Store {
       try {
         ret = JSON.parse(json);
       } catch (error) {
-        console.error(`Error parsing store object: ${key}. Returning default: ${def}. [${error}]`);
+        emitStructuredBrowserLog('error', `Error parsing store object: ${key}. Returning default: ${def}. [${error}]`);
       }
     }
     return ret;

--- a/packages/grafana-data/src/utils/structuredBrowserLog.ts
+++ b/packages/grafana-data/src/utils/structuredBrowserLog.ts
@@ -1,0 +1,56 @@
+/**
+ * Browser-only structured logging: emits a single record object to the console
+ * so messages are grep-friendly and observable. Used when Faro / GJA is disabled
+ * and from packages that cannot depend on `@grafana/runtime`.
+ *
+ * @public
+ */
+export type StructuredLogRecord = {
+  level: 'debug' | 'info' | 'warn' | 'error';
+  message: string;
+  context?: Record<string, unknown>;
+  error?: { name: string; message: string; stack?: string };
+  timestamp: string;
+};
+
+const GRAFANA_LOG_PREFIX = '[Grafana]';
+
+function timestamp(): string {
+  return new Date().toISOString();
+}
+
+/**
+ * Writes a structured log record using console.info / console.warn / console.error.
+ *
+ * @public
+ */
+export function emitStructuredBrowserLog(
+  level: 'debug' | 'info' | 'warn' | 'error',
+  message: string,
+  context?: Record<string, unknown>
+): void {
+  const record: StructuredLogRecord = { level, message, ...(context !== undefined ? { context } : {}), timestamp: timestamp() };
+  if (level === 'error') {
+    console.error(GRAFANA_LOG_PREFIX, record);
+  } else if (level === 'warn') {
+    console.warn(GRAFANA_LOG_PREFIX, record);
+  } else {
+    console.info(GRAFANA_LOG_PREFIX, record);
+  }
+}
+
+/**
+ * Writes an error record with message, optional context, and error metadata.
+ *
+ * @public
+ */
+export function emitStructuredBrowserError(error: Error, context?: Record<string, unknown>): void {
+  const record: StructuredLogRecord = {
+    level: 'error',
+    message: error.message,
+    ...(context !== undefined ? { context } : {}),
+    error: { name: error.name, message: error.message, stack: error.stack },
+    timestamp: timestamp(),
+  };
+  console.error(GRAFANA_LOG_PREFIX, record);
+}

--- a/packages/grafana-data/src/utils/url.ts
+++ b/packages/grafana-data/src/utils/url.ts
@@ -5,6 +5,7 @@
 import { isDateTime } from '../datetime/moment_wrapper';
 import { type ExploreUrlState, type URLRange } from '../types/explore';
 import { type RawTimeRange } from '../types/time';
+import { emitStructuredBrowserLog } from './structuredBrowserLog';
 
 /**
  * Type to represent the value of a single query variable.
@@ -226,7 +227,7 @@ export const urlUtil = {
  */
 export function serializeStateToUrlParam(urlState: Partial<ExploreUrlState>, compact?: boolean): string {
   if (compact !== undefined) {
-    console.warn('`compact` parameter is deprecated and will be removed in a future release');
+    emitStructuredBrowserLog('warn', '`compact` parameter is deprecated and will be removed in a future release');
   }
   return JSON.stringify(urlState);
 }

--- a/packages/grafana-data/src/vector/ArrayVector.ts
+++ b/packages/grafana-data/src/vector/ArrayVector.ts
@@ -1,3 +1,5 @@
+import { emitStructuredBrowserLog } from '../utils/structuredBrowserLog';
+
 const notice = 'ArrayVector is deprecated and will be removed in Grafana 11. Please use plain arrays for field.values.';
 let notified = false;
 
@@ -47,7 +49,7 @@ export class ArrayVector<T = unknown> extends Array<T> {
     this.buffer = buffer ?? [];
 
     if (!notified) {
-      console.warn(notice);
+      emitStructuredBrowserLog('warn', notice);
       notified = true;
     }
   }

--- a/packages/grafana-i18n/src/i18n.tsx
+++ b/packages/grafana-i18n/src/i18n.tsx
@@ -9,6 +9,7 @@ import { initRegionalFormat } from './dates';
 import { LANGUAGES } from './languages';
 import { type ResourceLoader, type Resources, type TFunction, type TransProps, type TransType } from './types';
 
+import { emitStructuredBrowserError, emitStructuredBrowserLog } from '@grafana/data';
 let tFunc: I18NextTFunction<string[], undefined> | undefined;
 let transComponent: TransType;
 
@@ -44,7 +45,7 @@ export async function loadNamespacedResources(namespace: string, language: strin
         const resources = await loader(resolvedLanguage);
         addResourceBundle(resolvedLanguage, namespace, resources);
       } catch (error) {
-        console.error(`Error loading resources for namespace ${namespace} and language: ${resolvedLanguage}`, error);
+        emitStructuredBrowserError(error instanceof Error ? error : new Error(String(error)), { message: String(`Error loading resources for namespace ${namespace} and language: ${resolvedLanguage}`) });
       }
     })
   );
@@ -202,8 +203,9 @@ export const t: TFunction = (id: string, defaultMessage: string, values?: Record
   initDefaultI18nInstance();
   if (!tFunc) {
     if (process.env.NODE_ENV !== 'test') {
-      console.warn(
-        't() was called before i18n was initialized. This is probably caused by calling t() in the root module scope, instead of lazily on render'
+      emitStructuredBrowserLog(
+        'warn',
+        't() was called before i18n was initialized. This is probably caused by calling t() in the root module scope instead of lazily on render.'
       );
     }
 

--- a/packages/grafana-prometheus/src/components/metrics-browser/ValueSelector.tsx
+++ b/packages/grafana-prometheus/src/components/metrics-browser/ValueSelector.tsx
@@ -10,6 +10,7 @@ import { LIST_ITEM_SIZE } from '../../constants';
 import { useMetricsBrowser } from './MetricsBrowserContext';
 import { getStylesMetricsBrowser, getStylesValueSelector } from './styles';
 
+import { grafanaStructuredLogger } from '@grafana/runtime';
 export function ValueSelector() {
   const styles = useStyles2(getStylesValueSelector);
   const sharedStyles = useStyles2(getStylesMetricsBrowser);
@@ -59,7 +60,7 @@ export function ValueSelector() {
         <div className={styles.valueListArea}>
           {Object.entries(filteredLabelValues).map(([lk, lv]) => {
             if (!lk || !lv) {
-              console.error('label values are empty:', { lk, lv });
+              grafanaStructuredLogger.logError(new Error('label values are empty'), { lk, lv });
               return null;
             }
             return (

--- a/packages/grafana-prometheus/src/components/monaco-query-field/getOverrideServices.ts
+++ b/packages/grafana-prometheus/src/components/monaco-query-field/getOverrideServices.ts
@@ -1,6 +1,7 @@
 // Core Grafana history https://github.com/grafana/grafana/blob/v11.0.0-preview/public/app/plugins/datasource/prometheus/components/monaco-query-field/getOverrideServices.ts
 import { type monacoTypes } from '@grafana/ui';
 
+import { grafanaStructuredLogger } from '@grafana/runtime';
 // this thing here is a workaround in a way.
 // what we want to achieve, is that when the autocomplete-window
 // opens, the "second, extra popup" with the extra help,
@@ -82,7 +83,7 @@ function makeStorageService() {
     },
 
     logStorage: (): void => {
-      console.log('logStorage: not implemented');
+      grafanaStructuredLogger.logInfo(String('logStorage: not implemented'));
     },
 
     migrate: (): Promise<void> => {

--- a/packages/grafana-prometheus/src/components/monaco-query-field/monaco-completion-provider/data_provider.ts
+++ b/packages/grafana-prometheus/src/components/monaco-query-field/monaco-completion-provider/data_provider.ts
@@ -6,6 +6,7 @@ import { removeQuotesIfExist } from '../../../language_utils';
 import { type PromQuery } from '../../../types';
 import { escapeForUtf8Support, isValidLegacyName } from '../../../utf8_support';
 
+import { grafanaStructuredLogger } from '@grafana/runtime';
 export const CODE_MODE_SUGGESTIONS_INCOMPLETE_EVENT = 'codeModeSuggestionsIncomplete';
 
 type SuggestionsIncompleteEvent = CustomEvent<{
@@ -80,7 +81,7 @@ export class DataProvider {
 
       return Array.isArray(result) ? result : [];
     } catch (error) {
-      console.warn('Failed to query metric names:', error);
+      grafanaStructuredLogger.logWarning(String('Failed to query metric names:'), { args: error });
       return [];
     }
   };

--- a/packages/grafana-prometheus/src/datasource.ts
+++ b/packages/grafana-prometheus/src/datasource.ts
@@ -71,6 +71,7 @@ import {
 import { utf8Support, wrapUtf8Filters } from './utf8_support';
 import { PrometheusVariableSupport } from './variables';
 
+import { grafanaStructuredLogger } from '@grafana/runtime';
 export class PrometheusDatasource
   extends DataSourceWithBackend<PromQuery, PromOptions>
   implements DataSourceWithQueryImportSupport<PromQuery>, DataSourceWithQueryExportSupport<PromQuery>
@@ -172,8 +173,8 @@ export class PrometheusDatasource
         this.ruleMappings = extractRuleMappingFromGroups(ruleGroups);
       }
     } catch (err) {
-      console.log('Rules API is experimental. Ignore next error.');
-      console.error(err);
+      grafanaStructuredLogger.logInfo(String('Rules API is experimental. Ignore next error.'));
+      grafanaStructuredLogger.logError(err instanceof Error ? err : new Error(String(err)));
     }
   }
 
@@ -352,7 +353,7 @@ export class PrometheusDatasource
       } catch (err) {
         // If status code of error is Method Not Allowed (405) and HTTP method is POST, retry with GET
         if (this.httpMethod === 'POST' && isFetchError(err) && (err.status === 405 || err.status === 400)) {
-          console.warn(`Couldn't use configured POST HTTP method for this request. Trying to use GET method instead.`);
+          grafanaStructuredLogger.logWarning(String(`Couldn't use configured POST HTTP method for this request. Trying to use GET method instead.`));
         } else {
           throw err;
         }

--- a/packages/grafana-prometheus/src/language_provider.ts
+++ b/packages/grafana-prometheus/src/language_provider.ts
@@ -22,6 +22,7 @@ import { buildVisualQueryFromString } from './querybuilder/parsing';
 import { LabelsApiClient, type ResourceApiClient, SeriesApiClient } from './resource_clients';
 import { type PromMetricsMetadata, type PromQuery } from './types';
 
+import { grafanaStructuredLogger } from '@grafana/runtime';
 interface PrometheusBaseLanguageProvider {
   datasource: PrometheusDatasource;
 
@@ -132,7 +133,7 @@ export class PrometheusLanguageProvider implements PrometheusLanguageProviderInt
       return res.data.data;
     } catch (error) {
       if (!isCancelledError(error)) {
-        console.error(error);
+        grafanaStructuredLogger.logError(error instanceof Error ? error : new Error(String(error)));
       }
     }
 

--- a/packages/grafana-prometheus/src/querybuilder/components/metrics-modal/MetricsModalContext.tsx
+++ b/packages/grafana-prometheus/src/querybuilder/components/metrics-modal/MetricsModalContext.tsx
@@ -23,6 +23,7 @@ import { generateMetricData } from './helpers';
 import { type MetricData, type MetricsData } from './types';
 import { fuzzySearch } from './uFuzzy';
 
+import { grafanaStructuredLogger } from '@grafana/runtime';
 export const DEFAULT_RESULTS_PER_PAGE = 25;
 
 type Pagination = {
@@ -167,7 +168,7 @@ export const MetricsModalContextProvider: FC<PropsWithChildren<MetricsModalConte
         } catch (error) {
           // Only update state if this is still the latest search
           if (searchId === latestSearchIdRef.current) {
-            console.error('Backend search failed:', error);
+            grafanaStructuredLogger.logError(error instanceof Error ? error : new Error(String(error)), { message: String('Backend search failed:') });
             setMetricsData([]); // Clear results on error
             setIsLoading(false);
           }

--- a/packages/grafana-prometheus/src/querybuilder/parsing.ts
+++ b/packages/grafana-prometheus/src/querybuilder/parsing.ts
@@ -44,6 +44,7 @@ import {
 import { type QueryBuilderLabelFilter, type QueryBuilderOperation } from './shared/types';
 import { type PromVisualQuery, type PromVisualQueryBinary } from './types';
 
+import { grafanaStructuredLogger } from '@grafana/runtime';
 /**
  * Parses a PromQL query into a visual query model.
  *
@@ -72,7 +73,7 @@ export function buildVisualQueryFromString(expr: string): Omit<Context, 'replace
     handleExpression(replacedExpr, node, context);
   } catch (err) {
     // Not ideal to log it here, but otherwise we would lose the stack trace.
-    console.error(err);
+    grafanaStructuredLogger.logError(err instanceof Error ? err : new Error(String(err)));
     if (err instanceof Error) {
       context.errors.push({
         text: err.message,

--- a/packages/grafana-prometheus/src/result_transformer.ts
+++ b/packages/grafana-prometheus/src/result_transformer.ts
@@ -23,6 +23,7 @@ import { getDataSourceSrv } from '@grafana/runtime';
 
 import { type ExemplarTraceIdDestination, type PromMetric, type PromQuery, type PromValue } from './types';
 
+import { grafanaStructuredLogger } from '@grafana/runtime';
 // handles case-insensitive Inf, +Inf, -Inf (with optional "inity" suffix)
 const INFINITY_SAMPLE_REGEX = /^[+-]?inf(?:inity)?$/i;
 
@@ -437,7 +438,7 @@ export function sortSeriesByLabel(s1: DataFrame, s2: DataFrame): number {
     le2 = parseSampleValue(s2.fields[1].state?.displayName ?? s2.name ?? s2.fields[1].name);
   } catch (err) {
     // fail if not integer. might happen with bad queries
-    console.error(err);
+    grafanaStructuredLogger.logError(err instanceof Error ? err : new Error(String(err)));
     return 0;
   }
 

--- a/packages/grafana-runtime/src/config.ts
+++ b/packages/grafana-runtime/src/config.ts
@@ -28,6 +28,7 @@ import {
   type CurrentUserDTO,
 } from '@grafana/data';
 
+import { emitStructuredBrowserError, emitStructuredBrowserLog } from '@grafana/data';
 /**
  * @deprecated Use the type from `@grafana/data`
  */
@@ -313,7 +314,7 @@ function overrideFeatureTogglesFromLocalStorage(config: GrafanaBootConfig) {
       const toggleState = featureValue === 'true' || featureValue === '1';
       // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
       featureToggles[featureName as keyof FeatureToggles] = toggleState;
-      console.log(`Setting feature toggle ${featureName} = ${toggleState} via localstorage`);
+      emitStructuredBrowserLog('info', String(`Setting feature toggle ${featureName} = ${toggleState} via localstorage`));
     }
   }
 }
@@ -339,9 +340,9 @@ function overrideFeatureTogglesFromUrl(config: GrafanaBootConfig) {
       if (toggleState !== featureToggles[key]) {
         if (isDevelopment || safeRuntimeFeatureFlags.has(featureName)) {
           featureToggles[featureName] = toggleState;
-          console.log(`Setting feature toggle ${featureName} = ${toggleState} via url`);
+          emitStructuredBrowserLog('info', String(`Setting feature toggle ${featureName} = ${toggleState} via url`));
         } else {
-          console.log(`Unable to change feature toggle ${featureName} via url in production.`);
+          emitStructuredBrowserLog('info', String(`Unable to change feature toggle ${featureName} via url in production.`));
         }
       }
     }
@@ -352,7 +353,7 @@ let bootData = window.grafanaBootData;
 
 if (!bootData) {
   if (process.env.NODE_ENV !== 'test') {
-    console.error('window.grafanaBootData was not set by the time config was initialized');
+    emitStructuredBrowserError(new Error('window.grafanaBootData was not set by the time config was initialized'));
   }
 
   bootData = {

--- a/packages/grafana-runtime/src/index.ts
+++ b/packages/grafana-runtime/src/index.ts
@@ -15,7 +15,9 @@ export {
   logWarning,
   logError,
   createMonitoringLogger,
+  grafanaStructuredLogger,
   logMeasurement,
+  type GrafanaStructuredLogContext,
   type MonitoringLogger,
 } from './utils/logging';
 export {

--- a/packages/grafana-runtime/src/internal/openFeature/index.ts
+++ b/packages/grafana-runtime/src/internal/openFeature/index.ts
@@ -6,6 +6,7 @@ import { type FeatureToggles } from '@grafana/data';
 import { config } from '../../config';
 import { logError } from '../../utils/logging';
 
+import { emitStructuredBrowserError } from '@grafana/data';
 function checkDefaultProvider(event?: EventDetails) {
   if (event?.domain) {
     return;
@@ -18,7 +19,7 @@ function checkDefaultProvider(event?: EventDetails) {
       'OpenFeature default domain provider has been unexpectedly changed. This may be caused by a plugin that is incorrectly using the default domain.',
       { cause: OpenFeature.getProvider() }
     );
-    console.error(err);
+    emitStructuredBrowserError(err instanceof Error ? err : new Error(String(err)));
     logError(err);
   }
 }

--- a/packages/grafana-runtime/src/services/pluginMeta/apps.test.ts
+++ b/packages/grafana-runtime/src/services/pluginMeta/apps.test.ts
@@ -106,10 +106,6 @@ describe('when useMTPlugins flag is enabled', () => {
         async ({ func }) => {
           await func();
 
-          expect(console.warn).toHaveBeenCalledTimes(1);
-          expect(console.warn).toHaveBeenCalledWith(
-            'PluginMeta: plugin meta yielded an empty result so Grafana is falling back to bootdata'
-          );
           expect(logger.logWarning).toHaveBeenCalledTimes(1);
           expect(logger.logWarning).toHaveBeenCalledWith(
             'PluginMeta: plugin meta yielded an empty result so Grafana is falling back to bootdata',
@@ -123,10 +119,6 @@ describe('when useMTPlugins flag is enabled', () => {
         async ({ func }) => {
           await func('');
 
-          expect(console.warn).toHaveBeenCalledTimes(1);
-          expect(console.warn).toHaveBeenCalledWith(
-            'PluginMeta: plugin meta yielded an empty result so Grafana is falling back to bootdata'
-          );
           expect(logger.logWarning).toHaveBeenCalledTimes(1);
           expect(logger.logWarning).toHaveBeenCalledWith(
             'PluginMeta: plugin meta yielded an empty result so Grafana is falling back to bootdata',

--- a/packages/grafana-runtime/src/services/pluginMeta/logging.ts
+++ b/packages/grafana-runtime/src/services/pluginMeta/logging.ts
@@ -14,12 +14,10 @@ function getLogger() {
 
 export function logPluginMetaWarning(message: string, type: PluginType): void {
   getLogger().logWarning(message, { type });
-  console.warn(message);
 }
 
 export function logPluginMetaError(message: string, error: unknown): void {
   getLogger().logError(new Error(message, { cause: error }));
-  console.error(message, error);
 }
 
 export function setPluginMetaLogger(override: MonitoringLogger) {

--- a/packages/grafana-runtime/src/services/pluginMeta/panels.test.ts
+++ b/packages/grafana-runtime/src/services/pluginMeta/panels.test.ts
@@ -159,10 +159,6 @@ describe('when useMTPlugins flag is enabled', () => {
       ])(`when func:$func is called then a warning should be logged`, async ({ func }) => {
         await func();
 
-        expect(console.warn).toHaveBeenCalledTimes(1);
-        expect(console.warn).toHaveBeenCalledWith(
-          'PluginMeta: plugin meta yielded an empty result so Grafana is falling back to bootdata'
-        );
         expect(logger.logWarning).toHaveBeenCalledTimes(1);
         expect(logger.logWarning).toHaveBeenCalledWith(
           'PluginMeta: plugin meta yielded an empty result so Grafana is falling back to bootdata',
@@ -175,10 +171,6 @@ describe('when useMTPlugins flag is enabled', () => {
         async ({ func }) => {
           await func('');
 
-          expect(console.warn).toHaveBeenCalledTimes(1);
-          expect(console.warn).toHaveBeenCalledWith(
-            'PluginMeta: plugin meta yielded an empty result so Grafana is falling back to bootdata'
-          );
           expect(logger.logWarning).toHaveBeenCalledTimes(1);
           expect(logger.logWarning).toHaveBeenCalledWith(
             'PluginMeta: plugin meta yielded an empty result so Grafana is falling back to bootdata',

--- a/packages/grafana-runtime/src/utils/chromeHeaderHeight.ts
+++ b/packages/grafana-runtime/src/utils/chromeHeaderHeight.ts
@@ -1,3 +1,6 @@
+
+
+import { emitStructuredBrowserError } from '@grafana/data';
 type ChromeHeaderHeightHook = () => number;
 
 let chromeHeaderHeightHook: ChromeHeaderHeightHook | undefined = undefined;
@@ -11,7 +14,7 @@ export const useChromeHeaderHeight = () => {
     if (process.env.NODE_ENV !== 'production') {
       throw new Error('useChromeHeaderHeight hook not found in @grafana/runtime');
     }
-    console.error('useChromeHeaderHeight hook not found');
+    emitStructuredBrowserError(new Error('useChromeHeaderHeight hook not found'));
   }
 
   return chromeHeaderHeightHook?.();

--- a/packages/grafana-runtime/src/utils/logging.ts
+++ b/packages/grafana-runtime/src/utils/logging.ts
@@ -1,6 +1,61 @@
+import { emitStructuredBrowserError, emitStructuredBrowserLog } from '@grafana/data';
 import { faro, type LogContext, LogLevel } from '@grafana/faro-web-sdk';
 
 import { config } from '../config';
+
+/** Context attached to frontend logs/errors. Values are normalized to strings for Faro. */
+export type GrafanaStructuredLogContext = Record<string, unknown>;
+
+function stringifyContextValue(value: unknown): string {
+  if (value === null || value === undefined) {
+    return '';
+  }
+  if (typeof value === 'string') {
+    return value;
+  }
+  if (typeof value === 'number' || typeof value === 'boolean' || typeof value === 'bigint') {
+    return String(value);
+  }
+  if (typeof value === 'symbol') {
+    return value.toString();
+  }
+  if (value instanceof Error) {
+    return `${value.name}: ${value.message}`;
+  }
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return Object.prototype.toString.call(value);
+  }
+}
+
+function toFaroContext(contexts?: GrafanaStructuredLogContext): LogContext | undefined {
+  if (!contexts) {
+    return undefined;
+  }
+  const entries = Object.entries(contexts).filter(([, v]) => v !== undefined);
+  if (entries.length === 0) {
+    return undefined;
+  }
+  const out: LogContext = {};
+  for (const [key, value] of entries) {
+    out[key] = stringifyContextValue(value);
+  }
+  return out;
+}
+
+function mergeStructuredContext(
+  source: string,
+  ...parts: Array<GrafanaStructuredLogContext | undefined>
+): GrafanaStructuredLogContext {
+  let merged: GrafanaStructuredLogContext = { source };
+  for (const part of parts) {
+    if (part !== undefined) {
+      merged = { ...merged, ...part };
+    }
+  }
+  return merged;
+}
 
 export { LogLevel };
 
@@ -8,13 +63,15 @@ export { LogLevel };
  * Log a message at INFO level
  * @public
  */
-export function logInfo(message: string, contexts?: LogContext) {
+export function logInfo(message: string, contexts?: GrafanaStructuredLogContext) {
   if (config.grafanaJavascriptAgent.enabled) {
     faro.api.pushLog([message], {
       level: LogLevel.INFO,
-      context: contexts,
+      context: toFaroContext(contexts),
     });
+    return;
   }
+  emitStructuredBrowserLog('info', message, contexts);
 }
 
 /**
@@ -22,13 +79,15 @@ export function logInfo(message: string, contexts?: LogContext) {
  *
  * @public
  */
-export function logWarning(message: string, contexts?: LogContext) {
+export function logWarning(message: string, contexts?: GrafanaStructuredLogContext) {
   if (config.grafanaJavascriptAgent.enabled) {
     faro.api.pushLog([message], {
       level: LogLevel.WARN,
-      context: contexts,
+      context: toFaroContext(contexts),
     });
+    return;
   }
+  emitStructuredBrowserLog('warn', message, contexts);
 }
 
 /**
@@ -36,13 +95,15 @@ export function logWarning(message: string, contexts?: LogContext) {
  *
  * @public
  */
-export function logDebug(message: string, contexts?: LogContext) {
+export function logDebug(message: string, contexts?: GrafanaStructuredLogContext) {
   if (config.grafanaJavascriptAgent.enabled) {
     faro.api.pushLog([message], {
       level: LogLevel.DEBUG,
-      context: contexts,
+      context: toFaroContext(contexts),
     });
+    return;
   }
+  emitStructuredBrowserLog('debug', message, contexts);
 }
 
 /**
@@ -50,12 +111,14 @@ export function logDebug(message: string, contexts?: LogContext) {
  *
  * @public
  */
-export function logError(err: Error, contexts?: LogContext) {
+export function logError(err: Error, contexts?: GrafanaStructuredLogContext) {
   if (config.grafanaJavascriptAgent.enabled) {
     faro.api.pushError(err, {
-      context: contexts,
+      context: toFaroContext(contexts),
     });
+    return;
   }
+  emitStructuredBrowserError(err, contexts);
 }
 
 /**
@@ -64,24 +127,26 @@ export function logError(err: Error, contexts?: LogContext) {
  * @public
  */
 export type MeasurementValues = Record<string, number>;
-export function logMeasurement(type: string, values: MeasurementValues, context?: LogContext) {
+export function logMeasurement(type: string, values: MeasurementValues, context?: GrafanaStructuredLogContext) {
   if (config.grafanaJavascriptAgent.enabled) {
     faro.api.pushMeasurement(
       {
         type,
         values,
       },
-      { context: context }
+      { context: toFaroContext(context) }
     );
+    return;
   }
+  emitStructuredBrowserLog('info', 'measurement', { ...(context ?? {}), measurementType: type, values });
 }
 
 export interface MonitoringLogger {
-  logDebug: (message: string, contexts?: LogContext) => void;
-  logInfo: (message: string, contexts?: LogContext) => void;
-  logWarning: (message: string, contexts?: LogContext) => void;
-  logError: (error: Error, contexts?: LogContext) => void;
-  logMeasurement: (type: string, measurement: MeasurementValues, contexts?: LogContext) => void;
+  logDebug: (message: string, contexts?: GrafanaStructuredLogContext) => void;
+  logInfo: (message: string, contexts?: GrafanaStructuredLogContext) => void;
+  logWarning: (message: string, contexts?: GrafanaStructuredLogContext) => void;
+  logError: (error: Error, contexts?: GrafanaStructuredLogContext) => void;
+  logMeasurement: (type: string, measurement: MeasurementValues, contexts?: GrafanaStructuredLogContext) => void;
 }
 /**
  * Creates a monitoring logger with five levels of logging methods: `logDebug`, `logInfo`, `logWarning`, `logError`, and `logMeasurement`.
@@ -98,12 +163,9 @@ export interface MonitoringLogger {
  * - `logMeasurement(measurement: Omit<MeasurementEvent, 'timestamp'>, contexts?: LogContext)`: Logs a measurement.
  * Each method combines the `defaultContext` (if provided), the `source`, and an optional `LogContext` parameter into a full context that is included with the log message.
  */
-export function createMonitoringLogger(source: string, defaultContext?: LogContext): MonitoringLogger {
-  const createFullContext = (contexts?: LogContext) => ({
-    source: source,
-    ...defaultContext,
-    ...contexts,
-  });
+export function createMonitoringLogger(source: string, defaultContext?: GrafanaStructuredLogContext): MonitoringLogger {
+  const createFullContext = (contexts?: GrafanaStructuredLogContext): GrafanaStructuredLogContext =>
+    mergeStructuredContext(source, defaultContext, contexts);
 
   return {
     /**
@@ -111,35 +173,39 @@ export function createMonitoringLogger(source: string, defaultContext?: LogConte
      * @param {string} message - The debug message to be logged.
      * @param {LogContext} [contexts] - Optional additional context to be included.
      */
-    logDebug: (message: string, contexts?: LogContext) => logDebug(message, createFullContext(contexts)),
+    logDebug: (message: string, contexts?: GrafanaStructuredLogContext) => logDebug(message, createFullContext(contexts)),
 
     /**
      * Logs an informational message with optional additional context.
      * @param {string} message - The informational message to be logged.
      * @param {LogContext} [contexts] - Optional additional context to be included.
      */
-    logInfo: (message: string, contexts?: LogContext) => logInfo(message, createFullContext(contexts)),
+    logInfo: (message: string, contexts?: GrafanaStructuredLogContext) => logInfo(message, createFullContext(contexts)),
 
     /**
      * Logs a warning message with optional additional context.
      * @param {string} message - The warning message to be logged.
      * @param {LogContext} [contexts] - Optional additional context to be included.
      */
-    logWarning: (message: string, contexts?: LogContext) => logWarning(message, createFullContext(contexts)),
+    logWarning: (message: string, contexts?: GrafanaStructuredLogContext) => logWarning(message, createFullContext(contexts)),
 
     /**
      * Logs an error with optional additional context.
      * @param {Error} error - The error object to be logged.
      * @param {LogContext} [contexts] - Optional additional context to be included.
      */
-    logError: (error: Error, contexts?: LogContext) => logError(error, createFullContext(contexts)),
+    logError: (error: Error, contexts?: GrafanaStructuredLogContext) =>
+      logError(error, createFullContext(contexts)),
 
     /**
      * Logs an measurement with optional additional context.
      * @param {MeasurementEvent} measurement - The measurement object to be recorded.
      * @param {LogContext} [contexts] - Optional additional context to be included.
      */
-    logMeasurement: (type: string, measurement: MeasurementValues, contexts?: LogContext) =>
+    logMeasurement: (type: string, measurement: MeasurementValues, contexts?: GrafanaStructuredLogContext) =>
       logMeasurement(type, measurement, createFullContext(contexts)),
   };
 }
+
+/** Default frontend logger when a feature-local logger is unnecessary. */
+export const grafanaStructuredLogger = createMonitoringLogger('grafana.frontend');

--- a/packages/grafana-runtime/src/utils/megaMenuOpen.ts
+++ b/packages/grafana-runtime/src/utils/megaMenuOpen.ts
@@ -1,3 +1,4 @@
+import { emitStructuredBrowserError } from '@grafana/data';
 type MegaMenuOpenHook = () => Readonly<[boolean, (open: boolean, persist?: boolean) => void]>;
 
 let megaMenuOpenHook: MegaMenuOpenHook | undefined = undefined;
@@ -15,7 +16,7 @@ export const useMegaMenuOpen: MegaMenuOpenHook = () => {
     if (process.env.NODE_ENV !== 'production') {
       throw new Error('useMegaMenuOpen hook not found in @grafana/runtime');
     }
-    return [false, () => console.error('MegaMenuOpen hook not found')];
+    return [false, () => emitStructuredBrowserError(new Error('MegaMenuOpen hook not found'))];
   }
 
   return megaMenuOpenHook();

--- a/packages/grafana-runtime/src/utils/migrationHandler.ts
+++ b/packages/grafana-runtime/src/utils/migrationHandler.ts
@@ -6,6 +6,7 @@ import { getBackendSrv } from '../services';
 
 import { DataSourceWithBackend } from './DataSourceWithBackend';
 
+import { emitStructuredBrowserLog } from '@grafana/data';
 /**
  * @alpha Experimental: Plugins implementing MigrationHandler interface will automatically have their queries migrated.
  */
@@ -20,7 +21,7 @@ export function isMigrationHandler(object: unknown): object is MigrationHandler 
 
 async function postMigrateRequest<TQuery extends DataQuery>(queries: TQuery[]): Promise<TQuery[]> {
   if (!(config.featureToggles.grafanaAPIServerWithExperimentalAPIs || config.featureToggles.datasourceAPIServers)) {
-    console.warn('migrateQuery is only available with the experimental API server');
+    emitStructuredBrowserLog('warn', String('migrateQuery is only available with the experimental API server'));
     return queries;
   }
 

--- a/packages/grafana-runtime/src/utils/plugin.ts
+++ b/packages/grafana-runtime/src/utils/plugin.ts
@@ -2,6 +2,7 @@ import { type PanelPlugin } from '@grafana/data';
 
 import { config } from '../config';
 
+import { emitStructuredBrowserError } from '@grafana/data';
 /**
  * Option to specify a plugin css that should be applied for the dark
  * and the light theme.
@@ -25,7 +26,7 @@ export async function loadPluginCss(options: PluginCssOptions): Promise<System.M
     const cssPath = config.bootData.user.theme === 'light' ? options.light : options.dark;
     return window.System.import(cssPath);
   } catch (err) {
-    console.error(err);
+    emitStructuredBrowserError(err instanceof Error ? err : new Error(String(err)));
   }
 }
 

--- a/packages/grafana-runtime/src/utils/qscheck.ts
+++ b/packages/grafana-runtime/src/utils/qscheck.ts
@@ -1,5 +1,6 @@
 import { type DataSourceInstanceSettings, type DataSourceJsonData } from '@grafana/data';
 
+import { emitStructuredBrowserError } from '@grafana/data';
 interface JsonData extends DataSourceJsonData {
   oauthPassThru?: unknown; // we do not assume boolean, to be more robust
   azureCredentials?: {
@@ -48,11 +49,11 @@ function parseAllowedTypes(data: unknown): AllowedTypes {
     if (types.every((x) => typeof x === 'string')) {
       return { types };
     } else {
-      console.error('qscheck.parseFlags: non-string item in allowed');
+      emitStructuredBrowserError(new Error('qscheck.parseFlags: non-string item in allowed'));
       return { types: [] };
     }
   } else {
-    console.error('qscheck.parseFlags: invalid data');
+    emitStructuredBrowserError(new Error('qscheck.parseFlags: invalid data'));
     return { types: [] };
   }
 }

--- a/packages/grafana-runtime/src/utils/returnToPrevious.ts
+++ b/packages/grafana-runtime/src/utils/returnToPrevious.ts
@@ -1,3 +1,5 @@
+
+import { emitStructuredBrowserError } from '@grafana/data';
 type ReturnToPreviousHook = () => (title: string, href?: string) => void;
 
 let rtpHook: ReturnToPreviousHook | undefined = undefined;
@@ -16,7 +18,7 @@ export const useReturnToPrevious: ReturnToPreviousHook = () => {
     if (process.env.NODE_ENV !== 'production') {
       throw new Error('useReturnToPrevious hook not found in @grafana/runtime');
     }
-    return () => console.error('ReturnToPrevious hook not found');
+    return () => emitStructuredBrowserError(new Error('ReturnToPrevious hook not found'));
   }
 
   return rtpHook();

--- a/packages/grafana-sql/src/datasource/SqlDatasource.ts
+++ b/packages/grafana-sql/src/datasource/SqlDatasource.ts
@@ -35,6 +35,7 @@ import { MACRO_NAMES } from '../constants';
 import { type DB, type SQLQuery, type SQLOptions, type SqlQueryModel, QueryFormat, type SQLDialect } from '../types';
 import migrateAnnotation from '../utils/migration';
 
+import { grafanaStructuredLogger } from '@grafana/runtime';
 export abstract class SqlDatasource extends DataSourceWithBackend<SQLQuery, SQLOptions> {
   uid: string;
   responseParser: ResponseParser;
@@ -215,7 +216,7 @@ export abstract class SqlDatasource extends DataSourceWithBackend<SQLQuery, SQLO
     try {
       response = await this.runMetaQuery(interpolatedQuery, range);
     } catch (error) {
-      console.error(error);
+      grafanaStructuredLogger.logError(error instanceof Error ? error : new Error(String(error)));
       throw new Error('error when executing the sql query');
     }
     return this.getResponseParser().transformMetricFindResponse(response);

--- a/packages/grafana-ui/src/components/Combobox/storyUtils.ts
+++ b/packages/grafana-ui/src/components/Combobox/storyUtils.ts
@@ -1,5 +1,6 @@
 import { type ComboboxOption } from './types';
 
+import { emitStructuredBrowserLog } from '@grafana/data';
 let fakeApiOptions: Array<ComboboxOption<string>>;
 export async function fakeSearchAPI(urlString: string): Promise<Array<ComboboxOption<string>>> {
   const searchParams = new URL(urlString).searchParams;
@@ -13,7 +14,7 @@ export async function fakeSearchAPI(urlString: string): Promise<Array<ComboboxOp
 
   if (!fakeApiOptions) {
     fakeApiOptions = await generateOptions(1000);
-    console.log('fakeApiOptions', fakeApiOptions);
+    emitStructuredBrowserLog('info', String('fakeApiOptions'), { args: fakeApiOptions });
   }
 
   if (!searchQuery || searchQuery.length === 0) {

--- a/packages/grafana-ui/src/components/Combobox/useOptions.ts
+++ b/packages/grafana-ui/src/components/Combobox/useOptions.ts
@@ -10,6 +10,7 @@ import { fuzzyFind, itemToString } from './filter';
 import { type ComboboxOption } from './types';
 import { StaleResultError, useLatestAsyncCall } from './useLatestAsyncCall';
 
+import { emitStructuredBrowserError } from '@grafana/data';
 type AsyncOptions<T extends string | number> =
   | Array<ComboboxOption<T>>
   | ((inputValue: string) => Promise<Array<ComboboxOption<T>>>);
@@ -51,7 +52,7 @@ export function useOptions<T extends string | number>(
               setAsyncLoading(false);
 
               if (error) {
-                console.error('Error loading async options for Combobox', error);
+                emitStructuredBrowserError(error instanceof Error ? error : new Error(String(error)), { message: String('Error loading async options for Combobox') });
               }
             }
           });

--- a/packages/grafana-ui/src/components/Combobox/utils.ts
+++ b/packages/grafana-ui/src/components/Combobox/utils.ts
@@ -1,4 +1,4 @@
-import { isIconName, type SelectableValue } from '@grafana/data';
+import { emitStructuredBrowserLog, isIconName, type SelectableValue } from '@grafana/data';
 
 import { type ComboboxOption } from './types';
 
@@ -25,11 +25,11 @@ export const selectableValueToComboboxOption = <T extends string | number>(
   v: SelectableValue<T>
 ): ComboboxOption<T> | undefined => {
   if (v == null || v.value == null) {
-    console.warn('selectableValueToComboboxOption: value is null or undefined', v);
+    emitStructuredBrowserLog('warn', String('selectableValueToComboboxOption: value is null or undefined'), { args: v });
     return undefined;
   }
   if (v.icon != null && !isIconName(v.icon)) {
-    console.warn('selectableValueToComboboxOption: icon is not a valid icon name', v.icon);
+    emitStructuredBrowserLog('warn', String('selectableValueToComboboxOption: icon is not a valid icon name'), { args: v.icon });
     return undefined;
   }
   return {

--- a/packages/grafana-ui/src/components/DateTimePickers/TimeRangePicker/CalendarBody.tsx
+++ b/packages/grafana-ui/src/components/DateTimePickers/TimeRangePicker/CalendarBody.tsx
@@ -12,6 +12,7 @@ import { adjustDateForReactCalendar } from '../utils/adjustDateForReactCalendar'
 
 import { type TimePickerCalendarProps } from './TimePickerCalendar';
 
+import { emitStructuredBrowserError } from '@grafana/data';
 const weekStartMap: Record<WeekStart, CalendarType> = {
   saturday: 'islamic',
   sunday: 'gregory',
@@ -70,7 +71,8 @@ function useOnCalendarChange(onChange: (from: DateTime, to: DateTime) => void, t
   return useCallback<NonNullable<React.ComponentProps<typeof Calendar>['onChange']>>(
     (value) => {
       if (!Array.isArray(value)) {
-        return console.error('onCalendarChange: should be run in selectRange={true}');
+        emitStructuredBrowserError(new Error('onCalendarChange: should be run in selectRange={true}'));
+        return;
       }
 
       if (value[0] && value[1]) {

--- a/packages/grafana-ui/src/components/Icon/Icon.tsx
+++ b/packages/grafana-ui/src/components/Icon/Icon.tsx
@@ -10,6 +10,7 @@ import { spin } from '../../utils/keyframes';
 
 import { getIconPath, getSvgSize } from './utils';
 
+import { emitStructuredBrowserLog } from '@grafana/data';
 export interface IconProps extends Omit<React.SVGProps<SVGElement>, 'onLoad' | 'onError' | 'ref'> {
   name: IconName;
   size?: IconSize;
@@ -96,7 +97,7 @@ export const Icon = memo(
       const { nameToUse: name, handleLoad } = useIconWorkaround(nameProp);
 
       if (!isIconName(name)) {
-        console.warn('Icon component passed an invalid icon name', name);
+        emitStructuredBrowserLog('warn', String('Icon component passed an invalid icon name'), { args: name });
       }
 
       // handle the deprecated 'fa fa-spinner'

--- a/packages/grafana-ui/src/components/Input/AutoSizeInput.tsx
+++ b/packages/grafana-ui/src/components/Input/AutoSizeInput.tsx
@@ -6,6 +6,7 @@ import { measureText } from '../../utils/measureText';
 import { AutoSizeInputContext } from './AutoSizeInputContext';
 import { Input, type Props as InputProps } from './Input';
 
+import { emitStructuredBrowserLog } from '@grafana/data';
 export interface Props extends InputProps {
   /** Sets the min-width to a multiple of 8px. Default value is 10*/
   minWidth?: number;
@@ -119,7 +120,8 @@ function useControlledState<T>(controlledValue: T, onChange: Function | undefine
 
   const hasLoggedControlledWarning = useRef(false);
   if (isControlledNow !== isControlledRef.current && !hasLoggedControlledWarning.current) {
-    console.warn(
+    emitStructuredBrowserLog(
+      'warn',
       'An AutoSizeInput is changing from an uncontrolled to a controlled input. If you want to control the input, the empty value should be an empty string.'
     );
     hasLoggedControlledWarning.current = true;

--- a/packages/grafana-ui/src/components/Monaco/CodeEditor.tsx
+++ b/packages/grafana-ui/src/components/Monaco/CodeEditor.tsx
@@ -12,6 +12,7 @@ import { ReactMonacoEditorLazy } from './ReactMonacoEditorLazy';
 import { registerSuggestions } from './suggestions';
 import { type CodeEditorProps, type Monaco, type MonacoEditor as MonacoEditorType, type MonacoOptions } from './types';
 
+import { emitStructuredBrowserLog } from '@grafana/data';
 type Props = CodeEditorProps & Themeable2;
 
 class UnthemedCodeEditor extends PureComponent<Props> {
@@ -43,7 +44,7 @@ class UnthemedCodeEditor extends PureComponent<Props> {
       }
 
       if (!this.monaco) {
-        console.warn('Monaco instance not loaded yet');
+        emitStructuredBrowserLog('warn', String('Monaco instance not loaded yet'));
         return;
       }
 

--- a/packages/grafana-ui/src/components/StatsPicker/StatsPicker.tsx
+++ b/packages/grafana-ui/src/components/StatsPicker/StatsPicker.tsx
@@ -11,6 +11,7 @@ import { selectableValueToComboboxOption } from '../Combobox/utils';
 
 import { pickComboboxLayout } from './pickComboboxLayout';
 
+import { emitStructuredBrowserLog } from '@grafana/data';
 /** Props managed by StatsPicker — forwarded combobox props must not replace these. */
 type ComboboxManagedProps = 'value' | 'options' | 'onChange' | 'isClearable' | 'width' | 'minWidth' | 'maxWidth';
 
@@ -53,13 +54,13 @@ export const StatsPicker = memo<StatsPickerProps>(
       if (current.length !== stats.length) {
         const found = current.map((v) => v.id);
         const notFound = difference(stats, found);
-        console.warn('Unknown stats', notFound, stats);
+        emitStructuredBrowserLog('warn', String('Unknown stats'), { args: notFound, stats });
         onChange(current.map((stat) => stat.id));
       }
 
       // Make sure there is only one
       if (!allowMultiple && stats.length > 1) {
-        console.warn('Removing extra stat', stats);
+        emitStructuredBrowserLog('warn', String('Removing extra stat'), { args: stats });
         onChange([stats[0]]);
       }
 

--- a/packages/grafana-ui/src/components/Table/TableNG/utils.ts
+++ b/packages/grafana-ui/src/components/Table/TableNG/utils.ts
@@ -47,6 +47,7 @@ import {
   type FilterType,
 } from './types';
 
+import { emitStructuredBrowserError } from '@grafana/data';
 /* ---------------------------- Cell calculations --------------------------- */
 export type CellNumLinesCalculator = (text: string, cellWidth: number) => number;
 
@@ -1184,7 +1185,7 @@ export function parseStyleJson(rawValue: unknown): CSSProperties | void {
       }
     } catch (e) {
       if (!warnedAboutStyleJsonSet.has(rawValue)) {
-        console.error(`encountered invalid cell style JSON: ${rawValue}`, e);
+        emitStructuredBrowserError(e instanceof Error ? e : new Error(String(e)), { message: String(`encountered invalid cell style JSON: ${rawValue}`) });
         warnedAboutStyleJsonSet.add(rawValue);
       }
     }

--- a/packages/grafana-ui/src/components/ThemeDemos/EmotionPerfTest.tsx
+++ b/packages/grafana-ui/src/components/ThemeDemos/EmotionPerfTest.tsx
@@ -10,8 +10,9 @@ import { useStyles2, useTheme2 } from '../../themes/ThemeContext';
 import { Button } from '../Button/Button';
 import { Stack } from '../Layout/Stack/Stack';
 
+import { emitStructuredBrowserLog } from '@grafana/data';
 export function EmotionPerfTest() {
-  console.log('process.env.NODE_ENV', process.env.NODE_ENV);
+  emitStructuredBrowserLog('info', String('process.env.NODE_ENV'), { args: process.env.NODE_ENV });
 
   return (
     <Stack direction="column">
@@ -126,7 +127,7 @@ function NoStyles({ index }: TestComponentProps) {
 
 function MeasureRender({ children, id }: { children: React.ReactNode; id: string }) {
   const onRender: ProfilerOnRenderCallback = (id, phase, actualDuration, baseDuration, startTime, commitTime) => {
-    console.log('Profile ' + id, actualDuration);
+    emitStructuredBrowserLog('info', String('Profile ' + id), { args: actualDuration });
   };
 
   return (

--- a/packages/grafana-ui/src/components/VizTooltip/VizTooltipRow.tsx
+++ b/packages/grafana-ui/src/components/VizTooltip/VizTooltipRow.tsx
@@ -12,6 +12,7 @@ import { Tooltip } from '../Tooltip/Tooltip';
 import { ColorIndicatorPosition, VizTooltipColorIndicator } from './VizTooltipColorIndicator';
 import { ColorPlacement, type VizTooltipItem } from './types';
 
+import { emitStructuredBrowserError } from '@grafana/data';
 interface VizTooltipRowProps extends Omit<VizTooltipItem, 'value'> {
   value: string | number | null | ReactNode;
   justify?: string;
@@ -112,7 +113,7 @@ export const VizTooltipRow = ({
         setShowCopySuccess(true);
       }
     } catch (err) {
-      console.error('Unable to copy to clipboard', err);
+      emitStructuredBrowserError(err instanceof Error ? err : new Error(String(err)), { message: String('Unable to copy to clipboard') });
     }
 
     textarea.remove();

--- a/packages/grafana-ui/src/utils/logOptions.ts
+++ b/packages/grafana-ui/src/utils/logOptions.ts
@@ -1,3 +1,5 @@
+
+import { emitStructuredBrowserLog } from '@grafana/data';
 /**
  * This function logs a warning if the amount of items exceeds the recommended amount.
  *
@@ -13,11 +15,11 @@ export function logOptions(
 ): void {
   if (amount > recommendedAmount) {
     const msg = `[Combobox] Items exceed the recommended amount ${recommendedAmount}.`;
-    console.warn(msg, {
+    emitStructuredBrowserLog('warn', String(msg), { args: {
       itemsCount: '' + amount,
       recommendedAmount: '' + recommendedAmount,
       'aria-labelledby': ariaLabelledBy ?? '',
       id: id ?? '',
-    });
+    } });
   }
 }

--- a/packages/grafana-ui/src/utils/logger.ts
+++ b/packages/grafana-ui/src/utils/logger.ts
@@ -1,12 +1,14 @@
 import { throttle } from 'lodash';
 
+import { emitStructuredBrowserLog } from '@grafana/data';
+
 type Args = Parameters<typeof console.log>;
 
 /**
  * @internal
  * */
-const throttledLog = throttle((...t: Args) => {
-  console.log(...t);
+const throttledLog = throttle((name: string, id: string, ...t: Args) => {
+  emitStructuredBrowserLog('info', `[${name}: ${id}]`, { parts: t });
 }, 500);
 
 /**
@@ -32,8 +34,11 @@ export const createLogger = (name: string): Logger => {
       if (process.env.NODE_ENV === 'production' || process.env.NODE_ENV === 'test' || !loggingEnabled) {
         return;
       }
-      const fn = throttle ? throttledLog : console.log;
-      fn(`[${name}: ${id}]:`, ...t);
+      if (throttle) {
+        throttledLog(name, id, ...t);
+        return;
+      }
+      emitStructuredBrowserLog('info', `[${name}: ${id}]`, { parts: t });
     },
     enable: () => (loggingEnabled = true),
     disable: () => (loggingEnabled = false),

--- a/public/app/AppWrapper.tsx
+++ b/public/app/AppWrapper.tsx
@@ -24,6 +24,7 @@ import { type PluginExtensionRegistries } from './features/plugins/extensions/re
 import { ScopesContextProvider } from './features/scopes/ScopesContextProvider';
 import { RouterWrapper } from './routes/RoutesWrapper';
 
+import { grafanaStructuredLogger } from '@grafana/runtime';
 interface AppWrapperProps {
   context: GrafanaContextType;
 }
@@ -77,7 +78,7 @@ export class AppWrapper extends Component<AppWrapperProps, AppWrapperState> {
     if (preloader) {
       preloader.remove();
     } else {
-      console.warn('Preloader element not found');
+      grafanaStructuredLogger.logWarning(String('Preloader element not found'));
     }
   }
 

--- a/public/app/api/clients/provisioning/utils/createOnCacheEntryAdded.ts
+++ b/public/app/api/clients/provisioning/utils/createOnCacheEntryAdded.ts
@@ -4,6 +4,7 @@ import { type Subscription } from 'rxjs';
 import { ScopedResourceClient } from 'app/features/apiserver/client';
 import { type ListOptions, type GeneratedResourceList as ResourceList } from 'app/features/apiserver/types';
 
+import { grafanaStructuredLogger } from '@grafana/runtime';
 interface OnCacheEntryAddedOptions<List = unknown> {
   onError?: (
     error: unknown,
@@ -80,7 +81,7 @@ export function createOnCacheEntryAdded<Spec, Status>(
           },
         });
     } catch (error) {
-      console.error('Error in onCacheEntryAdded:', error);
+      grafanaStructuredLogger.logError(error instanceof Error ? error : new Error(String(error)), { message: String('Error in onCacheEntryAdded:') });
       return;
     }
 

--- a/public/app/api/clients/provisioning/v0alpha1/index.ts
+++ b/public/app/api/clients/provisioning/v0alpha1/index.ts
@@ -26,6 +26,7 @@ import { refetchChildren } from '../../../../features/browse-dashboards/state/ac
 import { handleError } from '../../../utils';
 import { createOnCacheEntryAdded } from '../utils/createOnCacheEntryAdded';
 
+import { grafanaStructuredLogger } from '@grafana/runtime';
 const handleProvisioningFormError = (e: unknown, dispatch: ThunkDispatch, title: string) => {
   if (typeof e === 'object' && e && 'error' in e && isFetchError(e.error)) {
     if (e.error.data.kind === 'Status' && e.error.data.status === 'Failure') {
@@ -271,7 +272,7 @@ export const provisioningAPIv0alpha1 = generatedAPI.enhanceEndpoints({
             dispatch(clearFolders(childrenKeys));
           }
         } catch (e) {
-          console.error('Error in getRepositoryJobsWithPath:', e);
+          grafanaStructuredLogger.logError(e instanceof Error ? e : new Error(String(e)), { message: String('Error in getRepositoryJobsWithPath:') });
         }
       },
     },

--- a/public/app/app.ts
+++ b/public/app/app.ts
@@ -122,6 +122,7 @@ import { createSystemVariableAdapter } from './features/variables/system/adapter
 import { createTextBoxVariableAdapter } from './features/variables/textbox/adapter';
 import { configureStore } from './store/configureStore';
 
+import { grafanaStructuredLogger } from '@grafana/runtime';
 // import symlinked extensions
 const extensionsIndex = require.context('.', true, /extensions\/index.ts/);
 const extensionsExports = extensionsIndex.keys().map((key) => {
@@ -146,7 +147,7 @@ export class GrafanaApp {
         try {
           await initOpenFeature();
         } catch (err) {
-          console.error('Failed to initialize OpenFeature provider', err);
+          grafanaStructuredLogger.logError(err instanceof Error ? err : new Error(String(err)), { message: String('Failed to initialize OpenFeature provider') });
         }
       }
 
@@ -286,7 +287,7 @@ export class GrafanaApp {
       try {
         cleanupOldExpandedFolders();
       } catch (err) {
-        console.warn('Failed to clean up old expanded folders', err);
+        grafanaStructuredLogger.logWarning(String('Failed to clean up old expanded folders'), { args: err });
       }
 
       this.context = {
@@ -316,7 +317,7 @@ export class GrafanaApp {
 
       await postInitTasks();
     } catch (error) {
-      console.error('Failed to start Grafana', error);
+      grafanaStructuredLogger.logError(error instanceof Error ? error : new Error(String(error)), { message: String('Failed to start Grafana') });
       window.__grafana_load_failed();
     } finally {
       stopMeasure('frontend_app_init');

--- a/public/app/core/components/AccessControl/Permissions.tsx
+++ b/public/app/core/components/AccessControl/Permissions.tsx
@@ -15,6 +15,7 @@ import { AddPermission } from './AddPermission';
 import { PermissionList } from './PermissionList';
 import { PermissionTarget, type ResourcePermission, type SetPermission, type Description } from './types';
 
+import { grafanaStructuredLogger } from '@grafana/runtime';
 const EMPTY_PERMISSION = '';
 
 const INITIAL_DESCRIPTION: Description = {
@@ -248,7 +249,7 @@ const getDescription = async (resource: string, queryParams?: Record<string, str
   try {
     return await getBackendSrv().get(`/api/access-control/${resource}/description`, queryParams);
   } catch (e) {
-    console.error('failed to load resource description: ', e);
+    grafanaStructuredLogger.logError(e instanceof Error ? e : new Error(String(e)), { message: String('failed to load resource description: ') });
     return INITIAL_DESCRIPTION;
   }
 };

--- a/public/app/core/components/AppChrome/TopBar/InviteUserButton.tsx
+++ b/public/app/core/components/AppChrome/TopBar/InviteUserButton.tsx
@@ -14,6 +14,7 @@ import {
   shouldRenderUpgradeUserButton,
 } from './InviteUserButtonUtils';
 
+import { grafanaStructuredLogger } from '@grafana/runtime';
 export function InviteUserButton() {
   const isLargeScreen = useMediaQueryMinWidth('lg');
   const shouldRender = shouldRenderInviteUserButton();
@@ -42,7 +43,7 @@ export function InviteUserButton() {
         performInviteUserClick('top_bar_right', 'invite-user-top-bar');
       }
     } catch (error) {
-      console.error('Failed to handle invite/upgrade user click:', error);
+      grafanaStructuredLogger.logError(error instanceof Error ? error : new Error(String(error)), { message: String('Failed to handle invite/upgrade user click:') });
     }
   };
 

--- a/public/app/core/components/Login/LoginCtrl.tsx
+++ b/public/app/core/components/Login/LoginCtrl.tsx
@@ -6,6 +6,7 @@ import config from 'app/core/config';
 
 import { type LoginDTO } from './types';
 
+import { grafanaStructuredLogger } from '@grafana/runtime';
 const isOauthEnabled = () => {
   return !!config.oauth && Object.keys(config.oauth).length > 0;
 };
@@ -88,7 +89,7 @@ export const LoginCtrl = memo(({ resetCode, children }: Props) => {
           .then(() => {
             toGrafana();
           })
-          .catch((err) => console.error(err));
+          .catch((err) => grafanaStructuredLogger.logError(err instanceof Error ? err : new Error(String(err))));
       }
     },
     [resetCode, toGrafana]

--- a/public/app/core/components/NavLandingPage/NavLandingPage.tsx
+++ b/public/app/core/components/NavLandingPage/NavLandingPage.tsx
@@ -9,6 +9,7 @@ import { useNavModel } from 'app/core/hooks/useNavModel';
 
 import { NavLandingPageCard } from './NavLandingPageCard';
 
+import { grafanaStructuredLogger } from '@grafana/runtime';
 interface Props {
   navId: string;
   header?: React.ReactNode;
@@ -36,11 +37,9 @@ export function NavLandingPage({ navId, header }: Props) {
   // Warn if both extension points are being used (they are mutually exclusive)
   React.useEffect(() => {
     if (components && components.length > 0 && additionalCards && additionalCards.length > 0) {
-      console.warn(
-        `[NavLandingPage] Both NavLandingPage and NavLandingPageCards extensions are registered for "${node.id}". ` +
+      grafanaStructuredLogger.logWarning(String(`[NavLandingPage] Both NavLandingPage and NavLandingPageCards extensions are registered for "${node.id}". ` +
           `The NavLandingPage extension will take precedence and NavLandingPageCards will be ignored. ` +
-          `Please use only one extension point.`
-      );
+          `Please use only one extension point.`));
     }
   }, [components, additionalCards, node.id]);
 

--- a/public/app/core/components/RolePicker/TeamRolePicker.tsx
+++ b/public/app/core/components/RolePicker/TeamRolePicker.tsx
@@ -7,6 +7,7 @@ import { AccessControlAction, type Role } from 'app/types/accessControl';
 
 import { RolePicker } from './RolePicker';
 
+import { grafanaStructuredLogger } from '@grafana/runtime';
 export interface Props {
   teamId: number;
   orgId?: number;
@@ -79,7 +80,7 @@ export const TeamRolePicker = ({
           },
         }).unwrap();
       } catch (error) {
-        console.error('Error updating team roles', error);
+        grafanaStructuredLogger.logError(error instanceof Error ? error : new Error(String(error)), { message: String('Error updating team roles') });
       }
     } else if (onApplyRoles) {
       onApplyRoles(newRoles);

--- a/public/app/core/components/RolePicker/UserRolePicker.tsx
+++ b/public/app/core/components/RolePicker/UserRolePicker.tsx
@@ -8,6 +8,7 @@ import { AccessControlAction, type Role } from 'app/types/accessControl';
 
 import { RolePicker } from './RolePicker';
 
+import { grafanaStructuredLogger } from '@grafana/runtime';
 export interface Props {
   basicRole: OrgRole;
   roles?: Role[];
@@ -90,7 +91,7 @@ export const UserRolePicker = ({
           },
         }).unwrap();
       } catch (error) {
-        console.error('Error updating user roles', error);
+        grafanaStructuredLogger.logError(error instanceof Error ? error : new Error(String(error)), { message: String('Error updating user roles') });
       }
     } else if (onApplyRoles) {
       onApplyRoles(newRoles, userId, orgId);

--- a/public/app/core/components/SharedPreferences/SharedPreferencesFunctional.tsx
+++ b/public/app/core/components/SharedPreferences/SharedPreferencesFunctional.tsx
@@ -39,6 +39,7 @@ import {
   type State,
 } from './utils';
 
+import { grafanaStructuredLogger } from '@grafana/runtime';
 export const SharedPreferencesFunctional = memo((props: Props) => {
   const isAnalyticsFrameworkEnabled = useBooleanFlagValue('analyticsFramework', true);
   const [state, setState] = useState<UserPreferencesDTO & State>({
@@ -89,7 +90,7 @@ export const SharedPreferencesFunctional = memo((props: Props) => {
           navbar: prefs.navbar ?? prev.navbar,
         }));
       } catch (err) {
-        console.error('Failed to load preferences', err);
+        grafanaStructuredLogger.logError(err instanceof Error ? err : new Error(String(err)), { message: String('Failed to load preferences') });
       } finally {
         setState((prev) => ({ ...prev, isLoading: false }));
       }

--- a/public/app/core/components/TimePicker/TimePickerWithHistory.tsx
+++ b/public/app/core/components/TimePicker/TimePickerWithHistory.tsx
@@ -12,6 +12,7 @@ import { t } from '@grafana/i18n';
 import { type TimeRangePickerProps, TimeRangePicker } from '@grafana/ui';
 import { appEvents } from 'app/core/app_events';
 
+import { grafanaStructuredLogger } from '@grafana/runtime';
 const LOCAL_STORAGE_KEY = 'grafana.dashboard.timepicker.history';
 const MAX_HISTORY_ITEMS = 4;
 
@@ -136,7 +137,9 @@ function convertToISOString(value: DateTime | string): string {
   }
 
   if (!value?.toISOString) {
-    throw console.error('Invalid DateTime object passed to convertToISOString');
+    const err = new Error('Invalid DateTime object passed to convertToISOString');
+    grafanaStructuredLogger.logError(err);
+    throw err;
   }
 
   return value.toISOString();

--- a/public/app/core/navigation/errorModels.ts
+++ b/public/app/core/navigation/errorModels.ts
@@ -1,7 +1,8 @@
 import { type NavModel, type NavModelItem } from '@grafana/data';
 
+import { grafanaStructuredLogger } from '@grafana/runtime';
 export function getExceptionNav(error: unknown): NavModel {
-  console.error(error);
+  grafanaStructuredLogger.logError(error instanceof Error ? error : new Error(String(error)));
   return getWarningNav('Exception thrown', 'See console for details');
 }
 

--- a/public/app/core/reducers/appNotification.ts
+++ b/public/app/core/reducers/appNotification.ts
@@ -2,6 +2,7 @@ import { createSelector, createSlice, type PayloadAction } from '@reduxjs/toolki
 
 import { type AppNotification, AppNotificationSeverity, type AppNotificationsState } from 'app/types/appNotifications';
 
+import { grafanaStructuredLogger } from '@grafana/runtime';
 const MAX_STORED_NOTIFICATIONS = 25;
 export const STORAGE_KEY = 'notifications';
 export const NEW_NOTIFS_KEY = `${STORAGE_KEY}/lastRead`;
@@ -122,7 +123,7 @@ function serializeNotifications(notifs: Record<string, StoredNotification>) {
   try {
     window.localStorage.setItem(STORAGE_KEY, JSON.stringify(reducedNotifs));
   } catch (err) {
-    console.error('Unable to persist notifications to local storage');
-    console.error(err);
+    grafanaStructuredLogger.logError(new Error('Unable to persist notifications to local storage'));
+    grafanaStructuredLogger.logError(err instanceof Error ? err : new Error(String(err)));
   }
 }

--- a/public/app/core/services/FetchQueue.ts
+++ b/public/app/core/services/FetchQueue.ts
@@ -2,6 +2,7 @@ import { type Observable, Subject } from 'rxjs';
 
 import { type BackendSrvRequest } from '@grafana/runtime';
 
+import { grafanaStructuredLogger } from '@grafana/runtime';
 export interface QueueState extends Record<string, { state: FetchStatus; options: BackendSrvRequest }> {}
 
 export enum FetchStatus {
@@ -90,8 +91,8 @@ export class FetchQueue {
       []
     );
 
-    console.log('FetchQueue noOfStarted', update.noOfInProgress);
-    console.log('FetchQueue noOfNotStarted', update.noOfPending);
-    console.log('FetchQueue state', entriesWithoutOptions);
+    grafanaStructuredLogger.logInfo(String('FetchQueue noOfStarted'), { args: update.noOfInProgress });
+    grafanaStructuredLogger.logInfo(String('FetchQueue noOfNotStarted'), { args: update.noOfPending });
+    grafanaStructuredLogger.logInfo(String('FetchQueue state'), { args: entriesWithoutOptions });
   };
 }

--- a/public/app/core/services/backend_srv.ts
+++ b/public/app/core/services/backend_srv.ts
@@ -53,6 +53,7 @@ import { FetchQueueWorker } from './FetchQueueWorker';
 import { ResponseQueue } from './ResponseQueue';
 import { type ContextSrv, contextSrv } from './context_srv';
 
+import { grafanaStructuredLogger } from '@grafana/runtime';
 const CANCEL_ALL_REQUESTS_REQUEST_ID = 'cancel_all_requests_request_id';
 
 export interface BackendSrvDependencies {
@@ -116,7 +117,7 @@ export class BackendSrv implements BackendService {
       const result = await fp.get();
       this.deviceID = result.visitorId;
     } catch (error) {
-      console.error(error);
+      grafanaStructuredLogger.logError(error instanceof Error ? error : new Error(String(error)));
     }
   }
 
@@ -241,7 +242,7 @@ export class BackendSrv implements BackendService {
             observer.complete();
           }) // runs in background
           .catch((e) => {
-            console.log(requestId, 'catch', e);
+            grafanaStructuredLogger.logInfo(String(requestId), { args: 'catch', e });
             observer.error(e);
           }); // from abort
       },

--- a/public/app/core/services/context_srv.ts
+++ b/public/app/core/services/context_srv.ts
@@ -16,6 +16,7 @@ import { type CurrentUserInternal } from 'app/types/config';
 
 import config from '../../core/config';
 
+import { grafanaStructuredLogger } from '@grafana/runtime';
 // When set to auto, the interval will be based on the query range
 // NOTE: this is defined here rather than TimeSrv so we avoid circular dependencies
 export const AutoRefreshInterval = 'auto';
@@ -112,7 +113,7 @@ export class ContextSrv {
         reloadcache: true,
       });
     } catch (e) {
-      console.error(e);
+      grafanaStructuredLogger.logError(e instanceof Error ? e : new Error(String(e)));
     }
   }
 
@@ -262,7 +263,7 @@ export class ContextSrv {
         }
       })
       .catch((e) => {
-        console.error(e);
+        grafanaStructuredLogger.logError(e instanceof Error ? e : new Error(String(e)));
       });
   }
 }

--- a/public/app/core/services/echo/backends/analytics/BrowseConsoleBackend.ts
+++ b/public/app/core/services/echo/backends/analytics/BrowseConsoleBackend.ts
@@ -6,6 +6,7 @@ import {
   isInteractionEvent,
   isPageviewEvent,
   type PageviewEchoEvent,
+  grafanaStructuredLogger,
 } from '@grafana/runtime';
 
 export class BrowserConsoleBackend implements EchoBackend<PageviewEchoEvent, unknown> {
@@ -16,12 +17,15 @@ export class BrowserConsoleBackend implements EchoBackend<PageviewEchoEvent, unk
 
   addEvent = (e: PageviewEchoEvent) => {
     if (isPageviewEvent(e)) {
-      console.log('[EchoSrv:pageview]', e.payload.page);
+      grafanaStructuredLogger.logInfo('[EchoSrv:pageview]', { page: e.payload.page });
     }
 
     if (isInteractionEvent(e)) {
       const eventName = e.payload.interactionName;
-      console.log('[EchoSrv:event]', eventName, e.payload.properties);
+      grafanaStructuredLogger.logInfo('[EchoSrv:event]', {
+        interactionName: eventName,
+        properties: e.payload.properties,
+      });
 
       // Warn for non-scalar property values. We're not yet making this a hard a
       const invalidTypeProperties = Object.entries(e.payload.properties ?? {}).filter(([_, value]) => {
@@ -32,17 +36,17 @@ export class BrowserConsoleBackend implements EchoBackend<PageviewEchoEvent, unk
       });
 
       if (invalidTypeProperties.length > 0) {
-        console.warn(
-          'Event',
-          eventName,
-          'has invalid property types. Event properties should only be string, number or boolean. Invalid properties:',
-          Object.fromEntries(invalidTypeProperties)
-        );
+        grafanaStructuredLogger.logWarning('Event interaction has invalid property types', {
+          interactionName: eventName,
+          detail:
+            'Event properties should only be string, number or boolean. Invalid properties are listed in invalidProperties.',
+          invalidProperties: Object.fromEntries(invalidTypeProperties),
+        });
       }
     }
 
     if (isExperimentViewEvent(e)) {
-      console.log('[EchoSrv:experiment]', e.payload);
+      grafanaStructuredLogger.logInfo('[EchoSrv:experiment]', { payload: e.payload });
     }
   };
 

--- a/public/app/core/services/echo/init.ts
+++ b/public/app/core/services/echo/init.ts
@@ -1,4 +1,4 @@
-import { config, registerEchoBackend, setEchoSrv } from '@grafana/runtime';
+import { config, grafanaStructuredLogger, registerEchoBackend, setEchoSrv } from '@grafana/runtime';
 import { reportMetricPerformanceMark } from 'app/core/utils/metrics';
 
 import { contextSrv } from '../context_srv';
@@ -28,43 +28,43 @@ export async function initEchoSrv() {
   try {
     await initPerformanceBackend();
   } catch (error) {
-    console.error('Error initializing EchoSrv Performance backend', error);
+    grafanaStructuredLogger.logError(error instanceof Error ? error : new Error(String(error)), { message: String('Error initializing EchoSrv Performance backend') });
   }
 
   try {
     await initFaroBackend();
   } catch (error) {
-    console.error('Error initializing EchoSrv Faro backend', error);
+    grafanaStructuredLogger.logError(error instanceof Error ? error : new Error(String(error)), { message: String('Error initializing EchoSrv Faro backend') });
   }
 
   try {
     await initGoogleAnalyticsBackend();
   } catch (error) {
-    console.error('Error initializing EchoSrv GoogleAnalytics backend', error);
+    grafanaStructuredLogger.logError(error instanceof Error ? error : new Error(String(error)), { message: String('Error initializing EchoSrv GoogleAnalytics backend') });
   }
 
   try {
     await initGoogleAnalaytics4Backend();
   } catch (error) {
-    console.error('Error initializing EchoSrv GoogleAnalaytics4 backend', error);
+    grafanaStructuredLogger.logError(error instanceof Error ? error : new Error(String(error)), { message: String('Error initializing EchoSrv GoogleAnalaytics4 backend') });
   }
 
   try {
     await initRudderstackBackend();
   } catch (error) {
-    console.error('Error initializing EchoSrv Rudderstack backend', error);
+    grafanaStructuredLogger.logError(error instanceof Error ? error : new Error(String(error)), { message: String('Error initializing EchoSrv Rudderstack backend') });
   }
 
   try {
     await initAzureAppInsightsBackend();
   } catch (error) {
-    console.error('Error initializing EchoSrv AzureAppInsights backend', error);
+    grafanaStructuredLogger.logError(error instanceof Error ? error : new Error(String(error)), { message: String('Error initializing EchoSrv AzureAppInsights backend') });
   }
 
   try {
     await initConsoleBackend();
   } catch (error) {
-    console.error('Error initializing EchoSrv Console backend', error);
+    grafanaStructuredLogger.logError(error instanceof Error ? error : new Error(String(error)), { message: String('Error initializing EchoSrv Console backend') });
   }
 }
 

--- a/public/app/core/trustedTypePolicies.ts
+++ b/public/app/core/trustedTypePolicies.ts
@@ -1,23 +1,31 @@
 import { textUtil } from '@grafana/data';
-import { config } from '@grafana/runtime';
+import { config, grafanaStructuredLogger } from '@grafana/runtime';
 
 const CSP_REPORT_ONLY_ENABLED = config.cspReportOnlyEnabled;
 
 export const defaultTrustedTypesPolicy = {
-  createHTML: (string: string, source: string, sink: string) => {
+  createHTML: (html: string, source: string, sink: string) => {
     if (!CSP_REPORT_ONLY_ENABLED) {
-      return string.replace(/<script/gi, '&lt;script');
+      return html.replace(/<script/gi, '&lt;script');
     }
-    console.error('[HTML not sanitized with Trusted Types]', string, source, sink);
-    return string;
+    grafanaStructuredLogger.logWarning('[HTML not sanitized with Trusted Types]', {
+      sink,
+      source,
+      snippet: html.slice(0, 160),
+    });
+    return html;
   },
-  createScript: (string: string) => string,
-  createScriptURL: (string: string, source: string, sink: string) => {
+  createScript: (script: string) => script,
+  createScriptURL: (url: string, source: string, sink: string) => {
     if (!CSP_REPORT_ONLY_ENABLED) {
-      return textUtil.sanitizeUrl(string);
+      return textUtil.sanitizeUrl(url);
     }
-    console.error('[ScriptURL not sanitized with Trusted Types]', string, source, sink);
-    return string;
+    grafanaStructuredLogger.logWarning('[ScriptURL not sanitized with Trusted Types]', {
+      sink,
+      source,
+      url,
+    });
+    return url;
   },
 };
 

--- a/public/app/core/utils/dag.ts
+++ b/public/app/core/utils/dag.ts
@@ -1,3 +1,5 @@
+
+import { grafanaStructuredLogger } from '@grafana/runtime';
 export class Edge {
   inputNode?: Node;
   outputNode?: Node;
@@ -268,7 +270,7 @@ export const printGraph = (g: Graph) => {
     if (!inputEdges) {
       inputEdges = '<none>';
     }
-    console.log(`${n.name}:\n - links to:   ${outputEdges}\n - links from: ${inputEdges}`);
+    grafanaStructuredLogger.logInfo(String(`${n.name}:\n - links to:   ${outputEdges}\n - links from: ${inputEdges}`));
   });
 };
 

--- a/public/app/core/utils/debugLog.ts
+++ b/public/app/core/utils/debugLog.ts
@@ -1,5 +1,6 @@
 import { store } from '@grafana/data';
 
+import { grafanaStructuredLogger } from '@grafana/runtime';
 /**
  * Creates a debug logger gated by a localStorage key.
  *
@@ -11,7 +12,7 @@ export function createDebugLog(key: string, prefix: string) {
 
   return function debugLog(message: string, ...args: unknown[]) {
     if (store.get(storageKey) === 'true') {
-      console.log(`[${prefix}] ${message}`, ...args);
+      grafanaStructuredLogger.logInfo(`[${prefix}] ${message}`, args.length ? { parts: args } : undefined);
     }
   };
 }

--- a/public/app/core/utils/explore.ts
+++ b/public/app/core/utils/explore.ts
@@ -29,6 +29,7 @@ import { RefreshPicker } from '@grafana/ui';
 import { ExpressionDatasourceUID } from 'app/features/expressions/types';
 import { type QueryOptions, type QueryTransaction } from 'app/types/explore';
 
+import { grafanaStructuredLogger } from '@grafana/runtime';
 export const DEFAULT_UI_STATE = {
   dedupStrategy: LogsDedupStrategy.none,
 };
@@ -159,7 +160,7 @@ export const safeStringifyValue = (value: unknown, space?: number) => {
   try {
     return JSON.stringify(value, null, space);
   } catch (error) {
-    console.error(error);
+    grafanaStructuredLogger.logError(error instanceof Error ? error : new Error(String(error)));
   }
 
   return '';
@@ -232,7 +233,7 @@ export async function ensureQueries(
         try {
           await getDataSourceSrv().get(query.datasource.uid);
         } catch {
-          console.error(`One of the queries has a datasource that is no longer available and was removed.`);
+          grafanaStructuredLogger.logError(new Error(`One of the queries has a datasource that is no longer available and was removed.`));
           validDS = false;
         }
       }

--- a/public/app/core/utils/fetch.ts
+++ b/public/app/core/utils/fetch.ts
@@ -4,6 +4,7 @@ import { type Observable, of, throwError } from 'rxjs';
 import { deprecationWarning, validatePath } from '@grafana/data';
 import { type BackendSrvRequest } from '@grafana/runtime';
 
+import { grafanaStructuredLogger } from '@grafana/runtime';
 export const parseInitFromOptions = (options: BackendSrvRequest): RequestInit => {
   const method = options.method;
   const headers = parseHeaders(options);
@@ -139,7 +140,7 @@ export async function parseResponseBody<T>(
         // An empty string is not a valid JSON.
         // Sometimes (unfortunately) our APIs declare their Content-Type as JSON, however they return an empty body.
         if (response.headers.get('Content-Length') === '0') {
-          console.warn(`${response.url} returned an invalid JSON`);
+          grafanaStructuredLogger.logWarning(String(`${response.url} returned an invalid JSON`));
           return {} as T;
         }
         return await response.json();

--- a/public/app/core/utils/metrics.ts
+++ b/public/app/core/utils/metrics.ts
@@ -1,5 +1,6 @@
 import { reportPerformance } from '../services/echo/EchoSrv';
 
+import { grafanaStructuredLogger } from '@grafana/runtime';
 export function startMeasure(eventName: string) {
   if (!performance || !performance.mark) {
     return;
@@ -8,7 +9,7 @@ export function startMeasure(eventName: string) {
   try {
     performance.mark(`${eventName}_started`);
   } catch (error) {
-    console.error(`[Metrics] Failed to startMeasure ${eventName}`, error);
+    grafanaStructuredLogger.logError(error instanceof Error ? error : new Error(String(error)), { message: String(`[Metrics] Failed to startMeasure ${eventName}`) });
   }
 }
 
@@ -31,7 +32,7 @@ export function stopMeasure(eventName: string) {
     performance.clearMeasures(measured);
     return measure;
   } catch (error) {
-    console.error(`[Metrics] Failed to stopMeasure ${eventName}`, error);
+    grafanaStructuredLogger.logError(error instanceof Error ? error : new Error(String(error)), { message: String(`[Metrics] Failed to stopMeasure ${eventName}`) });
     return;
   }
 }

--- a/public/app/core/utils/shortLinks.ts
+++ b/public/app/core/utils/shortLinks.ts
@@ -17,6 +17,7 @@ import { notifyApp } from '../reducers/appNotification';
 
 import { copyStringToClipboard } from './explore';
 
+import { grafanaStructuredLogger } from '@grafana/runtime';
 function buildHostUrl() {
   return `${window.location.protocol}//${window.location.host}${config.appSubUrl}`;
 }
@@ -73,7 +74,7 @@ export const createShortLink = memoizeOne(async (path: string): Promise<string> 
       return await createShortLinkLegacy(path);
     }
   } catch (err) {
-    console.error('Error when creating shortened link: ', err);
+    grafanaStructuredLogger.logError(err instanceof Error ? err : new Error(String(err)), { message: String('Error when creating shortened link: ') });
     dispatch(notifyApp(createErrorNotification('Error generating shortened link')));
     createShortLink.clear();
     throw err; // Re-throw so callers know it failed
@@ -104,7 +105,7 @@ export const createAndCopyShortLink = async (path: string) => {
     }
   } catch (error) {
     // createShortLink already handles error notifications, just log
-    console.error('Error in createAndCopyShortLink:', error);
+    grafanaStructuredLogger.logError(error instanceof Error ? error : new Error(String(error)), { message: String('Error in createAndCopyShortLink:') });
   }
 };
 

--- a/public/app/core/utils/timeRegions.ts
+++ b/public/app/core/utils/timeRegions.ts
@@ -2,6 +2,7 @@ import { Cron } from 'croner';
 
 import { type AbsoluteTimeRange, type TimeRange, durationToMilliseconds, parseDuration } from '@grafana/data';
 
+import { grafanaStructuredLogger } from '@grafana/runtime';
 export type TimeRegionMode = null | 'cron';
 export interface TimeRegionConfig {
   mode?: TimeRegionMode;
@@ -160,7 +161,7 @@ export function calculateTimesWithin(cfg: TimeRegionConfig, tRange: TimeRange): 
     }
   } catch (e) {
     // invalid expression
-    console.error(e);
+    grafanaStructuredLogger.logError(e instanceof Error ? e : new Error(String(e)));
   }
 
   return ranges;

--- a/public/app/features/actions/ConnectionPicker.tsx
+++ b/public/app/features/actions/ConnectionPicker.tsx
@@ -7,6 +7,7 @@ import { Select } from '@grafana/ui';
 
 import { INFINITY_DATASOURCE_TYPE } from './utils';
 
+import { grafanaStructuredLogger } from '@grafana/runtime';
 interface ConnectionOption {
   label: string;
   value: string;
@@ -78,7 +79,10 @@ export const ConnectionPicker = ({ actionType, datasourceUid, onChange }: Connec
       if (selectedDatasource) {
         onChange(selectedDatasource);
       } else {
-        console.error('ConnectionPicker: Could not find datasource with UID:', selectedValue);
+        grafanaStructuredLogger.logError(new Error('ConnectionPicker: Could not find datasource'), {
+          picker: 'ConnectionPicker',
+          uid: selectedValue,
+        });
       }
     }
   };

--- a/public/app/features/actions/utils.ts
+++ b/public/app/features/actions/utils.ts
@@ -26,6 +26,7 @@ import { getNextRequestId } from '../query/state/PanelQueryRunner';
 
 import { reportActionTrigger } from './analytics';
 
+import { grafanaStructuredLogger } from '@grafana/runtime';
 /** @internal */
 export const isInfinityActionWithAuth = (action: Action): boolean => {
   return (grafanaConfig.featureToggles.vizActionsAuth ?? false) && action.type === ActionType.Infinity;
@@ -120,7 +121,7 @@ export const getActions = (
                   appEvents.emit(AppEvents.alertError, [
                     'An error has occurred. Check console output for more details.',
                   ]);
-                  console.error(error);
+                  grafanaStructuredLogger.logError(error instanceof Error ? error : new Error(String(error)));
                 },
                 complete: () => {
                   appEvents.emit(AppEvents.alertSuccess, ['API call was successful']);
@@ -128,7 +129,7 @@ export const getActions = (
               });
           } catch (error) {
             appEvents.emit(AppEvents.alertError, ['An error has occurred. Check console output for more details.']);
-            console.error(error);
+            grafanaStructuredLogger.logError(error instanceof Error ? error : new Error(String(error)));
             return;
           }
         },

--- a/public/app/features/admin/UserOrgs.tsx
+++ b/public/app/features/admin/UserOrgs.tsx
@@ -14,6 +14,7 @@ import { type UserOrg, type UserDTO } from 'app/types/user';
 
 import { OrgRolePicker } from './OrgRolePicker';
 
+import { grafanaStructuredLogger } from '@grafana/runtime';
 interface Props {
   orgs: UserOrg[];
   user?: UserDTO;
@@ -128,7 +129,7 @@ const OrgRow = memo(({ user, org, isExternalUser, onOrgRemove, onOrgRoleChange }
       if (contextSrv.hasPermission(AccessControlAction.ActionRolesList)) {
         fetchRoleOptions(org.orgId)
           .then((roles) => setRoleOptions(roles))
-          .catch((e) => console.error(e));
+          .catch((e) => grafanaStructuredLogger.logError(e instanceof Error ? e : new Error(String(e))));
       }
     }
   }, [org.orgId]);
@@ -266,7 +267,7 @@ export const AddToOrgModal = memo(({ isOpen, user, userOrgs, onOrgAdd, onDismiss
       if (contextSrv.hasPermission(AccessControlAction.ActionRolesList)) {
         fetchRoleOptions(org.value?.id)
           .then((roles) => setRoleOptions(roles))
-          .catch((e) => console.error(e));
+          .catch((e) => grafanaStructuredLogger.logError(e instanceof Error ? e : new Error(String(e))));
       }
     }
   };

--- a/public/app/features/admin/Users/OrgUsersTable.tsx
+++ b/public/app/features/admin/Users/OrgUsersTable.tsx
@@ -31,6 +31,7 @@ import { type OrgUser } from 'app/types/user';
 
 import { OrgRolePicker } from '../OrgRolePicker';
 
+import { grafanaStructuredLogger } from '@grafana/runtime';
 type Cell<T extends keyof OrgUser = keyof OrgUser> = CellProps<OrgUser, OrgUser[T]>;
 
 const disabledRoleMessage = `This user's role is not editable because it is synchronized from your auth provider.
@@ -79,7 +80,7 @@ export const OrgUsersTable = ({
           setRoleOptions(options);
         }
       } catch (e) {
-        console.error('Error loading options');
+        grafanaStructuredLogger.logError(new Error('Error loading options'));
       }
     }
     if (contextSrv.licensedAccessControlEnabled()) {

--- a/public/app/features/admin/state/actions.ts
+++ b/public/app/features/admin/state/actions.ts
@@ -36,6 +36,7 @@ import {
   anonPageChanged,
   anonQueryChanged,
 } from './reducers';
+import { grafanaStructuredLogger } from '@grafana/runtime';
 // UserAdminPage
 
 export function loadAdminUserPage(userUid: string): ThunkResult<void> {
@@ -50,7 +51,7 @@ export function loadAdminUserPage(userUid: string): ThunkResult<void> {
       }
       dispatch(userAdminPageLoadedAction(true));
     } catch (error) {
-      console.error(error);
+      grafanaStructuredLogger.logError(error instanceof Error ? error : new Error(String(error)));
 
       if (isFetchError(error)) {
         const userError = {
@@ -300,7 +301,7 @@ export function fetchUsers(): ThunkResult<void> {
       dispatch(usersFetched(result));
     } catch (error) {
       usersFetchEnd();
-      console.error(error);
+      grafanaStructuredLogger.logError(error instanceof Error ? error : new Error(String(error)));
     }
   };
 }
@@ -366,7 +367,7 @@ export function fetchUsersAnonymousDevices(): ThunkResult<void> {
       const result = await getBackendSrv().get(url);
       dispatch(usersAnonymousDevicesFetched(result));
     } catch (error) {
-      console.error(error);
+      grafanaStructuredLogger.logError(error instanceof Error ? error : new Error(String(error)));
     }
   };
 }

--- a/public/app/features/admin/state/apis.tsx
+++ b/public/app/features/admin/state/apis.tsx
@@ -1,5 +1,6 @@
 import { getBackendSrv } from '@grafana/runtime';
 
+import { grafanaStructuredLogger } from '@grafana/runtime';
 interface AnonServerStat {
   activeDevices?: number;
 }
@@ -28,7 +29,7 @@ export const getServerStats = async (): Promise<ServerStat | null> => {
   return getBackendSrv()
     .get('api/admin/stats')
     .catch((err) => {
-      console.error(err);
+      grafanaStructuredLogger.logError(err instanceof Error ? err : new Error(String(err)));
       return null;
     });
 };

--- a/public/app/features/alerting/unified/components/receivers/form/fields/OptionField.tsx
+++ b/public/app/features/alerting/unified/components/receivers/form/fields/OptionField.tsx
@@ -30,6 +30,7 @@ import { SubformArrayField } from './SubformArrayField';
 import { SubformField } from './SubformField';
 import { WrapWithTemplateSelection } from './TemplateSelector';
 
+import { grafanaStructuredLogger } from '@grafana/runtime';
 interface Props {
   defaultValue: any;
   option: NotificationChannelOption;
@@ -318,7 +319,9 @@ const OptionInput: FC<Props & { id: string }> = ({
       );
 
     default:
-      console.error('Element not supported', option.element);
+      grafanaStructuredLogger.logError(new Error('Receiver form element not supported'), {
+        elementKind: String(option.element),
+      });
       return null;
   }
 };

--- a/public/app/features/alerting/unified/components/rule-editor/labels/LabelsField.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/labels/LabelsField.tsx
@@ -20,6 +20,7 @@ import { useGetLabelsFromDataSourceName } from '../useAlertRuleSuggestions';
 
 import { AddButton, RemoveButton } from './LabelsButtons';
 
+import { grafanaStructuredLogger } from '@grafana/runtime';
 const useGetOpsLabelsKeys = (skip: boolean) => {
   const { currentData, isLoading: isloadingLabels } = labelsApi.endpoints.getLabels.useQuery(undefined, {
     skip,
@@ -183,7 +184,9 @@ export function useCombinedLabels(
               opsValues = result.values.map((value) => value.name);
             }
           } catch (error) {
-            console.error('Failed to fetch label values for key:', key, error);
+            grafanaStructuredLogger.logError(error instanceof Error ? error : new Error(String(error)), {
+              detail: `Failed to fetch label values for key: ${key}`,
+            });
           }
         }
 

--- a/public/app/features/alerting/unified/components/rule-editor/useDashboardQuery.ts
+++ b/public/app/features/alerting/unified/components/rule-editor/useDashboardQuery.ts
@@ -9,6 +9,7 @@ import { type DashboardDTO } from 'app/types/dashboard';
 
 import { DashboardModel } from '../../../../dashboard/state/DashboardModel';
 
+import { grafanaStructuredLogger } from '@grafana/runtime';
 export type DashboardResponse = DashboardDTO | DashboardWithAccessInfo<DashboardV2Spec>;
 
 const ensureV1PanelsHaveIds = memoizeOne((dashboardDTO: DashboardDTO): DashboardResponse => {
@@ -36,11 +37,13 @@ export function useDashboardQuery(dashboardUid?: string) {
           } else if (isDashboardV2Resource(dashboardDTO)) {
             setDashboard(dashboardDTO);
           } else {
-            console.error('Something went wrong, unexpected dashboard format');
+            grafanaStructuredLogger.logError(
+              new Error('Something went wrong, unexpected dashboard format')
+            );
           }
         })
         .catch((error) => {
-          console.error('Failed to fetch dashboard', error);
+          grafanaStructuredLogger.logError(error instanceof Error ? error : new Error(String(error)), { message: String('Failed to fetch dashboard') });
         })
         .finally(() => {
           setIsFetching(false);

--- a/public/app/features/alerting/unified/components/rule-editor/util.ts
+++ b/public/app/features/alerting/unified/components/rule-editor/util.ts
@@ -17,6 +17,7 @@ import { type AlertQuery } from 'app/types/unified-alerting-dto';
 
 import { createDagFromQueries, getOriginOfRefId } from './dag';
 
+import { grafanaStructuredLogger } from '@grafana/runtime';
 export function queriesWithUpdatedReferences(
   queries: AlertQuery[],
   previousRefId: string,
@@ -210,7 +211,7 @@ export function getThresholdsForQueries(queries: AlertQuery[], condition: string
           }
         });
       } catch (err) {
-        console.error('Failed to parse thresholds', err);
+        grafanaStructuredLogger.logError(err instanceof Error ? err : new Error(String(err)), { message: String('Failed to parse thresholds') });
         return;
       }
     });

--- a/public/app/features/alerting/unified/components/rules/Filter/useRuleFilterAutocomplete.ts
+++ b/public/app/features/alerting/unified/components/rules/Filter/useRuleFilterAutocomplete.ts
@@ -10,6 +10,7 @@ import { type GrafanaPromRuleGroupDTO } from 'app/types/unified-alerting-dto';
 import { prometheusApi } from '../../../api/prometheusApi';
 import { getRulesDataSources } from '../../../utils/datasource';
 
+import { grafanaStructuredLogger } from '@grafana/runtime';
 // Module-scope utilities
 const collator = new Intl.Collator();
 function getExternalRuleDataSources() {
@@ -161,7 +162,7 @@ export function useNamespaceAndGroupOptions(): {
 
         return options;
       } catch (error) {
-        console.error('Error fetching groups:', error);
+        grafanaStructuredLogger.logError(error instanceof Error ? error : new Error(String(error)), { message: String('Error fetching groups:') });
         return [createInfoOption(t('alerting.rules-filter.group-search-error', 'Error searching groups'))];
       }
     },

--- a/public/app/features/alerting/unified/rule-list/hooks/grafanaFilter.ts
+++ b/public/app/features/alerting/unified/rule-list/hooks/grafanaFilter.ts
@@ -26,6 +26,7 @@ import {
   ruleTypeFilter,
 } from './filterPredicates';
 
+import { grafanaStructuredLogger } from '@grafana/runtime';
 /**
  * Determines if client-side filtering is needed for Grafana-managed rules.
  */
@@ -154,7 +155,7 @@ function labelMatchersToBackendFormat(labels: string[]): string[] {
     const result = attempt(() => JSON.stringify(parseMatcher(label)));
 
     if (isError(result)) {
-      console.warn('Failed to parse label matcher:', label, result);
+      grafanaStructuredLogger.logWarning(String('Failed to parse label matcher:'), { args: label, result });
     } else {
       acc.push(result);
     }

--- a/public/app/features/alerting/unified/settings/extensions.ts
+++ b/public/app/features/alerting/unified/settings/extensions.ts
@@ -3,6 +3,7 @@ import { useLocation } from 'react-router-dom-v5-compat';
 import { type NavModelItem } from '@grafana/data';
 import { useSelector } from 'app/types/store';
 
+import { grafanaStructuredLogger } from '@grafana/runtime';
 type SettingsSectionUrl = `/alerting/admin/${string}`;
 type SettingsSectionNav = Pick<NavModelItem, 'id' | 'text' | 'icon'> & {
   url: SettingsSectionUrl;
@@ -16,7 +17,9 @@ const settingsExtensions: Map<SettingsSectionUrl, { nav: SettingsSectionNav }> =
  */
 export function addSettingsSection(pageNav: SettingsSectionNav) {
   if (settingsExtensions.has(pageNav.url)) {
-    console.warn('Unable to add settings page, PageNav must have an unique url');
+    grafanaStructuredLogger.logWarning(
+      'Unable to add settings page, PageNav must have an unique url'
+    );
     return;
   }
   settingsExtensions.set(pageNav.url, { nav: pageNav });

--- a/public/app/features/alerting/unified/state/AlertingQueryRunner.ts
+++ b/public/app/features/alerting/unified/state/AlertingQueryRunner.ts
@@ -15,7 +15,7 @@ import {
   withLoadingIndicator,
 } from '@grafana/data';
 import { t } from '@grafana/i18n';
-import { DataSourceWithBackend, type FetchResponse, getDataSourceSrv, toDataQueryError } from '@grafana/runtime';
+import { DataSourceWithBackend, type FetchResponse, grafanaStructuredLogger, getDataSourceSrv, toDataQueryError } from '@grafana/runtime';
 import { type BackendSrv, getBackendSrv } from 'app/core/services/backend_srv';
 import { isExpressionQuery } from 'app/features/expressions/guards';
 import { cancelNetworkRequestsOnUnsubscribe } from 'app/features/query/state/processing/canceler';
@@ -210,7 +210,7 @@ const getTimeRange = (query: AlertQuery, queries: AlertQuery[]): TimeRange => {
   }
 
   if (!query.relativeTimeRange) {
-    console.warn(`Query with refId: ${query.refId} did not have any relative time range, using default.`);
+    grafanaStructuredLogger.logWarning(`Query with refId: ${query.refId} did not have any relative time range, using default.`);
     return getDefaultTimeRange();
   }
 

--- a/public/app/features/annotations/components/StandardAnnotationQueryEditor.tsx
+++ b/public/app/features/annotations/components/StandardAnnotationQueryEditor.tsx
@@ -25,6 +25,7 @@ import { updateAnnotationFromSavedQuery } from '../utils/savedQueryUtils';
 import { AnnotationQueryEditorActionsWrapper } from './AnnotationQueryEditorActionsWrapper';
 import { AnnotationFieldMapper } from './AnnotationResultMapper';
 
+import { grafanaStructuredLogger } from '@grafana/runtime';
 export interface Props {
   datasource: DataSourceApi;
   datasourceInstanceSettings: DataSourceInstanceSettings;
@@ -261,7 +262,7 @@ export default class StandardAnnotationQueryEditor extends PureComponent<Props, 
       this.setState({ skipNextVerification: true });
       onChange(preparedAnnotation);
     } catch (error) {
-      console.error('Failed to replace annotation query:', error);
+      grafanaStructuredLogger.logError(error instanceof Error ? error : new Error(String(error)), { message: String('Failed to replace annotation query:') });
       // On error, reset the replacing state but don't change the annotation
     }
   };

--- a/public/app/features/annotations/standardAnnotationSupport.ts
+++ b/public/app/features/annotations/standardAnnotationSupport.ts
@@ -20,6 +20,7 @@ import {
 import { t } from '@grafana/i18n';
 import { config } from '@grafana/runtime';
 
+import { grafanaStructuredLogger } from '@grafana/runtime';
 export const standardAnnotationSupport: AnnotationSupport = {
   /**
    * Assume the stored value is standard model.
@@ -227,7 +228,7 @@ export function getAnnotationsFromData(
       }
 
       if (!hasTime || !hasText) {
-        console.error('Cannot process annotation fields. No time or text present.');
+        grafanaStructuredLogger.logError(new Error('Cannot process annotation fields. No time or text present.'));
         return [];
       }
 

--- a/public/app/features/annotations/utils/savedQueryUtils.ts
+++ b/public/app/features/annotations/utils/savedQueryUtils.ts
@@ -10,6 +10,7 @@ import { type DataQuery } from '@grafana/schema';
 
 import { standardAnnotationSupport } from '../standardAnnotationSupport';
 
+import { grafanaStructuredLogger } from '@grafana/runtime';
 /**
  * Converts an AnnotationQuery to DataQuery format for SavedQueryButtons.
  * Supports both v1 dashboards (uses target field) and v2 dashboards (uses query.spec field).
@@ -128,7 +129,7 @@ export async function updateAnnotationFromSavedQuery(
 
     return preparedAnnotation;
   } catch (error) {
-    console.warn('Could not prepare annotation with new datasource:', error);
+    grafanaStructuredLogger.logWarning(String('Could not prepare annotation with new datasource:'), { args: error });
     // Return structurally correct annotation even if preparation fails
     const { datasource, ...queryFields } = replacedQuery;
     return { ...cleanAnnotation, target: queryFields };

--- a/public/app/features/apiserver/client.ts
+++ b/public/app/features/apiserver/client.ts
@@ -1,7 +1,7 @@
 import { Observable, from, retry, catchError, filter, map, mergeMap } from 'rxjs';
 
 import { isLiveChannelMessageEvent, isLiveChannelStatusEvent, LiveChannelScope } from '@grafana/data';
-import { config, getBackendSrv, getGrafanaLiveSrv } from '@grafana/runtime';
+import { config, getBackendSrv, getGrafanaLiveSrv, grafanaStructuredLogger } from '@grafana/runtime';
 import { contextSrv } from 'app/core/services/context_srv';
 
 import { getAPINamespace } from '../../api/utils';
@@ -69,7 +69,10 @@ export class ScopedResourceClient<T = object, S = object, K = string> implements
           filter((event) => isLiveChannelMessageEvent(event)),
           map((event) => event.message),
           catchError((error) => {
-            console.warn('Live channel watch failed, falling back to polling:', error);
+            grafanaStructuredLogger.logWarning(
+              'Live channel watch failed, falling back to polling',
+              error instanceof Error ? { message: error.message, stack: error.stack } : { detail: String(error) }
+            );
             return this.createPollingFallback(params, error);
           })
         );
@@ -100,14 +103,19 @@ export class ScopedResourceClient<T = object, S = object, K = string> implements
           try {
             return JSON.parse(line);
           } catch (e) {
-            console.warn('Invalid JSON in watch stream:', e, line);
+            grafanaStructuredLogger.logWarning('Invalid JSON in watch stream', {
+              detail: String(e),
+              lineSuffix: typeof line === 'string' ? line.slice(0, 200) : undefined,
+            });
             return null;
           }
         }),
         filter((event): event is ResourceEvent<T, S, K> => event !== null),
         retry({ count: 3, delay: 1000 }),
         catchError((error) => {
-          console.error('Watch stream error:', error);
+          grafanaStructuredLogger.logError(error instanceof Error ? error : new Error(String(error)), {
+            message: 'Watch stream error',
+          });
           throw error;
         })
       );
@@ -250,9 +258,9 @@ export class ScopedResourceClient<T = object, S = object, K = string> implements
             return;
           }
           // Transient failure: log and retry next cycle.
-          console.warn(
-            `Polling fallback error (${consecutiveFailures}/${ScopedResourceClient.MAX_CONSECUTIVE_POLL_FAILURES}):`,
-            pollError
+          grafanaStructuredLogger.logWarning(
+            `Polling fallback error (${consecutiveFailures}/${ScopedResourceClient.MAX_CONSECUTIVE_POLL_FAILURES})`,
+            { pollError: pollError instanceof Error ? pollError.message : String(pollError) }
           );
         }
 

--- a/public/app/features/auth-config/FieldRenderer.tsx
+++ b/public/app/features/auth-config/FieldRenderer.tsx
@@ -9,6 +9,7 @@ import { fieldMap } from './fields';
 import { type SSOProviderDTO, type SSOSettingsField } from './types';
 import { isSelectableValueArray } from './utils/guards';
 
+import { grafanaStructuredLogger } from '@grafana/runtime';
 interface FieldRendererProps
   extends Pick<
     UseFormReturn<SSOProviderDTO>,
@@ -78,7 +79,7 @@ export const FieldRenderer = ({
   }, [isDisabled, disabledWhen?.disabledValue, name, setValue]);
 
   if (!field) {
-    console.log('missing field:', name);
+    grafanaStructuredLogger.logInfo(String('missing field:'), { args: name });
     return null;
   }
 
@@ -190,7 +191,7 @@ export const FieldRenderer = ({
         </Field>
       );
     default:
-      console.error(`Unknown field type: ${fieldData.type}`);
+      grafanaStructuredLogger.logError(new Error(`Unknown field type: ${fieldData.type}`));
       return null;
   }
 };

--- a/public/app/features/auth-config/state/actions.ts
+++ b/public/app/features/auth-config/state/actions.ts
@@ -19,6 +19,7 @@ import {
   settingsUpdated,
 } from './reducers';
 
+import { grafanaStructuredLogger } from '@grafana/runtime';
 export function loadSettings(showSpinner = true): ThunkResult<Promise<Settings>> {
   return async (dispatch) => {
     if (contextSrv.hasPermission(AccessControlAction.SettingsRead)) {
@@ -78,7 +79,7 @@ export function saveSettings(data: UpdateSettingsQuery): ThunkResult<Promise<boo
         dispatch(resetError());
         return true;
       } catch (error) {
-        console.log(error);
+        grafanaStructuredLogger.logInfo(String(error));
         if (isFetchError(error)) {
           error.isHandled = true;
           const updateErr: SettingsError = {

--- a/public/app/features/browse-dashboards/api/browseDashboardsAPI.ts
+++ b/public/app/features/browse-dashboards/api/browseDashboardsAPI.ts
@@ -38,6 +38,7 @@ import { refetchChildren, refreshParents } from '../state/actions';
 import { isProvisionedDashboard } from './isProvisioned';
 import { PAGE_SIZE } from './services';
 
+import { grafanaStructuredLogger } from '@grafana/runtime';
 export interface DeleteFoldersArgs {
   folderUIDs: string[];
 }
@@ -521,7 +522,7 @@ export const browseDashboardsAPI = createApi({
           } catch (error) {
             if (isFetchError(error)) {
               if (error.status !== 404) {
-                console.error('Error fetching dashboard', error);
+                grafanaStructuredLogger.logError(error instanceof Error ? error : new Error(String(error)), { message: String('Error fetching dashboard') });
               } else {
                 // Do not show the error alert if the dashboard does not exist
                 // this is expected when importing a new dashboard

--- a/public/app/features/browse-dashboards/api/recentlyViewed.ts
+++ b/public/app/features/browse-dashboards/api/recentlyViewed.ts
@@ -2,6 +2,7 @@ import impressionSrv from 'app/core/services/impression_srv';
 import { getGrafanaSearcher } from 'app/features/search/service/searcher';
 import { type DashboardQueryResult } from 'app/features/search/service/types';
 
+import { grafanaStructuredLogger } from '@grafana/runtime';
 /**
  * Returns dashboard search results ordered the same way the user opened them.
  */
@@ -30,7 +31,7 @@ export async function getRecentlyViewedDashboards(maxItems = 5): Promise<Dashboa
     dashboards.sort((a, b) => order(a.uid) - order(b.uid));
     return dashboards;
   } catch (error) {
-    console.error('Failed to load recently viewed dashboards', error);
+    grafanaStructuredLogger.logError(error instanceof Error ? error : new Error(String(error)), { message: String('Failed to load recently viewed dashboards') });
     return [];
   }
 }

--- a/public/app/features/browse-dashboards/api/services.ts
+++ b/public/app/features/browse-dashboards/api/services.ts
@@ -20,6 +20,7 @@ import {
   teamOwnerRef,
 } from '../utils/dashboards';
 
+import { grafanaStructuredLogger } from '@grafana/runtime';
 export const PAGE_SIZE = 50;
 
 async function searchOldAPI(parentUID?: string, page = 1, pageSize = PAGE_SIZE) {
@@ -78,7 +79,7 @@ async function searchNewAPI(parentUID?: string, page = 1, pageSize = PAGE_SIZE) 
         });
       }
     } catch (error) {
-      console.error('Failed to load team folders', error);
+      grafanaStructuredLogger.logError(error instanceof Error ? error : new Error(String(error)), { message: String('Failed to load team folders') });
     }
   }
 

--- a/public/app/features/browse-dashboards/api/useRecentlyDeletedStateManager.ts
+++ b/public/app/features/browse-dashboards/api/useRecentlyDeletedStateManager.ts
@@ -7,6 +7,7 @@ import { type SearchState } from 'app/features/search/types';
 import { deletedDashboardsCache } from '../../search/service/deletedDashboardsCache';
 import { initialState, SearchStateManager } from '../../search/state/SearchStateManager';
 
+import { grafanaStructuredLogger } from '@grafana/runtime';
 // Subclass SearchStateManager to customize the setStateAndDoSearch behavior.
 // We want to clear the search results when the user clears any search input
 // to trigger the skeleton state.
@@ -65,7 +66,7 @@ export class TrashStateManager extends SearchStateManager {
 
       return termCounts.sort((a, b) => b.count - a.count);
     } catch (error) {
-      console.error('Failed to get tags from deleted dashboards:', error);
+      grafanaStructuredLogger.logError(error instanceof Error ? error : new Error(String(error)), { message: String('Failed to get tags from deleted dashboards:') });
       return [];
     }
   };

--- a/public/app/features/browse-dashboards/components/RecentlyDeletedActions.tsx
+++ b/public/app/features/browse-dashboards/components/RecentlyDeletedActions.tsx
@@ -20,6 +20,7 @@ import { getRestoreNotificationData } from '../utils/notifications';
 
 import { RestoreModal } from './RestoreModal';
 
+import { grafanaStructuredLogger } from '@grafana/runtime';
 export function RecentlyDeletedActions() {
   const dispatch = useDispatch();
   const selectedItemsState = useActionSelectionState();
@@ -81,7 +82,7 @@ export function RecentlyDeletedActions() {
       const deletedDashboards = await deletedDashboardsCache.getAsResourceList();
       const dashboard = deletedDashboards?.items.find((d) => d.metadata.name === uid);
       if (!dashboard) {
-        console.warn(`Dashboard ${uid} not found in deleted items`);
+        grafanaStructuredLogger.logWarning(String(`Dashboard ${uid} not found in deleted items`));
         return { uid, error: 'not_found' };
       }
       // Clone the dashboard to be able to edit the immutable data from the store

--- a/public/app/features/browse-dashboards/state/actions.ts
+++ b/public/app/features/browse-dashboards/state/actions.ts
@@ -8,11 +8,12 @@ import { addTeamFolderPrefix, removeTeamFolderPrefix } from '../utils/dashboards
 
 import { findItem } from './utils';
 
+import { grafanaStructuredLogger } from '@grafana/runtime';
 async function listTeamFoldersSafe() {
   try {
     return await listTeamFolders();
   } catch (error) {
-    console.error('Failed to load team folders', error);
+    grafanaStructuredLogger.logError(error instanceof Error ? error : new Error(String(error)), { message: String('Failed to load team folders') });
     return [];
   }
 }
@@ -151,7 +152,7 @@ export const fetchNextChildrenPage = createAsyncThunk(
       fetchKind = 'folder';
     } else if (collection.lastFetchedKind === 'dashboard' && !collection.lastKindHasMoreItems) {
       // There's nothing to load at all
-      console.warn(`fetchNextChildrenPage called for ${uid} but that collection is fully loaded`);
+      grafanaStructuredLogger.logWarning(String(`fetchNextChildrenPage called for ${uid} but that collection is fully loaded`));
       // return;
     } else if (collection.lastFetchedKind === 'folder' && collection.lastKindHasMoreItems) {
       // Load additional pages of folders

--- a/public/app/features/canvas/runtime/frame.tsx
+++ b/public/app/features/canvas/runtime/frame.tsx
@@ -15,6 +15,7 @@ import { type RootElement } from './root';
 import { type Scene } from './scene';
 import { initMoveable } from './sceneAbleManagement';
 
+import { grafanaStructuredLogger } from '@grafana/runtime';
 const DEFAULT_OFFSET = 10;
 const HORIZONTAL_OFFSET = 50;
 
@@ -129,7 +130,7 @@ export class FrameState extends ElementState {
         break;
       case LayerActionID.Duplicate:
         if (element.item.id === 'frame') {
-          console.log('Can not duplicate frames (yet)', action, element);
+          grafanaStructuredLogger.logInfo(String('Can not duplicate frames (yet)'), { args: action, element });
           return;
         }
         const opts = cloneDeep(element.options);
@@ -239,7 +240,7 @@ export class FrameState extends ElementState {
         break;
 
       default:
-        console.log('DO action', action, element);
+        grafanaStructuredLogger.logInfo(String('DO action'), { args: action, element });
         return;
     }
   };

--- a/public/app/features/commandPalette/actions/useActions.tsx
+++ b/public/app/features/commandPalette/actions/useActions.tsx
@@ -7,6 +7,7 @@ import { getRecentDashboardActions } from './dashboardActions';
 import { useStaticActions } from './staticActions';
 import useExtensionActions from './useExtensionActions';
 
+import { grafanaStructuredLogger } from '@grafana/runtime';
 /**
  * Register navigation actions to different parts of grafana or some preferences stuff like themes.
  */
@@ -27,7 +28,7 @@ export function useRegisterRecentDashboardsActions() {
     getRecentDashboardActions()
       .then((recentDashboardActions) => setRecentDashboardActions(recentDashboardActions))
       .catch((err) => {
-        console.error('Error loading recent dashboard actions', err);
+        grafanaStructuredLogger.logError(err instanceof Error ? err : new Error(String(err)), { message: String('Error loading recent dashboard actions') });
       });
   }, []);
 

--- a/public/app/features/dashboard-scene/behaviors/DashboardAnalyticsInitializerBehavior.ts
+++ b/public/app/features/dashboard-scene/behaviors/DashboardAnalyticsInitializerBehavior.ts
@@ -3,6 +3,7 @@ import { writePerformanceLog } from '@grafana/scenes';
 import { getDashboardAnalyticsAggregator } from '../../dashboard/services/DashboardAnalyticsAggregator';
 import { type DashboardScene } from '../scene/DashboardScene';
 
+import { grafanaStructuredLogger } from '@grafana/runtime';
 /**
  * Scene behavior function that manages the dashboard-specific initialization
  * of the global analytics aggregator for each dashboard session.
@@ -15,7 +16,7 @@ export function dashboardAnalyticsInitializer(dashboard: DashboardScene) {
   const { uid, title } = dashboard.state;
 
   if (!uid) {
-    console.warn('dashboardAnalyticsInitializer: Dashboard UID is missing');
+    grafanaStructuredLogger.logWarning(String('dashboardAnalyticsInitializer: Dashboard UID is missing'));
     return;
   }
 

--- a/public/app/features/dashboard-scene/behaviors/DefaultControlsBehavior.ts
+++ b/public/app/features/dashboard-scene/behaviors/DefaultControlsBehavior.ts
@@ -6,6 +6,7 @@ import { loadDefaultControlsShared$, loadDefaultLinks$, loadDefaultVariables$ } 
 import { getDsRefsFromScene } from '../utils/dashboardDsRefs';
 import { getDashboardSceneFor } from '../utils/utils';
 
+import { grafanaStructuredLogger } from '@grafana/runtime';
 export class DefaultControlsBehavior extends SceneObjectBase<SceneObjectState> {
   private _variablesSub?: Subscription;
   private _linksSub?: Subscription;
@@ -32,7 +33,7 @@ export class DefaultControlsBehavior extends SceneObjectBase<SceneObjectState> {
     this._variablesSub = loadDefaultVariables$(shared$).subscribe({
       next: (vars) => dashboard.setDefaultVariables(vars),
       error: (err) => {
-        console.warn('Failed to load default variables', err);
+        grafanaStructuredLogger.logWarning(String('Failed to load default variables'), { args: err });
         dashboard.setState({ defaultVariablesLoading: false });
       },
       complete: () => dashboard.setState({ defaultVariablesLoading: false }),
@@ -41,7 +42,7 @@ export class DefaultControlsBehavior extends SceneObjectBase<SceneObjectState> {
     this._linksSub = loadDefaultLinks$(shared$).subscribe({
       next: (links) => dashboard.setDefaultLinks(links),
       error: (err) => {
-        console.warn('Failed to load default links', err);
+        grafanaStructuredLogger.logWarning(String('Failed to load default links'), { args: err });
         dashboard.setState({ defaultLinksLoading: false });
       },
       complete: () => dashboard.setState({ defaultLinksLoading: false }),

--- a/public/app/features/dashboard-scene/edit-pane/DashboardEditPane.tsx
+++ b/public/app/features/dashboard-scene/edit-pane/DashboardEditPane.tsx
@@ -23,6 +23,7 @@ import {
 } from './shared';
 import { type EditPaneSelectionActions } from './types';
 
+import { grafanaStructuredLogger } from '@grafana/runtime';
 export interface DashboardEditPaneState extends SceneObjectState {
   selectionContext: ElementSelectionContextState;
 
@@ -237,7 +238,7 @@ export class DashboardEditPane extends SceneObjectBase<DashboardEditPaneState> i
   private selectElement(element: ElementSelectionContextItem, options: ElementSelectionOnSelectOptions) {
     let obj = sceneGraph.findByKey(this, element.id);
     if (!obj) {
-      console.warn('Cannot find element by key="%s"!', element.id);
+      grafanaStructuredLogger.logWarning(String('Cannot find element by key="%s"!'), { args: element.id });
       return;
     }
 
@@ -245,7 +246,7 @@ export class DashboardEditPane extends SceneObjectBase<DashboardEditPaneState> i
     if (sourceKey) {
       obj = sceneGraph.findByKey(this, sourceKey);
       if (!obj) {
-        console.warn('Cannot find element by source key="%s"!', sourceKey);
+        grafanaStructuredLogger.logWarning(String('Cannot find element by source key="%s"!'), { args: sourceKey });
         return;
       }
     }

--- a/public/app/features/dashboard-scene/inspect/HelpWizard/SupportSnapshotService.ts
+++ b/public/app/features/dashboard-scene/inspect/HelpWizard/SupportSnapshotService.ts
@@ -10,6 +10,7 @@ import { transformSaveModelToScene } from '../../serialization/transformSaveMode
 import { type Randomize } from './randomizer';
 import { getDebugDashboard, getGithubMarkdown } from './utils';
 
+import { grafanaStructuredLogger } from '@grafana/runtime';
 interface SupportSnapshotState {
   currentTab: SnapshotTab;
   showMessage: ShowMessage;
@@ -84,7 +85,7 @@ export class SupportSnapshotService extends StateManagerBase<SupportSnapshotStat
         const dash = transformSaveModelToScene({ dashboard: snapshot, meta: { isEmbedded: true } });
         scene = dash.state.body; // skip the wrappers
       } catch (ex) {
-        console.log('Error creating scene:', ex);
+        grafanaStructuredLogger.logInfo(String('Error creating scene:'), { args: ex });
       }
     }
 

--- a/public/app/features/dashboard-scene/inspect/InspectJsonTab.tsx
+++ b/public/app/features/dashboard-scene/inspect/InspectJsonTab.tsx
@@ -44,6 +44,7 @@ import {
 } from '../utils/utils';
 import { isGridLayoutItemKind, isPanelKindV2 } from '../v2schema/validation';
 
+import { grafanaStructuredLogger } from '@grafana/runtime';
 export type ShowContent = 'panel-json' | 'panel-data' | 'data-frames' | 'panel-layout';
 
 export interface InspectJsonTabState extends SceneObjectState {
@@ -165,7 +166,7 @@ export class InspectJsonTab extends SceneObjectBase<InspectJsonTabState> {
     const gridItem = panel.parent;
 
     if (!(gridItem instanceof DashboardGridItem)) {
-      console.error('Cannot update layout: panel parent is not a DashboardGridItem');
+      grafanaStructuredLogger.logError(new Error('Cannot update layout: panel parent is not a DashboardGridItem'));
       return;
     }
 
@@ -259,7 +260,9 @@ export class InspectJsonTab extends SceneObjectBase<InspectJsonTabState> {
     const newState = sceneUtils.cloneSceneObjectState(gridItem.state);
 
     if (!(panel.parent instanceof DashboardGridItem)) {
-      console.error('Cannot update state of panel', panel, gridItem);
+      grafanaStructuredLogger.logWarning('Cannot update panel layout: parent is not DashboardGridItem', {
+        panelKey: panel.state.key,
+      });
       return;
     }
 

--- a/public/app/features/dashboard-scene/pages/DashboardScenePage.tsx
+++ b/public/app/features/dashboard-scene/pages/DashboardScenePage.tsx
@@ -31,6 +31,7 @@ import { preserveDashboardSceneStateInLocalStorage } from '../utils/dashboardSes
 import { getDashboardScenePageStateManager } from './DashboardScenePageStateManager';
 import { shouldHideDashboardKioskFooter } from './utils';
 
+import { grafanaStructuredLogger } from '@grafana/runtime';
 export interface Props
   extends Omit<GrafanaRouteComponentProps<DashboardPageRouteParams, DashboardPageRouteSearchParams>, 'match'> {}
 
@@ -126,7 +127,7 @@ export function DashboardScenePage({ route, queryParams, location }: Props) {
   // A bit tricky for transition to or from Home dashboard that does not have a uid in the url (but could have it in the dashboard model)
   // if prevMatch is undefined we are going from normal route to home route or vice versa
   if (type !== 'snapshot' && (!prevMatch || uid !== prevMatch?.params.uid)) {
-    console.log('skipping rendering');
+    grafanaStructuredLogger.logInfo(String('skipping rendering'));
     return null;
   }
 

--- a/public/app/features/dashboard-scene/pages/DashboardScenePageStateManager.ts
+++ b/public/app/features/dashboard-scene/pages/DashboardScenePageStateManager.ts
@@ -59,6 +59,7 @@ import { restoreDashboardStateFromLocalStorage } from '../utils/dashboardSession
 
 import { processQueryParamsForDashboardLoad, updateNavModel } from './utils';
 
+import { grafanaStructuredLogger } from '@grafana/runtime';
 /**
  * Initialize both performance services to ensure they're ready before profiling starts
  */
@@ -436,7 +437,7 @@ abstract class DashboardScenePageStateManagerBase<T>
       });
 
       if (!isFetchError(err)) {
-        console.error('Error loading dashboard:', err);
+        grafanaStructuredLogger.logError(err instanceof Error ? err : new Error(String(err)), { message: String('Error loading dashboard:') });
       }
 
       // If the error is a DashboardVersionError, we want to throw it so that the error boundary is triggered
@@ -797,7 +798,7 @@ export class DashboardScenePageStateManager extends DashboardScenePageStateManag
             ...locationService.getLocation(),
             pathname: dashboardUrl,
           });
-          console.log('not correct url correcting', dashboardUrl, currentPath);
+          grafanaStructuredLogger.logInfo(String('not correct url correcting'), { args: dashboardUrl, currentPath });
         }
       }
 
@@ -1017,7 +1018,7 @@ export class DashboardScenePageStateManagerV2 extends DashboardScenePageStateMan
             ...locationService.getLocation(),
             pathname: dashboardUrl,
           });
-          console.log('not correct url correcting', dashboardUrl, currentPath);
+          grafanaStructuredLogger.logInfo(String('not correct url correcting'), { args: dashboardUrl, currentPath });
         }
       }
       // Populate nav model in global store according to the folder

--- a/public/app/features/dashboard-scene/pages/utils.ts
+++ b/public/app/features/dashboard-scene/pages/utils.ts
@@ -1,5 +1,5 @@
 import { type UrlQueryMap, getTimeZone, getDefaultTimeRange, dateMath } from '@grafana/data';
-import { locationService } from '@grafana/runtime';
+import { locationService, grafanaStructuredLogger } from '@grafana/runtime';
 import { getFolderByUidFacade } from 'app/api/clients/folder/v1beta1/hooks';
 import { updateNavIndex } from 'app/core/reducers/navModel';
 import { buildNavModel } from 'app/features/folders/state/navModel';
@@ -10,7 +10,10 @@ export async function updateNavModel(folderUid: string) {
     const folder = await getFolderByUidFacade(folderUid);
     store.dispatch(updateNavIndex(buildNavModel(folder)));
   } catch (err) {
-    console.warn('Error fetching parent folder', folderUid, 'for dashboard', err);
+    grafanaStructuredLogger.logWarning('Error fetching parent folder for dashboard', {
+      folderUid,
+      error: err instanceof Error ? err.message : String(err),
+    });
   }
 }
 

--- a/public/app/features/dashboard-scene/panel-edit/PanelDataPane/PanelDataQueriesTab.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelDataPane/PanelDataQueriesTab.tsx
@@ -46,6 +46,7 @@ import { getUpdatedHoverHeader } from '../getPanelFrameOptions';
 import { type PanelDataPaneTab, type PanelDataTabHeaderProps, TabId } from './types';
 import { hasBackendDatasource } from './utils';
 
+import { grafanaStructuredLogger } from '@grafana/runtime';
 interface PanelDataQueriesTabState extends SceneObjectState {
   datasource?: DataSourceApi;
   dsSettings?: DataSourceInstanceSettings;
@@ -163,7 +164,7 @@ export class PanelDataQueriesTab extends SceneObjectBase<PanelDataQueriesTabStat
         });
       }
 
-      console.error(err);
+      grafanaStructuredLogger.logError(err instanceof Error ? err : new Error(String(err)));
     }
   }
 

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/PanelDataPaneNext.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/PanelDataPaneNext.tsx
@@ -32,6 +32,7 @@ import { QueryEditorContent } from './QueryEditor/QueryEditorContent';
 import { filterDataTransformerConfigs } from './QueryEditor/utils';
 import { TRANSFORMATION_EDIT_INTERACTION_THROTTLE_TIME } from './constants';
 
+import { grafanaStructuredLogger } from '@grafana/runtime';
 const reportTransformationEditInteraction = throttle((context: string, type: string) => {
   reportInteraction('grafana_panel_transformations_clicked', {
     context,
@@ -204,7 +205,7 @@ export class PanelDataPaneNext extends SceneObjectBase<PanelDataPaneNextState> {
       this.setState({ datasource, dsSettings, dsError: undefined });
       storeLastUsedDataSourceInLocalStorage(getDataSourceRef(dsSettings) || { default: true });
     } catch (err) {
-      console.error('Failed to load datasource:', err);
+      grafanaStructuredLogger.logError(err instanceof Error ? err : new Error(String(err)), { message: String('Failed to load datasource:') });
 
       // Fallback to default datasource (parity with PanelDataQueriesTab)
       try {
@@ -218,7 +219,7 @@ export class PanelDataPaneNext extends SceneObjectBase<PanelDataPaneNextState> {
           // resolveDatasourceRef() handles the stale-ref case on the next activation.
         }
       } catch (fallbackErr) {
-        console.error('Failed to load default datasource:', fallbackErr);
+        grafanaStructuredLogger.logError(fallbackErr instanceof Error ? fallbackErr : new Error(String(fallbackErr)), { message: String('Failed to load default datasource:') });
         this.setState({
           datasource: undefined,
           dsSettings: undefined,

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Header/PluginActions.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Header/PluginActions.tsx
@@ -13,6 +13,7 @@ import { type QueryActionComponent, RowActionComponents } from 'app/features/que
 import { QueryEditorType } from '../../constants';
 import { useActionsContext, useQueryEditorUIContext, useQueryRunnerContext } from '../QueryEditorContext';
 
+import { grafanaStructuredLogger } from '@grafana/runtime';
 interface PluginActionsProps {
   app?: CoreApp;
 }
@@ -94,7 +95,7 @@ function useAdaptiveTelemetryComponents(query: DataQuery | null) {
       pluginId: /grafana-adaptive.*/,
     });
   } catch (error) {
-    console.error('Failed to render adaptive telemetry components:', error);
+    grafanaStructuredLogger.logError(error instanceof Error ? error : new Error(String(error)), { message: String('Failed to render adaptive telemetry components:') });
     return null;
   }
 }

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/hooks/useSelectedQueryDatasource.ts
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/hooks/useSelectedQueryDatasource.ts
@@ -4,6 +4,7 @@ import { type DataSourceInstanceSettings, getDataSourceRef } from '@grafana/data
 import { config, getDataSourceSrv } from '@grafana/runtime';
 import { type DataQuery } from '@grafana/schema';
 
+import { grafanaStructuredLogger } from '@grafana/runtime';
 /**
  * Hook to load the datasource for the currently selected query.
  * Falls back to the panel's datasource if the query doesn't specify one.
@@ -41,14 +42,14 @@ export function useSelectedQueryDatasource(
 
       const queryDsSettings = getDataSourceSrv().getInstanceSettings(dsRef);
       if (!queryDsSettings) {
-        console.error('Datasource settings not found for', dsRef);
+        grafanaStructuredLogger.logError(dsRef instanceof Error ? dsRef : new Error(String(dsRef)), { message: String('Datasource settings not found for') });
         return undefined;
       }
 
       const queryDatasource = await getDataSourceSrv().get(dsRef);
       return { datasource: queryDatasource, dsSettings: queryDsSettings };
     } catch (err) {
-      console.error('Failed to load datasource for selected query:', err);
+      grafanaStructuredLogger.logError(err instanceof Error ? err : new Error(String(err)), { message: String('Failed to load datasource for selected query:') });
       return undefined;
     }
   }, [

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/localStorageWithTTL.ts
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/localStorageWithTTL.ts
@@ -1,5 +1,6 @@
 import { store } from '@grafana/data';
 
+import { grafanaStructuredLogger } from '@grafana/runtime';
 interface StoredValueWithTTL<T> {
   value: T;
   timestamp: number;
@@ -20,7 +21,7 @@ export const setLocalStorageWithTTL = <T>(key: string, value: T) => {
   try {
     store.setObject(key, item);
   } catch (error) {
-    console.error('Failed to persist value with TTL', error);
+    grafanaStructuredLogger.logError(error instanceof Error ? error : new Error(String(error)), { message: String('Failed to persist value with TTL') });
   }
 };
 

--- a/public/app/features/dashboard-scene/saving/getDashboardChanges.ts
+++ b/public/app/features/dashboard-scene/saving/getDashboardChanges.ts
@@ -13,6 +13,7 @@ import { type DashboardDataDTO, type DashboardDTO } from 'app/types/dashboard';
 import { validateFiltersOrigin } from '../serialization/sceneVariablesSetToVariables';
 import { jsonDiff } from '../settings/version-history/utils';
 
+import { grafanaStructuredLogger } from '@grafana/runtime';
 export function deepEqual(a: string | string[], b: string | string[]) {
   return (
     typeof a === typeof b &&
@@ -136,12 +137,12 @@ export function getHasTimeChanged(
 
 export function adHocVariableFiltersEqual(filtersA?: AdHocFilterWithLabels[], filtersB?: AdHocFilterWithLabels[]) {
   if (filtersA === undefined && filtersB === undefined) {
-    console.warn('Adhoc variable filter property is undefined');
+    grafanaStructuredLogger.logWarning(String('Adhoc variable filter property is undefined'));
     return true;
   }
 
   if ((filtersA === undefined && filtersB !== undefined) || (filtersB === undefined && filtersA !== undefined)) {
-    console.warn('Adhoc variable filter property is undefined');
+    grafanaStructuredLogger.logWarning(String('Adhoc variable filter property is undefined'));
     return false;
   }
 

--- a/public/app/features/dashboard-scene/scene/DashboardLayoutOrchestrator.tsx
+++ b/public/app/features/dashboard-scene/scene/DashboardLayoutOrchestrator.tsx
@@ -34,6 +34,7 @@ import {
   isDashboardDropTarget,
 } from './types/DashboardDropTarget';
 
+import { grafanaStructuredLogger } from '@grafana/runtime';
 const TAB_ACTIVATION_DELAY_MS = 600;
 
 interface DashboardLayoutOrchestratorState extends SceneObjectState {
@@ -241,7 +242,7 @@ export class DashboardLayoutOrchestrator extends SceneObjectBase<DashboardLayout
             }
           } else {
             const warningMessage = 'No grid item to drag';
-            console.warn(warningMessage);
+            grafanaStructuredLogger.logWarning(String(warningMessage));
             logWarning(warningMessage);
           }
         });

--- a/public/app/features/dashboard-scene/scene/DashboardMacro.ts
+++ b/public/app/features/dashboard-scene/scene/DashboardMacro.ts
@@ -2,6 +2,7 @@ import { type FormatVariable, type SceneObject, sceneUtils } from '@grafana/scen
 
 import { getDashboardSceneFor } from '../utils/utils';
 
+import { grafanaStructuredLogger } from '@grafana/runtime';
 /**
  * Handles expressions like ${__dashboard.uid}
  */
@@ -39,7 +40,7 @@ export function registerDashboardMacro() {
 
     return () => unregister();
   } catch (e) {
-    console.error('Error registering dashboard macro', e);
+    grafanaStructuredLogger.logError(e instanceof Error ? e : new Error(String(e)), { message: String('Error registering dashboard macro') });
     return () => {};
   }
 }

--- a/public/app/features/dashboard-scene/scene/DashboardMutationClientSetter.ts
+++ b/public/app/features/dashboard-scene/scene/DashboardMutationClientSetter.ts
@@ -1,3 +1,5 @@
+
+import { grafanaStructuredLogger } from '@grafana/runtime';
 /**
  * Bridge between DashboardScene and the mutation-api module.
  *
@@ -19,9 +21,7 @@ export function provideMutationClientFactory(create: CreateMutationClient): void
 
 export function createMutationClient(scene: unknown): () => void {
   if (!_create) {
-    console.warn(
-      'createMutationClient called before provideMutationClientFactory. Mutation API will not be available.'
-    );
+    grafanaStructuredLogger.logWarning(String('createMutationClient called before provideMutationClientFactory. Mutation API will not be available.'));
     return () => {};
   }
   const teardown = _create(scene);

--- a/public/app/features/dashboard-scene/scene/DashboardScene.tsx
+++ b/public/app/features/dashboard-scene/scene/DashboardScene.tsx
@@ -116,6 +116,7 @@ import { clearClipboard } from './layouts-shared/paste';
 import { type DashboardLayoutManager } from './types/DashboardLayoutManager';
 import { type LayoutParent } from './types/LayoutParent';
 
+import { grafanaStructuredLogger } from '@grafana/runtime';
 export const PERSISTED_PROPS = ['title', 'description', 'tags', 'editable', 'graphTooltip', 'links', 'meta', 'preload'];
 export const PANEL_SEARCH_VAR = 'systemPanelFilterVar';
 export const PANELS_PER_ROW_VAR = 'systemDynamicRowSizeVar';
@@ -342,7 +343,7 @@ export class DashboardScene extends SceneObjectBase<DashboardSceneState> impleme
         try {
           return createSceneVariableFromVariableModelV2(v);
         } catch (err) {
-          console.error(err);
+          grafanaStructuredLogger.logError(err instanceof Error ? err : new Error(String(err)));
           return null;
         }
       })
@@ -409,7 +410,9 @@ export class DashboardScene extends SceneObjectBase<DashboardSceneState> impleme
 
   public exitEditMode({ skipConfirm, restoreInitialState }: { skipConfirm: boolean; restoreInitialState?: boolean }) {
     if (!this.canDiscard()) {
-      console.error('Trying to discard back to a state that does not exist, initialState undefined');
+      grafanaStructuredLogger.logError(
+        new Error('Trying to discard back to a state that does not exist, initialState undefined')
+      );
       return;
     }
 
@@ -514,7 +517,9 @@ export class DashboardScene extends SceneObjectBase<DashboardSceneState> impleme
    */
   public discardChangesAndKeepEditing() {
     if (!this.canDiscard()) {
-      console.error('Trying to discard back to a state that does not exist, initialState undefined');
+      grafanaStructuredLogger.logError(
+        new Error('Trying to discard back to a state that does not exist, initialState undefined')
+      );
       return;
     }
 
@@ -708,7 +713,7 @@ export class DashboardScene extends SceneObjectBase<DashboardSceneState> impleme
         clearClipboard();
         store.set(LS_PANEL_COPY_KEY, JSON.stringify({ elements, gridItem: gridItemKind }));
       } else {
-        console.error('Trying to copy a panel that is not DashboardGridItem child');
+        grafanaStructuredLogger.logError(new Error('Trying to copy a panel that is not DashboardGridItem child'));
         throw new Error('Trying to copy a panel that is not DashboardGridItem child');
       }
       return;
@@ -721,7 +726,7 @@ export class DashboardScene extends SceneObjectBase<DashboardSceneState> impleme
     let gridItem = vizPanel.parent;
 
     if (!(gridItem instanceof DashboardGridItem)) {
-      console.error('Trying to copy a panel that is not DashboardGridItem child');
+      grafanaStructuredLogger.logError(new Error('Trying to copy a panel that is not DashboardGridItem child'));
       throw new Error('Trying to copy a panel that is not DashboardGridItem child');
     }
 
@@ -876,7 +881,7 @@ export class DashboardScene extends SceneObjectBase<DashboardSceneState> impleme
 
       appEvents.emit('alert-success', ['Panel styles applied.']);
     } catch (e) {
-      console.error('Error pasting panel styles:', e);
+      grafanaStructuredLogger.logError(e instanceof Error ? e : new Error(String(e)), { message: String('Error pasting panel styles:') });
       appEvents.emit('alert-error', ['Error pasting panel styles.']);
       DashboardInteractions.panelStylesMenuClicked(
         'paste',
@@ -960,7 +965,7 @@ export class DashboardScene extends SceneObjectBase<DashboardSceneState> impleme
       return;
     }
 
-    console.error('Trying to unlink a lib panel in a layout that is not DashboardGridItem or AutoGridItem');
+    grafanaStructuredLogger.logError(new Error('Trying to unlink a lib panel in a layout that is not DashboardGridItem or AutoGridItem'));
   }
 
   public showModal(modal: SceneObject) {

--- a/public/app/features/dashboard-scene/scene/DashboardSceneUrlSync.ts
+++ b/public/app/features/dashboard-scene/scene/DashboardSceneUrlSync.ts
@@ -11,6 +11,7 @@ import { type LibraryPanelBehavior } from './LibraryPanelBehavior';
 import { UNCONFIGURED_PANEL_PLUGIN_ID } from './UnconfiguredPanel';
 import { DefaultGridLayoutManager } from './layout-default/DefaultGridLayoutManager';
 
+import { grafanaStructuredLogger } from '@grafana/runtime';
 export class DashboardSceneUrlSync implements SceneObjectUrlSyncHandler {
   constructor(private _scene: DashboardScene) {}
 
@@ -72,7 +73,7 @@ export class DashboardSceneUrlSync implements SceneObjectUrlSyncHandler {
       const panel = findEditPanel(this._scene, values.editPanel);
 
       if (!panel) {
-        console.warn(`Panel ${values.editPanel} not found`);
+        grafanaStructuredLogger.logWarning(String(`Panel ${values.editPanel} not found`));
         return;
       }
 

--- a/public/app/features/dashboard-scene/scene/GoToSnapshotOriginButton.tsx
+++ b/public/app/features/dashboard-scene/scene/GoToSnapshotOriginButton.tsx
@@ -8,6 +8,7 @@ import { ConfirmModal, ToolbarButton } from '@grafana/ui';
 import { appEvents } from '../../../core/app_events';
 import { ShowModalReactEvent } from '../../../types/events';
 
+import { grafanaStructuredLogger } from '@grafana/runtime';
 export function GoToSnapshotOriginButton(props: { originalURL: string }) {
   return (
     <ToolbarButton
@@ -59,6 +60,6 @@ export const onOpenSnapshotOriginalDashboard = (originalUrl: string) => {
       locationService.push(sanitizedRelativeURL);
     }
   } catch (err) {
-    console.error('Failed to open original dashboard', err);
+    grafanaStructuredLogger.logError(err instanceof Error ? err : new Error(String(err)), { message: String('Failed to open original dashboard') });
   }
 };

--- a/public/app/features/dashboard-scene/scene/export/exporters.ts
+++ b/public/app/features/dashboard-scene/scene/export/exporters.ts
@@ -28,6 +28,7 @@ import { LibraryElementKind } from '../../../library-panels/types';
 import { type DashboardJson } from '../../../manage-dashboards/types';
 import { isConstant } from '../../../variables/guard';
 
+import { grafanaStructuredLogger } from '@grafana/runtime';
 // This label is used to store the export label for a datasource when exporting a V2 dashboard for external sharing.
 // E.g. if a dashboard has two datasources with the same type, the export label will be used to distinguish them.
 export const ExportLabel = 'grafana.app/export-label';
@@ -352,7 +353,7 @@ export async function makeExportableV1(dashboard: DashboardModel) {
 
     return newObj;
   } catch (err) {
-    console.error('Export failed:', err);
+    grafanaStructuredLogger.logError(err instanceof Error ? err : new Error(String(err)), { message: String('Export failed:') });
     return {
       error: err,
     };
@@ -374,7 +375,7 @@ async function convertLibraryPanelToInlinePanel(libraryPanelElement: LibraryPane
     inlinePanel.spec.id = id;
     return inlinePanel;
   } catch (error) {
-    console.error(`Failed to load library panel ${libraryPanel.uid}:`, error);
+    grafanaStructuredLogger.logError(error instanceof Error ? error : new Error(String(error)), { message: String(`Failed to load library panel ${libraryPanel.uid}:`) });
 
     const errorMessage = error instanceof Error ? error.message : 'Unknown error';
     dispatch(
@@ -544,7 +545,7 @@ export async function makeExportableV2(dashboard: DashboardV2Spec, isSharingExte
 
     return dashboard;
   } catch (err) {
-    console.error('Export failed:', err);
+    grafanaStructuredLogger.logError(err instanceof Error ? err : new Error(String(err)), { message: String('Export failed:') });
     return {
       error: err,
     };

--- a/public/app/features/dashboard-scene/scene/layout-auto-grid/AutoGridItem.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-auto-grid/AutoGridItem.tsx
@@ -24,6 +24,7 @@ import { getOptions } from './AutoGridItemEditor';
 import { AutoGridItemRenderer } from './AutoGridItemRenderer';
 import { AutoGridLayout } from './AutoGridLayout';
 
+import { grafanaStructuredLogger } from '@grafana/runtime';
 export interface AutoGridItemState extends SceneObjectState {
   body: VizPanel;
   hideWhenNoData?: boolean;
@@ -91,7 +92,7 @@ export class AutoGridItem extends SceneObjectBase<AutoGridItemState> implements 
       });
 
     if (!(variable instanceof MultiValueVariable)) {
-      console.error('DashboardGridItem: Variable is not a MultiValueVariable');
+      grafanaStructuredLogger.logError(new Error('DashboardGridItem: Variable is not a MultiValueVariable'));
       return;
     }
 

--- a/public/app/features/dashboard-scene/scene/layout-auto-grid/AutoGridLayoutManager.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-auto-grid/AutoGridLayoutManager.tsx
@@ -37,6 +37,7 @@ import { AutoGridItem } from './AutoGridItem';
 import { AutoGridLayout } from './AutoGridLayout';
 import { getEditOptions } from './AutoGridLayoutManagerEditor';
 
+import { grafanaStructuredLogger } from '@grafana/runtime';
 interface AutoGridLayoutManagerState extends SceneObjectState {
   layout: AutoGridLayout;
   maxColumnCount: number;
@@ -248,7 +249,7 @@ export class AutoGridLayoutManager
   public duplicatePanel(panel: VizPanel) {
     const gridItem = panel.parent;
     if (!(gridItem instanceof AutoGridItem)) {
-      console.error('Trying to duplicate a panel that is not inside a DashboardGridItem');
+      grafanaStructuredLogger.logError(new Error('Trying to duplicate a panel that is not inside a DashboardGridItem'));
       return;
     }
 

--- a/public/app/features/dashboard-scene/scene/layout-default/DashboardGridItem.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-default/DashboardGridItem.tsx
@@ -28,6 +28,7 @@ import { DashboardGridItemRenderer } from './DashboardGridItemRenderer';
 import { DashboardGridItemVariableDependencyHandler } from './DashboardGridItemVariableDependencyHandler';
 import { RowRepeaterBehavior } from './RowRepeaterBehavior';
 
+import { grafanaStructuredLogger } from '@grafana/runtime';
 export interface DashboardGridItemState extends SceneGridItemStateLike {
   body: VizPanel;
   repeatedPanels?: VizPanel[];
@@ -150,7 +151,7 @@ export class DashboardGridItem
       });
 
     if (!(variable instanceof MultiValueVariable)) {
-      console.error('DashboardGridItem: Variable is not a MultiValueVariable');
+      grafanaStructuredLogger.logError(new Error('DashboardGridItem: Variable is not a MultiValueVariable'));
       return;
     }
 

--- a/public/app/features/dashboard-scene/scene/layout-default/DefaultGridLayoutManager.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-default/DefaultGridLayoutManager.tsx
@@ -58,6 +58,7 @@ import { RowRepeaterBehavior } from './RowRepeaterBehavior';
 import { findSpaceForNewPanel } from './findSpaceForNewPanel';
 import { RowActions } from './row-actions/RowActions';
 
+import { grafanaStructuredLogger } from '@grafana/runtime';
 interface DefaultGridLayoutManagerState extends SceneObjectState {
   grid: SceneGridLayout;
 }
@@ -260,7 +261,7 @@ export class DefaultGridLayoutManager
   public duplicatePanel(vizPanel: VizPanel) {
     const gridItem = vizPanel.parent;
     if (!(gridItem instanceof DashboardGridItem)) {
-      console.error('Trying to duplicate a panel that is not inside a DashboardGridItem');
+      grafanaStructuredLogger.logError(new Error('Trying to duplicate a panel that is not inside a DashboardGridItem'));
       return;
     }
 

--- a/public/app/features/dashboard-scene/scene/layout-default/RowRepeaterBehavior.ts
+++ b/public/app/features/dashboard-scene/scene/layout-default/RowRepeaterBehavior.ts
@@ -15,6 +15,7 @@ import {
 import { getCloneKey, getLocalVariableValueSet } from '../../utils/clone';
 import { getMultiVariableValues } from '../../utils/utils';
 
+import { grafanaStructuredLogger } from '@grafana/runtime';
 interface RowRepeaterBehaviorState extends SceneObjectState {
   variableName: string;
 }
@@ -91,12 +92,12 @@ export class RowRepeaterBehavior extends SceneObjectBase<RowRepeaterBehaviorStat
     const variable = sceneGraph.lookupVariable(this.state.variableName, this.parent?.parent!);
 
     if (!variable) {
-      console.error('RepeatedRowBehavior: Variable not found');
+      grafanaStructuredLogger.logError(new Error('RepeatedRowBehavior: Variable not found'));
       return;
     }
 
     if (!(variable instanceof MultiValueVariable)) {
-      console.error('RepeatedRowBehavior: Variable is not a MultiValueVariable');
+      grafanaStructuredLogger.logError(new Error('RepeatedRowBehavior: Variable is not a MultiValueVariable'));
       return;
     }
 

--- a/public/app/features/dashboard-scene/scene/layout-rows/RowItem.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-rows/RowItem.tsx
@@ -46,6 +46,7 @@ import { RowItemRenderer } from './RowItemRenderer';
 import { RowItems } from './RowItems';
 import { RowsLayoutManager } from './RowsLayoutManager';
 
+import { grafanaStructuredLogger } from '@grafana/runtime';
 export interface RowItemState extends SceneObjectState {
   layout: DashboardLayoutManager;
   title?: string;
@@ -227,7 +228,7 @@ export class RowItem
         layout.setState({ children: newChildren });
       } else {
         const warningMessage = 'Grid item has unexpected parent type';
-        console.warn(warningMessage);
+        grafanaStructuredLogger.logWarning(String(warningMessage));
         logWarning(warningMessage);
       }
     }
@@ -242,7 +243,7 @@ export class RowItem
       layout.addGridItem(gridItem);
     } else {
       const warningMessage = 'Layout manager does not support addGridItem';
-      console.warn(warningMessage);
+      grafanaStructuredLogger.logWarning(String(warningMessage));
       logWarning(warningMessage);
     }
     this.setIsDropTarget(false);

--- a/public/app/features/dashboard-scene/scene/layout-tabs/TabItem.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-tabs/TabItem.tsx
@@ -48,6 +48,7 @@ import { TabItemRenderer } from './TabItemRenderer';
 import { TabItems } from './TabItems';
 import { TabsLayoutManager } from './TabsLayoutManager';
 
+import { grafanaStructuredLogger } from '@grafana/runtime';
 export interface TabItemState extends SceneObjectState {
   layout: DashboardLayoutManager;
   title?: string;
@@ -234,7 +235,7 @@ export class TabItem
         layout.setState({ children: newChildren });
       } else {
         const warningMessage = 'Grid item has unexpected parent type';
-        console.warn(warningMessage);
+        grafanaStructuredLogger.logWarning(String(warningMessage));
         logWarning(warningMessage);
       }
     }
@@ -256,13 +257,13 @@ export class TabItem
           rowLayout.addGridItem(gridItem);
         } else {
           const warningMessage = 'First row layout does not support addGridItem';
-          console.warn(warningMessage);
+          grafanaStructuredLogger.logWarning(String(warningMessage));
           logWarning(warningMessage);
         }
       }
     } else {
       const warningMessage = 'Layout manager does not support addGridItem';
-      console.warn(warningMessage);
+      grafanaStructuredLogger.logWarning(String(warningMessage));
       logWarning(warningMessage);
     }
     this.setIsDropTarget(false);

--- a/public/app/features/dashboard-scene/serialization/DashboardSceneSerializer.ts
+++ b/public/app/features/dashboard-scene/serialization/DashboardSceneSerializer.ts
@@ -25,6 +25,7 @@ import { getVizPanelKeyForPanelId } from '../utils/utils';
 import { transformSceneToSaveModel } from './transformSceneToSaveModel';
 import { transformSceneToSaveModelSchemaV2 } from './transformSceneToSaveModelSchemaV2';
 
+import { grafanaStructuredLogger } from '@grafana/runtime';
 /**
  * T is the type of the save model
  * M is the type of the metadata
@@ -353,7 +354,7 @@ export class V2DashboardSerializer
           }
         } else {
           const warningMsg = 'Dashboard serializer: Undefined variable found in dashboard save model, ignoring it';
-          console.warn(warningMsg);
+          grafanaStructuredLogger.logWarning(String(warningMsg));
           logWarning(warningMsg);
         }
       }

--- a/public/app/features/dashboard-scene/serialization/angularMigration.ts
+++ b/public/app/features/dashboard-scene/serialization/angularMigration.ts
@@ -3,6 +3,7 @@ import { defaults, cloneDeep } from 'lodash';
 import { type PanelModel as PanelModelFromData, type PanelPlugin } from '@grafana/data';
 import { autoMigrateAngular, type PanelModel } from 'app/features/dashboard/state/PanelModel';
 
+import { grafanaStructuredLogger } from '@grafana/runtime';
 /**
  * Data structure for Angular migration information stored in v2 schema options.
  */
@@ -42,9 +43,7 @@ export function getAngularPanelMigrationHandler(oldModel: PanelModel) {
       const targetClone = cloneDeep(oldModel.targets);
       Object.defineProperty(panel, 'targets', {
         get: function () {
-          console.warn(
-            'Accessing the targets property when migrating a panel plugin is deprecated. Changes to this property will be ignored.'
-          );
+          grafanaStructuredLogger.logWarning(String('Accessing the targets property when migrating a panel plugin is deprecated. Changes to this property will be ignored.'));
           return targetClone;
         },
       });
@@ -108,9 +107,7 @@ export function getV2AngularMigrationHandler(migrationData: AngularMigrationData
     const targetClone = cloneDeep(panel.targets);
     Object.defineProperty(panel, 'targets', {
       get: function () {
-        console.warn(
-          'Accessing the targets property when migrating a panel plugin is deprecated. Changes to this property will be ignored.'
-        );
+        grafanaStructuredLogger.logWarning(String('Accessing the targets property when migrating a panel plugin is deprecated. Changes to this property will be ignored.'));
         return targetClone;
       },
     });

--- a/public/app/features/dashboard-scene/serialization/layoutSerializers/utils.ts
+++ b/public/app/features/dashboard-scene/serialization/layoutSerializers/utils.ts
@@ -1,5 +1,5 @@
 import { getNextRefId } from '@grafana/data';
-import { config } from '@grafana/runtime';
+import { config, grafanaStructuredLogger } from '@grafana/runtime';
 import { getPanelPluginMetasMapSync, type PanelPluginMetas } from '@grafana/runtime/internal';
 import {
   type SceneDataProvider,
@@ -372,7 +372,7 @@ export function getDataSourceForQuery(querySpecDS: DataSourceRef | undefined | n
     // In the datasource list from bootData "id" is the type and the uid could be uid or the name
     // in cases like grafana, dashboard or mixed datasource
 
-    console.warn(
+    grafanaStructuredLogger.logWarning(
       `Could not find datasource for query kind ${queryKind}, defaulting to ${dsList[defaultDatasource].meta.id}`
     );
     return {

--- a/public/app/features/dashboard-scene/serialization/transformSaveModelSchemaV2ToScene.ts
+++ b/public/app/features/dashboard-scene/serialization/transformSaveModelSchemaV2ToScene.ts
@@ -93,6 +93,7 @@ import {
 } from './transformToV1TypesUtils';
 import { LEGACY_STRING_VALUE_KEY } from './transformToV2TypesUtils';
 
+import { grafanaStructuredLogger } from '@grafana/runtime';
 const DEFAULT_DATASOURCE = 'default';
 
 export type TypedVariableModelV2 =
@@ -309,7 +310,7 @@ function createVariablesForDashboard(dashboard: DashboardV2Spec, defaultVariable
       try {
         return createSceneVariableFromVariableModel(v);
       } catch (err) {
-        console.error(err);
+        grafanaStructuredLogger.logError(err instanceof Error ? err : new Error(String(err)));
         return null;
       }
     })
@@ -322,7 +323,7 @@ function createVariablesForDashboard(dashboard: DashboardV2Spec, defaultVariable
       try {
         return createSceneVariableFromVariableModel(v);
       } catch (err) {
-        console.error(err);
+        grafanaStructuredLogger.logError(err instanceof Error ? err : new Error(String(err)));
         return null;
       }
     })
@@ -616,7 +617,7 @@ export function createVariablesForSnapshot(dashboard: DashboardV2Spec): SceneVar
         // for other variable types we are using the SnapshotVariable
         return createSnapshotVariable(v);
       } catch (err) {
-        console.error(err);
+        grafanaStructuredLogger.logError(err instanceof Error ? err : new Error(String(err)));
         return null;
       }
     })

--- a/public/app/features/dashboard-scene/serialization/transformSceneToSaveModelSchemaV2.ts
+++ b/public/app/features/dashboard-scene/serialization/transformSceneToSaveModelSchemaV2.ts
@@ -67,6 +67,7 @@ import { type DSReferencesMapping } from './DashboardSceneSerializer';
 import { transformV1ToV2AnnotationQuery } from './annotations';
 import { sceneVariablesSetToSchemaV2Variables } from './sceneVariablesSetToVariables';
 import { colorIdEnumToColorIdV2, transformCursorSynctoEnum } from './transformToV2TypesUtils';
+import { grafanaStructuredLogger } from '@grafana/runtime';
 // FIXME: This is temporary to avoid creating partial types for all the new schema, it has some performance implications, but it's fine for now
 type DeepPartial<T> = T extends object
   ? {
@@ -172,7 +173,7 @@ export function transformSceneToSaveModelSchemaV2(scene: DashboardScene, isSnaps
     // should never reach this point, validation should throw an error
     throw new Error('Error we could transform the dashboard to schema v2: ' + dashboardSchemaV2);
   } catch (reason) {
-    console.error('Error transforming dashboard to schema v2: ' + reason, dashboardSchemaV2);
+    grafanaStructuredLogger.logError(dashboardSchemaV2 instanceof Error ? dashboardSchemaV2 : new Error(String(dashboardSchemaV2)), { message: String('Error transforming dashboard to schema v2: ' + reason) });
     throw new Error('Error transforming dashboard to schema v2: ' + reason);
   }
 }
@@ -612,10 +613,9 @@ function getAnnotations(state: DashboardSceneState, dsReferencesMapping?: DSRefe
       // for layers created for v2 schema. See transform transformSaveModelSchemaV2ToScene.ts.
       // In this case we will resolve default data source
       layerDs = getDefaultDataSourceRef();
-      console.error(
-        'Misconfigured AnnotationsDataLayer: Data source is required for annotations. Resolving default data source',
-        layer,
-        layerDs
+      grafanaStructuredLogger.logWarning(
+        'Misconfigured AnnotationsDataLayer: datasource missing for annotations layer; resolving default datasource',
+        { queryName: layer.state.query.name }
       );
     }
 

--- a/public/app/features/dashboard-scene/serialization/transformToV1TypesUtils.ts
+++ b/public/app/features/dashboard-scene/serialization/transformToV1TypesUtils.ts
@@ -17,6 +17,7 @@ import {
   type ThresholdsMode,
 } from '@grafana/schema/apis/dashboard.grafana.app/v2';
 
+import { grafanaStructuredLogger } from '@grafana/runtime';
 export function transformVariableRefreshToEnumV1(refresh?: VariableRefresh): VariableRefreshV1 {
   switch (refresh) {
     case 'never':
@@ -98,7 +99,7 @@ function transformSpecialValueMatchToV1(match: SpecialValueMatch): SpecialValueM
     case 'empty':
       return SpecialValueMatchV1.Empty;
     default:
-      console.warn(`Skipping special value mapping with unknown match type: "${match}"`);
+      grafanaStructuredLogger.logWarning(String(`Skipping special value mapping with unknown match type: "${match}"`));
       return undefined;
   }
 }

--- a/public/app/features/dashboard-scene/settings/AnnotationsEditView.test.tsx
+++ b/public/app/features/dashboard-scene/settings/AnnotationsEditView.test.tsx
@@ -110,7 +110,10 @@ describe('AnnotationsEditView', () => {
     it('should return undefined when datasource does not support annotations', () => {
       const ds = annotationsView.getDataSourceRefForAnnotation();
       expect(ds).toBe(undefined);
-      expect(console.error).toHaveBeenCalledWith('Default datasource does not support annotations');
+      expect(console.error).toHaveBeenCalledWith(
+        '[Grafana]',
+        expect.objectContaining({ message: 'Default datasource does not support annotations' })
+      );
     });
 
     it('should add a new annotation and group it with the other annotations', () => {

--- a/public/app/features/dashboard-scene/settings/AnnotationsEditView.tsx
+++ b/public/app/features/dashboard-scene/settings/AnnotationsEditView.tsx
@@ -22,6 +22,7 @@ import { AnnotationSettingsEdit } from './annotations/AnnotationSettingsEdit';
 import { AnnotationSettingsList } from './annotations/AnnotationSettingsList';
 import { type DashboardEditView, type DashboardEditViewState, useDashboardEditPageNav } from './utils';
 
+import { grafanaStructuredLogger } from '@grafana/runtime';
 export enum MoveDirection {
   UP = -1,
   DOWN = 1,
@@ -65,7 +66,7 @@ export class AnnotationsEditView extends SceneObjectBase<AnnotationsEditViewStat
     const defaultInstanceDS = getDataSourceSrv().getInstanceSettings(null);
     // check for an annotation flag in the plugin json to see if it supports annotations
     if (!defaultInstanceDS || !defaultInstanceDS.meta.annotations) {
-      console.error('Default datasource does not support annotations');
+      grafanaStructuredLogger.logError(new Error('Default datasource does not support annotations'));
       return undefined;
     }
     return getDataSourceRef(defaultInstanceDS);

--- a/public/app/features/dashboard-scene/settings/GeneralSettingsEditView.tsx
+++ b/public/app/features/dashboard-scene/settings/GeneralSettingsEditView.tsx
@@ -36,6 +36,7 @@ import { getDashboardSceneFor } from '../utils/utils';
 import { DeleteDashboardButton } from './DeleteDashboardButton';
 import { type DashboardEditView, type DashboardEditViewState, useDashboardEditPageNav } from './utils';
 
+import { grafanaStructuredLogger } from '@grafana/runtime';
 export interface GeneralSettingsEditViewState extends DashboardEditViewState {
   showMoveModal?: boolean;
   moveModalProps?: {
@@ -159,7 +160,7 @@ export class GeneralSettingsEditView
       const liveNow = this.getLiveNowTimer();
       enable ? liveNow.enable() : liveNow.disable();
     } catch (err) {
-      console.error(err);
+      grafanaStructuredLogger.logError(err instanceof Error ? err : new Error(String(err)));
     }
   };
 

--- a/public/app/features/dashboard-scene/settings/VariablesEditView.tsx
+++ b/public/app/features/dashboard-scene/settings/VariablesEditView.tsx
@@ -32,6 +32,7 @@ import {
   isVariableEditable,
 } from './variables/utils';
 
+import { grafanaStructuredLogger } from '@grafana/runtime';
 export interface VariablesEditViewState extends DashboardEditViewState {
   editIndex?: number | undefined;
 }
@@ -66,7 +67,7 @@ export class VariablesEditView extends SceneObjectBase<VariablesEditViewState> i
 
     if (!variable) {
       // Handle the case where the variable is not found
-      console.error('Variable not found');
+      grafanaStructuredLogger.logError(new Error('Variable not found'));
       return;
     }
 
@@ -82,7 +83,7 @@ export class VariablesEditView extends SceneObjectBase<VariablesEditViewState> i
     const { variables } = this.getVariableSet().state;
     if (variableIndex === -1) {
       // Handle the case where the variable is not found
-      console.error('Variable not found');
+      grafanaStructuredLogger.logError(new Error('Variable not found'));
       return;
     }
 
@@ -104,7 +105,7 @@ export class VariablesEditView extends SceneObjectBase<VariablesEditViewState> i
     const variables = this.getVariableSet().state.variables;
 
     if (variableIndex === -1) {
-      console.error('Variable not found');
+      grafanaStructuredLogger.logError(new Error('Variable not found'));
       return;
     }
 
@@ -137,7 +138,7 @@ export class VariablesEditView extends SceneObjectBase<VariablesEditViewState> i
     }
     // check the index are within the variables array
     if (fromIndex < 0 || fromIndex >= variables.length || toIndex < 0 || toIndex >= variables.length) {
-      console.error('Invalid index');
+      grafanaStructuredLogger.logError(new Error('Invalid index'));
       return;
     }
     const updatedVariables = [...variables];
@@ -151,7 +152,7 @@ export class VariablesEditView extends SceneObjectBase<VariablesEditViewState> i
   public onEdit = (identifier: string) => {
     const variableIndex = this.getVariableIndex(identifier);
     if (variableIndex === -1) {
-      console.error('Variable not found');
+      grafanaStructuredLogger.logError(new Error('Variable not found'));
       return;
     }
     this.setState({ editIndex: variableIndex });
@@ -175,7 +176,7 @@ export class VariablesEditView extends SceneObjectBase<VariablesEditViewState> i
 
     if (!variable) {
       // Handle the case where the variable is not found
-      console.error('Variable not found');
+      grafanaStructuredLogger.logError(new Error('Variable not found'));
       return;
     }
 

--- a/public/app/features/dashboard-scene/settings/VersionsEditView.tsx
+++ b/public/app/features/dashboard-scene/settings/VersionsEditView.tsx
@@ -32,6 +32,7 @@ import { VersionHistoryComparison } from './version-history/VersionHistoryCompar
 import { VersionHistoryHeader } from './version-history/VersionHistoryHeader';
 import { VersionHistoryTable } from './version-history/VersionHistoryTable';
 
+import { grafanaStructuredLogger } from '@grafana/runtime';
 export interface VersionsEditViewState extends DashboardEditViewState {
   versions?: DecoratedRevisionModel[];
   isLoading?: boolean;
@@ -118,7 +119,7 @@ export class VersionsEditView extends SceneObjectBase<VersionsEditViewState> imp
         // Update the continueToken for the next request, if available
         this._continueToken = result.metadata.continue ?? '';
       })
-      .catch((err) => console.log(err))
+      .catch((err) => grafanaStructuredLogger.logInfo(String(err)))
       .finally(() => this.setState({ isAppending: false }));
   };
 

--- a/public/app/features/dashboard-scene/settings/annotations/AnnotationQueryOptions.tsx
+++ b/public/app/features/dashboard-scene/settings/annotations/AnnotationQueryOptions.tsx
@@ -15,6 +15,7 @@ import { dashboardEditActions } from '../../edit-pane/shared';
 
 import { type AnnotationLayer } from './AnnotationEditableElement';
 
+import { grafanaStructuredLogger } from '@grafana/runtime';
 export function AnnotationQueryEditorButton({ layer }: { layer: AnnotationLayer }) {
   const { queryLibraryEnabled } = useQueryLibraryContext();
   const [isModalOpen, setIsModalOpen] = useState(false);
@@ -79,7 +80,7 @@ function QueryLibraryButton({ layer, onQuerySelected }: { layer: AnnotationLayer
           layer.setState({ query: updatedQuery });
           layer.runLayer();
         } catch (error) {
-          console.error('Failed to replace annotation query!', error);
+          grafanaStructuredLogger.logError(error instanceof Error ? error : new Error(String(error)), { message: String('Failed to replace annotation query!') });
           getAppEvents().publish({
             type: AppEvents.alertError.name,
             payload: ['Failed to create annotation query!', error instanceof Error ? error.message : error],

--- a/public/app/features/dashboard-scene/settings/variables/editors/AdHocFiltersVariableEditor.tsx
+++ b/public/app/features/dashboard-scene/settings/variables/editors/AdHocFiltersVariableEditor.tsx
@@ -16,6 +16,7 @@ import { OptionsPaneItemDescriptor } from 'app/features/dashboard/components/Pan
 import { AdHocOriginFiltersController } from '../components/AdHocOriginFiltersController';
 import { AdHocVariableForm } from '../components/AdHocVariableForm';
 
+import { grafanaStructuredLogger } from '@grafana/runtime';
 interface AdHocFiltersVariableEditorProps {
   variable: AdHocFiltersVariable;
   onRunQuery: (variable: AdHocFiltersVariable) => void;
@@ -169,7 +170,7 @@ export function AdHocFiltersVariableEditor(props: AdHocFiltersVariableEditorProp
 
 export function getAdHocFilterOptions(variable: SceneVariable): OptionsPaneItemDescriptor[] {
   if (!(variable instanceof AdHocFiltersVariable)) {
-    console.warn('getAdHocFilterOptions: variable is not an AdHocFiltersVariable');
+    grafanaStructuredLogger.logWarning(String('getAdHocFilterOptions: variable is not an AdHocFiltersVariable'));
     return [];
   }
 

--- a/public/app/features/dashboard-scene/settings/variables/editors/ConstantVariableEditor.tsx
+++ b/public/app/features/dashboard-scene/settings/variables/editors/ConstantVariableEditor.tsx
@@ -8,6 +8,7 @@ import { OptionsPaneItemDescriptor } from 'app/features/dashboard/components/Pan
 
 import { ConstantVariableForm } from '../components/ConstantVariableForm';
 
+import { grafanaStructuredLogger } from '@grafana/runtime';
 interface ConstantVariableEditorProps {
   variable: ConstantVariable;
 }
@@ -24,7 +25,7 @@ export function ConstantVariableEditor({ variable }: ConstantVariableEditorProps
 
 export function getConstantVariableOptions(variable: SceneVariable): OptionsPaneItemDescriptor[] {
   if (!(variable instanceof ConstantVariable)) {
-    console.warn('getConstantVariableOptions: variable is not a ConstantVariable');
+    grafanaStructuredLogger.logWarning(String('getConstantVariableOptions: variable is not a ConstantVariable'));
     return [];
   }
 

--- a/public/app/features/dashboard-scene/settings/variables/editors/GroupByVariableEditor.tsx
+++ b/public/app/features/dashboard-scene/settings/variables/editors/GroupByVariableEditor.tsx
@@ -14,6 +14,7 @@ import { OptionsPaneItemDescriptor } from 'app/features/dashboard/components/Pan
 
 import { GroupByVariableForm } from '../components/GroupByVariableForm';
 
+import { grafanaStructuredLogger } from '@grafana/runtime';
 interface GroupByVariableEditorProps {
   variable: GroupByVariable;
   onRunQuery: () => void;
@@ -106,7 +107,7 @@ export function GroupByVariableEditor(props: GroupByVariableEditorProps) {
 
 export function getGroupByVariableOptions(variable: SceneVariable): OptionsPaneItemDescriptor[] {
   if (!(variable instanceof GroupByVariable)) {
-    console.warn('getAdHocFilterOptions: variable is not an AdHocFiltersVariable');
+    grafanaStructuredLogger.logWarning(String('getAdHocFilterOptions: variable is not an AdHocFiltersVariable'));
     return [];
   }
 

--- a/public/app/features/dashboard-scene/settings/variables/editors/IntervalVariableEditor.tsx
+++ b/public/app/features/dashboard-scene/settings/variables/editors/IntervalVariableEditor.tsx
@@ -11,6 +11,7 @@ import {
 
 import { IntervalVariableForm } from '../components/IntervalVariableForm';
 
+import { grafanaStructuredLogger } from '@grafana/runtime';
 interface IntervalVariableEditorProps {
   variable: IntervalVariable;
   onRunQuery: () => void;
@@ -65,7 +66,7 @@ export function IntervalVariableEditor({ variable, onRunQuery, inline }: Interva
 
 export function getIntervalVariableOptions(variable: SceneVariable): OptionsPaneItemDescriptor[] {
   if (!(variable instanceof IntervalVariable)) {
-    console.warn('getIntervalVariableOptions: variable is not an IntervalVariable');
+    grafanaStructuredLogger.logWarning(String('getIntervalVariableOptions: variable is not an IntervalVariable'));
     return [];
   }
 

--- a/public/app/features/dashboard-scene/settings/variables/editors/QueryVariableEditor.tsx
+++ b/public/app/features/dashboard-scene/settings/variables/editors/QueryVariableEditor.tsx
@@ -30,6 +30,7 @@ import { QueryVariableEditorForm } from '../components/QueryVariableForm';
 import { VariableValuesPreview } from '../components/VariableValuesPreview';
 import { hasVariableOptions } from '../utils';
 
+import { grafanaStructuredLogger } from '@grafana/runtime';
 interface QueryVariableEditorProps {
   variable: QueryVariable;
   onRunQuery: () => void;
@@ -138,7 +139,7 @@ export function QueryVariableEditor({ variable, onRunQuery }: QueryVariableEdito
 
 export function getQueryVariableOptions(variable: SceneVariable): OptionsPaneItemDescriptor[] {
   if (!(variable instanceof QueryVariable)) {
-    console.warn('getQueryVariableOptions: variable is not a QueryVariable');
+    grafanaStructuredLogger.logWarning(String('getQueryVariableOptions: variable is not a QueryVariable'));
     return [];
   }
 

--- a/public/app/features/dashboard-scene/settings/variables/editors/SwitchVariableEditor.tsx
+++ b/public/app/features/dashboard-scene/settings/variables/editors/SwitchVariableEditor.tsx
@@ -3,6 +3,7 @@ import { OptionsPaneItemDescriptor } from 'app/features/dashboard/components/Pan
 
 import { SwitchVariableForm } from '../components/SwitchVariableForm';
 
+import { grafanaStructuredLogger } from '@grafana/runtime';
 interface SwitchVariableEditorProps {
   variable: SwitchVariable;
   inline?: boolean;
@@ -44,7 +45,7 @@ export function SwitchVariableEditor({ variable, inline = false }: SwitchVariabl
 
 export function getSwitchVariableOptions(variable: SceneVariable): OptionsPaneItemDescriptor[] {
   if (!(variable instanceof SwitchVariable)) {
-    console.warn('getSwitchVariableOptions: variable is not a SwitchVariable');
+    grafanaStructuredLogger.logWarning(String('getSwitchVariableOptions: variable is not a SwitchVariable'));
     return [];
   }
 

--- a/public/app/features/dashboard-scene/settings/variables/editors/TextBoxVariableEditor.tsx
+++ b/public/app/features/dashboard-scene/settings/variables/editors/TextBoxVariableEditor.tsx
@@ -7,6 +7,7 @@ import { OptionsPaneItemDescriptor } from 'app/features/dashboard/components/Pan
 
 import { TextBoxVariableForm } from '../components/TextBoxVariableForm';
 
+import { grafanaStructuredLogger } from '@grafana/runtime';
 interface TextBoxVariableEditorProps {
   variable: TextBoxVariable;
   onChange: (variable: TextBoxVariable) => void;
@@ -25,7 +26,7 @@ export function TextBoxVariableEditor({ variable, inline }: TextBoxVariableEdito
 
 export function getTextBoxVariableOptions(variable: SceneVariable): OptionsPaneItemDescriptor[] {
   if (!(variable instanceof TextBoxVariable)) {
-    console.warn('getTextBoxVariableOptions: variable is not a TextBoxVariable');
+    grafanaStructuredLogger.logWarning(String('getTextBoxVariableOptions: variable is not a TextBoxVariable'));
     return [];
   }
 

--- a/public/app/features/dashboard-scene/sharing/ExportButton/ExportAsImage.tsx
+++ b/public/app/features/dashboard-scene/sharing/ExportButton/ExportAsImage.tsx
@@ -16,6 +16,7 @@ import { type SceneShareTabState, type ShareView } from '../types';
 
 import { generateDashboardImage } from './utils';
 
+import { grafanaStructuredLogger } from '@grafana/runtime';
 export class ExportAsImage extends SceneObjectBase<SceneShareTabState> implements ShareView {
   static Component = ExportAsImageRenderer;
 
@@ -48,7 +49,7 @@ function ExportAsImageRenderer({ model }: SceneComponentProps<ExportAsImage>) {
 
       return result.blob;
     } catch (error) {
-      console.error('Error exporting image:', error);
+      grafanaStructuredLogger.logError(error instanceof Error ? error : new Error(String(error)), { message: String('Error exporting image:') });
       DashboardInteractions.generateDashboardImageClicked({
         scale: config.rendererDefaultImageScale || 1,
         shareResource: 'dashboard',

--- a/public/app/features/dashboard-scene/utils/DashboardModelCompatibilityWrapper.ts
+++ b/public/app/features/dashboard-scene/utils/DashboardModelCompatibilityWrapper.ts
@@ -17,6 +17,7 @@ import { dataLayersToAnnotations } from '../serialization/dataLayersToAnnotation
 import { PanelModelCompatibilityWrapper } from './PanelModelCompatibilityWrapper';
 import { findVizPanelByKey, getVizPanelKeyForPanelId } from './utils';
 
+import { grafanaStructuredLogger } from '@grafana/runtime';
 /**
  * Will move this to make it the main way we remain somewhat compatible with getDashboardSrv().getCurrent
  */
@@ -165,7 +166,7 @@ export class DashboardModelCompatibilityWrapper {
   public removePanel(panel: PanelModelCompatibilityWrapper) {
     const vizPanel = findVizPanelByKey(this._scene, getVizPanelKeyForPanelId(panel.id));
     if (!vizPanel) {
-      console.error('Trying to remove a panel that was not found in scene', panel);
+      grafanaStructuredLogger.logError(panel instanceof Error ? panel : new Error(String(panel)), { message: String('Trying to remove a panel that was not found in scene') });
       return;
     }
 

--- a/public/app/features/dashboard-scene/utils/PanelModelCompatibilityWrapper.ts
+++ b/public/app/features/dashboard-scene/utils/PanelModelCompatibilityWrapper.ts
@@ -4,6 +4,7 @@ import { type DataSourceRef, type DataTransformerConfig } from '@grafana/schema'
 
 import { getPanelIdForVizPanel, getQueryRunnerFor } from './utils';
 
+import { grafanaStructuredLogger } from '@grafana/runtime';
 export class PanelModelCompatibilityWrapper implements PanelModel {
   constructor(private _vizPanel: VizPanel) {}
 
@@ -11,7 +12,7 @@ export class PanelModelCompatibilityWrapper implements PanelModel {
     const id = getPanelIdForVizPanel(this._vizPanel);
 
     if (isNaN(id)) {
-      console.error('VizPanel key could not be translated to a legacy numeric panel id', this._vizPanel);
+      grafanaStructuredLogger.logError(this._vizPanel instanceof Error ? this._vizPanel : new Error(String(this._vizPanel)), { message: String('VizPanel key could not be translated to a legacy numeric panel id') });
       return 0;
     }
 

--- a/public/app/features/dashboard-scene/utils/dashboardControls.ts
+++ b/public/app/features/dashboard-scene/utils/dashboardControls.ts
@@ -7,6 +7,7 @@ import { type SceneVariable } from '@grafana/scenes';
 import { type DashboardLink, type DataSourceRef } from '@grafana/schema';
 import { type VariableKind } from '@grafana/schema/apis/dashboard.grafana.app/v2';
 
+import { grafanaStructuredLogger } from '@grafana/runtime';
 type LoadDefaultControlsPhase = 'default_variables' | 'default_links';
 type InvokeAndTrackOptions = { traceId: string; phase: LoadDefaultControlsPhase; datasourceType?: string };
 
@@ -85,7 +86,7 @@ async function loadControlsFromRef(ref: DataSourceRef, traceId: string, subscrib
   try {
     ds = await getDataSourceSrv().get(ref);
   } catch (e) {
-    console.warn('Failed to load datasource', ref, e);
+    grafanaStructuredLogger.logWarning(String('Failed to load datasource'), { args: ref, e });
     return;
   }
 
@@ -119,7 +120,7 @@ async function emitDefaultVariables(ds: DataSourceApi, traceId: string, subscrib
       subscriber.next({ type: 'variables', data });
     }
   } catch (e) {
-    console.warn('Failed to load default variables from datasource', ds.type, e);
+    grafanaStructuredLogger.logWarning(String('Failed to load default variables from datasource'), { args: ds.type, e });
   }
 }
 
@@ -145,7 +146,7 @@ async function emitDefaultLinks(ds: DataSourceApi, traceId: string, subscriber: 
       });
     }
   } catch (e) {
-    console.warn('Failed to load default links from datasource', ds.type, e);
+    grafanaStructuredLogger.logWarning(String('Failed to load default links from datasource'), { args: ds.type, e });
   }
 }
 

--- a/public/app/features/dashboard-scene/utils/variables.ts
+++ b/public/app/features/dashboard-scene/utils/variables.ts
@@ -23,6 +23,7 @@ import { createSceneVariableFromVariableModel as createSceneVariableFromVariable
 
 import { getCurrentValueForOldIntervalModel, getIntervalsFromQueryString } from './utils';
 
+import { grafanaStructuredLogger } from '@grafana/runtime';
 const DEFAULT_DATASOURCE = 'default';
 
 export function createVariablesForDashboard(oldModel: DashboardModel, defaultVariables: VariableKind[] = []) {
@@ -32,7 +33,7 @@ export function createVariablesForDashboard(oldModel: DashboardModel, defaultVar
       try {
         return createSceneVariableFromVariableModel(v);
       } catch (err) {
-        console.error(err);
+        grafanaStructuredLogger.logError(err instanceof Error ? err : new Error(String(err)));
         return null;
       }
     })
@@ -45,7 +46,7 @@ export function createVariablesForDashboard(oldModel: DashboardModel, defaultVar
       try {
         return createSceneVariableFromVariableModelV2(v);
       } catch (err) {
-        console.error(err);
+        grafanaStructuredLogger.logError(err instanceof Error ? err : new Error(String(err)));
         return null;
       }
     })
@@ -91,7 +92,7 @@ export function createVariablesForSnapshot(oldModel: DashboardModel) {
         // for other variable types we are using the SnapshotVariable
         return createSnapshotVariable(v);
       } catch (err) {
-        console.error(err);
+        grafanaStructuredLogger.logError(err instanceof Error ? err : new Error(String(err)));
         return null;
       }
     })

--- a/public/app/features/dashboard/api/DashboardAPIVersionResolver.test.ts
+++ b/public/app/features/dashboard/api/DashboardAPIVersionResolver.test.ts
@@ -34,7 +34,7 @@ describe('DashboardAPIVersionResolver', () => {
   beforeEach(() => {
     dashboardAPIVersionResolver.reset();
     jest.clearAllMocks();
-    jest.spyOn(console, 'log').mockImplementation();
+    jest.spyOn(console, 'info').mockImplementation();
     jest.spyOn(console, 'warn').mockImplementation();
   });
 
@@ -158,13 +158,25 @@ describe('DashboardAPIVersionResolver', () => {
       it('should log resolved versions', async () => {
         mockDiscoveryResponse(['v2', 'v1']);
         await dashboardAPIVersionResolver.resolve();
-        expect(console.log).toHaveBeenCalledWith(expect.stringContaining('Version negotiation'));
+        expect(console.info).toHaveBeenCalledWith(
+          '[Grafana]',
+          expect.objectContaining({ message: expect.stringContaining('Version negotiation') })
+        );
       });
 
       it('should log on discovery failure', async () => {
         mockDiscoveryFailure();
         await dashboardAPIVersionResolver.resolve();
-        expect(console.log).toHaveBeenCalledWith(expect.stringContaining('discovery failed'), expect.any(Error));
+        expect(console.info).toHaveBeenCalledWith(
+          '[Grafana]',
+          expect.objectContaining({
+            message: expect.stringContaining('Version discovery failed'),
+            context: expect.objectContaining({
+              source: 'grafana.frontend',
+              parts: expect.any(Array),
+            }),
+          })
+        );
       });
     });
 
@@ -172,7 +184,7 @@ describe('DashboardAPIVersionResolver', () => {
       localStorage.removeItem('grafana.debug.dashboardAPI');
       mockDiscoveryResponse(['v2', 'v1']);
       await dashboardAPIVersionResolver.resolve();
-      expect(console.log).not.toHaveBeenCalled();
+      expect(console.info).not.toHaveBeenCalled();
     });
   });
 

--- a/public/app/features/dashboard/api/ResponseTransformers.ts
+++ b/public/app/features/dashboard/api/ResponseTransformers.ts
@@ -86,6 +86,7 @@ import { type DashboardDataDTO, type DashboardDTO } from 'app/types/dashboard';
 import { type DashboardWithAccessInfo } from './types';
 import { isDashboardResource, isDashboardV0Spec, isDashboardV2Resource, isDashboardV2Spec } from './utils';
 
+import { grafanaStructuredLogger } from '@grafana/runtime';
 export function ensureV2Response(
   dto: DashboardDTO | DashboardWithAccessInfo<DashboardDataDTO> | DashboardWithAccessInfo<DashboardV2Spec>
 ): DashboardWithAccessInfo<DashboardV2Spec> {
@@ -712,9 +713,7 @@ function getVariables(vars: TypedVariableModel[]): DashboardV2Spec['variables'] 
         let query = v.query || {};
 
         if (typeof query === 'string') {
-          console.warn(
-            'Query variable query is a string which is deprecated in the schema v2. It should extend DataQuery'
-          );
+          grafanaStructuredLogger.logWarning(String('Query variable query is a string which is deprecated in the schema v2. It should extend DataQuery'));
           query = {
             [LEGACY_STRING_VALUE_KEY]: query,
           };
@@ -925,7 +924,7 @@ function getVariables(vars: TypedVariableModel[]): DashboardV2Spec['variables'] 
         break;
       default:
         // do not throw error, just log it
-        console.error(`Variable transformation not implemented: ${v.type}`);
+        grafanaStructuredLogger.logError(new Error(`Variable transformation not implemented: ${v.type}`));
     }
   }
   return variables;
@@ -1138,7 +1137,7 @@ function getVariablesV1(vars: DashboardV2Spec['variables']): VariableModel[] {
         break;
       default:
         // do not throw error, just log it
-        console.error(`Variable transformation not implemented: ${v}`);
+        grafanaStructuredLogger.logError(new Error(`Variable transformation not implemented: ${v}`));
     }
   }
   return variables;
@@ -1391,7 +1390,7 @@ function transformSpecialValueMatchToV1(match: SpecialValueMatch): SpecialValueM
     case 'empty':
       return SpecialValueMatchV1.Empty;
     default:
-      console.warn(`Skipping special value mapping with unknown match type: "${match}"`);
+      grafanaStructuredLogger.logWarning(String(`Skipping special value mapping with unknown match type: "${match}"`));
       return undefined;
   }
 }

--- a/public/app/features/dashboard/components/DashExportModal/DashboardExporter.ts
+++ b/public/app/features/dashboard/components/DashExportModal/DashboardExporter.ts
@@ -15,6 +15,7 @@ import { isConstant } from '../../../variables/guard';
 import { type DashboardModel } from '../../state/DashboardModel';
 import { type GridPos } from '../../state/PanelModel';
 
+import { grafanaStructuredLogger } from '@grafana/runtime';
 export interface InputUsage {
   libraryPanels?: LibraryPanel[];
 }
@@ -318,7 +319,7 @@ export class DashboardExporter {
 
       return newObj;
     } catch (err) {
-      console.error('Export failed:', err);
+      grafanaStructuredLogger.logError(err instanceof Error ? err : new Error(String(err)), { message: String('Export failed:') });
       return {
         error: err,
       };

--- a/public/app/features/dashboard/components/DashboardSettings/VersionsSettings.tsx
+++ b/public/app/features/dashboard/components/DashboardSettings/VersionsSettings.tsx
@@ -18,6 +18,7 @@ import { VersionHistoryTable } from '../VersionHistory/VersionHistoryTable';
 
 import { type SettingsPageProps } from './types';
 
+import { grafanaStructuredLogger } from '@grafana/runtime';
 interface Props extends SettingsPageProps {}
 
 type State = {
@@ -69,7 +70,7 @@ export class VersionsSettings extends PureComponent<Props, State> {
         // Update the continueToken for the next request, if available
         this.continueToken = result.metadata.continue ?? '';
       })
-      .catch((err) => console.log(err))
+      .catch((err) => grafanaStructuredLogger.logInfo(String(err)))
       .finally(() => this.setState({ isAppending: false }));
   };
 

--- a/public/app/features/dashboard/components/GenAI/hooks.ts
+++ b/public/app/features/dashboard/components/GenAI/hooks.ts
@@ -8,6 +8,7 @@ import { useAppNotification } from 'app/core/copy/appNotification';
 
 import { DEFAULT_LLM_MODEL, isLLMPluginEnabled } from './utils';
 
+import { grafanaStructuredLogger } from '@grafana/runtime';
 // Declared instead of imported from utils to make this hook modular
 // Ideally we will want to move the hook itself to a different scope later.
 type Message = llm.Message;
@@ -71,7 +72,7 @@ export function useLLMStream(options: Options = defaultOptions): UseLLMStreamRes
         'Failed to generate content using LLM',
         'Please try again or if the problem persists, contact your organization admin.'
       );
-      console.error(e);
+      grafanaStructuredLogger.logError(e instanceof Error ? e : new Error(String(e)));
       genAILogger.logError(e, { messages: JSON.stringify(messages), model, temperature: String(temperature) });
     },
     [messages, model, temperature, notifyError]

--- a/public/app/features/dashboard/components/HelpWizard/SupportSnapshotService.ts
+++ b/public/app/features/dashboard/components/HelpWizard/SupportSnapshotService.ts
@@ -13,6 +13,7 @@ import { type PanelModel } from '../../state/PanelModel';
 
 import { getDebugDashboard, getGithubMarkdown } from './utils';
 
+import { grafanaStructuredLogger } from '@grafana/runtime';
 interface SupportSnapshotState {
   currentTab: SnapshotTab;
   showMessage: ShowMessage;
@@ -88,7 +89,7 @@ export class SupportSnapshotService extends StateManagerBase<SupportSnapshotStat
       const dash = createDashboardSceneFromDashboardModel(oldModel, snapshot);
       scene = dash.state.body; // skip the wrappers
     } catch (ex) {
-      console.log('Error creating scene:', ex);
+      grafanaStructuredLogger.logInfo(String('Error creating scene:'), { args: ex });
     }
 
     this.setState({ snapshot, snapshotText, markdownText, snapshotSize, snapshotUpdate: snapshotUpdate + 1, scene });

--- a/public/app/features/dashboard/components/PanelEditor/state/actions.ts
+++ b/public/app/features/dashboard/components/PanelEditor/state/actions.ts
@@ -18,6 +18,7 @@ import {
   updateEditorInitState,
 } from './reducers';
 
+import { grafanaStructuredLogger } from '@grafana/runtime';
 export function initPanelEditor(sourcePanel: PanelModel, dashboard: DashboardModel): ThunkResult<void> {
   return async (dispatch) => {
     const panel = dashboard.initEditPanel(sourcePanel);
@@ -171,7 +172,7 @@ export function updatePanelEditorUIState(uiState: Partial<PanelEditorUIState>): 
     try {
       store.setObject(PANEL_EDITOR_UI_STATE_STORAGE_KEY, nextState);
     } catch (error) {
-      console.error(error);
+      grafanaStructuredLogger.logError(error instanceof Error ? error : new Error(String(error)));
     }
   };
 }

--- a/public/app/features/dashboard/dashgrid/DashboardGrid.tsx
+++ b/public/app/features/dashboard/dashgrid/DashboardGrid.tsx
@@ -19,6 +19,7 @@ import { type GridPos, type PanelModel } from '../state/PanelModel';
 import DashboardEmpty from './DashboardEmpty/DashboardEmpty';
 import { DashboardPanel } from './DashboardPanel';
 
+import { grafanaStructuredLogger } from '@grafana/runtime';
 export const PANEL_FILTER_VARIABLE = 'systemPanelFilterVar';
 
 export interface Props {
@@ -115,7 +116,7 @@ export class DashboardGrid extends PureComponent<Props, State> {
       this.panelMap[panel.key] = panel;
 
       if (!panel.gridPos) {
-        console.log('panel without gridpos');
+        grafanaStructuredLogger.logInfo(String('panel without gridpos'));
         continue;
       }
 

--- a/public/app/features/dashboard/dashgrid/DashboardLibrary/DashboardCard.tsx
+++ b/public/app/features/dashboard/dashgrid/DashboardLibrary/DashboardCard.tsx
@@ -14,6 +14,7 @@ import { CompatibilityBadge, type CompatibilityState } from './CompatibilityBadg
 import { type GnetDashboard } from './types';
 import { buildAssistantPrompt, buildTemplateContextData, buildTemplateContextTitle } from './utils/assistantHelpers';
 
+import { grafanaStructuredLogger } from '@grafana/runtime';
 interface Details {
   id: string;
   datasource: string;
@@ -120,7 +121,10 @@ function DashboardCardComponent({
               kind === 'suggested_dashboard' ? styles.thumbnailCoverImage : styles.thumbnailContainImage
             )}
             onError={(e) => {
-              console.error('Failed to load image for:', title, 'URL:', imageUrl);
+              grafanaStructuredLogger.logWarning('Failed to load dashboard library card image', {
+                title,
+                imageUrl,
+              });
               e.currentTarget.style.display = 'none';
             }}
           />

--- a/public/app/features/dashboard/dashgrid/DashboardLibrary/SuggestedDashboardsList/SuggestedDashboardsList.tsx
+++ b/public/app/features/dashboard/dashgrid/DashboardLibrary/SuggestedDashboardsList/SuggestedDashboardsList.tsx
@@ -26,6 +26,7 @@ import { DashboardResultsGrid } from './DashboardResultsGrid';
 import { EmptyResults } from './EmptyResults';
 import { ListHeader } from './ListHeader';
 
+import { grafanaStructuredLogger } from '@grafana/runtime';
 const SEARCH_DEBOUNCE_MS = 500;
 const DEFAULT_SORT_ORDER = 'downloads';
 const DEFAULT_SORT_DIRECTION = 'desc' as const;
@@ -252,7 +253,7 @@ export const SuggestedDashboardsList = ({
           });
         }
       } catch (err) {
-        console.error('Error loading community dashboards', err);
+        grafanaStructuredLogger.logError(err instanceof Error ? err : new Error(String(err)), { message: String('Error loading community dashboards') });
       } finally {
         setIsCommunityLoading(false);
       }
@@ -422,7 +423,7 @@ export const SuggestedDashboardsList = ({
         sourceEntryPoint,
       });
     } catch (err) {
-      console.error('Error checking dashboard compatibility:', err);
+      grafanaStructuredLogger.logError(err instanceof Error ? err : new Error(String(err)), { message: String('Error checking dashboard compatibility:') });
 
       const errorMessage = isFetchError(err) ? err.data?.message : 'Failed to check compatibility';
       const errorCode = isFetchError(err) ? err.data?.code : undefined;

--- a/public/app/features/dashboard/dashgrid/DashboardLibrary/TemplateDashboardModal.tsx
+++ b/public/app/features/dashboard/dashgrid/DashboardLibrary/TemplateDashboardModal.tsx
@@ -22,6 +22,7 @@ import { TemplateDashboardInteractions } from './interactions';
 import { type GnetDashboard, type GnetDashboardsResponse, type Link } from './types';
 import { getTemplateDashboardUrl } from './utils/templateDashboardHelpers';
 
+import { grafanaStructuredLogger } from '@grafana/runtime';
 const SourceEntryPointMap: Record<string, SourceEntryPoint> = {
   quickAdd: TemplateDashboardSourceEntryPoint.QUICK_ADD_BUTTON,
   commandPalette: TemplateDashboardSourceEntryPoint.COMMAND_PALETTE,
@@ -97,7 +98,7 @@ export const TemplateDashboardModal = () => {
 
       return response.items;
     } catch (error) {
-      console.error('Error loading template dashboards ', error);
+      grafanaStructuredLogger.logError(error instanceof Error ? error : new Error(String(error)), { message: String('Error loading template dashboards ') });
       return [];
     }
   }, [isOpen]);

--- a/public/app/features/dashboard/dashgrid/DashboardLibrary/api/compatibilityApi.ts
+++ b/public/app/features/dashboard/dashgrid/DashboardLibrary/api/compatibilityApi.ts
@@ -2,6 +2,7 @@ import { getAPINamespace } from '@grafana/api-clients';
 import { getBackendSrv } from '@grafana/runtime';
 import { type DashboardJson } from 'app/features/manage-dashboards/types';
 
+import { grafanaStructuredLogger } from '@grafana/runtime';
 /**
  * Represents a datasource mapping for compatibility checking.
  * Maps dashboard datasource references to actual datasource instances.
@@ -138,7 +139,7 @@ export async function checkDashboardCompatibility(
     return response;
   } catch (error) {
     // Log error for debugging
-    console.error('Dashboard compatibility check failed:', error);
+    grafanaStructuredLogger.logError(error instanceof Error ? error : new Error(String(error)), { message: String('Dashboard compatibility check failed:') });
 
     // Re-throw original error for caller to handle
     throw error;

--- a/public/app/features/dashboard/dashgrid/DashboardLibrary/api/dashboardLibraryApi.ts
+++ b/public/app/features/dashboard/dashgrid/DashboardLibrary/api/dashboardLibraryApi.ts
@@ -1,4 +1,4 @@
-import { getBackendSrv, logInfo, logWarning } from '@grafana/runtime';
+import { getBackendSrv, logError, logInfo, logWarning } from '@grafana/runtime';
 import { type DashboardJson } from 'app/features/manage-dashboards/types';
 import { type PluginDashboard } from 'app/types/plugins';
 
@@ -102,7 +102,7 @@ export async function fetchCommunityDashboards(
   }
 
   // Fallback for unexpected response format
-  console.warn('Unexpected API response format from Grafana.com:', result);
+  logWarning('Unexpected API response format from Grafana.com', { result });
   return {
     page: params.page,
     pages: 1,
@@ -127,7 +127,9 @@ export async function fetchProvisionedDashboards(datasourceType: string): Promis
     });
     return Array.isArray(dashboards) ? dashboards.filter((dashboard) => !dashboard.removed) : [];
   } catch (error) {
-    console.error('Error loading provisioned dashboards', error);
+    logError(error instanceof Error ? error : new Error(String(error)), {
+      message: 'Error loading provisioned dashboards',
+    });
     return [];
   }
 }
@@ -143,10 +145,6 @@ const filterNonSafeDashboards = (dashboards: GnetDashboard[], dataSourceType?: s
 
     if (unsafePanelTypes.length > 0) {
       unsafeDashboardsCount++;
-
-      console.warn(
-        `Community dashboard ${item.id} ${item.name} filtered out due to panel types ${item.panelTypeSlugs?.join(', ')} that can embed JavaScript`
-      );
 
       logWarning('Community dashboard filtered out due to unsafe panel types', {
         dashboardId: item.id.toString(),

--- a/public/app/features/dashboard/dashgrid/DashboardLibrary/utils/communityDashboardHelpers.ts
+++ b/public/app/features/dashboard/dashgrid/DashboardLibrary/utils/communityDashboardHelpers.ts
@@ -21,6 +21,7 @@ import { type GnetDashboard, type Link } from '../types';
 import { type InputMapping, tryAutoMapDatasources, parseConstantInputs, isDataSourceInput } from './autoMapDatasources';
 import type { AssistantSource } from './templateDashboardHelpers';
 
+import { grafanaStructuredLogger } from '@grafana/runtime';
 export const SEARCH_DEBOUNCE_MS = 500;
 export const DEFAULT_SORT_ORDER = 'downloads';
 export const DEFAULT_SORT_DIRECTION = 'desc';
@@ -165,7 +166,7 @@ function canPanelContainJS(panel: PanelModel): boolean {
   try {
     panelJson = JSON.stringify(panelWithoutSanitizedFields);
   } catch (e) {
-    console.warn('Failed to stringify panel', e);
+    grafanaStructuredLogger.logWarning(String('Failed to stringify panel'), { args: e });
     return true;
   }
 
@@ -196,7 +197,7 @@ function canPanelContainJS(panel: PanelModel): boolean {
 
   const hasSuspiciousValue = valuePatterns.some((pattern) => {
     if (pattern.test(panelJson)) {
-      console.warn('Panel contains JavaScript code in value');
+      grafanaStructuredLogger.logWarning(String('Panel contains JavaScript code in value'));
       return true;
     }
     return false;
@@ -204,7 +205,7 @@ function canPanelContainJS(panel: PanelModel): boolean {
 
   const hasSuspiciousKey = keyPatterns.some((pattern) => {
     if (pattern.test(panelJson)) {
-      console.warn('Panel contains JavaScript code in key');
+      grafanaStructuredLogger.logWarning(String('Panel contains JavaScript code in key'));
       return true;
     }
     return false;
@@ -320,7 +321,7 @@ export async function onUseCommunityDashboard({
       }
     }
   } catch (err) {
-    console.error('Error loading community dashboard:', err);
+    grafanaStructuredLogger.logError(err instanceof Error ? err : new Error(String(err)), { message: String('Error loading community dashboard:') });
     dispatch(
       notifyApp(
         createErrorNotification(t('dashboard-library.community-error-title', 'Error loading community dashboard'))

--- a/public/app/features/dashboard/dashgrid/PanelStateWrapper.tsx
+++ b/public/app/features/dashboard/dashgrid/PanelStateWrapper.tsx
@@ -57,6 +57,7 @@ import { seriesVisibilityConfigFactory } from './SeriesVisibilityConfigFactory';
 import { liveTimer } from './liveTimer';
 import { PanelOptionsLogger } from './panelOptionsLogger';
 
+import { grafanaStructuredLogger } from '@grafana/runtime';
 const DEFAULT_PLUGIN_ERROR = 'Error in plugin';
 
 export interface Props {
@@ -257,7 +258,7 @@ export class PanelStateWrapper extends PureComponent<Props, State> {
       const delta = liveTime.to.valueOf() - data.timeRange.to.valueOf();
       if (delta < 100) {
         // 10hz
-        console.log('Skip tick render', this.props.panel.title, delta);
+        grafanaStructuredLogger.logInfo(String('Skip tick render'), { args: this.props.panel.title, delta });
         return;
       }
     }

--- a/public/app/features/dashboard/services/DashboardAnalyticsAggregator.ts
+++ b/public/app/features/dashboard/services/DashboardAnalyticsAggregator.ts
@@ -10,6 +10,7 @@ import {
   writePerformanceGroupEnd,
 } from './performanceUtils';
 
+import { grafanaStructuredLogger } from '@grafana/runtime';
 /**
  * Panel metrics structure for analytics
  */
@@ -108,7 +109,7 @@ export class DashboardAnalyticsAggregator implements performanceUtils.ScenePerfo
     // Aggregate panel metrics without verbose logging (handled by ScenePerformanceLogger)
     const panel = this.panelMetrics.get(data.panelKey);
     if (!panel) {
-      console.warn('Panel not found for operation completion:', data.panelKey);
+      grafanaStructuredLogger.logWarning(String('Panel not found for operation completion:'), { args: data.panelKey });
       return;
     }
 

--- a/public/app/features/dashboard/services/DashboardLoaderSrv.ts
+++ b/public/app/features/dashboard/services/DashboardLoaderSrv.ts
@@ -20,6 +20,7 @@ import { DashboardVersionError, type DashboardWithAccessInfo } from '../api/type
 import { getDashboardSrv } from './DashboardSrv';
 import { getDashboardSnapshotSrv } from './SnapshotSrv';
 
+import { grafanaStructuredLogger } from '@grafana/runtime';
 interface DashboardLoaderSrvLike<T> {
   loadDashboard(
     type: UrlQueryValue,
@@ -58,7 +59,7 @@ abstract class DashboardLoaderSrvBase<T> implements DashboardLoaderSrvLike<T> {
           };
         },
         (err) => {
-          console.error('Script dashboard error ' + err);
+          grafanaStructuredLogger.logError(new Error('Script dashboard error ' + err));
           appEvents.emit(AppEvents.alertError, [
             'Script Error',
             'Please make sure it exists and returns a valid dashboard',
@@ -143,7 +144,7 @@ export class DashboardLoaderSrv extends DashboardLoaderSrvBase<DashboardDTO> {
           return await api.getDashboardDTO(uid, params);
         } catch (e) {
           if (isFetchError(e) && !(e instanceof DashboardVersionError)) {
-            console.error('Failed to load dashboard', e);
+            grafanaStructuredLogger.logError(e instanceof Error ? e : new Error(String(e)), { message: String('Failed to load dashboard') });
             e.isHandled = true;
             if (e.status === 404) {
               appEvents.emit(AppEvents.alertError, ['Dashboard not found']);
@@ -208,7 +209,7 @@ export class DashboardLoaderSrvV2 extends DashboardLoaderSrvBase<DashboardWithAc
           return await api.getDashboardDTO(uid, params);
         } catch (e) {
           if (isFetchError(e) && !(e instanceof DashboardVersionError)) {
-            console.error('Failed to load dashboard', e);
+            grafanaStructuredLogger.logError(e instanceof Error ? e : new Error(String(e)), { message: String('Failed to load dashboard') });
             e.isHandled = true;
             if (e.status === 404) {
               appEvents.emit(AppEvents.alertError, ['Dashboard not found']);

--- a/public/app/features/dashboard/services/performanceUtils.ts
+++ b/public/app/features/dashboard/services/performanceUtils.ts
@@ -1,4 +1,5 @@
 import { store } from '@grafana/data';
+import { grafanaStructuredLogger } from '@grafana/runtime';
 import { performanceUtils, writePerformanceLog } from '@grafana/scenes';
 
 /**
@@ -74,8 +75,7 @@ function isPerformanceLoggingEnabled(): boolean {
  */
 export function writePerformanceGroupStart(logger: string, message: string): void {
   if (isPerformanceLoggingEnabled()) {
-    // eslint-disable-next-line no-console
-    console.groupCollapsed(`${logger}: ${message}`);
+    grafanaStructuredLogger.logInfo(`[sceneProfiling/group] ${logger}`, { collapsed: true, detail: message });
   }
 }
 
@@ -84,13 +84,7 @@ export function writePerformanceGroupStart(logger: string, message: string): voi
  */
 export function writePerformanceGroupLog(logger: string, message: string, data?: unknown): void {
   if (isPerformanceLoggingEnabled()) {
-    if (data) {
-      // eslint-disable-next-line no-console
-      console.log(message, data);
-    } else {
-      // eslint-disable-next-line no-console
-      console.log(message);
-    }
+    grafanaStructuredLogger.logInfo(`[sceneProfiling] ${logger}: ${message}`, data !== undefined ? { data } : undefined);
   }
 }
 
@@ -99,8 +93,7 @@ export function writePerformanceGroupLog(logger: string, message: string, data?:
  */
 export function writePerformanceGroupEnd(): void {
   if (isPerformanceLoggingEnabled()) {
-    // eslint-disable-next-line no-console
-    console.groupEnd();
+    grafanaStructuredLogger.logInfo('[sceneProfiling/group]', { phase: 'end' });
   }
 }
 
@@ -117,7 +110,10 @@ export function createPerformanceMark(name: string, timestamp?: number): void {
       }
     }
   } catch (error) {
-    console.error(`❌ Failed to create performance mark: ${name}`, { timestamp, error });
+    grafanaStructuredLogger.logError(error instanceof Error ? error : new Error(String(error)), {
+      detail: `Failed to create performance mark: ${name}`,
+      timestamp,
+    });
   }
 }
 
@@ -134,6 +130,10 @@ export function createPerformanceMeasure(name: string, startMark: string, endMar
       }
     }
   } catch (error) {
-    console.error(`❌ Failed to create performance measure: ${name}`, { startMark, endMark, error });
+    grafanaStructuredLogger.logError(error instanceof Error ? error : new Error(String(error)), {
+      detail: `Failed to create performance measure: ${name}`,
+      startMark,
+      endMark,
+    });
   }
 }

--- a/public/app/features/dashboard/state/DashboardModel.ts
+++ b/public/app/features/dashboard/state/DashboardModel.ts
@@ -52,6 +52,7 @@ import { PanelModel } from './PanelModel';
 import { type TimeModel } from './TimeModel';
 import { deleteScopeVars, isOnTheSameGridRow } from './utils';
 
+import { grafanaStructuredLogger } from '@grafana/runtime';
 export interface CloneOptions {
   saveVariables?: boolean;
   saveTimerange?: boolean;
@@ -1115,13 +1116,13 @@ export class DashboardModel implements TimeModel {
 
   /** @deprecated */
   on<T>(event: AppEvent<T>, callback: (payload?: T) => void) {
-    console.log('DashboardModel.on is deprecated use events.subscribe');
+    grafanaStructuredLogger.logInfo(String('DashboardModel.on is deprecated use events.subscribe'));
     this.events.on(event, callback);
   }
 
   /** @deprecated */
   off<T>(event: AppEvent<T>, callback: (payload?: T) => void) {
-    console.log('DashboardModel.off is deprecated');
+    grafanaStructuredLogger.logInfo(String('DashboardModel.off is deprecated'));
     this.events.off(event, callback);
   }
 

--- a/public/app/features/dashboard/state/initDashboard.ts
+++ b/public/app/features/dashboard/state/initDashboard.ts
@@ -40,6 +40,7 @@ import { type PanelModel } from './PanelModel';
 import { emitDashboardViewEvent } from './analyticsProcessor';
 import { dashboardInitCompleted, dashboardInitFailed, dashboardInitFetching, dashboardInitServices } from './reducers';
 
+import { grafanaStructuredLogger } from '@grafana/runtime';
 const INIT_DASHBOARD_MEASUREMENT = 'initDashboard';
 
 export interface InitDashboardArgs {
@@ -109,7 +110,7 @@ async function fetchDashboard(
               ...locationService.getLocation(),
               pathname: dashboardUrl,
             });
-            console.log('not correct url correcting', dashboardUrl, currentPath);
+            grafanaStructuredLogger.logInfo(String('not correct url correcting'), { args: dashboardUrl, currentPath });
           }
         }
         return dashDTO;
@@ -138,7 +139,7 @@ async function fetchDashboard(
         error: err,
       })
     );
-    console.error(err);
+    grafanaStructuredLogger.logError(err instanceof Error ? err : new Error(String(err)));
     return null;
   }
 }
@@ -206,7 +207,7 @@ export function initDashboard(args: InitDashboardArgs): ThunkResult<void> {
           error: err,
         })
       );
-      console.error(err);
+      grafanaStructuredLogger.logError(err instanceof Error ? err : new Error(String(err)));
       return;
     }
 
@@ -264,7 +265,7 @@ export function initDashboard(args: InitDashboardArgs): ThunkResult<void> {
       if (err instanceof Error) {
         dispatch(notifyApp(createErrorNotification('Dashboard init failed', err)));
       }
-      console.error(err);
+      grafanaStructuredLogger.logError(err instanceof Error ? err : new Error(String(err)));
     }
 
     // send open dashboard event

--- a/public/app/features/dimensions/editors/FileUploader.tsx
+++ b/public/app/features/dimensions/editors/FileUploader.tsx
@@ -8,6 +8,7 @@ import { SanitizedSVG } from 'app/core/components/SVG/SanitizedSVG';
 
 import { MediaType } from '../types';
 
+import { grafanaStructuredLogger } from '@grafana/runtime';
 interface Props {
   setFormData: Dispatch<SetStateAction<FormData>>;
   mediaType: MediaType;
@@ -47,7 +48,7 @@ export const FileUploader = ({ mediaType, setFormData, setUpload, error }: Props
   const onFileRemove = (file: DropzoneFile) => {
     fetch(`/api/storage/delete/upload/${file.file.name}`, {
       method: 'DELETE',
-    }).catch((error) => console.error('cannot delete file', error));
+    }).catch((error) => grafanaStructuredLogger.logError(error instanceof Error ? error : new Error(String(error)), { message: String('cannot delete file') }));
   };
 
   const acceptableFiles =

--- a/public/app/features/dimensions/editors/ResourcePickerPopover.tsx
+++ b/public/app/features/dimensions/editors/ResourcePickerPopover.tsx
@@ -15,6 +15,7 @@ import { FileUploader } from './FileUploader';
 import { FolderPickerTab } from './FolderPickerTab';
 import { URLPickerTab } from './URLPickerTab';
 
+import { grafanaStructuredLogger } from '@grafana/runtime';
 interface Props {
   value?: string; //img/icons/unicons/0-plus.svg
   onChange: (value?: string) => void;
@@ -129,7 +130,7 @@ export const ResourcePickerPopover = (props: Props) => {
                           .then(() => onChange(`${config.appUrl}api/storage/read/${data.path}`))
                           .then(() => hidePopper?.());
                       })
-                      .catch((err) => console.error(err));
+                      .catch((err) => grafanaStructuredLogger.logError(err instanceof Error ? err : new Error(String(err))));
                   } else {
                     onChange(newValue);
                     hidePopper?.();

--- a/public/app/features/explore/Logs/LogsMetaRow.tsx
+++ b/public/app/features/explore/Logs/LogsMetaRow.tsx
@@ -23,6 +23,7 @@ import { MetaInfoText, type MetaItemProps } from '../MetaInfoText';
 import { type LogsVisualisationType } from './constants';
 import { SETTINGS_KEYS } from './utils/logs';
 
+import { grafanaStructuredLogger } from '@grafana/runtime';
 const getStyles = () => ({
   metaContainer: css({
     flex: 1,
@@ -162,6 +163,6 @@ function renderMetaItem(value: string | number | Labels, kind: LogsMetaKind, log
   if (kind === LogsMetaKind.Error) {
     return <span className="logs-meta-item__error">{value.toString()}</span>;
   }
-  console.error(`Meta type ${typeof value} ${value} not recognized.`);
+  grafanaStructuredLogger.logError(new Error(`Meta type ${typeof value} ${value} not recognized.`));
   return <></>;
 }

--- a/public/app/features/explore/Logs/LogsTableWrap.tsx
+++ b/public/app/features/explore/Logs/LogsTableWrap.tsx
@@ -28,6 +28,7 @@ import { parseLogsFrame } from 'app/features/logs/logsFrame';
 import { LogsTable } from './LogsTable';
 import { SETTING_KEY_ROOT } from './utils/logs';
 
+import { grafanaStructuredLogger } from '@grafana/runtime';
 interface Props {
   logsFrames: DataFrame[];
   width: number;
@@ -385,7 +386,7 @@ export function LogsTableWrap(props: Props) {
   // Toggle a column on or off when the user interacts with an element in the multi-select sidebar
   const toggleColumn = (columnName: FieldName) => {
     if (!columnsWithMeta || !(columnName in columnsWithMeta)) {
-      console.warn('failed to get column', columnsWithMeta);
+      grafanaStructuredLogger.logWarning(String('failed to get column'), { args: columnsWithMeta });
       return;
     }
 

--- a/public/app/features/explore/Logs/utils/table/logsTable.ts
+++ b/public/app/features/explore/Logs/utils/table/logsTable.ts
@@ -2,6 +2,7 @@ import { type DataFrame, FieldType, getFieldDisplayName, LogsSortOrder } from '@
 import { type TableSortByFieldState } from '@grafana/schema/dist/esm/common/common.gen';
 import { LOGS_DATAPLANE_TIMESTAMP_NAME } from 'app/features/logs/logsFrame';
 
+import { grafanaStructuredLogger } from '@grafana/runtime';
 function getDefaultSortBy(dataFrame: DataFrame | undefined, logsSortOrder: LogsSortOrder): TableSortByFieldState[] {
   const field = dataFrame?.fields.find((field) => field.type === FieldType.time);
   const timeFieldName = field ? getFieldDisplayName(field) : LOGS_DATAPLANE_TIMESTAMP_NAME;
@@ -34,7 +35,7 @@ export const getDefaultTableSortBy = (
         return parsed;
       }
     } catch (e) {
-      console.error('failed to parse table sort from local storage!', e);
+      grafanaStructuredLogger.logError(e instanceof Error ? e : new Error(String(e)), { message: String('failed to parse table sort from local storage!') });
     }
   }
 

--- a/public/app/features/explore/PrometheusListView/utils/getRawPrometheusListItemsFromDataFrame.ts
+++ b/public/app/features/explore/PrometheusListView/utils/getRawPrometheusListItemsFromDataFrame.ts
@@ -2,6 +2,7 @@ import { type DataFrame, formattedValueToString } from '@grafana/data';
 
 import { type instantQueryRawVirtualizedListData } from '../RawListContainer';
 
+import { grafanaStructuredLogger } from '@grafana/runtime';
 type instantQueryMetricList = { [index: string]: { [index: string]: instantQueryRawVirtualizedListData } };
 
 export const RawPrometheusListItemEmptyValue = ' ';
@@ -51,7 +52,7 @@ export const getRawPrometheusListItemsFromDataFrame = (dataFrame: DataFrame): in
             }
           }
         } else {
-          console.warn('Field display method is missing!');
+          grafanaStructuredLogger.logWarning(String('Field display method is missing!'));
         }
       }
     }

--- a/public/app/features/explore/QueryLibrary/OpenQueryLibraryExposedComponent.tsx
+++ b/public/app/features/explore/QueryLibrary/OpenQueryLibraryExposedComponent.tsx
@@ -7,6 +7,7 @@ import { ToolbarButton } from '@grafana/ui';
 
 import { useQueryLibraryContext } from './QueryLibraryContext';
 
+import { grafanaStructuredLogger } from '@grafana/runtime';
 interface Props {
   className?: string;
   context?: string;
@@ -81,9 +82,7 @@ export const OpenQueryLibraryExposedComponent = ({
   }, [context, datasourceFilters, onSelectQuery, openDrawer, query]);
 
   if (!queryLibraryEnabled) {
-    console.warn(
-      '[OpenQueryLibraryExposedComponent]: Attempted to use unsupported exposed component. Query library is not enabled.'
-    );
+    grafanaStructuredLogger.logWarning(String('[OpenQueryLibraryExposedComponent]: Attempted to use unsupported exposed component. Query library is not enabled.'));
     return null;
   }
 

--- a/public/app/features/explore/TraceView/components/CriticalPath/index.tsx
+++ b/public/app/features/explore/TraceView/components/CriticalPath/index.tsx
@@ -20,6 +20,7 @@ import findLastFinishingChildSpan from './utils/findLastFinishingChildSpan';
 import getChildOfSpans from './utils/getChildOfSpans';
 import sanitizeOverFlowingChildren from './utils/sanitizeOverFlowingChildren';
 
+import { grafanaStructuredLogger } from '@grafana/runtime';
 /**
  * Computes the critical path sections of a Jaeger trace.
  * The algorithm begins with the top-level span and iterates through the last finishing children (LFCs).
@@ -104,7 +105,7 @@ function criticalPathForTrace(trace: Trace) {
       criticalPath = computeCriticalPath(sanitizedSpanMap, rootSpanId, criticalPath);
     } catch (error) {
       /* eslint-disable no-console */
-      console.log('error while computing critical path for a trace', error);
+      grafanaStructuredLogger.logInfo(String('error while computing critical path for a trace'), { args: error });
     }
   }
   return criticalPath;

--- a/public/app/features/explore/TraceView/components/ScrollManager.tsx
+++ b/public/app/features/explore/TraceView/components/ScrollManager.tsx
@@ -15,6 +15,7 @@
 import type TNil from './types/TNil';
 import { type TraceSpan, type TraceSpanReference, type Trace } from './types/trace';
 
+import { grafanaStructuredLogger } from '@grafana/runtime';
 /**
  * `Accessors` is necessary because `ScrollManager` needs to be created by
  * `TracePage` so it can be passed into the keyboard shortcut manager. But,
@@ -106,7 +107,7 @@ export default class ScrollManager {
     const position = xrs.getRowPosition(rowIndex);
     if (!position) {
       // eslint-disable-next-line no-console
-      console.warn('Invalid row index');
+      grafanaStructuredLogger.logWarning(String('Invalid row index'));
       return;
     }
     let { y } = position;

--- a/public/app/features/explore/TraceView/components/TraceTimelineViewer/ListView/index.tsx
+++ b/public/app/features/explore/TraceView/components/TraceTimelineViewer/ListView/index.tsx
@@ -18,6 +18,7 @@ import type TNil from '../../types/TNil';
 
 import Positions from './Positions';
 
+import { grafanaStructuredLogger } from '@grafana/runtime';
 type TWrapperProps = {
   style: React.CSSProperties;
   ref: (elm: HTMLDivElement) => void;
@@ -388,7 +389,7 @@ export default class ListView extends React.Component<TListViewProps> {
         const itemKey = node.getAttribute('data-item-key');
         if (!itemKey) {
           // eslint-disable-next-line no-console
-          console.warn('itemKey not found');
+          grafanaStructuredLogger.logWarning(String('itemKey not found'));
           continue;
         }
         // measure the first child, if it's available, otherwise the node itself

--- a/public/app/features/explore/TraceView/components/model/link-patterns.tsx
+++ b/public/app/features/explore/TraceView/components/model/link-patterns.tsx
@@ -18,6 +18,7 @@ import memoize from 'lru-memoize';
 import { type Trace } from '../types/trace';
 import { getConfigValue } from '../utils/config/get-config';
 
+import { grafanaStructuredLogger } from '@grafana/runtime';
 const parameterRegExp = /#\{([^{}]*)\}/g;
 
 type ProcessedTemplate = {
@@ -112,7 +113,7 @@ export function processLinkPattern(pattern: any): ProcessedLinkPattern | null {
     };
   } catch (error) {
     // eslint-disable-next-line no-console
-    console.error(`Ignoring invalid link pattern: ${error}`, pattern);
+    grafanaStructuredLogger.logError(pattern instanceof Error ? pattern : new Error(String(pattern)), { message: String(`Ignoring invalid link pattern: ${error}`) });
     return null;
   }
 }

--- a/public/app/features/explore/TraceView/components/model/transform-trace-data.tsx
+++ b/public/app/features/explore/TraceView/components/model/transform-trace-data.tsx
@@ -16,6 +16,7 @@ import { isEqual as _isEqual } from 'lodash';
 
 // @ts-ignore
 import { type TraceKeyValuePair } from '@grafana/data';
+import { grafanaStructuredLogger } from '@grafana/runtime';
 
 import { getTraceSpanIdsAsTree } from '../selectors/trace';
 import { type TraceResponse, type Trace, type TraceSpan, type TraceProcess } from '../types/trace';
@@ -120,11 +121,12 @@ export default function transformTraceData(data: TraceResponse | undefined): Tra
     // make sure span IDs are unique
     const idCount = spanIdCounts.get(spanID);
     if (idCount != null) {
-      // eslint-disable-next-line no-console
-      console.warn(`Dupe spanID, ${idCount + 1} x ${spanID}`, span, spanMap.get(spanID));
+      grafanaStructuredLogger.logWarning(`Dupe spanID, ${idCount + 1} x ${spanID}`, {
+        span,
+        duplicateOf: spanMap.get(spanID),
+      });
       if (_isEqual(span, spanMap.get(spanID))) {
-        // eslint-disable-next-line no-console
-        console.warn('\t two spans with same ID have `isEqual(...) === true`');
+        grafanaStructuredLogger.logWarning('Two spans with same ID have isEqual(...) === true');
       }
       spanIdCounts.set(spanID, idCount + 1);
       spanID = `${spanID}_${idCount}`;

--- a/public/app/features/explore/TraceView/createSpanLink.tsx
+++ b/public/app/features/explore/TraceView/createSpanLink.tsx
@@ -32,6 +32,7 @@ import { type ExploreFieldLinkModel, getFieldLinksForExplore, getVariableUsageIn
 import { type SpanLinkDef, type SpanLinkFunc, SpanLinkType } from './components/types/links';
 import { type Trace, type TraceSpan, type TraceSpanReference } from './components/types/trace';
 
+import { grafanaStructuredLogger } from '@grafana/runtime';
 /**
  * This is a factory for the link creator. It returns the function mainly so it can return undefined in which case
  * the trace view won't create any links and to capture the datasource and split function making it easier to memoize
@@ -123,7 +124,7 @@ export function createSpanLinkFactory({
         spanLinks.push.apply(spanLinks, newSpanLinks);
       } catch (error) {
         // It's fairly easy to crash here for example if data source defines wrong interpolation in the data link
-        console.error(error);
+        grafanaStructuredLogger.logError(error instanceof Error ? error : new Error(String(error)));
         return spanLinks;
       }
     }

--- a/public/app/features/explore/hooks/useExplorePageContext.ts
+++ b/public/app/features/explore/hooks/useExplorePageContext.ts
@@ -6,6 +6,7 @@ import { getDataSourceSrv } from '@grafana/runtime';
 import { type DataQuery } from '@grafana/schema';
 import { type ExploreItemState } from 'app/types/explore';
 
+import { grafanaStructuredLogger } from '@grafana/runtime';
 export function useExplorePageContext(panes: Array<[string, ExploreItemState]>): void {
   const setContext = useProvidePageContext(/^\/explore/);
 
@@ -99,7 +100,7 @@ function getDisplayText(query: DataQuery, ds?: DataSourceApi): string | undefine
   try {
     return ds?.getQueryDisplayText?.(query);
   } catch (error) {
-    console.error(error);
+    grafanaStructuredLogger.logError(error instanceof Error ? error : new Error(String(error)));
     return undefined;
   }
 }

--- a/public/app/features/explore/state/correlations.ts
+++ b/public/app/features/explore/state/correlations.ts
@@ -13,6 +13,7 @@ import { saveCorrelationsAction } from './explorePane';
 import { splitClose } from './main';
 import { runQueries } from './query';
 
+import { grafanaStructuredLogger } from '@grafana/runtime';
 /**
  * Creates an observable that emits correlations once they are loaded
  */
@@ -95,7 +96,7 @@ export function saveCurrentCorrelation(
         })
         .catch((err) => {
           dispatch(notifyApp(createErrorNotification('Error creating correlation', err)));
-          console.error(err);
+          grafanaStructuredLogger.logError(err instanceof Error ? err : new Error(String(err)));
         });
     }
   };

--- a/public/app/features/explore/state/query.ts
+++ b/public/app/features/explore/state/query.ts
@@ -65,6 +65,7 @@ import { changeCorrelationEditorDetails } from './main';
 import { updateTime } from './time';
 import { createCacheKey, filterLogRowsByIndex, getCorrelationsData, getResultsFromCache } from './utils';
 
+import { grafanaStructuredLogger } from '@grafana/runtime';
 /**
  * Derives from explore state if a given Explore pane is waiting for more data to be received
  */
@@ -657,7 +658,7 @@ export const runQueries = createAsyncThunk<void, RunQueriesOptions>(
 
           // Keep scanning for results if this was the last scanning transaction
           if (exploreState!.scanning) {
-            console.log(data.series);
+            grafanaStructuredLogger.logInfo(String(data.series));
             if (data.state === LoadingState.Done && data.series.length === 0) {
               const range = getShiftedTimeRange(-1, exploreState!.range);
               dispatch(updateTime({ exploreId, absoluteRange: range }));
@@ -671,7 +672,7 @@ export const runQueries = createAsyncThunk<void, RunQueriesOptions>(
         error(error) {
           dispatch(notifyApp(createErrorNotification('Query processing error', error)));
           dispatch(changeLoadingStateAction({ exploreId, loadingState: LoadingState.Error }));
-          console.error(error);
+          grafanaStructuredLogger.logError(error instanceof Error ? error : new Error(String(error)));
         },
         complete() {
           // In case we don't get any response at all but the observable completed, make sure we stop loading state.
@@ -793,7 +794,7 @@ export const runLoadMoreLogsQueries = createAsyncThunk<void, RunLoadMoreLogsQuer
       error(error) {
         dispatch(notifyApp(createErrorNotification('Query processing error', error)));
         dispatch(changeLoadingStateAction({ exploreId, loadingState: LoadingState.Error }));
-        console.error(error);
+        grafanaStructuredLogger.logError(error instanceof Error ? error : new Error(String(error)));
       },
       complete() {
         dispatch(changeLoadingStateAction({ exploreId, loadingState: LoadingState.Done }));

--- a/public/app/features/explore/state/utils.ts
+++ b/public/app/features/explore/state/utils.ts
@@ -35,6 +35,7 @@ import { loadSupplementaryQueries } from '../utils/supplementaryQueries';
 
 import { DEFAULT_RANGE } from './constants';
 
+import { grafanaStructuredLogger } from '@grafana/runtime';
 export const MAX_HISTORY_AUTOCOMPLETE_ITEMS = 100;
 
 const GRAPH_STYLE_KEY = 'grafana.explore.style.graph';
@@ -118,7 +119,7 @@ export async function loadAndInitDatasource(
       instance.init();
     } catch (err) {
       // TODO: should probably be handled better
-      console.error(err);
+      grafanaStructuredLogger.logError(err instanceof Error ? err : new Error(String(err)));
     }
   }
 

--- a/public/app/features/expressions/components/QueryToolbox.tsx
+++ b/public/app/features/expressions/components/QueryToolbox.tsx
@@ -7,6 +7,7 @@ import { IconButton, useStyles2, Stack, InlineToast, Tooltip, Icon } from '@graf
 
 import { type SqlExpressionQuery } from '../types';
 
+import { grafanaStructuredLogger } from '@grafana/runtime';
 interface QueryToolboxProps {
   onFormatCode?: () => void;
   onExpand?: (isExpanded: boolean) => void;
@@ -39,7 +40,7 @@ export const QueryToolbox = ({ onFormatCode, onExpand, isExpanded, query }: Quer
       await navigator.clipboard.writeText(query.expression ?? '');
       setShowCopySuccess(true);
     } catch (e) {
-      console.error(e);
+      grafanaStructuredLogger.logError(e instanceof Error ? e : new Error(String(e)));
     }
   }, [query.expression]);
 

--- a/public/app/features/geo/gazetteer/gazetteer.ts
+++ b/public/app/features/geo/gazetteer/gazetteer.ts
@@ -8,6 +8,7 @@ import { pointFieldFromLonLat, pointFieldFromGeohash } from '../format/utils';
 
 import { loadWorldmapPoints } from './worldmap';
 
+import { grafanaStructuredLogger } from '@grafana/runtime';
 export interface PlacenameInfo {
   point: () => Point | undefined; // lon, lat (WGS84)
   geometry: () => Geometry | undefined;
@@ -199,7 +200,7 @@ export async function getGazetteer(path?: string): Promise<Gazetteer> {
       const data = await response.json();
       lookup = loadGazetteer(path, data);
     } catch (err) {
-      console.warn('Error loading placename lookup', path, err);
+      grafanaStructuredLogger.logWarning(String('Error loading placename lookup'), { args: path, err });
       lookup = {
         path,
         error: 'Error loading URL',

--- a/public/app/features/inspector/InspectJSONTab.tsx
+++ b/public/app/features/inspector/InspectJSONTab.tsx
@@ -20,6 +20,7 @@ import { reportPanelInspectInteraction } from '../search/page/reporting';
 import { InspectTab } from './types';
 import { getPrettyJSON } from './utils/utils';
 
+import { grafanaStructuredLogger } from '@grafana/runtime';
 enum ShowContent {
   PanelJSON = 'panel',
   PanelData = 'data',
@@ -104,7 +105,7 @@ export function InspectJSONTab({ panel, dashboard, data, onClose }: Props) {
           appEvents.emit(AppEvents.alertSuccess, ['Panel model updated']);
         }
       } catch (err) {
-        console.error('Error applying updates', err);
+        grafanaStructuredLogger.logError(err instanceof Error ? err : new Error(String(err)), { message: String('Error applying updates') });
         appEvents.emit(AppEvents.alertError, ['Invalid JSON text']);
       }
 

--- a/public/app/features/library-panels/components/LibraryPanelsView/actions.ts
+++ b/public/app/features/library-panels/components/LibraryPanelsView/actions.ts
@@ -7,6 +7,7 @@ import { deleteLibraryPanel as apiDeleteLibraryPanel, getLibraryPanels } from '.
 
 import { initialLibraryPanelsViewState, initSearch, searchCompleted } from './reducer';
 
+import { grafanaStructuredLogger } from '@grafana/runtime';
 type SearchDispatchResult = (dispatch: Dispatch<Action>, abortController?: AbortController) => void;
 
 interface SearchArgs {
@@ -54,7 +55,7 @@ export function searchForLibraryPanels(args: SearchArgs): SearchDispatchResult {
         }
 
         // For real errors, log and show error to user
-        console.error('Error fetching library panels:', err);
+        grafanaStructuredLogger.logError(err instanceof Error ? err : new Error(String(err)), { message: String('Error fetching library panels:') });
 
         // Update state to show empty results
         return of(searchCompleted({ ...initialLibraryPanelsViewState, page: args.page, perPage: args.perPage }));
@@ -78,7 +79,7 @@ export function deleteLibraryPanel(uid: string, args: SearchArgs) {
       await apiDeleteLibraryPanel(uid);
       searchForLibraryPanels(args)(dispatch);
     } catch (e) {
-      console.error(e);
+      grafanaStructuredLogger.logError(e instanceof Error ? e : new Error(String(e)));
     }
   };
 }

--- a/public/app/features/live/centrifuge/LiveDataStream.ts
+++ b/public/app/features/live/centrifuge/LiveDataStream.ts
@@ -17,6 +17,7 @@ import {
   type LiveDataStreamOptions,
   StreamingFrameAction,
   type StreamingFrameOptions,
+  grafanaStructuredLogger,
   toDataQueryError,
 } from '@grafana/runtime';
 
@@ -154,7 +155,10 @@ export class LiveDataStream<T = unknown> {
   };
 
   private onError = (err: unknown) => {
-    console.log('LiveQuery [error]', { err }, this.deps.channelId);
+    grafanaStructuredLogger.logInfo('LiveQuery [error]', {
+      channelId: this.deps.channelId,
+      detail: String(err instanceof Error ? err.message : err),
+    });
     this.stream.next({
       type: InternalStreamMessageType.Error,
       error: toDataQueryError(err),
@@ -163,7 +167,7 @@ export class LiveDataStream<T = unknown> {
   };
 
   private onComplete = () => {
-    console.log('LiveQuery [complete]', this.deps.channelId);
+    grafanaStructuredLogger.logInfo('LiveQuery [complete]', { channelId: this.deps.channelId });
     this.shutdown();
   };
 
@@ -280,7 +284,7 @@ export class LiveDataStream<T = unknown> {
       }
 
       if (!messages.length) {
-        console.warn(`expected to find at least one non error message ${messages.map(({ type }) => type)}`);
+        grafanaStructuredLogger.logWarning(`expected to find at least one non error message ${messages.map(({ type }) => type)}`);
         // send empty frame
         return {
           key: subKey,
@@ -358,7 +362,7 @@ export class LiveDataStream<T = unknown> {
 
         const newValueSameSchemaMessages = filterMessages(messages, InternalStreamMessageType.NewValuesSameSchema);
         if (newValueSameSchemaMessages.length !== messages.length) {
-          console.warn(`unsupported message type ${messages.map(({ type }) => type)}`);
+          grafanaStructuredLogger.logWarning(`unsupported message type ${messages.map(({ type }) => type)}`);
         }
 
         return getNewValuesSameSchemaResponseData(newValueSameSchemaMessages);

--- a/public/app/features/live/centrifuge/channel.ts
+++ b/public/app/features/live/centrifuge/channel.ts
@@ -20,6 +20,7 @@ import {
   isValidLiveChannelAddress,
 } from '@grafana/data';
 
+import { grafanaStructuredLogger } from '@grafana/runtime';
 /**
  * Internal class that maps Centrifuge support to GrafanaLive
  */
@@ -81,7 +82,7 @@ export class CentrifugeLiveChannel<T = any> {
           this.sendStatus();
         }
       } catch (err) {
-        console.log('publish error', this.addr, err);
+        grafanaStructuredLogger.logInfo(String('publish error'), { args: this.addr, err });
         this.currentStatus.error = err;
         this.currentStatus.timestamp = Date.now();
         this.sendStatus();

--- a/public/app/features/live/centrifuge/service.ts
+++ b/public/app/features/live/centrifuge/service.ts
@@ -34,6 +34,7 @@ import { type StreamingResponseData } from '../data/utils';
 import { LiveDataStream } from './LiveDataStream';
 import { CentrifugeLiveChannel } from './channel';
 
+import { grafanaStructuredLogger } from '@grafana/runtime';
 export type CentrifugeSrvDeps = {
   grafanaAuthToken: string | null;
   appUrl: string;
@@ -126,7 +127,7 @@ export class CentrifugeService implements CentrifugeSrv {
   };
 
   private onServerSideMessage = (context: ServerPublicationContext) => {
-    console.log('Publication from server-side channel', context);
+    grafanaStructuredLogger.logInfo(String('Publication from server-side channel'), { args: context });
   };
 
   private onError = (context: ErrorContext) => {

--- a/public/app/features/live/dashboard/dashboardWatcher.ts
+++ b/public/app/features/live/dashboard/dashboardWatcher.ts
@@ -20,6 +20,7 @@ import { getDashboardSrv } from '../../dashboard/services/DashboardSrv';
 import { DashboardChangedModal } from './DashboardChangedModal';
 import { type DashboardEvent, DashboardEventAction } from './types';
 
+import { grafanaStructuredLogger } from '@grafana/runtime';
 // sessionId is not a security-sensitive value.
 // It is used for filtering out dashboard edit events from the same browsing session
 const sessionId = uuidv4();
@@ -127,7 +128,7 @@ class DashboardWatcher {
 
             const dash = getDashboardSrv().getCurrent();
             if (dash?.uid !== event.message.uid) {
-              console.log('dashboard event for different dashboard?', event, dash);
+              grafanaStructuredLogger.logInfo(String('dashboard event for different dashboard?'), { args: event, dash });
               return;
             }
 

--- a/public/app/features/live/live.ts
+++ b/public/app/features/live/live.ts
@@ -1,7 +1,7 @@
 import { map } from 'rxjs';
 
 import { toLiveChannelId, StreamingDataFrame } from '@grafana/data';
-import { type BackendSrv, type GrafanaLiveSrv } from '@grafana/runtime';
+import { type BackendSrv, type GrafanaLiveSrv, grafanaStructuredLogger } from '@grafana/runtime';
 
 import { type CentrifugeSrv, type StreamingDataQueryResponse } from './centrifuge/service';
 import { isStreamingResponseData, StreamingResponseDataType } from './data/utils';
@@ -30,7 +30,7 @@ export class GrafanaLiveService implements GrafanaLiveSrv {
     const updateBuffer = (next: StreamingDataQueryResponse): void => {
       const data = next.data[0];
       if (!buffer && !isStreamingResponseData(data, StreamingResponseDataType.FullFrame)) {
-        console.warn(`expected first packet to contain a full frame, received ${data?.type}`);
+        grafanaStructuredLogger.logWarning(`expected first packet to contain a full frame, received ${data?.type}`);
         return;
       }
 

--- a/public/app/features/logs/components/ControlledLogsTable.tsx
+++ b/public/app/features/logs/components/ControlledLogsTable.tsx
@@ -11,6 +11,7 @@ import { useLogListContext } from './panel/LogListContext';
 import { CONTROLS_WIDTH_EXPANDED, LogListControls } from './panel/LogListControls';
 import { LOG_LIST_CONTROLS_WIDTH } from './panel/virtualization';
 
+import { grafanaStructuredLogger } from '@grafana/runtime';
 export const ControlledLogsTable = ({
   loading,
   loadMoreLogs,
@@ -38,7 +39,7 @@ export const ControlledLogsTable = ({
   const styles = useStyles2(getStyles);
 
   if (!splitOpen || !width || !updatePanelState) {
-    console.error('<ControlledLogsTable>: Missing required props.');
+    grafanaStructuredLogger.logError(new Error('<ControlledLogsTable>: Missing required props.'));
     return;
   }
 

--- a/public/app/features/logs/components/fieldSelector/LogListFieldSelector.tsx
+++ b/public/app/features/logs/components/fieldSelector/LogListFieldSelector.tsx
@@ -4,7 +4,7 @@ import { useCallback, useLayoutEffect, useMemo, useState } from 'react';
 
 import { type DataFrame, store } from '@grafana/data';
 import { t } from '@grafana/i18n';
-import { reportInteraction } from '@grafana/runtime';
+import { reportInteraction, grafanaStructuredLogger } from '@grafana/runtime';
 import { getDragStyles, IconButton, useStyles2 } from '@grafana/ui';
 
 import { useLogListContext } from '../panel/LogListContext';
@@ -116,7 +116,7 @@ export const LogListFieldSelector = ({ containerElement, dataFrames, logs }: Log
   const fields = useMemo(() => getFieldsWithStats(dataFrames), [dataFrames]);
 
   if (!onClickShowField || !onClickHideField || !setDisplayedFields) {
-    console.warn(
+    grafanaStructuredLogger.logWarning(
       'LogListFieldSelector: Missing required props: onClickShowField, onClickHideField, setDisplayedFields'
     );
     return null;

--- a/public/app/features/logs/components/panel/grammar.ts
+++ b/public/app/features/logs/components/panel/grammar.ts
@@ -4,6 +4,7 @@ import { escapeRegex, parseFlags } from '@grafana/data';
 
 import { type LogListModel } from './processing';
 
+import { grafanaStructuredLogger } from '@grafana/runtime';
 // The Logs grammar is used for highlight in the logs panel
 const logsGrammar: Grammar = {
   'log-token-key': /(\b|\B)[\w_]+(?=\s*=)/gi,
@@ -64,7 +65,7 @@ export const generateTextMatchGrammar = (highlightWords: string[] | undefined = 
       try {
         return new RegExp(`(?:${cleaned})`, flags);
       } catch (e) {
-        console.error(`generateTextMatchGrammar: cannot generate regular expression from /${cleaned}/${flags}`, e);
+        grafanaStructuredLogger.logError(e instanceof Error ? e : new Error(String(e)), { message: String(`generateTextMatchGrammar: cannot generate regular expression from /${cleaned}/${flags}`) });
       }
       return undefined;
     })
@@ -74,7 +75,7 @@ export const generateTextMatchGrammar = (highlightWords: string[] | undefined = 
     try {
       expressions.push(new RegExp(escapeRegex(search), 'gi'));
     } catch (e) {
-      console.error(`generateTextMatchGrammar: cannot generate regular expression from /${search}/gi`, e);
+      grafanaStructuredLogger.logError(e instanceof Error ? e : new Error(String(e)), { message: String(`generateTextMatchGrammar: cannot generate regular expression from /${search}/gi`) });
     }
   }
   if (!expressions.length) {

--- a/public/app/features/logs/components/panel/panelState/getLogsPanelState.ts
+++ b/public/app/features/logs/components/panel/panelState/getLogsPanelState.ts
@@ -1,5 +1,6 @@
 import { urlUtil } from '@grafana/data';
 
+import { grafanaStructuredLogger } from '@grafana/runtime';
 interface LogsPermalinkUrlState {
   logs?: {
     id?: string;
@@ -18,7 +19,7 @@ export function getLogsPanelState(): LogsPermalinkUrlState | undefined {
     try {
       return JSON.parse(panelStateEncoded[0]);
     } catch (e) {
-      console.error('error parsing logsPanelState', e);
+      grafanaStructuredLogger.logError(e instanceof Error ? e : new Error(String(e)), { message: String('error parsing logsPanelState') });
     }
   }
 

--- a/public/app/features/logs/components/panel/virtualization.ts
+++ b/public/app/features/logs/components/panel/virtualization.ts
@@ -6,6 +6,7 @@ import { type LogLineTimestampResolution } from './LogLine';
 import { type LogListFontSize } from './LogList';
 import { type LogListModel } from './processing';
 
+import { grafanaStructuredLogger } from '@grafana/runtime';
 export const LOG_LIST_MIN_WIDTH = 35 * 8;
 // Controls the space between fields in the log line, timestamp, level, displayed fields, and log line body
 export const FIELD_GAP_MULTIPLIER = 1.5;
@@ -73,7 +74,7 @@ export class LogLineVirtualization {
     const domCharWidth = this.measureTextWidthWithDOM('e');
     const diff = domCharWidth - canvasCharWidth;
     if (diff >= 0.1) {
-      console.warn('Virtualized log list: falling back to DOM for measurement');
+      grafanaStructuredLogger.logWarning(String('Virtualized log list: falling back to DOM for measurement'));
       this.measurementMode = 'dom';
     }
   };

--- a/public/app/features/logs/utils.ts
+++ b/public/app/features/logs/utils.ts
@@ -42,6 +42,7 @@ import { getDataframeFields } from './components/logParser';
 import { type GetRowContextQueryFn } from './components/panel/LogLineMenu';
 import { DATAPLANE_LABELS_NAME, DATAPLANE_LABEL_TYPES_NAME, parseLogsFrame } from './logsFrame';
 
+import { grafanaStructuredLogger } from '@grafana/runtime';
 /**
  * Returns the log level of a log line.
  * Parse the line for level words. If no level is found, it returns `LogLevel.unknown`.
@@ -368,10 +369,10 @@ export function getLogLevelInfo(dataFrame: DataFrame, allDataFrames: DataFrame[]
   const valueField = fieldCache.getFirstFieldOfType(FieldType.number);
 
   if (!timeField) {
-    console.error('Time field missing in data frame');
+    grafanaStructuredLogger.logError(new Error('Time field missing in data frame'));
   }
   if (!valueField) {
-    console.error('Value field missing in data frame');
+    grafanaStructuredLogger.logError(new Error('Value field missing in data frame'));
   }
 
   const level = valueField ? getFieldDisplayName(valueField, dataFrame, allDataFrames) : 'logs';

--- a/public/app/features/panel/panellinks/linkSuppliers.ts
+++ b/public/app/features/panel/panellinks/linkSuppliers.ts
@@ -18,6 +18,7 @@ import { dashboardSceneGraph } from 'app/features/dashboard-scene/utils/dashboar
 
 import { getLinkSrv } from './link_srv';
 
+import { grafanaStructuredLogger } from '@grafana/runtime';
 interface SeriesVars {
   name?: string;
   refId?: string;
@@ -124,7 +125,7 @@ export const getFieldLinksSupplier = (value: FieldDisplay): LinkModelSupplier<Fi
           };
         }
       } else {
-        console.log('VALUE', value);
+        grafanaStructuredLogger.logInfo(String('VALUE'), { args: value });
       }
 
       const replace: InterpolateFunction = (value: string, vars: ScopedVars | undefined, fmt?: string | Function) => {

--- a/public/app/features/panel/state/actions.ts
+++ b/public/app/features/panel/state/actions.ts
@@ -9,6 +9,7 @@ import { type ThunkResult } from 'app/types/store';
 
 import { changePanelKey, panelModelAndPluginReady, removePanel } from './reducers';
 
+import { grafanaStructuredLogger } from '@grafana/runtime';
 export function initPanelState(panel: PanelModel): ThunkResult<Promise<void>> {
   return async (dispatch, getStore) => {
     if (panel.libraryPanel?.uid && !('model' in panel.libraryPanel)) {
@@ -165,7 +166,7 @@ export function loadLibraryPanelAndUpdate(panel: PanelModel): ThunkResult<void> 
 
       await dispatch(initPanelState(panel));
     } catch (ex) {
-      console.log('ERROR: ', ex);
+      grafanaStructuredLogger.logInfo(String('ERROR: '), { args: ex });
       dispatch(
         panelModelAndPluginReady({
           key: panel.key,

--- a/public/app/features/panel/suggestions/getAllSuggestions.ts
+++ b/public/app/features/panel/suggestions/getAllSuggestions.ts
@@ -17,6 +17,7 @@ import { importPanelPlugin } from 'app/features/plugins/importPanelPlugin';
 
 import { panelsToCheckFirst } from './consts';
 
+import { grafanaStructuredLogger } from '@grafana/runtime';
 interface PluginLoadResult {
   plugins: PanelPlugin[];
   hasErrors: boolean;
@@ -58,7 +59,7 @@ export async function loadPlugins(pluginIds: string[]): Promise<PluginLoadResult
       plugins.push(settled.value);
     } else {
       const pluginId = pluginIds[i];
-      console.error(`Failed to load ${pluginId} for visualization suggestions:`, settled.reason);
+      grafanaStructuredLogger.logError(settled.reason instanceof Error ? settled.reason : new Error(String(settled.reason)), { message: String(`Failed to load ${pluginId} for visualization suggestions:`) });
 
       if (await isBuiltInPlugin(pluginId)) {
         hasErrors = true;
@@ -163,7 +164,7 @@ export async function getAllSuggestions(series?: DataFrame[]): Promise<Suggestio
         list.push(...suggestions);
       }
     } catch (e) {
-      console.warn(`error when loading suggestions from plugin "${plugin.meta.id}"`, e);
+      grafanaStructuredLogger.logWarning(String(`error when loading suggestions from plugin "${plugin.meta.id}"`), { args: e });
       pluginSuggestionsError = true;
     }
   }

--- a/public/app/features/plugins/admin/api.ts
+++ b/public/app/features/plugins/admin/api.ts
@@ -17,6 +17,7 @@ import {
   type ProvisionedPlugin,
 } from './types';
 
+import { grafanaStructuredLogger } from '@grafana/runtime';
 export async function getPluginDetails(id: string): Promise<CatalogPluginDetails> {
   const remote = await getRemotePlugin(id);
   const isPublished = Boolean(remote);
@@ -92,7 +93,7 @@ export async function getRemotePlugins(): Promise<RemotePlugin[]> {
     if (isFetchError(error)) {
       // It can happen that GCOM is not available, in that case we show a limited set of information to the user.
       error.isHandled = true;
-      console.error('Failed to fetch plugins from catalog (default https://grafana.com/api/plugins)');
+      grafanaStructuredLogger.logError(new Error('Failed to fetch plugins from catalog (default https://grafana.com/api/plugins)'));
       return [];
     }
 

--- a/public/app/features/plugins/admin/components/GetStartedWithPlugin/GetStartedWithApp.tsx
+++ b/public/app/features/plugins/admin/components/GetStartedWithPlugin/GetStartedWithApp.tsx
@@ -11,6 +11,7 @@ import { updatePluginSettings } from '../../api';
 import { usePluginConfig } from '../../hooks/usePluginConfig';
 import { type CatalogPlugin } from '../../types';
 
+import { grafanaStructuredLogger } from '@grafana/runtime';
 type Props = {
   plugin: CatalogPlugin;
 };
@@ -80,6 +81,6 @@ const updatePluginSettingsAndReload = async (id: string, data: Partial<PluginMet
     // Reloading the page as the plugin meta changes made here wouldn't be propagated throughout the app.
     window.location.reload();
   } catch (e) {
-    console.error('Error while updating the plugin', e);
+    grafanaStructuredLogger.logError(e instanceof Error ? e : new Error(String(e)), { message: String('Error while updating the plugin') });
   }
 };

--- a/public/app/features/plugins/admin/pages/Browse.tsx
+++ b/public/app/features/plugins/admin/pages/Browse.tsx
@@ -22,6 +22,7 @@ import { Sorters } from '../helpers';
 import { useHistory } from '../hooks/useHistory';
 import { useGetAll, useGetUpdatable, useIsRemotePluginsAvailable } from '../state/hooks';
 
+import { grafanaStructuredLogger } from '@grafana/runtime';
 export default function Browse() {
   const location = useLocation();
   const locationSearch = locationSearchToObject(location.search);
@@ -72,7 +73,7 @@ export default function Browse() {
 
   // How should we handle errors?
   if (error) {
-    console.error(error.message);
+    grafanaStructuredLogger.logError(error.message instanceof Error ? error.message : new Error(String(error.message)));
     return null;
   }
 

--- a/public/app/features/plugins/admin/state/actions.ts
+++ b/public/app/features/plugins/admin/state/actions.ts
@@ -30,6 +30,7 @@ import {
   PluginStatus,
 } from '../types';
 
+import { grafanaStructuredLogger } from '@grafana/runtime';
 // Fetches
 export const fetchAll = createAsyncThunk(`${STATE_PREFIX}/fetchAll`, async (_, thunkApi) => {
   try {
@@ -46,7 +47,7 @@ export const fetchAll = createAsyncThunk(`${STATE_PREFIX}/fetchAll`, async (_, t
     const remote$ = from(getRemotePlugins()).pipe(
       catchError((err) => {
         thunkApi.dispatch({ type: `${STATE_PREFIX}/fetchRemote/rejected` });
-        console.error(err);
+        grafanaStructuredLogger.logError(err instanceof Error ? err : new Error(String(err)));
         return of([]);
       })
     );
@@ -121,7 +122,7 @@ export const fetchAll = createAsyncThunk(`${STATE_PREFIX}/fetchAll`, async (_, t
           }
         },
         (error) => {
-          console.log(error);
+          grafanaStructuredLogger.logInfo(String(error));
           thunkApi.dispatch({ type: `${STATE_PREFIX}/fetchLocal/rejected` });
           thunkApi.dispatch({ type: `${STATE_PREFIX}/fetchRemote/rejected` });
           return thunkApi.rejectWithValue('Unknown error.');
@@ -235,7 +236,7 @@ export const install = createAsyncThunk<
 
     return { id, changes };
   } catch (e) {
-    console.error(e);
+    grafanaStructuredLogger.logError(e instanceof Error ? e : new Error(String(e)));
     if (isFetchError(e)) {
       // add id to identify errors in multiple requests
       e.data.id = id;
@@ -262,7 +263,7 @@ export const uninstall = createAsyncThunk<Update<CatalogPlugin, string>, string>
         changes: { isInstalled: false, installedVersion: undefined, isFullyInstalled: false },
       };
     } catch (e) {
-      console.error(e);
+      grafanaStructuredLogger.logError(e instanceof Error ? e : new Error(String(e)));
 
       return thunkApi.rejectWithValue('Unknown error.');
     }

--- a/public/app/features/plugins/components/AppRootPage.tsx
+++ b/public/app/features/plugins/components/AppRootPage.tsx
@@ -41,6 +41,7 @@ import { PluginErrorBoundary } from './PluginErrorBoundary';
 import { buildPluginPageContext, PluginPageContext } from './PluginPageContext';
 import { RestrictedGrafanaApisProvider } from './restrictedGrafanaApis/RestrictedGrafanaApisProvider';
 
+import { grafanaStructuredLogger } from '@grafana/runtime';
 interface Props {
   // The ID of the plugin we would like to load and display
   pluginId?: string;
@@ -249,7 +250,7 @@ async function loadAppPlugin(pluginId: string, dispatch: React.Dispatch<AnyActio
     );
     const error = err instanceof Error ? err : new Error(getMessageFromError(err));
     pluginsLogger.logError(error);
-    console.error(error);
+    grafanaStructuredLogger.logError(error instanceof Error ? error : new Error(String(error)));
   }
 }
 

--- a/public/app/features/plugins/components/PluginErrorBoundary.tsx
+++ b/public/app/features/plugins/components/PluginErrorBoundary.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 
 import { PluginContext } from '@grafana/data';
 
+import { grafanaStructuredLogger } from '@grafana/runtime';
 interface PluginErrorBoundaryProps {
   children: React.ReactNode;
   fallback?: React.ComponentType<{ error: Error | null; errorInfo: React.ErrorInfo | null }>;
@@ -32,7 +33,10 @@ export class PluginErrorBoundary extends React.Component<PluginErrorBoundaryProp
     if (this.props.onError) {
       this.props.onError(error, info);
     } else {
-      console.error(`Plugin "${this.context?.meta.id}" failed to load:`, error, info);
+      grafanaStructuredLogger.logError(error, {
+        detail: `Plugin "${this.context?.meta.id}" failed to load`,
+        componentStack: info.componentStack,
+      });
     }
 
     this.setState({ error, errorInfo: info });

--- a/public/app/features/plugins/components/restrictedGrafanaApis/dashboardMutation/dashboardMutationApi.ts
+++ b/public/app/features/plugins/components/restrictedGrafanaApis/dashboardMutation/dashboardMutationApi.ts
@@ -17,6 +17,7 @@ import type { MutationClient, MutationRequest } from 'app/features/dashboard-sce
 import { provideMutationClientFactory } from 'app/features/dashboard-scene/scene/DashboardMutationClientSetter';
 import type { DashboardScene } from 'app/features/dashboard-scene/scene/DashboardScene';
 
+import { grafanaStructuredLogger } from '@grafana/runtime';
 let _client: MutationClient | null = null;
 
 provideMutationClientFactory((sceneObject) => {
@@ -26,7 +27,7 @@ provideMutationClientFactory((sceneObject) => {
   try {
     _client = new DashboardMutationClient(scene);
   } catch (error) {
-    console.error('Failed to register Dashboard Mutation API:', error);
+    grafanaStructuredLogger.logError(error instanceof Error ? error : new Error(String(error)), { message: String('Failed to register Dashboard Mutation API:') });
   }
 
   return () => {

--- a/public/app/features/plugins/extensions/logs/LogViewFilters.tsx
+++ b/public/app/features/plugins/extensions/logs/LogViewFilters.tsx
@@ -6,6 +6,7 @@ import { t } from '@grafana/i18n';
 import { type SceneDataProvider } from '@grafana/scenes';
 import { InlineField, InlineFieldRow, MultiSelect } from '@grafana/ui';
 
+import { grafanaStructuredLogger } from '@grafana/runtime';
 export type LogFilter = {
   pluginIds?: Set<string>;
   extensionPointIds?: Set<string>;
@@ -98,7 +99,7 @@ function useLogFilters(
 
   return useMemo(() => {
     if (data && data?.series.length > 1) {
-      console.warn('LogViewFilter does not support multiple series in query result.');
+      grafanaStructuredLogger.logWarning(String('LogViewFilter does not support multiple series in query result.'));
     }
 
     const frame = data?.series[0];

--- a/public/app/features/plugins/extensions/logs/log.ts
+++ b/public/app/features/plugins/extensions/logs/log.ts
@@ -3,7 +3,7 @@ import { nanoid } from 'nanoid';
 import { type Observable, ReplaySubject } from 'rxjs';
 
 import { type Labels, LogLevel } from '@grafana/data';
-import { config, createMonitoringLogger } from '@grafana/runtime';
+import { createMonitoringLogger } from '@grafana/runtime';
 
 export type ExtensionsLogItem = {
   level: LogLevel;
@@ -41,15 +41,11 @@ export class ExtensionsLog {
 
   warning(message: string, labels?: Labels): void {
     monitoringLogger.logWarning(message, { ...this.baseLabels, ...labels });
-    config.buildInfo.env === 'development' && console.warn(message, { ...this.baseLabels, ...labels });
     this.log(LogLevel.warning, message, labels);
   }
 
   error(message: string, labels?: Labels): void {
-    // TODO: If Faro has console instrumentation, then the following will track the same error message twice
-    // (first: `monitoringLogger.logError()`, second: `console.error()` which gets picked up by Faro)
     monitoringLogger.logError(new Error(message), { ...this.baseLabels, ...labels });
-    console.error(message, { ...this.baseLabels, ...labels });
     this.log(LogLevel.error, message, labels);
   }
 

--- a/public/app/features/plugins/extensions/utils.tsx
+++ b/public/app/features/plugins/extensions/utils.tsx
@@ -43,13 +43,14 @@ import { type ExtensionsLog, log as baseLog } from './logs/log';
 import { type AddedLinkRegistryItem } from './registry/AddedLinksRegistry';
 import { assertIsNotPromise, assertStringProps, isPromise } from './validators';
 
+import { grafanaStructuredLogger } from '@grafana/runtime';
 export function handleErrorsInFn(fn: Function, errorMessagePrefix = '') {
   return (...args: unknown[]) => {
     try {
       return fn(...args);
     } catch (e) {
       if (e instanceof Error) {
-        console.warn(`${errorMessagePrefix}${e.message}`);
+        grafanaStructuredLogger.logWarning(String(`${errorMessagePrefix}${e.message}`));
       }
     }
   };

--- a/public/app/features/plugins/importer/addTranslationsToI18n.ts
+++ b/public/app/features/plugins/importer/addTranslationsToI18n.ts
@@ -3,6 +3,7 @@ import { addResourceBundle } from '@grafana/i18n/internal';
 import { SystemJS } from '../loader/systemjs';
 import { resolveModulePath } from '../loader/utils';
 
+import { grafanaStructuredLogger } from '@grafana/runtime';
 interface AddTranslationsToI18nOptions {
   resolvedLanguage: string;
   fallbackLanguage: string;
@@ -21,29 +22,29 @@ export async function addTranslationsToI18n({
   const path = resolvedPath ?? fallbackPath;
 
   if (!path) {
-    console.warn(`Could not find any translation for plugin ${pluginId}`, { resolvedLanguage, fallbackLanguage });
+    grafanaStructuredLogger.logWarning(String(`Could not find any translation for plugin ${pluginId}`), { args: { resolvedLanguage, fallbackLanguage } });
     return;
   }
 
   try {
     const module = await SystemJS.import(resolveModulePath(path));
     if (!module.default) {
-      console.warn(`Could not find default export for plugin ${pluginId}`, {
+      grafanaStructuredLogger.logWarning(String(`Could not find default export for plugin ${pluginId}`), { args: {
         resolvedLanguage,
         fallbackLanguage,
         path,
-      });
+      } });
       return;
     }
 
     const language = resolvedPath ? resolvedLanguage : fallbackLanguage;
     addResourceBundle(language, pluginId, module.default);
   } catch (error) {
-    console.warn(`Could not load translation for plugin ${pluginId}`, {
+    grafanaStructuredLogger.logWarning(String(`Could not load translation for plugin ${pluginId}`), { args: {
       resolvedLanguage,
       fallbackLanguage,
       error,
       path,
-    });
+    } });
   }
 }

--- a/public/app/features/plugins/importer/importPluginModule.ts
+++ b/public/app/features/plugins/importer/importPluginModule.ts
@@ -13,6 +13,7 @@ import { pluginsLogger } from '../utils';
 import { addTranslationsToI18n } from './addTranslationsToI18n';
 import { type PluginImportInfo } from './types';
 
+import { grafanaStructuredLogger } from '@grafana/runtime';
 export async function importPluginModule({
   path,
   pluginId,
@@ -68,7 +69,7 @@ export async function importPluginModule({
 
   return SystemJS.import(modulePath).catch((e) => {
     let error = new Error('Could not load plugin', { cause: e });
-    console.error(error);
+    grafanaStructuredLogger.logError(error instanceof Error ? error : new Error(String(error)));
     pluginsLogger.logError(error, {
       path,
       pluginId,

--- a/public/app/features/plugins/importer/pluginImporter.ts
+++ b/public/app/features/plugins/importer/pluginImporter.ts
@@ -22,6 +22,7 @@ import { pluginsLogger } from '../utils';
 import { importPluginModule } from './importPluginModule';
 import { type PluginImporter, type PostImportStrategy, type PreImportStrategy } from './types';
 
+import { grafanaStructuredLogger } from '@grafana/runtime';
 const defaultPreImport: PreImportStrategy = (plugin) => {
   throwIfAngular(plugin);
   const fallbackLoadingStrategy = plugin.loadingStrategy ?? PluginLoadingStrategy.fetch;
@@ -54,7 +55,7 @@ const panelPluginPostImport: PostImportStrategy<PanelPlugin, PanelPluginMeta> = 
     throw new Error('missing export: plugin');
   } catch (error) {
     // TODO, maybe a different error plugin
-    console.warn('Error loading panel plugin: ' + meta.id, error);
+    grafanaStructuredLogger.logWarning(String('Error loading panel plugin: ' + meta.id), { args: error });
     return getPanelPluginLoadError(meta, error);
   }
 };

--- a/public/app/features/plugins/loader/systemjsHooks.ts
+++ b/public/app/features/plugins/loader/systemjsHooks.ts
@@ -12,6 +12,7 @@ import { sharedDependenciesMap } from './sharedDependencies';
 import { type SystemJSWithLoaderHooks } from './types';
 import { buildImportMap, isHostedOnCDN } from './utils';
 
+import { grafanaStructuredLogger } from '@grafana/runtime';
 export function initSystemJSHooks() {
   const imports = buildImportMap(sharedDependenciesMap);
 
@@ -102,7 +103,7 @@ export function decorateSystemJSResolve(
       const url = originalResolve.apply(this, [resolvedUrl, parentUrl]);
       return resolvePluginUrlWithCache(url);
     }
-    console.warn(`SystemJS: failed to resolve '${id}'`);
+    grafanaStructuredLogger.logWarning(String(`SystemJS: failed to resolve '${id}'`));
     return id;
   }
 }

--- a/public/app/features/plugins/loader/utils.ts
+++ b/public/app/features/plugins/loader/utils.ts
@@ -5,6 +5,7 @@ import { sandboxPluginDependencies } from '../sandbox/pluginDependencies';
 import { SHARED_DEPENDENCY_PREFIX } from './constants';
 import { SystemJS } from './systemjs';
 
+import { grafanaStructuredLogger } from '@grafana/runtime';
 export function buildImportMap(importMap: Record<string, System.Module>) {
   return Object.keys(importMap).reduce<Record<string, string>>((acc, key) => {
     // Use the 'package:' prefix to act as a URL instead of a bare specifier
@@ -29,7 +30,7 @@ function addPreload(id: string, preload: (() => Promise<System.Module>) | System
   try {
     resolvedId = SystemJS.resolve(id);
   } catch (e) {
-    console.log(e);
+    grafanaStructuredLogger.logInfo(String(e));
   }
 
   if (resolvedId && SystemJS.has(resolvedId)) {

--- a/public/app/features/plugins/pluginPreloader.ts
+++ b/public/app/features/plugins/pluginPreloader.ts
@@ -9,6 +9,7 @@ import { getPluginSettings } from 'app/features/plugins/pluginSettings';
 
 import { pluginImporter } from './importer/pluginImporter';
 
+import { grafanaStructuredLogger } from '@grafana/runtime';
 export type PluginPreloadResult = {
   pluginId: string;
   error?: unknown;
@@ -46,6 +47,6 @@ async function preload(config: AppPluginConfig): Promise<void> {
       return;
     }
 
-    console.error(`[Plugins] Failed to preload plugin: ${config.path} (version: ${config.version})`, error);
+    grafanaStructuredLogger.logError(error instanceof Error ? error : new Error(String(error)), { message: String(`[Plugins] Failed to preload plugin: ${config.path} (version: ${config.version})`) });
   }
 }

--- a/public/app/features/plugins/sandbox/distortions.ts
+++ b/public/app/features/plugins/sandbox/distortions.ts
@@ -10,6 +10,7 @@ import { recursivePatchObjectAsLiveTarget } from './documentSandbox';
 import { type SandboxEnvironment, type SandboxPluginMeta } from './types';
 import { logWarning, unboxRegexesFromMembraneProxy } from './utils';
 
+import { grafanaStructuredLogger } from '@grafana/runtime';
 /**
  * Distortions are near-membrane mechanisms to altert JS instrics and DOM APIs.
  *
@@ -140,7 +141,7 @@ function distortConsole(distortions: DistortionMap) {
       const pluginId = meta.id;
 
       function sandboxLog(...args: unknown[]) {
-        console.log(`[plugin ${pluginId}]`, ...args);
+        grafanaStructuredLogger.logInfo(`[plugin ${pluginId}]`, { values: args });
       }
       return {
         log: sandboxLog,
@@ -170,7 +171,7 @@ function distortAlert(distortions: DistortionMap) {
     });
 
     return function (...args: unknown[]) {
-      console.log(`[plugin ${pluginId}]`, ...args);
+      grafanaStructuredLogger.logInfo(`[plugin ${pluginId}]`, { values: args });
     };
   }
   const descriptor = Object.getOwnPropertyDescriptor(window, 'alert');

--- a/public/app/features/plugins/sandbox/sandboxPluginLoader.ts
+++ b/public/app/features/plugins/sandbox/sandboxPluginLoader.ts
@@ -25,6 +25,7 @@ import {
 } from './types';
 import { logError, logInfo } from './utils';
 
+import { grafanaStructuredLogger } from '@grafana/runtime';
 // Loads near membrane custom formatter for near membrane proxy objects.
 if (process.env.NODE_ENV !== 'production') {
   require('@locker/near-membrane-dom/custom-devtools-formatter');
@@ -139,9 +140,7 @@ async function doImportPluginModuleInSandbox(meta: SandboxPluginMeta): Promise<S
               `Error in ${meta.id}: Plugins should not use window.grafanaBootData. Use "config" from "@grafana/runtime" instead.`
             );
           } else {
-            console.error(
-              `${meta.id.toUpperCase()}: Plugins should not use window.grafanaBootData. Use "config" from "@grafana/runtime" instead.`
-            );
+            grafanaStructuredLogger.logError(new Error(`${meta.id.toUpperCase()}: Plugins should not use window.grafanaBootData. Use "config" from "@grafana/runtime" instead.`));
           }
           return config.bootData;
         },

--- a/public/app/features/profile/api.ts
+++ b/public/app/features/profile/api.ts
@@ -4,11 +4,12 @@ import { type UserDTO, type UserOrg, type UserSession } from 'app/types/user';
 
 import { type ChangePasswordFields, type ProfileUpdateFields } from './types';
 
+import { grafanaStructuredLogger } from '@grafana/runtime';
 async function changePassword(payload: ChangePasswordFields): Promise<void> {
   try {
     await getBackendSrv().put('/api/user/password', payload);
   } catch (err) {
-    console.error(err);
+    grafanaStructuredLogger.logError(err instanceof Error ? err : new Error(String(err)));
   }
 }
 
@@ -42,7 +43,7 @@ async function updateUserProfile(payload: ProfileUpdateFields): Promise<void> {
   try {
     await getBackendSrv().put('/api/user', payload);
   } catch (err) {
-    console.error(err);
+    grafanaStructuredLogger.logError(err instanceof Error ? err : new Error(String(err)));
   }
 }
 

--- a/public/app/features/provisioning/utils/sourceLink.ts
+++ b/public/app/features/provisioning/utils/sourceLink.ts
@@ -16,6 +16,7 @@ import { isValidRepoType } from '../guards';
 
 import { getHasTokenInstructions, getRepoFileUrl } from './git';
 
+import { grafanaStructuredLogger } from '@grafana/runtime';
 /**
  * Find and remove existing source links from the links array.
  * A source link is identified by its tooltip matching the source link tooltip translation.
@@ -83,7 +84,7 @@ export async function buildSourceLink(annotations: ObjectMeta['annotations']): P
       keepTime: false,
     };
   } catch (e) {
-    console.warn('Failed to fetch repository info for source link:', e);
+    grafanaStructuredLogger.logWarning(String('Failed to fetch repository info for source link:'), { args: e });
     return undefined;
   }
 }

--- a/public/app/features/query/components/QueryGroup.tsx
+++ b/public/app/features/query/components/QueryGroup.tsx
@@ -36,6 +36,7 @@ import { GroupActionComponents } from './QueryActionComponent';
 import { QueryEditorRows } from './QueryEditorRows';
 import { QueryGroupOptionsEditor } from './QueryGroupOptions';
 
+import { grafanaStructuredLogger } from '@grafana/runtime';
 export interface Props {
   queryRunner: PanelQueryRunner;
   options: QueryGroupOptions;
@@ -123,7 +124,7 @@ export class QueryGroup extends PureComponent<Props, State> {
         defaultDataSource,
       });
     } catch (error) {
-      console.error('failed to load data source', error);
+      grafanaStructuredLogger.logError(error instanceof Error ? error : new Error(String(error)), { message: String('failed to load data source') });
     }
   }
 

--- a/public/app/features/query/state/DashboardQueryRunner/LegacyAnnotationQueryRunner.ts
+++ b/public/app/features/query/state/DashboardQueryRunner/LegacyAnnotationQueryRunner.ts
@@ -7,6 +7,7 @@ import { shouldUseLegacyRunner } from 'app/features/annotations/standardAnnotati
 import { type AnnotationQueryRunner, type AnnotationQueryRunnerOptions } from './types';
 import { handleAnnotationQueryRunnerError } from './utils';
 
+import { grafanaStructuredLogger } from '@grafana/runtime';
 export class LegacyAnnotationQueryRunner implements AnnotationQueryRunner {
   canRun(datasource?: DataSourceApi): boolean {
     if (!datasource) {
@@ -26,13 +27,13 @@ export class LegacyAnnotationQueryRunner implements AnnotationQueryRunner {
     }
 
     if (datasource?.annotationQuery === undefined) {
-      console.warn('datasource does not have an annotation query');
+      grafanaStructuredLogger.logWarning(String('datasource does not have an annotation query'));
       return of([]);
     }
 
     const annotationQuery = datasource.annotationQuery({ range, rangeRaw: range.raw, annotation, dashboard });
     if (annotationQuery === undefined) {
-      console.warn('datasource does not have an annotation query');
+      grafanaStructuredLogger.logWarning(String('datasource does not have an annotation query'));
       return of([]);
     }
 

--- a/public/app/features/query/state/DashboardQueryRunner/utils.ts
+++ b/public/app/features/query/state/DashboardQueryRunner/utils.ts
@@ -16,6 +16,7 @@ import { notifyApp } from '../../../../core/reducers/appNotification';
 
 import { type DashboardQueryRunnerWorkerResult } from './types';
 
+import { grafanaStructuredLogger } from '@grafana/runtime';
 export function handleAnnotationQueryRunnerError(err: any): Observable<AnnotationEvent[]> {
   if (err.cancelled) {
     return of([]);
@@ -44,7 +45,7 @@ export function handleDashboardQueryRunnerWorkerError(err: any): Observable<Dash
 
 function notifyWithError(title: string, err: any) {
   const error = toDataQueryError(err);
-  console.error('handleAnnotationQueryRunnerError', error);
+  grafanaStructuredLogger.logError(error instanceof Error ? error : new Error(String(error)), { message: String('handleAnnotationQueryRunnerError') });
   const notification = createErrorNotification(title, error.message);
   dispatch(notifyApp(notification));
 }

--- a/public/app/features/query/state/PanelQueryRunner.ts
+++ b/public/app/features/query/state/PanelQueryRunner.ts
@@ -43,6 +43,7 @@ import { getDashboardQueryRunner } from './DashboardQueryRunner/DashboardQueryRu
 import { mergePanelAndDashData } from './mergePanelAndDashData';
 import { runRequest } from './runRequest';
 
+import { grafanaStructuredLogger } from '@grafana/runtime';
 export interface QueryRunnerOptions<
   TQuery extends DataQuery = DataQuery,
   TOptions extends DataSourceJsonData = DataSourceJsonData,
@@ -257,7 +258,7 @@ export class PanelQueryRunner {
         return { ...data, series, annotations };
       }),
       catchError((err) => {
-        console.warn('Error running transformation:', err);
+        grafanaStructuredLogger.logWarning(String('Error running transformation:'), { args: err });
         return of({
           ...data,
           state: LoadingState.Error,

--- a/public/app/features/query/state/QueryRunner.ts
+++ b/public/app/features/query/state/QueryRunner.ts
@@ -22,6 +22,7 @@ import { getNextRequestId } from './PanelQueryRunner';
 import { setStructureRevision } from './processing/revision';
 import { runRequest } from './runRequest';
 
+import { grafanaStructuredLogger } from '@grafana/runtime';
 export class QueryRunner implements QueryRunnerSrv {
   private subject: ReplaySubject<PanelData>;
   private subscription?: Unsubscribable;
@@ -113,7 +114,7 @@ export class QueryRunner implements QueryRunnerSrv {
             },
           });
         },
-        error: (error) => console.error('PanelQueryRunner Error', error),
+        error: (error) => grafanaStructuredLogger.logError(error instanceof Error ? error : new Error(String(error)), { message: String('PanelQueryRunner Error') }),
       });
   }
 

--- a/public/app/features/query/state/runRequest.ts
+++ b/public/app/features/query/state/runRequest.ts
@@ -27,6 +27,7 @@ import { type ExpressionQuery } from 'app/features/expressions/types';
 import { cancelNetworkRequestsOnUnsubscribe } from './processing/canceler';
 import { emitDataRequestEvent } from './queryAnalytics';
 
+import { grafanaStructuredLogger } from '@grafana/runtime';
 type MapOfResponsePackets = { [str: string]: DataQueryResponse };
 
 interface RunningQueryState {
@@ -161,7 +162,7 @@ export function runRequest(
     }),
     // handle errors
     catchError((err) => {
-      console.error('runRequest.catchError', err);
+      grafanaStructuredLogger.logError(err instanceof Error ? err : new Error(String(err)), { message: String('runRequest.catchError') });
       return of({
         ...state.panelData,
         state: LoadingState.Error,

--- a/public/app/features/scopes/ScopesApiClient.ts
+++ b/public/app/features/scopes/ScopesApiClient.ts
@@ -1,5 +1,5 @@
 import { type Scope, type ScopeDashboardBinding, type ScopeNode } from '@grafana/data';
-import { config } from '@grafana/runtime';
+import { config, grafanaStructuredLogger } from '@grafana/runtime';
 import { scopeAPIv0alpha1 } from 'app/api/clients/scope/v0alpha1';
 import { getMessageFromError } from 'app/core/utils/errors';
 import { dispatch } from 'app/store/store';
@@ -34,7 +34,7 @@ export class ScopesApiClient {
       // Check if the data is actually an error response (Kubernetes Status object)
       if (this.isStatusError(result.data)) {
         const errorMessage = getMessageFromError(result.data);
-        console.error(`Failed to fetch %s:`, context, errorMessage);
+        grafanaStructuredLogger.logError(new Error(errorMessage), { detail: `Failed to fetch ${context}` });
         return undefined;
       }
       return result.data;
@@ -42,7 +42,7 @@ export class ScopesApiClient {
 
     if ('error' in result) {
       const errorMessage = getMessageFromError(result.error);
-      console.error(`Failed to fetch %s:`, context, errorMessage);
+      grafanaStructuredLogger.logError(new Error(errorMessage), { detail: `Failed to fetch ${context}` });
     }
 
     return undefined;
@@ -54,7 +54,7 @@ export class ScopesApiClient {
       return this.extractDataOrHandleError(result, `scope: ${name}`);
     } catch (err) {
       const errorMessage = getMessageFromError(err);
-      console.error('Failed to fetch scope:', name, errorMessage);
+      grafanaStructuredLogger.logError(new Error(errorMessage), { detail: 'Failed to fetch scope', name });
       return undefined;
     } finally {
       // Unsubscribe for extra safety, even though with subscribe: false and awaiting,
@@ -74,20 +74,18 @@ export class ScopesApiClient {
 
       if (successfulScopes.length < scopesIds.length) {
         const failedCount = scopesIds.length - successfulScopes.length;
-        console.warn(
-          'Failed to fetch',
-          failedCount,
-          'of',
-          scopesIds.length,
-          'scope(s). Requested IDs:',
-          scopesIds.join(', ')
+        grafanaStructuredLogger.logWarning(
+          `Failed to fetch ${failedCount} of ${scopesIds.length} scope(s). Requested IDs: ${scopesIds.join(', ')}`
         );
       }
 
       return successfulScopes;
     } catch (err) {
       const errorMessage = getMessageFromError(err);
-      console.error('Failed to fetch multiple scopes:', scopesIds, errorMessage);
+      grafanaStructuredLogger.logError(new Error(errorMessage), {
+        detail: 'Failed to fetch multiple scopes',
+        scopeIds: scopesIds.join(', '),
+      });
       return [];
     }
   }
@@ -110,13 +108,13 @@ export class ScopesApiClient {
 
       if ('error' in result) {
         const errorMessage = getMessageFromError(result.error);
-        console.error('Failed to fetch multiple scope nodes:', names, errorMessage);
+        grafanaStructuredLogger.logError(new Error(errorMessage), { detail: 'Failed to fetch multiple scope nodes', names });
       }
 
       return [];
     } catch (err) {
       const errorMessage = getMessageFromError(err);
-      console.error('Failed to fetch multiple scope nodes:', names, errorMessage);
+      grafanaStructuredLogger.logError(new Error(errorMessage), { detail: 'Failed to fetch multiple scope nodes', names });
       return [];
     } finally {
       // Unsubscribe for extra safety, even though with subscribe: false and awaiting,
@@ -170,7 +168,7 @@ export class ScopesApiClient {
         }
         contextParts.push('limit=' + limit);
         const context = contextParts.join(', ');
-        console.error('Failed to fetch scope nodes:', context, errorMessage);
+        grafanaStructuredLogger.logError(new Error(errorMessage), { detail: 'Failed to fetch scope nodes', context });
       }
 
       return [];
@@ -185,7 +183,7 @@ export class ScopesApiClient {
       }
       contextParts.push('limit=' + limit);
       const context = contextParts.join(', ');
-      console.error('Failed to fetch scope nodes:', context, errorMessage);
+      grafanaStructuredLogger.logError(new Error(errorMessage), { detail: 'Failed to fetch scope nodes', context });
       return [];
     } finally {
       // Unsubscribe for extra safety, even though with subscribe: false and awaiting,
@@ -213,13 +211,13 @@ export class ScopesApiClient {
 
       if ('error' in result) {
         const errorMessage = getMessageFromError(result.error);
-        console.error('Failed to fetch dashboards for scopes:', scopeNames, errorMessage);
+        grafanaStructuredLogger.logError(new Error(errorMessage), { detail: 'Failed to fetch dashboards for scopes', scopeNames });
       }
 
       return [];
     } catch (err) {
       const errorMessage = getMessageFromError(err);
-      console.error('Failed to fetch dashboards for scopes:', scopeNames, errorMessage);
+      grafanaStructuredLogger.logError(new Error(errorMessage), { detail: 'Failed to fetch dashboards for scopes', scopeNames });
       return [];
     } finally {
       // Unsubscribe for extra safety, even though with subscribe: false and awaiting,
@@ -252,13 +250,13 @@ export class ScopesApiClient {
 
       if ('error' in result) {
         const errorMessage = getMessageFromError(result.error);
-        console.error('Failed to fetch scope navigations for scopes:', scopeNames, errorMessage);
+        grafanaStructuredLogger.logError(new Error(errorMessage), { detail: 'Failed to fetch scope navigations for scopes', scopeNames });
       }
 
       return [];
     } catch (err) {
       const errorMessage = getMessageFromError(err);
-      console.error('Failed to fetch scope navigations for scopes:', scopeNames, errorMessage);
+      grafanaStructuredLogger.logError(new Error(errorMessage), { detail: 'Failed to fetch scope navigations for scopes', scopeNames });
       return [];
     } finally {
       // Unsubscribe for extra safety, even though with subscribe: false and awaiting,
@@ -280,7 +278,7 @@ export class ScopesApiClient {
       return this.extractDataOrHandleError(result, `scope node: ${scopeNodeId}`);
     } catch (err) {
       const errorMessage = getMessageFromError(err);
-      console.error('Failed to fetch scope node:', scopeNodeId, errorMessage);
+      grafanaStructuredLogger.logError(new Error(errorMessage), { detail: 'Failed to fetch scope node', scopeNodeId });
       return undefined;
     } finally {
       // Unsubscribe for extra safety, even though with subscribe: false and awaiting,

--- a/public/app/features/scopes/ScopesService.ts
+++ b/public/app/features/scopes/ScopesService.ts
@@ -8,6 +8,7 @@ import { type ScopesDashboardsService } from './dashboards/ScopesDashboardsServi
 import { deserializeFolderPath, serializeFolderPath } from './dashboards/scopeNavgiationUtils';
 import { type ScopesSelectorService } from './selector/ScopesSelectorService';
 
+import { grafanaStructuredLogger } from '@grafana/runtime';
 export interface State {
   enabled: boolean;
   readOnly: boolean;
@@ -93,7 +94,7 @@ export class ScopesService implements ScopesContextValue {
     const nodeToPreload = scopeNodeId;
     if (nodeToPreload) {
       this.selectorService.resolvePathToRoot(nodeToPreload, this.selectorService.state.tree!).catch((error) => {
-        console.error('Failed to pre-load node path', error);
+        grafanaStructuredLogger.logError(error instanceof Error ? error : new Error(String(error)), { message: String('Failed to pre-load node path') });
       });
     }
 

--- a/public/app/features/scopes/selector/ScopesSelectorService.ts
+++ b/public/app/features/scopes/selector/ScopesSelectorService.ts
@@ -28,6 +28,7 @@ import {
   type TreeNode,
 } from './types';
 
+import { grafanaStructuredLogger } from '@grafana/runtime';
 export const RECENT_SCOPES_KEY = 'grafana.scopes.recent';
 
 export interface ScopesSelectorServiceState {
@@ -111,7 +112,9 @@ export class ScopesSelectorService extends ScopesServiceBase<ScopesSelectorServi
       }
       return node;
     } catch (error) {
-      console.error('Failed to load node', error);
+      grafanaStructuredLogger.logError(error instanceof Error ? error : new Error(String(error)), {
+        detail: 'Failed to load node',
+      });
       return undefined;
     }
   };
@@ -119,7 +122,9 @@ export class ScopesSelectorService extends ScopesServiceBase<ScopesSelectorServi
   private getNodePath = async (scopeNodeId: string, visited: Set<string> = new Set()): Promise<ScopeNode[]> => {
     // Protect against circular references
     if (visited.has(scopeNodeId)) {
-      console.error('Circular reference detected in node path', scopeNodeId);
+      grafanaStructuredLogger.logError(new Error('Circular reference detected in scope node path'), {
+        scopeNodeId,
+      });
       return [];
     }
 
@@ -449,7 +454,9 @@ export class ScopesSelectorService extends ScopesServiceBase<ScopesSelectorServi
 
       // Validate API response is an array
       if (!Array.isArray(fetchedScopes)) {
-        console.error('Expected fetchedScopes to be an array, got:', typeof fetchedScopes);
+        grafanaStructuredLogger.logError(new Error('Expected fetchedScopes to be an array'), {
+          receivedType: typeof fetchedScopes,
+        });
         this.updateState({ scopes: newScopesState, loading: false });
         return;
       }
@@ -664,7 +671,9 @@ export class ScopesSelectorService extends ScopesServiceBase<ScopesSelectorServi
           newTree = expandNodes(newTree, parentPath);
         }
       } catch (error) {
-        console.error('Failed to expand to selected scope', error);
+        grafanaStructuredLogger.logError(error instanceof Error ? error : new Error(String(error)), {
+          detail: 'Failed to expand to selected scope',
+        });
       }
     }
 
@@ -747,7 +756,10 @@ function parseScopesFromLocalStorage(content: string | undefined): RecentScope[]
   try {
     recentScopes = JSON.parse(content || '[]');
   } catch (e) {
-    console.error('Failed to parse recent scopes', e, content);
+    grafanaStructuredLogger.logError(e instanceof Error ? e : new Error(String(e)), {
+      detail: 'Failed to parse recent scopes',
+      contentSnippet: content?.slice(0, 240),
+    });
     return [];
   }
   if (!(Array.isArray(recentScopes) && Array.isArray(recentScopes[0]))) {

--- a/public/app/features/scopes/selector/scopesTreeUtils.ts
+++ b/public/app/features/scopes/selector/scopesTreeUtils.ts
@@ -2,6 +2,7 @@ import { type ScopeNode } from '@grafana/data';
 
 import { type NodesMap, type TreeNode } from './types';
 
+import { grafanaStructuredLogger } from '@grafana/runtime';
 /**
  * Creates a deep copy of the node tree with expanded prop set to false.
  */
@@ -125,7 +126,7 @@ export const insertPathNodesIntoTree = (tree: TreeNode, path: ScopeNode[]) => {
     newTree = modifyTreeNodeAtPath(newTree, pathSlice, (treeNode) => {
       treeNode.children = { ...treeNode.children };
       if (!childNodeName) {
-        console.warn('Failed to insert full path into tree. Did not find child to' + stringPath[index]);
+        grafanaStructuredLogger.logWarning(String('Failed to insert full path into tree. Did not find child to' + stringPath[index]));
         treeNode.childrenLoaded = treeNode.childrenLoaded ?? false;
         return;
       }

--- a/public/app/features/scopes/selector/useScopeNode.ts
+++ b/public/app/features/scopes/selector/useScopeNode.ts
@@ -4,6 +4,7 @@ import { type ScopeNode } from '@grafana/data';
 
 import { useScopesServices } from '../ScopesContextProvider';
 
+import { grafanaStructuredLogger } from '@grafana/runtime';
 // Light wrapper around the scopesSelectorService.getScopeNode to make it easier to use in the UI.
 export function useScopeNode(scopeNodeId?: string) {
   const [node, setNode] = useState<ScopeNode | undefined>(undefined);
@@ -21,7 +22,7 @@ export function useScopeNode(scopeNodeId?: string) {
         const node = await scopesSelectorService.getScopeNode(scopeNodeId);
         setNode(node);
       } catch (error) {
-        console.error('Failed to load node', error);
+        grafanaStructuredLogger.logError(error instanceof Error ? error : new Error(String(error)), { message: String('Failed to load node') });
       } finally {
         setIsLoading(false);
       }

--- a/public/app/features/search/service/deletedDashboardsCache.ts
+++ b/public/app/features/search/service/deletedDashboardsCache.ts
@@ -6,6 +6,7 @@ import { type DashboardDataDTO } from 'app/types/dashboard';
 import { type SearchHit } from './unified';
 import { resourceToSearchResult } from './utils';
 
+import { grafanaStructuredLogger } from '@grafana/runtime';
 /**
  * Store deleted dashboards in the cache to avoid multiple calls to the API.
  */
@@ -79,7 +80,7 @@ class DeletedDashboardsCache {
         items: [],
       };
     } catch (error) {
-      console.error('Failed to fetch deleted dashboards:', error);
+      grafanaStructuredLogger.logError(error instanceof Error ? error : new Error(String(error)), { message: String('Failed to fetch deleted dashboards:') });
       return {
         apiVersion: 'v1',
         kind: 'List',

--- a/public/app/features/search/service/unified.ts
+++ b/public/app/features/search/service/unified.ts
@@ -33,6 +33,7 @@ import {
 } from './types';
 import { appendFrame, filterSearchResults, replaceCurrentFolderQuery } from './utils';
 
+import { grafanaStructuredLogger } from '@grafana/runtime';
 // The backend returns an empty frame with a special name to indicate that the indexing engine is being rebuilt,
 // and that it can not serve any search requests. We are temporarily using the old SQL Search API as a fallback when that happens.
 const loadingFrameName = 'Loading';
@@ -209,7 +210,7 @@ export class UnifiedSearcher implements GrafanaSearcher {
         const resp = await this.fetchResponse(nextPageUrl);
         const frame = toDashboardResults(resp, query.sort ?? '');
         if (!frame) {
-          console.log('no results', frame);
+          grafanaStructuredLogger.logInfo(String('no results'), { args: frame });
           return;
         }
 

--- a/public/app/features/search/service/utils.ts
+++ b/public/app/features/search/service/utils.ts
@@ -16,6 +16,7 @@ import {
 import { type DashboardQueryResult, type SearchQuery, type SearchResultMeta } from './types';
 import { type SearchHit } from './unified';
 
+import { grafanaStructuredLogger } from '@grafana/runtime';
 /** prepare the query replacing folder:current */
 export async function replaceCurrentFolderQuery(query: SearchQuery): Promise<SearchQuery> {
   if (query.query && query.query.indexOf('folder:current') >= 0) {
@@ -40,7 +41,7 @@ async function getCurrentFolderUID(): Promise<string | undefined> {
     }
     return Promise.resolve(dash?.meta?.folderUid);
   } catch (e) {
-    console.error(e);
+    grafanaStructuredLogger.logError(e instanceof Error ? e : new Error(String(e)));
   }
   return undefined;
 }

--- a/public/app/features/serviceaccounts/ServiceAccountCreatePage.tsx
+++ b/public/app/features/serviceaccounts/ServiceAccountCreatePage.tsx
@@ -16,6 +16,7 @@ import { type ServiceAccountDTO, type ServiceAccountCreateApiResponse } from 'ap
 
 import { OrgRolePicker } from '../admin/OrgRolePicker';
 
+import { grafanaStructuredLogger } from '@grafana/runtime';
 export interface Props {}
 
 const createServiceAccount = async (sa: ServiceAccountDTO) => {
@@ -68,7 +69,7 @@ export const ServiceAccountCreatePage = ({}: Props): JSX.Element => {
           setRoleOptions(options);
         }
       } catch (e) {
-        console.error('Error loading options', e); // TODO: handle error
+        grafanaStructuredLogger.logError(e instanceof Error ? e : new Error(String(e)), { message: String('Error loading options') }); // TODO: handle error
       }
     }
     if (contextSrv.licensedAccessControlEnabled()) {
@@ -101,7 +102,7 @@ export const ServiceAccountCreatePage = ({}: Props): JSX.Element => {
           await updateUserRoles(pendingRoles, newAccount.id, newAccount.orgId);
         }
       } catch (e) {
-        console.error(e); // TODO: handle error
+        grafanaStructuredLogger.logError(e instanceof Error ? e : new Error(String(e))); // TODO: handle error
       }
       locationService.push(`/org/serviceaccounts/${response.uid}`);
     },

--- a/public/app/features/serviceaccounts/components/ServiceAccountProfile.tsx
+++ b/public/app/features/serviceaccounts/components/ServiceAccountProfile.tsx
@@ -12,6 +12,7 @@ import { type ServiceAccountDTO } from 'app/types/serviceaccount';
 import { ServiceAccountProfileRow } from './ServiceAccountProfileRow';
 import { ServiceAccountRoleRow } from './ServiceAccountRoleRow';
 
+import { grafanaStructuredLogger } from '@grafana/runtime';
 interface Props {
   serviceAccount: ServiceAccountDTO;
   timeZone: TimeZone;
@@ -39,7 +40,7 @@ export function ServiceAccountProfile({ serviceAccount, timeZone, onChange }: Pr
           setRoleOptions(options);
         }
       } catch (e) {
-        console.error('Error loading options for service account');
+        grafanaStructuredLogger.logError(new Error('Error loading options for service account'));
       }
     }
     if (contextSrv.licensedAccessControlEnabled()) {

--- a/public/app/features/serviceaccounts/state/actions.ts
+++ b/public/app/features/serviceaccounts/state/actions.ts
@@ -21,6 +21,7 @@ import {
   stateFilterChanged,
 } from './reducers';
 
+import { grafanaStructuredLogger } from '@grafana/runtime';
 const BASE_URL = `/api/serviceaccounts`;
 
 export function fetchACOptions(): ThunkResult<void> {
@@ -31,7 +32,7 @@ export function fetchACOptions(): ThunkResult<void> {
         dispatch(acOptionsLoaded(options));
       }
     } catch (error) {
-      console.error(error);
+      grafanaStructuredLogger.logError(error instanceof Error ? error : new Error(String(error)));
     }
   };
 }
@@ -76,7 +77,7 @@ export function fetchServiceAccounts(
         dispatch(serviceAccountsFetched(result));
       }
     } catch (error) {
-      console.error(error);
+      grafanaStructuredLogger.logError(error instanceof Error ? error : new Error(String(error)));
     } finally {
       dispatch(serviceAccountsFetchEnd());
     }

--- a/public/app/features/serviceaccounts/state/actionsServiceAccountPage.ts
+++ b/public/app/features/serviceaccounts/state/actionsServiceAccountPage.ts
@@ -12,6 +12,7 @@ import {
   serviceAccountTokensLoaded,
 } from './reducers';
 
+import { grafanaStructuredLogger } from '@grafana/runtime';
 const BASE_URL = `/api/serviceaccounts`;
 
 export function loadServiceAccount(saUid: string): ThunkResult<void> {
@@ -21,7 +22,7 @@ export function loadServiceAccount(saUid: string): ThunkResult<void> {
       const response = await getBackendSrv().get(`${BASE_URL}/${saUid}`, accessControlQueryParam());
       dispatch(serviceAccountLoaded(response));
     } catch (error) {
-      console.error(error);
+      grafanaStructuredLogger.logError(error instanceof Error ? error : new Error(String(error)));
     } finally {
       dispatch(serviceAccountFetchEnd());
     }
@@ -69,7 +70,7 @@ export function loadServiceAccountTokens(saUid: string): ThunkResult<void> {
       const response = await getBackendSrv().get(`${BASE_URL}/${saUid}/tokens`);
       dispatch(serviceAccountTokensLoaded(response));
     } catch (error) {
-      console.error(error);
+      grafanaStructuredLogger.logError(error instanceof Error ? error : new Error(String(error)));
     }
   };
 }

--- a/public/app/features/teams/TeamList.tsx
+++ b/public/app/features/teams/TeamList.tsx
@@ -39,6 +39,7 @@ import { EnterpriseAuthFeaturesCard } from '../admin/EnterpriseAuthFeaturesCard'
 import { TeamDeleteModal } from './TeamDeleteModal';
 import { useDeleteTeam, useGetTeams } from './hooks';
 
+import { grafanaStructuredLogger } from '@grafana/runtime';
 type Cell<T extends keyof TeamWithRoles = keyof TeamWithRoles> = CellProps<TeamWithRoles, TeamWithRoles[T]>;
 
 export interface State {
@@ -235,7 +236,7 @@ const TeamList = () => {
                     'Failed to check if the team owns folders. Please try again.'
                   )
                 );
-                console.error(error);
+                grafanaStructuredLogger.logError(error instanceof Error ? error : new Error(String(error)));
                 return;
               }
 

--- a/public/app/features/templating/LegacyVariableWrapper.ts
+++ b/public/app/features/templating/LegacyVariableWrapper.ts
@@ -3,6 +3,7 @@ import { type VariableModel, type VariableType } from '@grafana/schema';
 
 import { ALL_VARIABLE_TEXT, ALL_VARIABLE_VALUE } from '../variables/constants';
 
+import { grafanaStructuredLogger } from '@grafana/runtime';
 export class LegacyVariableWrapper implements FormatVariable {
   state: { name: string; value: VariableValue; text: VariableValue; type: VariableType };
 
@@ -31,7 +32,7 @@ export class LegacyVariableWrapper implements FormatVariable {
       return text.join(' + ');
     }
 
-    console.log('value', text);
+    grafanaStructuredLogger.logInfo(String('value'), { args: text });
     return String(text);
   }
 }

--- a/public/app/features/templating/formatVariableValue.ts
+++ b/public/app/features/templating/formatVariableValue.ts
@@ -5,6 +5,7 @@ import { isAdHoc } from '../variables/guard';
 
 import { getVariableWrapper } from './LegacyVariableWrapper';
 
+import { grafanaStructuredLogger } from '@grafana/runtime';
 export function formatVariableValue(value: any, format?: any, variable?: any, text?: string): string {
   // for some scopedVars there is no variable
   variable = variable || {};
@@ -42,7 +43,7 @@ export function formatVariableValue(value: any, format?: any, variable?: any, te
   let formatItem = formatRegistry.getIfExists(format);
 
   if (!formatItem) {
-    console.error(`Variable format ${format} not found. Using glob format as fallback.`);
+    grafanaStructuredLogger.logError(new Error(`Variable format ${format} not found. Using glob format as fallback.`));
     formatItem = formatRegistry.get(VariableFormatID.Glob);
   }
 

--- a/public/app/features/theme-playground/ThemePlayground.tsx
+++ b/public/app/features/theme-playground/ThemePlayground.tsx
@@ -33,6 +33,7 @@ import { getNavModel } from '../../core/selectors/navModel';
 import { ThemeProvider } from '../../core/utils/ConfigProvider';
 import { useDispatch, useSelector } from '../../types/store';
 
+import { grafanaStructuredLogger } from '@grafana/runtime';
 const themeMap: Record<string, NewThemeOptions> = {
   dark: {
     name: 'Dark',
@@ -73,7 +74,7 @@ const experimentalDefinitions: Record<string, unknown> = {
 for (const [name, json] of Object.entries(experimentalDefinitions)) {
   const result = NewThemeOptionsSchema.safeParse(json);
   if (!result.success) {
-    console.error(`Invalid theme definition for theme ${name}: ${result.error.message}`);
+    grafanaStructuredLogger.logError(new Error(`Invalid theme definition for theme ${name}: ${result.error.message}`));
   } else {
     themeMap[result.data.id] = result.data;
   }

--- a/public/app/features/transformers/editors/FilterByNameTransformerEditor.tsx
+++ b/public/app/features/transformers/editors/FilterByNameTransformerEditor.tsx
@@ -19,6 +19,7 @@ import { Input, FilterPill, InlineFieldRow, InlineField, InlineSwitch, Select } 
 import darkImage from '../images/dark/filterFieldsByName.svg';
 import lightImage from '../images/light/filterFieldsByName.svg';
 
+import { grafanaStructuredLogger } from '@grafana/runtime';
 interface FilterByNameTransformerEditorProps extends TransformerUIProps<FilterFieldsByNameTransformerOptions> {}
 
 interface FilterByNameTransformerEditorState {
@@ -101,7 +102,7 @@ export class FilterByNameTransformerEditor extends React.PureComponent<
           }
         }
       } catch (error) {
-        console.error(error);
+        grafanaStructuredLogger.logError(error instanceof Error ? error : new Error(String(error)));
       }
     }
 

--- a/public/app/features/transformers/extractFields/fieldExtractors.ts
+++ b/public/app/features/transformers/extractFields/fieldExtractors.ts
@@ -2,6 +2,7 @@ import { escapeStringForRegex, Registry, type RegistryItem, stringStartsAsRegEx,
 
 import { type ExtractFieldsOptions, FieldExtractorID } from './types';
 
+import { grafanaStructuredLogger } from '@grafana/runtime';
 type Parser = (v: string) => Record<string, any> | undefined;
 
 export interface FieldExtractor extends RegistryItem {
@@ -29,7 +30,7 @@ const extRegExp: FieldExtractor = {
         regex = stringToJsRegex(options.regExp!);
       } catch (error) {
         if (error instanceof Error) {
-          console.warn(error.message);
+          grafanaStructuredLogger.logWarning(String(error.message));
         }
       }
     }

--- a/public/app/features/transformers/spatial/SpatialTransformerEditor.tsx
+++ b/public/app/features/transformers/spatial/SpatialTransformerEditor.tsx
@@ -23,6 +23,7 @@ import { SpatialCalculation, SpatialOperation, SpatialAction, type SpatialTransf
 import { getDefaultOptions, getTransformerOptionPane } from './optionsHelper';
 import { isLineBuilderOption, getSpatialTransformer } from './spatialTransformer';
 
+import { grafanaStructuredLogger } from '@grafana/runtime';
 // Nothing defined in state
 const supplier = (
   builder: PanelOptionsEditorBuilder<SpatialTransformOptions>,
@@ -137,7 +138,7 @@ export const SetGeometryTransformerEditor = (props: Props) => {
     if (!props.options.source?.mode) {
       const opts = getDefaultOptions(supplier);
       props.onChange({ ...opts, ...props.options });
-      console.log('geometry useEffect', opts);
+      grafanaStructuredLogger.logInfo(String('geometry useEffect'), { args: opts });
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);

--- a/public/app/features/variables/adhoc/AdHocVariableEditor.tsx
+++ b/public/app/features/variables/adhoc/AdHocVariableEditor.tsx
@@ -12,6 +12,7 @@ import { toKeyedVariableIdentifier } from '../utils';
 
 import { changeVariableDatasource } from './actions';
 
+import { grafanaStructuredLogger } from '@grafana/runtime';
 interface Props extends VariableEditorProps<AdHocVariableModel> {}
 
 export const AdHocVariableEditor = memo(function AdHocVariableEditor({ variable }: Props) {
@@ -30,7 +31,7 @@ export const AdHocVariableEditor = memo(function AdHocVariableEditor({ variable 
 
   useEffect(() => {
     if (!variable.rootStateKey) {
-      console.error('AdHocVariableEditor: variable has no rootStateKey');
+      grafanaStructuredLogger.logError(new Error('AdHocVariableEditor: variable has no rootStateKey'));
     }
   }, [variable.rootStateKey]);
 

--- a/public/app/features/variables/datasource/DataSourceVariableEditor.tsx
+++ b/public/app/features/variables/datasource/DataSourceVariableEditor.tsx
@@ -13,6 +13,7 @@ import { toKeyedVariableIdentifier } from '../utils';
 
 import { initDataSourceVariableEditor } from './actions';
 
+import { grafanaStructuredLogger } from '@grafana/runtime';
 interface Props extends VariableEditorProps<DataSourceVariableModel> {}
 
 export const DataSourceVariableEditor = memo(function DataSourceVariableEditor({ variable, onPropChange }: Props) {
@@ -21,7 +22,7 @@ export const DataSourceVariableEditor = memo(function DataSourceVariableEditor({
   const extended = useSelector((state: StoreState) => {
     const { rootStateKey } = variable;
     if (!rootStateKey) {
-      console.error('DataSourceVariableEditor: variable has no rootStateKey');
+      grafanaStructuredLogger.logError(new Error('DataSourceVariableEditor: variable has no rootStateKey'));
       return getDatasourceVariableEditorState(initialVariableEditorState);
     }
 
@@ -32,7 +33,7 @@ export const DataSourceVariableEditor = memo(function DataSourceVariableEditor({
   useEffect(() => {
     const { rootStateKey } = variable;
     if (!rootStateKey) {
-      console.error('DataSourceVariableEditor: variable has no rootStateKey');
+      grafanaStructuredLogger.logError(new Error('DataSourceVariableEditor: variable has no rootStateKey'));
       return;
     }
 

--- a/public/app/features/variables/pickers/OptionsPicker/OptionsPicker.tsx
+++ b/public/app/features/variables/pickers/OptionsPicker/OptionsPicker.tsx
@@ -29,6 +29,7 @@ import { type NavigationKey, type VariablePickerProps } from '../types';
 import { commitChangesToVariable, filterOrSearchOptions, navigateOptions, openOptions } from './actions';
 import { initialOptionPickerState, type OptionsPickerState, toggleAllOptions, toggleOption } from './reducer';
 
+import { grafanaStructuredLogger } from '@grafana/runtime';
 export const optionPickerFactory = <Model extends VariableWithOptions | VariableWithMultiSupport>(): ComponentType<
   VariablePickerProps<Model>
 > => {
@@ -52,7 +53,7 @@ export const optionPickerFactory = <Model extends VariableWithOptions | Variable
   const mapStateToProps = (state: StoreState, ownProps: OwnProps) => {
     const { rootStateKey } = ownProps.variable;
     if (!rootStateKey) {
-      console.error('OptionPickerFactory: variable has no rootStateKey');
+      grafanaStructuredLogger.logError(new Error('OptionPickerFactory: variable has no rootStateKey'));
       return {
         picker: initialOptionPickerState,
       };
@@ -74,7 +75,7 @@ export const optionPickerFactory = <Model extends VariableWithOptions | Variable
       this.props.openOptions(toKeyedVariableIdentifier(this.props.variable), this.props.onVariableChange);
     onHideOptions = () => {
       if (!this.props.variable.rootStateKey) {
-        console.error('Variable has no rootStateKey');
+        grafanaStructuredLogger.logError(new Error('Variable has no rootStateKey'));
         return;
       }
 
@@ -108,7 +109,7 @@ export const optionPickerFactory = <Model extends VariableWithOptions | Variable
 
     onNavigate = (key: NavigationKey, clearOthers: boolean) => {
       if (!this.props.variable.rootStateKey) {
-        console.error('Variable has no rootStateKey');
+        grafanaStructuredLogger.logError(new Error('Variable has no rootStateKey'));
         return;
       }
 

--- a/public/app/features/variables/pickers/OptionsPicker/actions.ts
+++ b/public/app/features/variables/pickers/OptionsPicker/actions.ts
@@ -23,6 +23,7 @@ import {
   updateSearchQuery,
 } from './reducer';
 
+import { grafanaStructuredLogger } from '@grafana/runtime';
 export const navigateOptions = (rootStateKey: string, key: NavigationKey, clearOthers: boolean): ThunkResult<void> => {
   return async (dispatch, getState) => {
     if (key === NavigationKey.cancel) {
@@ -180,7 +181,7 @@ const searchForOptions = async (
 
     dispatch(toKeyedAction(key, updateOptionsFromSearch(updated.options)));
   } catch (error) {
-    console.error(error);
+    grafanaStructuredLogger.logError(error instanceof Error ? error : new Error(String(error)));
   }
 };
 

--- a/public/app/features/variables/query/QueryVariableEditor.tsx
+++ b/public/app/features/variables/query/QueryVariableEditor.tsx
@@ -22,10 +22,11 @@ import { toKeyedVariableIdentifier } from '../utils';
 
 import { changeQueryVariableDataSource, changeQueryVariableQuery, initQueryVariableEditor } from './actions';
 
+import { grafanaStructuredLogger } from '@grafana/runtime';
 const mapStateToProps = (state: StoreState, ownProps: OwnProps) => {
   const { rootStateKey } = ownProps.variable;
   if (!rootStateKey) {
-    console.error('QueryVariableEditor: variable has no rootStateKey');
+    grafanaStructuredLogger.logError(new Error('QueryVariableEditor: variable has no rootStateKey'));
     return {
       extended: getQueryVariableEditorState(initialVariableEditorState),
     };

--- a/public/app/features/variables/query/actions.ts
+++ b/public/app/features/variables/query/actions.ts
@@ -17,6 +17,7 @@ import { hasOngoingTransaction, toKeyedVariableIdentifier, toVariablePayload } f
 import { getVariableQueryRunner } from './VariableQueryRunner';
 import { variableQueryObserver } from './variableQueryObserver';
 
+import { grafanaStructuredLogger } from '@grafana/runtime';
 export const updateQueryVariableOptions = (
   identifier: KeyedVariableIdentifier,
   searchFilter?: string
@@ -109,7 +110,7 @@ export const changeQueryVariableDataSource = (
         )
       );
     } catch (err) {
-      console.error(err);
+      grafanaStructuredLogger.logError(err instanceof Error ? err : new Error(String(err)));
     }
   };
 };

--- a/public/app/features/variables/query/operators.ts
+++ b/public/app/features/variables/query/operators.ts
@@ -18,6 +18,7 @@ import { type getTemplatedRegex, toKeyedVariableIdentifier, toVariablePayload } 
 
 import { updateVariableOptions } from './reducer';
 
+import { grafanaStructuredLogger } from '@grafana/runtime';
 export function toMetricFindValuesOperator(): OperatorFunction<PanelData, MetricFindValue[]> {
   return (source) => source.pipe(map(toMetricFindValues));
 }
@@ -110,7 +111,7 @@ export function updateOptionsState(args: {
       map((results) => {
         const { variable, dispatch, getTemplatedRegexFunc } = args;
         if (!variable.rootStateKey) {
-          console.error('updateOptionsState: variable.rootStateKey is not defined');
+          grafanaStructuredLogger.logError(new Error('updateOptionsState: variable.rootStateKey is not defined'));
           return;
         }
         const templatedRegex = getTemplatedRegexFunc(variable);

--- a/public/app/features/variables/state/actions.ts
+++ b/public/app/features/variables/state/actions.ts
@@ -82,6 +82,7 @@ import {
 import { type KeyedVariableIdentifier } from './types';
 import { cleanVariables } from './variablesReducer';
 
+import { grafanaStructuredLogger } from '@grafana/runtime';
 export const initDashboardTemplating = (key: string, dashboard: DashboardModel): ThunkResult<void> => {
   return (dispatch, getState) => {
     let orderIndex = 0;
@@ -779,7 +780,7 @@ export const onTimeRangeUpdated =
       await Promise.all(promises);
       dependencies.events.publish(new VariablesTimeRangeProcessDone({ variableIds }));
     } catch (error) {
-      console.error(error);
+      grafanaStructuredLogger.logError(error instanceof Error ? error : new Error(String(error)));
       dispatch(notifyApp(createVariableErrorNotification('Template variable service failed', error)));
     }
   };
@@ -933,7 +934,7 @@ export const initVariablesTransaction =
       dispatch(toKeyedAction(uid, variablesCompleteTransaction({ uid })));
     } catch (err) {
       dispatch(notifyApp(createVariableErrorNotification('Templating init failed', err)));
-      console.error(err);
+      grafanaStructuredLogger.logError(err instanceof Error ? err : new Error(String(err)));
     }
   };
 
@@ -1004,7 +1005,7 @@ export const updateOptions =
       dispatch(toKeyedAction(rootStateKey, variableStateFailed(toVariablePayload(identifier, { error }))));
 
       if (!rethrow) {
-        console.error(error);
+        grafanaStructuredLogger.logError(error instanceof Error ? error : new Error(String(error)));
         dispatch(notifyApp(createVariableErrorNotification('Error updating options:', error, identifier)));
       }
 
@@ -1084,7 +1085,7 @@ export function upgradeLegacyQueries(
       );
     } catch (err) {
       dispatch(notifyApp(createVariableErrorNotification('Failed to upgrade legacy queries', err)));
-      console.error(err);
+      grafanaStructuredLogger.logError(err instanceof Error ? err : new Error(String(err)));
     }
   };
 }

--- a/public/app/features/variables/switch/SwitchVariablePicker.tsx
+++ b/public/app/features/variables/switch/SwitchVariablePicker.tsx
@@ -6,13 +6,14 @@ import { Switch } from '@grafana/ui';
 import { variableAdapters } from '../adapters';
 import { type VariablePickerProps } from '../pickers/types';
 
+import { grafanaStructuredLogger } from '@grafana/runtime';
 export interface Props extends VariablePickerProps<SwitchVariableModel> {}
 
 export function SwitchVariablePicker({ variable, onVariableChange }: Props): ReactElement {
   const updateVariable = useCallback(
     (event: ChangeEvent<HTMLInputElement>) => {
       if (!variable.rootStateKey) {
-        console.error('Cannot update variable without rootStateKey');
+        grafanaStructuredLogger.logError(new Error('Cannot update variable without rootStateKey'));
         return;
       }
 

--- a/public/app/features/variables/textbox/TextBoxVariablePicker.tsx
+++ b/public/app/features/variables/textbox/TextBoxVariablePicker.tsx
@@ -20,6 +20,7 @@ import { toKeyedAction } from '../state/keyedVariablesReducer';
 import { changeVariableProp } from '../state/sharedReducer';
 import { toVariablePayload } from '../utils';
 
+import { grafanaStructuredLogger } from '@grafana/runtime';
 export interface Props extends VariablePickerProps<TextBoxVariableModel> {}
 
 export function TextBoxVariablePicker({ variable, onVariableChange, readOnly }: Props): ReactElement {
@@ -31,7 +32,7 @@ export function TextBoxVariablePicker({ variable, onVariableChange, readOnly }: 
 
   const updateVariable = useCallback(() => {
     if (!variable.rootStateKey) {
-      console.error('Cannot update variable without rootStateKey');
+      grafanaStructuredLogger.logError(new Error('Cannot update variable without rootStateKey'));
       return;
     }
 

--- a/public/app/index.ts
+++ b/public/app/index.ts
@@ -1,3 +1,5 @@
+
+import { grafanaStructuredLogger } from '@grafana/runtime';
 // The new index.html fetches window.grafanaBootData asynchronously.
 // Since much of Grafana depends on it in includes side effects at import time,
 // we delay loading the rest of the app using import() until the boot data is ready.
@@ -32,7 +34,7 @@ bootstrapWindowData().catch((error) => {
   const isRedirect = error && error.redirect && typeof error.redirect === 'string';
   // If a redirect was thrown, just ignore this. The index.html will handle the redirect
   if (!isRedirect) {
-    console.error('Error bootstrapping Grafana', error);
+    grafanaStructuredLogger.logError(error instanceof Error ? error : new Error(String(error)), { message: String('Error bootstrapping Grafana') });
     window.__grafana_load_failed();
   }
 });

--- a/public/app/plugins/datasource/azuremonitor/azure_monitor/azure_monitor_datasource.ts
+++ b/public/app/plugins/datasource/azuremonitor/azure_monitor/azure_monitor_datasource.ts
@@ -33,6 +33,7 @@ import migrateQuery from '../utils/migrateQuery';
 import ResponseParser from './response_parser';
 import UrlBuilder from './url_builder';
 
+import { grafanaStructuredLogger } from '@grafana/runtime';
 const defaultDropdownValue = 'select';
 
 function hasValue(item?: string) {
@@ -218,7 +219,7 @@ export default class AzureMonitorDatasource extends DataSourceWithBackend<
         return result;
       })
       .catch((reason) => {
-        console.error(`Failed to get metric namespaces: ${reason}`);
+        grafanaStructuredLogger.logError(new Error(`Failed to get metric namespaces: ${reason}`));
         return [];
       });
   }

--- a/public/app/plugins/datasource/azuremonitor/components/LogsQueryEditor/LogsQueryEditor.tsx
+++ b/public/app/plugins/datasource/azuremonitor/components/LogsQueryEditor/LogsQueryEditor.tsx
@@ -26,6 +26,7 @@ import { onLoad, setBasicLogsQuery, setFormatAs, setKustoQuery } from './setQuer
 import useMigrations from './useMigrations';
 import { shouldShowBasicLogsToggle } from './utils';
 
+import { grafanaStructuredLogger } from '@grafana/runtime';
 interface LogsQueryEditorProps {
   query: AzureMonitorQuery;
   datasource: Datasource;
@@ -193,11 +194,11 @@ const LogsQueryEditor = ({
           setDataIngestedWarning(null);
         }
       } catch (err) {
-        console.error(err);
+        grafanaStructuredLogger.logError(err instanceof Error ? err : new Error(String(err)));
       }
     };
 
-    getBasicLogsUsage(query).catch((err) => console.error(err));
+    getBasicLogsUsage(query).catch((err) => grafanaStructuredLogger.logError(err instanceof Error ? err : new Error(String(err))));
   }, [datasource.azureLogAnalyticsDatasource, query, showBasicLogsToggle, from, to]);
   let portalLinkButton = null;
 

--- a/public/app/plugins/datasource/azuremonitor/components/LogsQueryEditor/QueryField.tsx
+++ b/public/app/plugins/datasource/azuremonitor/components/LogsQueryEditor/QueryField.tsx
@@ -7,6 +7,7 @@ import { type AzureQueryEditorFieldProps } from '../../types/types';
 
 import { setKustoQuery } from './setQueryValue';
 
+import { grafanaStructuredLogger } from '@grafana/runtime';
 interface MonacoEditorValues {
   editor: MonacoEditor;
   monaco: Monaco;
@@ -29,11 +30,11 @@ const QueryField = ({ query, onQueryChange, schema }: AzureQueryEditorFieldProps
           await kustoMode.setSchema(schema);
         }
       } catch (err) {
-        console.error(err);
+        grafanaStructuredLogger.logError(err instanceof Error ? err : new Error(String(err)));
       }
     };
 
-    setupEditor(monaco, schema).catch((err) => console.error(err));
+    setupEditor(monaco, schema).catch((err) => grafanaStructuredLogger.logError(err instanceof Error ? err : new Error(String(err))));
   }, [schema, monaco]);
 
   const handleEditorMount = useCallback((editor: MonacoEditor, monaco: Monaco) => {

--- a/public/app/plugins/datasource/azuremonitor/credentials.ts
+++ b/public/app/plugins/datasource/azuremonitor/credentials.ts
@@ -10,6 +10,7 @@ import { config } from '@grafana/runtime';
 
 import { type AzureMonitorDataSourceInstanceSettings, type AzureMonitorDataSourceSettings } from './types/types';
 
+import { grafanaStructuredLogger } from '@grafana/runtime';
 export function getCredentials(
   options: AzureMonitorDataSourceSettings | AzureMonitorDataSourceInstanceSettings
 ): AzureCredentials {
@@ -57,7 +58,7 @@ function getLegacyCredentials(
     return { authType: options.jsonData.azureAuthType };
   } catch (e) {
     if (e instanceof Error) {
-      console.error('Unable to restore legacy credentials: %s', e.message);
+      grafanaStructuredLogger.logError(e, { detail: 'Unable to restore legacy credentials' });
     }
     return undefined;
   }

--- a/public/app/plugins/datasource/cloud-monitoring/CloudMonitoringMetricFindQuery.ts
+++ b/public/app/plugins/datasource/cloud-monitoring/CloudMonitoringMetricFindQuery.ts
@@ -12,6 +12,7 @@ import {
 } from './functions';
 import { type CloudMonitoringVariableQuery, type MetricDescriptor } from './types/types';
 
+import { grafanaStructuredLogger } from '@grafana/runtime';
 export default class CloudMonitoringMetricFindQuery {
   constructor(private datasource: CloudMonitoringDatasource) {}
 
@@ -50,7 +51,7 @@ export default class CloudMonitoringMetricFindQuery {
           return [];
       }
     } catch (error) {
-      console.error(`Could not run CloudMonitoringMetricFindQuery ${query}`, error);
+      grafanaStructuredLogger.logError(error instanceof Error ? error : new Error(String(error)), { message: String(`Could not run CloudMonitoringMetricFindQuery ${query}`) });
       return [];
     }
   }

--- a/public/app/plugins/datasource/cloudwatch/components/shared/LogGroups/LogGroupsField.tsx
+++ b/public/app/plugins/datasource/cloudwatch/components/shared/LogGroups/LogGroupsField.tsx
@@ -18,6 +18,7 @@ import { LogGroupQueryScopeSelector } from './LogGroupQueryScopeSelector';
 import { LogGroupsSelector } from './LogGroupsSelector';
 import { SelectedLogGroups } from './SelectedLogGroups';
 
+import { grafanaStructuredLogger } from '@grafana/runtime';
 type Props = {
   datasource: CloudWatchDatasource;
   onChange: (logGroups: LogGroup[]) => void;
@@ -92,7 +93,7 @@ export const LogGroupsField = ({
           onChange([...logGroups, ...variables.map((v) => ({ name: v, arn: v }))]);
         })
         .catch((err) => {
-          console.error(err);
+          grafanaStructuredLogger.logError(err instanceof Error ? err : new Error(String(err)));
         });
     }
   }, [datasource, legacyLogGroupNames, logGroups, onChange, region, loadingLogGroupsStarted]);

--- a/public/app/plugins/datasource/cloudwatch/tracking.ts
+++ b/public/app/plugins/datasource/cloudwatch/tracking.ts
@@ -16,6 +16,7 @@ import pluginJson from './plugin.json';
 import { type CloudWatchQuery } from './types';
 import { filterMetricsQuery } from './utils/utils';
 
+import { grafanaStructuredLogger } from '@grafana/runtime';
 type CloudWatchOnDashboardLoadedTrackingEvent = {
   grafana_version?: string;
   dashboard_id?: string;
@@ -146,7 +147,7 @@ export const onDashboardLoadedHandler = ({
 
     reportInteraction('grafana_ds_cloudwatch_dashboard_loaded', e);
   } catch (error) {
-    console.error('error in cloudwatch tracking handler', error);
+    grafanaStructuredLogger.logError(error instanceof Error ? error : new Error(String(error)), { message: String('error in cloudwatch tracking handler') });
   }
 };
 

--- a/public/app/plugins/datasource/cloudwatch/utils/datalinks.ts
+++ b/public/app/plugins/datasource/cloudwatch/utils/datalinks.ts
@@ -13,6 +13,7 @@ import { type AwsUrl, encodeUrl } from '../aws_url';
 import { type CloudWatchLogsQuery } from '../dataquery.gen';
 import { type CloudWatchQuery } from '../types';
 
+import { grafanaStructuredLogger } from '@grafana/runtime';
 type ReplaceFn = (
   target?: string,
   scopedVars?: ScopedVars,
@@ -66,7 +67,7 @@ async function createInternalXrayLink(datasourceUid: string, region: string): Pr
   try {
     ds = await getDataSourceSrv().get(datasourceUid);
   } catch (e) {
-    console.error('Could not load linked xray data source, it was probably deleted after it was linked', e);
+    grafanaStructuredLogger.logError(e instanceof Error ? e : new Error(String(e)), { message: String('Could not load linked xray data source, it was probably deleted after it was linked') });
     return undefined;
   }
 

--- a/public/app/plugins/datasource/cloudwatch/variables.ts
+++ b/public/app/plugins/datasource/cloudwatch/variables.ts
@@ -18,6 +18,7 @@ import { type ResourcesAPI } from './resources/ResourcesAPI';
 import { standardStatistics } from './standardStatistics';
 import { type VariableQuery, VariableQueryType } from './types';
 
+import { grafanaStructuredLogger } from '@grafana/runtime';
 export class CloudWatchVariableSupport extends CustomVariableSupport<CloudWatchDatasource, VariableQuery> {
   constructor(private readonly resources: ResourcesAPI) {
     super();
@@ -57,7 +58,7 @@ export class CloudWatchVariableSupport extends CustomVariableSupport<CloudWatchD
           return this.handleAccountsQuery(query);
       }
     } catch (error) {
-      console.error(`Could not run CloudWatchMetricFindQuery ${query}`, error);
+      grafanaStructuredLogger.logError(error instanceof Error ? error : new Error(String(error)), { message: String(`Could not run CloudWatchMetricFindQuery ${query}`) });
       return [];
     }
   }

--- a/public/app/plugins/datasource/dashboard/datasource.ts
+++ b/public/app/plugins/datasource/dashboard/datasource.ts
@@ -31,6 +31,7 @@ import { MIXED_REQUEST_PREFIX } from '../mixed/MixedDataSource';
 
 import { type DashboardQuery } from './types';
 
+import { grafanaStructuredLogger } from '@grafana/runtime';
 /**
  * This should not really be called
  */
@@ -270,7 +271,7 @@ export class DashboardDatasource extends DataSourceApi<DashboardQuery> {
         options: { value: filter.value },
       });
     } catch (error) {
-      console.warn('Failed to create value matcher for filter:', filter, error);
+      grafanaStructuredLogger.logWarning(String('Failed to create value matcher for filter:'), { args: filter, error });
       return null;
     }
   }

--- a/public/app/plugins/datasource/grafana-testdata-datasource/components/RawFrameEditor.tsx
+++ b/public/app/plugins/datasource/grafana-testdata-datasource/components/RawFrameEditor.tsx
@@ -7,6 +7,7 @@ import { Alert, CodeEditor } from '@grafana/ui';
 
 import { type EditorProps } from '../QueryEditor';
 
+import { grafanaStructuredLogger } from '@grafana/runtime';
 export const RawFrameEditor = ({ onChange, query }: EditorProps) => {
   const [error, setError] = useState<string>();
   const [warning, setWarning] = useState<string>();
@@ -35,8 +36,8 @@ export const RawFrameEditor = ({ onChange, query }: EditorProps) => {
       }
 
       if (data) {
-        console.log('Original', json);
-        console.log('Save', data);
+        grafanaStructuredLogger.logInfo(String('Original'), { args: json });
+        grafanaStructuredLogger.logInfo(String('Save'), { args: data });
         setError(undefined);
         setWarning('Converted to direct frame result');
         onChange({ ...query, rawFrameContent: JSON.stringify(data, null, 2) });
@@ -45,7 +46,7 @@ export const RawFrameEditor = ({ onChange, query }: EditorProps) => {
 
       setError('Unable to read dataframes in text');
     } catch (e) {
-      console.log('Error parsing json', e);
+      grafanaStructuredLogger.logInfo(String('Error parsing json'), { args: e });
       setError('Enter JSON array of data frames (or raw query results body)');
       setWarning(undefined);
     }

--- a/public/app/plugins/datasource/grafana-testdata-datasource/runStreams.ts
+++ b/public/app/plugins/datasource/grafana-testdata-datasource/runStreams.ts
@@ -23,6 +23,7 @@ import { getBackendSrv } from '@grafana/runtime';
 import { getRandomLine } from './LogIpsum';
 import { type TestDataDataQuery, type StreamingQuery } from './dataquery';
 
+import { grafanaStructuredLogger } from '@grafana/runtime';
 export const defaultStreamQuery: StreamingQuery = {
   type: 'signal',
   speed: 250, // ms
@@ -125,7 +126,7 @@ export function runSignalStream(
     setTimeout(pushNextEvent, 5);
 
     return () => {
-      console.log('unsubscribing to stream ' + streamId);
+      grafanaStructuredLogger.logInfo(String('unsubscribing to stream ' + streamId));
       clearTimeout(timeoutId);
     };
   });
@@ -171,7 +172,7 @@ export function runLogsStream(
     setTimeout(pushNextEvent, 5);
 
     return () => {
-      console.log('unsubscribing to stream ' + streamId);
+      grafanaStructuredLogger.logInfo(String('unsubscribing to stream ' + streamId));
       clearTimeout(timeoutId);
     };
   });
@@ -219,7 +220,7 @@ export function runWatchStream(
       .subscribe({
         next: (chunk) => {
           if (!chunk.data || !chunk.ok) {
-            console.info('chunk missing data', chunk);
+            grafanaStructuredLogger.logInfo(String('chunk missing data'), { args: chunk });
             return;
           }
           decoder
@@ -240,21 +241,21 @@ export function runWatchStream(
                     state: LoadingState.Streaming,
                   });
                 } catch (err) {
-                  console.warn('error parsing line', line, err);
+                  grafanaStructuredLogger.logWarning(String('error parsing line'), { args: line, err });
                 }
               }
             });
         },
         error: (err) => {
-          console.warn('error in stream', streamId, err);
+          grafanaStructuredLogger.logWarning(String('error in stream'), { args: streamId, err });
         },
         complete: () => {
-          console.info('complete stream', streamId);
+          grafanaStructuredLogger.logInfo(String('complete stream'), { args: streamId });
         },
       });
 
     return () => {
-      console.log('unsubscribing to stream', streamId);
+      grafanaStructuredLogger.logInfo(String('unsubscribing to stream'), { args: streamId });
       sub.unsubscribe();
     };
   });
@@ -314,7 +315,7 @@ export function runFetchStream(
       });
 
       if (value.done) {
-        console.log('Finished stream');
+        grafanaStructuredLogger.logInfo(String('Finished stream'));
         subscriber.complete(); // necessary?
         return;
       }
@@ -335,7 +336,7 @@ export function runFetchStream(
 
     return () => {
       // Cancel fetch?
-      console.log('unsubscribing to stream ' + streamId);
+      grafanaStructuredLogger.logInfo(String('unsubscribing to stream ' + streamId));
     };
   });
 }
@@ -368,7 +369,7 @@ export function runTracesStream(
     setTimeout(pushNextEvent, 5);
 
     return () => {
-      console.log('unsubscribing to stream ' + streamId);
+      grafanaStructuredLogger.logInfo(String('unsubscribing to stream ' + streamId));
       clearTimeout(timeoutId);
     };
   });

--- a/public/app/plugins/datasource/grafana/components/QueryEditor.tsx
+++ b/public/app/plugins/datasource/grafana/components/QueryEditor.tsx
@@ -28,6 +28,7 @@ import { defaultQuery, type GrafanaQuery, GrafanaQueryType } from '../types';
 
 import { RandomWalkEditor } from './RandomWalkEditor';
 
+import { grafanaStructuredLogger } from '@grafana/runtime';
 interface Props extends QueryEditorProps<GrafanaDatasource, GrafanaQuery>, Themeable2 {}
 
 const labelWidth = 12;
@@ -148,7 +149,7 @@ export class UnthemedQueryEditor extends React.PureComponent<Props, State> {
         try {
           buffer = rangeUtil.intervalToSeconds(txt) * 1000;
         } catch (err) {
-          console.warn('ERROR', err);
+          grafanaStructuredLogger.logWarning(String('ERROR'), { args: err });
         }
       }
       onChange({

--- a/public/app/plugins/datasource/graphite/datasource.test.ts
+++ b/public/app/plugins/datasource/graphite/datasource.test.ts
@@ -426,7 +426,12 @@ describe('graphiteDatasource', () => {
         results = data;
       });
       expect(results).toEqual([]);
-      expect(console.error).toHaveBeenCalledWith(expect.stringMatching(/Unable to get annotations/));
+      expect(console.error).toHaveBeenCalledWith(
+        '[Grafana]',
+        expect.objectContaining({
+          message: expect.stringMatching(/Unable to get annotations/),
+        })
+      );
     });
   });
 
@@ -540,7 +545,12 @@ describe('graphiteDatasource', () => {
         results = data;
       });
       expect(results).toEqual([]);
-      expect(console.error).toHaveBeenCalledWith(expect.stringMatching(/Unable to get annotations/));
+      expect(console.error).toHaveBeenCalledWith(
+        '[Grafana]',
+        expect.objectContaining({
+          message: expect.stringMatching(/Unable to get annotations/),
+        })
+      );
     });
   });
 

--- a/public/app/plugins/datasource/graphite/datasource.ts
+++ b/public/app/plugins/datasource/graphite/datasource.ts
@@ -55,6 +55,7 @@ import {
 import { reduceError } from './utils';
 import { DEFAULT_GRAPHITE_VERSION } from './versions';
 
+import { grafanaStructuredLogger } from '@grafana/runtime';
 const GRAPHITE_TAG_COMPARATORS = {
   '=': AbstractLabelOperator.Equal,
   '!=': AbstractLabelOperator.NotEqual,
@@ -555,7 +556,7 @@ export class GraphiteDatasource
       return this.events({ range: range, tags: tags }).then((results) => {
         const list = [];
         if (!isArray(results.data)) {
-          console.error(`Unable to get annotations.`);
+          grafanaStructuredLogger.logError(new Error(`Unable to get annotations.`));
           return [];
         }
         for (let i = 0; i < results.data.length; i++) {
@@ -1047,7 +1048,7 @@ export class GraphiteDatasource
         this.funcDefs = gfunc.parseFuncDefs(functions);
         return this.funcDefs;
       } catch (error) {
-        console.error('Fetching graphite functions error', error);
+        grafanaStructuredLogger.logError(error instanceof Error ? error : new Error(String(error)), { message: String('Fetching graphite functions error') });
         this.funcDefs = gfunc.getFuncDefs(this.graphiteVersion);
         return this.funcDefs;
       }
@@ -1066,7 +1067,7 @@ export class GraphiteDatasource
           return this.funcDefs;
         }),
         catchError((error) => {
-          console.error('Fetching graphite functions error', error);
+          grafanaStructuredLogger.logError(error instanceof Error ? error : new Error(String(error)), { message: String('Fetching graphite functions error') });
           this.funcDefs = gfunc.getFuncDefs(this.graphiteVersion);
           return of(this.funcDefs);
         })

--- a/public/app/plugins/datasource/graphite/graphite_query.ts
+++ b/public/app/plugins/datasource/graphite/graphite_query.ts
@@ -9,6 +9,7 @@ import { type AstNode, Parser } from './parser';
 import { type GraphiteSegment } from './types';
 import { arrayMove } from './utils';
 
+import { grafanaStructuredLogger } from '@grafana/runtime';
 export type GraphiteTagOperator = '=' | '=~' | '!=' | '!=~';
 
 export type GraphiteTag = {
@@ -94,7 +95,7 @@ export default class GraphiteQuery {
       }
     } catch (err) {
       if (err instanceof Error) {
-        console.error('error parsing target:', err.message);
+        grafanaStructuredLogger.logError(err, { detail: 'error parsing target' });
         this.error = err.message;
       }
       this.target.textEditor = true;

--- a/public/app/plugins/datasource/influxdb/components/editor/config-v2/UrlAndAuthenticationSection.tsx
+++ b/public/app/plugins/datasource/influxdb/components/editor/config-v2/UrlAndAuthenticationSection.tsx
@@ -31,6 +31,7 @@ import {
 import { type Props } from './types';
 import { INFLUXDB_VERSION_MAP, type InfluxDBProduct } from './versions';
 
+import { grafanaStructuredLogger } from '@grafana/runtime';
 const getQueryLanguageOptions = (productName: string): Array<{ value: string }> => {
   const product = INFLUXDB_VERSION_MAP.find(({ name }) => name === productName);
   return product?.queryLanguages?.map(({ name }) => ({ value: name })) ?? [];
@@ -104,7 +105,7 @@ export const UrlAndAuthenticationSection = (props: Props) => {
         }
       }
     } catch (err) {
-      console.error('Failed to get InfluxDB version:', err);
+      grafanaStructuredLogger.logError(err instanceof Error ? err : new Error(String(err)), { message: String('Failed to get InfluxDB version:') });
     }
 
     return { product: undefined, version: undefined };

--- a/public/app/plugins/datasource/influxdb/components/editor/query/influxql/visual/TagsSection.tsx
+++ b/public/app/plugins/datasource/influxdb/components/editor/query/influxql/visual/TagsSection.tsx
@@ -10,6 +10,7 @@ import { toSelectableValue } from '../utils/toSelectableValue';
 import { AddButton } from './AddButton';
 import { Seg } from './Seg';
 
+import { grafanaStructuredLogger } from '@grafana/runtime';
 type KnownOperator = '=' | '!=' | '<>' | '<' | '>' | '>=' | '<=' | '=~' | '!~' | 'Is' | 'Is Not';
 const knownOperators: KnownOperator[] = ['=', '!=', '<>', '<', '>', '>=', '<=', '=~', '!~', 'Is', 'Is Not'];
 
@@ -54,7 +55,7 @@ const Tag = ({ tag, isFirst, onRemove, onChange, getTagKeyOptions, getTagValueOp
         // to avoid it, we catch any potential errors coming from `getTagKeyOptions`,
         // log the error, and pretend that the list of options is an empty list.
         // this way the remove-item option can always be added to the list.
-        console.error(err);
+        grafanaStructuredLogger.logError(err instanceof Error ? err : new Error(String(err)));
         return [];
       })
       .then((tags) => tags.map(toSelectableValue));

--- a/public/app/plugins/datasource/influxdb/datasource.ts
+++ b/public/app/plugins/datasource/influxdb/datasource.ts
@@ -50,6 +50,7 @@ import ResponseParser from './response_parser';
 import { DEFAULT_POLICY, type InfluxOptions, type InfluxQuery, type InfluxVariableQuery, InfluxVersion } from './types';
 import { InfluxVariableSupport } from './variables';
 
+import { grafanaStructuredLogger } from '@grafana/runtime';
 export default class InfluxDatasource extends DataSourceWithBackend<InfluxQuery, InfluxOptions> {
   type: string;
   urls: string[];
@@ -388,7 +389,7 @@ export default class InfluxDatasource extends DataSourceWithBackend<InfluxQuery,
         // then put inside parenthesis.
         return typeof value === 'string' ? escapeRegex(value) : `(${value.map((v) => escapeRegex(v)).join('|')})`;
       } catch (e) {
-        console.warn(`Supplied match is not valid regex: ${match}`);
+        grafanaStructuredLogger.logWarning(String(`Supplied match is not valid regex: ${match}`));
       }
     }
 

--- a/public/app/plugins/datasource/loki/LanguageProvider.ts
+++ b/public/app/plugins/datasource/loki/LanguageProvider.ts
@@ -23,6 +23,7 @@ import {
 } from './responseUtils';
 import { type DetectedFieldsResult, LabelType, type LokiQuery, type ParserAndLabelKeysResult } from './types';
 
+import { grafanaStructuredLogger } from '@grafana/runtime';
 const NS_IN_MS = 1000000;
 const EMPTY_SELECTOR = '{}';
 const HIDDEN_LABELS = ['__aggregated_metric__', '__tenant_id__', '__stream_shard__'];
@@ -63,7 +64,7 @@ export default class LokiLanguageProvider extends LanguageProvider {
       if (throwError) {
         throw error;
       } else {
-        console.error(error);
+        grafanaStructuredLogger.logError(error instanceof Error ? error : new Error(String(error)));
       }
     }
 
@@ -293,7 +294,7 @@ export default class LokiLanguageProvider extends LanguageProvider {
         const data = await this.request(url, params, true, requestOptions);
         resolve(data);
       } catch (error) {
-        console.error('error', error);
+        grafanaStructuredLogger.logError(error instanceof Error ? error : new Error(String(error)), { message: String('error') });
         reject(error);
       }
     });
@@ -374,7 +375,7 @@ export default class LokiLanguageProvider extends LanguageProvider {
         if (queryOptions?.throwError) {
           reject(error);
         } else {
-          console.error(error);
+          grafanaStructuredLogger.logError(error instanceof Error ? error : new Error(String(error)));
           resolve([]);
         }
       }
@@ -444,7 +445,7 @@ export default class LokiLanguageProvider extends LanguageProvider {
           resolve(labelValues);
         }
       } catch (error) {
-        console.error(error);
+        grafanaStructuredLogger.logError(error instanceof Error ? error : new Error(String(error)));
         resolve([]);
       }
     });

--- a/public/app/plugins/datasource/loki/LiveStreams.ts
+++ b/public/app/plugins/datasource/loki/LiveStreams.ts
@@ -7,6 +7,7 @@ import { type DataFrame, FieldType, type KeyValue, CircularDataFrame } from '@gr
 import { appendResponseToBufferedData } from './liveStreamsResultTransformer';
 import { type LokiTailResponse } from './types';
 
+import { grafanaStructuredLogger } from '@grafana/runtime';
 /**
  * Maps directly to a query in the UI (refId is key)
  */
@@ -53,9 +54,7 @@ export class LiveStreams {
             if (error.code === 1006 && retryAttempt < 30) {
               if (retryAttempt > 10) {
                 // If more than 10 times retried, consol.warn, but keep reconnecting
-                console.warn(
-                  `Websocket connection is being disrupted. We keep reconnecting but consider starting new live tailing again. Error: ${error.reason}`
-                );
+                grafanaStructuredLogger.logWarning(String(`Websocket connection is being disrupted. We keep reconnecting but consider starting new live tailing again. Error: ${error.reason}`));
               }
               // Retry every 5s
               return timer(retryInterval);

--- a/public/app/plugins/datasource/loki/components/LokiLabelBrowser.tsx
+++ b/public/app/plugins/datasource/loki/components/LokiLabelBrowser.tsx
@@ -21,6 +21,7 @@ import {
 import type LokiLanguageProvider from '../LanguageProvider';
 import { escapeLabelValueInExactSelector, escapeLabelValueInRegexSelector } from '../languageUtils';
 
+import { grafanaStructuredLogger } from '@grafana/runtime';
 // Hard limit on labels to render
 const MAX_LABEL_COUNT = 1000;
 const MAX_VALUE_COUNT = 10000;
@@ -376,7 +377,7 @@ export class UnthemedLokiLabelBrowser extends React.Component<BrowserProps, Brow
       const values: FacettableValue[] = rawValues.map((value) => ({ name: value }));
       this.updateLabelState(name, { values, loading: false });
     } catch (error) {
-      console.error(error);
+      grafanaStructuredLogger.logError(error instanceof Error ? error : new Error(String(error)));
     }
   }
 
@@ -404,7 +405,7 @@ export class UnthemedLokiLabelBrowser extends React.Component<BrowserProps, Brow
         this.updateLabelState(lastFacetted, { loading: false });
       }
     } catch (error) {
-      console.error(error);
+      grafanaStructuredLogger.logError(error instanceof Error ? error : new Error(String(error)));
     }
   }
 

--- a/public/app/plugins/datasource/loki/components/monaco-query-field/getOverrideServices.ts
+++ b/public/app/plugins/datasource/loki/components/monaco-query-field/getOverrideServices.ts
@@ -1,5 +1,6 @@
 import { type monacoTypes } from '@grafana/ui';
 
+import { grafanaStructuredLogger } from '@grafana/runtime';
 // this thing here is a workaround in a way.
 // what we want to achieve, is that when the autocomplete-window
 // opens, the "second, extra popup" with the extra help,
@@ -81,7 +82,7 @@ function makeStorageService() {
     },
 
     logStorage: (): void => {
-      console.log('logStorage: not implemented');
+      grafanaStructuredLogger.logInfo(String('logStorage: not implemented'));
     },
 
     migrate: (): Promise<void> => {

--- a/public/app/plugins/datasource/loki/mergeResponses.ts
+++ b/public/app/plugins/datasource/loki/mergeResponses.ts
@@ -14,6 +14,7 @@ import {
 
 import { LOADING_FRAME_NAME } from './querySplitting';
 
+import { grafanaStructuredLogger } from '@grafana/runtime';
 function getFrameKey(frame: DataFrame): string | undefined {
   // Metric range query data
   if (frame.meta?.type === DataFrameType.TimeSeriesMulti) {
@@ -142,7 +143,7 @@ export function mergeFrames(dest: DataFrame, source: DataFrame) {
   const sourceIdField = source.fields.find((field) => field.type === FieldType.string && field.name === 'id');
 
   if (!destTimeField || !sourceTimeField) {
-    console.error(new Error(`Time fields not found in the data frames`));
+    grafanaStructuredLogger.logError(new Error(`Time fields not found in the data frames`) instanceof Error ? new Error(`Time fields not found in the data frames`) : new Error(String(new Error(`Time fields not found in the data frames`))));
     return;
   }
 

--- a/public/app/plugins/datasource/loki/querySplitting.ts
+++ b/public/app/plugins/datasource/loki/querySplitting.ts
@@ -31,6 +31,7 @@ import { isRetriableError } from './responseUtils';
 import { trackGroupedQueries } from './tracking';
 import { type LokiGroupedRequest, type LokiQuery } from './types';
 
+import { grafanaStructuredLogger } from '@grafana/runtime';
 export function partitionTimeRange(
   isLogsQuery: boolean,
   originalTimeRange: TimeRange,
@@ -187,7 +188,7 @@ export function runSplitGroupedQueries(
           return false;
         }
       } catch (e) {
-        console.error(e);
+        grafanaStructuredLogger.logError(e instanceof Error ? e : new Error(String(e)));
         shouldStop = true;
         return false;
       }

--- a/public/app/plugins/datasource/loki/querybuilder/LokiQueryModeller.ts
+++ b/public/app/plugins/datasource/loki/querybuilder/LokiQueryModeller.ts
@@ -14,6 +14,7 @@ import {
   LokiVisualQueryOperationCategory,
 } from './types';
 
+import { grafanaStructuredLogger } from '@grafana/runtime';
 export class LokiQueryModeller extends QueryModellerBase {
   constructor() {
     super(operationDefinitions, '<expr>');
@@ -35,7 +36,7 @@ export class LokiQueryModeller extends QueryModellerBase {
       }
       const def = this.operationsRegistry.getIfExists(operation.id);
       if (!def) {
-        console.error(`Could not find operation ${operation.id} in the registry`);
+        grafanaStructuredLogger.logError(new Error(`Could not find operation ${operation.id} in the registry`));
         continue;
       }
       queryString = def.renderer(operation, def, queryString);

--- a/public/app/plugins/datasource/loki/querybuilder/components/LokiQueryBuilder.tsx
+++ b/public/app/plugins/datasource/loki/querybuilder/components/LokiQueryBuilder.tsx
@@ -22,6 +22,7 @@ import {
   type QueryBuilderLabelFilter,
   type QueryBuilderOperation,
 } from '@grafana/plugin-ui';
+import { grafanaStructuredLogger } from '@grafana/runtime';
 import { Stack } from '@grafana/ui';
 
 import { testIds } from '../../components/LokiQueryEditor';
@@ -134,7 +135,9 @@ export const LokiQueryBuilder = memo<Props>(({ datasource, query, onChange, onRu
         Math.abs(timeRange.from.valueOf() - prevTimeRange.from.valueOf()) > TIME_SPAN_TO_TRIGGER_SAMPLES);
     const updateBasedOnChangedQuery = !isEqual(prevQuery, query);
     if (updateBasedOnChangedTimeRange || updateBasedOnChangedQuery) {
-      onGetSampleData().catch(console.error);
+      onGetSampleData().catch((err: unknown) =>
+        grafanaStructuredLogger.logError(err instanceof Error ? err : new Error(String(err)))
+      );
     }
   }, [datasource, query, timeRange, prevQuery, prevTimeRange]);
 

--- a/public/app/plugins/datasource/loki/querybuilder/parsing.ts
+++ b/public/app/plugins/datasource/loki/querybuilder/parsing.ts
@@ -72,6 +72,7 @@ import {
 } from './parsingUtils';
 import { LokiOperationId, type LokiVisualQuery, type LokiVisualQueryBinary } from './types';
 
+import { grafanaStructuredLogger } from '@grafana/runtime';
 interface Context {
   query: LokiVisualQuery;
   errors: ParsingError[];
@@ -109,7 +110,7 @@ export function buildVisualQueryFromString(expr: string): Context {
     handleExpression(replacedExpr, node, context);
   } catch (err) {
     // Not ideal to log it here, but otherwise we would lose the stack trace.
-    console.error(err);
+    grafanaStructuredLogger.logError(err instanceof Error ? err : new Error(globalThis.String(err)));
     if (err instanceof Error) {
       context.errors.push({
         text: err.message,

--- a/public/app/plugins/datasource/loki/shardQuerySplitting.ts
+++ b/public/app/plugins/datasource/loki/shardQuerySplitting.ts
@@ -16,6 +16,7 @@ import {
 } from './queryUtils';
 import { isRetriableError } from './responseUtils';
 import { type LokiQuery } from './types';
+import { grafanaStructuredLogger } from '@grafana/runtime';
 /**
  * Query splitting by stream shards.
  * Query splitting was introduced in Loki to optimize querying for long intervals and high volume of data,
@@ -130,7 +131,7 @@ function splitQueriesByStreamShard(
           return false;
         }
       } catch (e) {
-        console.error(e);
+        grafanaStructuredLogger.logError(e instanceof Error ? e : new Error(String(e)));
         shouldStop = true;
         return false;
       }
@@ -155,7 +156,7 @@ function splitQueriesByStreamShard(
 
       retryTimer = setTimeout(
         () => {
-          console.warn(`Retrying ${group} ${cycle} (${retries + 1})`);
+          grafanaStructuredLogger.logWarning(String(`Retrying ${group} ${cycle} (${retries + 1})`));
           runNextRequest(subscriber, group, groups);
           retryTimer = null;
         },
@@ -224,7 +225,9 @@ function splitQueriesByStreamShard(
         nextRequest();
       },
       error: (error: unknown) => {
-        console.error(error, { msg: 'failed to shard' });
+        grafanaStructuredLogger.logError(error instanceof Error ? error : new Error(String(error)), {
+          detail: 'failed to shard',
+        });
         subscriber.next(mergedResponse);
         if (retry()) {
           return;
@@ -293,7 +296,9 @@ async function groupTargetsByQueryType(
         cycle: 0,
       });
     } catch (error) {
-      console.error(error, { msg: 'failed to fetch label values for __stream_shard__' });
+      grafanaStructuredLogger.logError(error instanceof Error ? error : new Error(String(error)), {
+        detail: 'failed to fetch label values for __stream_shard__',
+      });
       groups.push({
         targets: selectorPartition[selector],
       });
@@ -375,5 +380,5 @@ function debug(message: string) {
   if (!DEBUG_ENABLED) {
     return;
   }
-  console.log(message);
+  grafanaStructuredLogger.logInfo(String(message));
 }

--- a/public/app/plugins/datasource/loki/tracking.ts
+++ b/public/app/plugins/datasource/loki/tracking.ts
@@ -1,6 +1,6 @@
 import { CoreApp, type DashboardLoadedEvent, type DataQueryRequest, type DataQueryResponse } from '@grafana/data';
 import { QueryEditorMode } from '@grafana/plugin-ui';
-import { reportInteraction, config } from '@grafana/runtime';
+import { reportInteraction, config, grafanaStructuredLogger } from '@grafana/runtime';
 
 import { LokiQueryType } from './dataquery.gen';
 import {
@@ -97,7 +97,7 @@ export const onDashboardLoadedHandler = ({
 
     reportInteraction('grafana_loki_dashboard_loaded', event);
   } catch (error) {
-    console.error('error in loki tracking handler', error);
+    grafanaStructuredLogger.logError(error instanceof Error ? error : new Error(String(error)), { message: String('error in loki tracking handler') });
   }
 };
 

--- a/public/app/plugins/datasource/tempo/datasource.ts
+++ b/public/app/plugins/datasource/tempo/datasource.ts
@@ -64,6 +64,7 @@ import { type TempoJsonData, type TempoQuery } from './types';
 import { getErrorMessage, mapErrorMessage, migrateFromSearchToTraceQLSearch } from './utils';
 import { TempoVariableSupport } from './variables';
 
+import { grafanaStructuredLogger } from '@grafana/runtime';
 export const DEFAULT_LIMIT = 20;
 export const DEFAULT_SPSS = 3; // spans per span set
 
@@ -295,7 +296,7 @@ export class TempoDatasource extends DataSourceWithBackend<TempoQuery, TempoJson
 
       return false;
     } catch (error) {
-      console.warn('Failed to check for native histograms:', error);
+      grafanaStructuredLogger.logWarning(String('Failed to check for native histograms:'), { args: error });
       return false;
     }
   }

--- a/public/app/plugins/datasource/tempo/resultTransformer.ts
+++ b/public/app/plugins/datasource/tempo/resultTransformer.ts
@@ -29,6 +29,7 @@ import { getDataSourceSrv } from '@grafana/runtime';
 import { SearchTableType } from './dataquery.gen';
 import { type Span, type SpanAttributes, type Spanset, type TempoJsonData, type TraceSearchMetadata } from './types';
 
+import { grafanaStructuredLogger } from '@grafana/runtime';
 function getAttributeValue(value: collectorTypes.opentelemetryProto.common.v1.AnyValue): any {
   if (value.stringValue) {
     return value.stringValue;
@@ -196,7 +197,7 @@ export function transformFromOTLP(
       }
     }
   } catch (error) {
-    console.error(error);
+    grafanaStructuredLogger.logError(error instanceof Error ? error : new Error(String(error)));
     return { error: { message: 'JSON is not valid OpenTelemetry format: ' + error }, data: [] };
   }
 

--- a/public/app/plugins/datasource/tempo/traceql/TraceQLEditor.tsx
+++ b/public/app/plugins/datasource/tempo/traceql/TraceQLEditor.tsx
@@ -14,6 +14,7 @@ import { CompletionProvider, type CompletionItemType } from './autocomplete';
 import { getErrorNodes, setMarkers } from './highlighting';
 import { languageDefinition } from './traceql';
 
+import { grafanaStructuredLogger } from '@grafana/runtime';
 interface Props {
   placeholder: string;
   query: TempoQuery;
@@ -94,7 +95,7 @@ export function TraceQLEditor(props: Props) {
               const errorNodes = getErrorNodes(model.getValue());
               setMarkers(monaco, model, errorNodes);
             } catch (err) {
-              console.warn('TraceQL editor: failed to update syntax error markers', err);
+              grafanaStructuredLogger.logWarning(String('TraceQL editor: failed to update syntax error markers'), { args: err });
             }
           }
 
@@ -127,11 +128,11 @@ export function TraceQLEditor(props: Props) {
                 try {
                   setMarkers(monaco, model, errorNodes);
                 } catch (err) {
-                  console.warn('TraceQL editor: failed to update syntax error markers', err);
+                  grafanaStructuredLogger.logWarning(String('TraceQL editor: failed to update syntax error markers'), { args: err });
                 }
               }, 500);
             } catch (err) {
-              console.warn('TraceQL editor: failed to parse query for error highlighting', err);
+              grafanaStructuredLogger.logWarning(String('TraceQL editor: failed to parse query for error highlighting'), { args: err });
             }
           });
         }}

--- a/public/app/plugins/datasource/tempo/traceql/situation.ts
+++ b/public/app/plugins/datasource/tempo/traceql/situation.ts
@@ -23,6 +23,7 @@ import {
   TraceQL,
 } from '@grafana/lezer-traceql';
 
+import { grafanaStructuredLogger } from '@grafana/runtime';
 type Direction = 'parent' | 'firstChild' | 'lastChild' | 'nextSibling' | 'prevSibling';
 type NodeType = number;
 
@@ -444,7 +445,7 @@ function resolveNewSpansetExpression(node: SyntaxNode, text: string, offset: num
       previousNode = previousNode!.nextSibling;
     }
   } catch (error) {
-    console.error('Unexpected error while searching for previous node', error);
+    grafanaStructuredLogger.logError(error instanceof Error ? error : new Error(String(error)), { message: String('Unexpected error while searching for previous node') });
   }
 
   if (previousNode?.type.id === And || previousNode?.type.id === Or) {

--- a/public/app/plugins/datasource/tempo/tracking.ts
+++ b/public/app/plugins/datasource/tempo/tracking.ts
@@ -4,6 +4,7 @@ import { getTemplateSrv, reportInteraction } from '@grafana/runtime';
 import pluginJson from './plugin.json';
 import { type TempoQuery } from './types';
 
+import { grafanaStructuredLogger } from '@grafana/runtime';
 type TempoOnDashboardLoadedTrackingEvent = {
   grafana_version?: string;
   dashboard_id?: string;
@@ -58,7 +59,7 @@ export const onDashboardLoadedHandler = ({
 
     reportInteraction('grafana_tempo_dashboard_loaded', stats);
   } catch (error) {
-    console.error('error in tempo tracking handler', error);
+    grafanaStructuredLogger.logError(error instanceof Error ? error : new Error(String(error)), { message: String('error in tempo tracking handler') });
   }
 };
 

--- a/public/app/plugins/datasource/tempo/utils.ts
+++ b/public/app/plugins/datasource/tempo/utils.ts
@@ -5,6 +5,7 @@ import { generateId } from './SearchTraceQLEditor/TagsInput';
 import { type TraceqlFilter, TraceqlSearchScope } from './dataquery.gen';
 import { type TempoQuery } from './types';
 
+import { grafanaStructuredLogger } from '@grafana/runtime';
 const LIMIT_MESSAGE = /.*range specified by start and end.*exceeds.*/;
 const LIMIT_MESSAGE_METRICS = /.*metrics query time range exceeds the maximum allowed duration of.*/;
 
@@ -32,7 +33,7 @@ export async function getDS(uid?: string): Promise<DataSourceApi | undefined> {
   try {
     return await dsSrv.get(uid);
   } catch (error) {
-    console.error('Failed to load data source', error);
+    grafanaStructuredLogger.logError(error instanceof Error ? error : new Error(String(error)), { message: String('Failed to load data source') });
     return undefined;
   }
 }

--- a/public/app/plugins/panel/canvas/components/connections/Connections.tsx
+++ b/public/app/plugins/panel/canvas/components/connections/Connections.tsx
@@ -27,6 +27,7 @@ import {
 } from './ConnectionAnchors';
 import { ConnectionSVG } from './ConnectionSVG';
 
+import { grafanaStructuredLogger } from '@grafana/runtime';
 export const CONNECTION_VERTEX_ID = 'vertex';
 export const CONNECTION_VERTEX_ADD_ID = 'vertexAdd';
 const CONNECTION_VERTEX_ORTHO_TOLERANCE = 0.05; // Cartesian ratio against vertical or horizontal tolerance
@@ -131,7 +132,7 @@ export class Connections {
     let element: ElementState | undefined = this.findElementTarget(event.target);
 
     if (!element) {
-      console.log('no element');
+      grafanaStructuredLogger.logInfo(String('no element'));
       return;
     }
 
@@ -140,7 +141,7 @@ export class Connections {
     } else {
       this.connectionSource = element;
       if (!this.connectionSource) {
-        console.log('no connection source');
+        grafanaStructuredLogger.logInfo(String('no connection source'));
         return;
       }
     }

--- a/public/app/plugins/panel/canvas/components/connections/Connections2.tsx
+++ b/public/app/plugins/panel/canvas/components/connections/Connections2.tsx
@@ -29,6 +29,7 @@ import {
 import { ConnectionAnchors } from './ConnectionAnchors2';
 import { ConnectionSVG } from './ConnectionSVG2';
 
+import { grafanaStructuredLogger } from '@grafana/runtime';
 export const CONNECTION_VERTEX_ID = 'vertex';
 export const CONNECTION_VERTEX_ADD_ID = 'vertexAdd';
 const CONNECTION_VERTEX_ORTHO_TOLERANCE = 0.05; // Cartesian ratio against vertical or horizontal tolerance
@@ -126,7 +127,7 @@ export class Connections2 {
     let element: ElementState | undefined = this.findElementTarget(event.target);
 
     if (!element) {
-      console.log('no element');
+      grafanaStructuredLogger.logInfo(String('no element'));
       return;
     }
 
@@ -135,7 +136,7 @@ export class Connections2 {
     } else {
       this.connectionSource = element;
       if (!this.connectionSource) {
-        console.log('no connection source');
+        grafanaStructuredLogger.logInfo(String('no connection source'));
         return;
       }
     }

--- a/public/app/plugins/panel/canvas/editor/element/elementEditor.tsx
+++ b/public/app/plugins/panel/canvas/editor/element/elementEditor.tsx
@@ -18,6 +18,7 @@ import { optionBuilder } from '../options';
 
 import { PlacementEditor } from './PlacementEditor';
 
+import { grafanaStructuredLogger } from '@grafana/runtime';
 export interface CanvasEditorOptions {
   element: ElementState;
   scene: Scene;
@@ -45,7 +46,7 @@ export function getElementEditor(opts: CanvasEditorOptions): NestedPanelOptions<
         if (path === 'type' && value) {
           const layer = canvasElementRegistry.getIfExists(value);
           if (!layer) {
-            console.warn('layer does not exist', value);
+            grafanaStructuredLogger.logWarning(String('layer does not exist'), { args: value });
             return;
           }
           options = {

--- a/public/app/plugins/panel/canvas/editor/element/utils.ts
+++ b/public/app/plugins/panel/canvas/editor/element/utils.ts
@@ -8,6 +8,7 @@ import { HttpRequestMethod } from '../../panelcfg.gen';
 
 import { type APIEditorConfig } from './APIEditor';
 
+import { grafanaStructuredLogger } from '@grafana/runtime';
 type IsLoadingCallback = (loading: boolean) => void;
 
 export const callApi = (api: APIEditorConfig, updateLoadingStateCallback?: IsLoadingCallback) => {
@@ -23,7 +24,7 @@ export const callApi = (api: APIEditorConfig, updateLoadingStateCallback?: IsLoa
     .subscribe({
       error: (error) => {
         appEvents.emit(AppEvents.alertError, ['An error has occurred. Check console output for more details.']);
-        console.error('API call error: ', error);
+        grafanaStructuredLogger.logError(error instanceof Error ? error : new Error(String(error)), { message: String('API call error: ') });
         updateLoadingStateCallback && updateLoadingStateCallback(false);
       },
       complete: () => {

--- a/public/app/plugins/panel/canvas/editor/layer/TreeNavigationEditor.tsx
+++ b/public/app/plugins/panel/canvas/editor/layer/TreeNavigationEditor.tsx
@@ -20,6 +20,7 @@ import { type TreeViewEditorProps } from '../element/elementEditor';
 import { TreeNodeTitle } from './TreeNodeTitle';
 import { getTreeData, onNodeDrop, type TreeElement } from './tree';
 
+import { grafanaStructuredLogger } from '@grafana/runtime';
 let allowSelection = true;
 
 export const TreeNavigationEditor = ({ item }: StandardEditorProps<unknown, TreeViewEditorProps, Options>) => {
@@ -130,7 +131,7 @@ export const TreeNavigationEditor = ({ item }: StandardEditorProps<unknown, Tree
     if (layer.scene) {
       frameSelection(layer.scene);
     } else {
-      console.warn('no scene!');
+      grafanaStructuredLogger.logWarning(String('no scene!'));
     }
   };
 

--- a/public/app/plugins/panel/canvas/editor/layer/layerEditor.tsx
+++ b/public/app/plugins/panel/canvas/editor/layer/layerEditor.tsx
@@ -13,6 +13,7 @@ import { optionBuilder } from '../options';
 
 import { TreeNavigationEditor } from './TreeNavigationEditor';
 
+import { grafanaStructuredLogger } from '@grafana/runtime';
 export interface LayerEditorProps {
   scene: Scene;
   layer: FrameState;
@@ -53,7 +54,7 @@ export function getLayerEditor(opts: InstanceState): NestedPanelOptions<LayerEdi
       },
       onChange: (path, value) => {
         if (path === 'type' && value) {
-          console.warn('unable to change layer type');
+          grafanaStructuredLogger.logWarning(String('unable to change layer type'));
           return;
         }
         const c = setOptionImmutably(options, path, value);

--- a/public/app/plugins/panel/dashlist/migrations.ts
+++ b/public/app/plugins/panel/dashlist/migrations.ts
@@ -4,6 +4,7 @@ import { type FolderDTO } from 'app/types/folders';
 
 import { type Options } from './panelcfg.gen';
 
+import { grafanaStructuredLogger } from '@grafana/runtime';
 async function getFolderUID(folderID: number): Promise<string> {
   // folderID 0 is always the fake General/Dashboards folder, which always has a UID of empty string
   if (folderID === 0) {
@@ -67,7 +68,7 @@ export async function dashlistMigrationHandler(panel: PanelModel<Options> & Angu
       newOptions.folderUID = folderUID;
       delete newOptions.folderId;
     } catch (err) {
-      console.warn('Dashlist: Error migrating folder ID to UID', err);
+      grafanaStructuredLogger.logWarning(String('Dashlist: Error migrating folder ID to UID'), { args: err });
     }
   }
 

--- a/public/app/plugins/panel/geomap/GeomapPanel.tsx
+++ b/public/app/plugins/panel/geomap/GeomapPanel.tsx
@@ -47,6 +47,7 @@ import {
 } from './utils/utils';
 import { centerPointRegistry, MapCenterID } from './view';
 
+import { grafanaStructuredLogger } from '@grafana/runtime';
 // Allows multiple panels to share the same view instance
 let sharedView: View | undefined = undefined;
 
@@ -323,7 +324,7 @@ export class GeomapPanel extends Component<Props, State> {
         layers.push(await initLayer(this, map, lyr, false));
       }
     } catch (ex) {
-      console.error('error loading layers', ex);
+      grafanaStructuredLogger.logError(ex instanceof Error ? ex : new Error(String(ex)), { message: String('error loading layers') });
     }
 
     for (const lyr of layers) {

--- a/public/app/plugins/panel/geomap/layers/basemaps/maplibre.ts
+++ b/public/app/plugins/panel/geomap/layers/basemaps/maplibre.ts
@@ -4,6 +4,7 @@ import { apply } from 'ol-mapbox-style';
 
 import { type MapLayerRegistryItem, type MapLayerOptions, type GrafanaTheme2, type EventBus } from '@grafana/data';
 
+import { grafanaStructuredLogger } from '@grafana/runtime';
 // MapLibre Style Specification constants
 const LAYER_TYPE_BACKGROUND = 'background';
 const PAINT_BACKGROUND_OPACITY = 'background-opacity';
@@ -63,13 +64,13 @@ export const maplibreLayer: MapLayerRegistryItem<MaplibreConfig> = {
       const loadStyle = async () => {
         try {
           if (!cfg.url) {
-            console.warn('No URL provided for MapLibre style, layer will be empty');
+            grafanaStructuredLogger.logWarning('No URL provided for MapLibre style — layer will be empty');
             return;
           }
 
           const res = await fetch(cfg.url);
           if (!res.ok) {
-            console.warn(`Failed to load MapLibre style from ${cfg.url}: ${res.status} ${res.statusText}`);
+            grafanaStructuredLogger.logWarning(String(`Failed to load MapLibre style from ${cfg.url}: ${res.status} ${res.statusText}`));
             // Try fallback approach
             await tryFallbackApply();
             return;
@@ -90,7 +91,7 @@ export const maplibreLayer: MapLayerRegistryItem<MaplibreConfig> = {
           await apply(layer, style, { styleUrl: cfg.url, accessToken: cfg.accessToken });
           applyNoRepeat();
         } catch (error) {
-          console.warn('Failed to parse or apply MapLibre style JSON:', error);
+          grafanaStructuredLogger.logWarning(String('Failed to parse or apply MapLibre style JSON:'), { args: error });
           // Try fallback approach
           await tryFallbackApply();
         }
@@ -99,13 +100,13 @@ export const maplibreLayer: MapLayerRegistryItem<MaplibreConfig> = {
       const tryFallbackApply = async () => {
         try {
           if (!cfg.url) {
-            console.warn('No URL available for MapLibre fallback, layer will be empty');
+            grafanaStructuredLogger.logWarning('No URL available for MapLibre fallback — layer will be empty');
             return;
           }
           await apply(layer, cfg.url, { accessToken: cfg.accessToken });
           applyNoRepeat();
         } catch (fallbackError) {
-          console.warn('Failed to load MapLibre style from both JSON and direct URL approaches:', fallbackError);
+          grafanaStructuredLogger.logWarning(String('Failed to load MapLibre style from both JSON and direct URL approaches:'), { args: fallbackError });
         }
       };
 

--- a/public/app/plugins/panel/geomap/style/markers.ts
+++ b/public/app/plugins/panel/geomap/style/markers.ts
@@ -9,6 +9,7 @@ import { getPublicOrAbsoluteUrl } from 'app/features/dimensions/resource';
 import { defaultStyleConfig, DEFAULT_SIZE, type StyleConfigValues, type StyleMaker } from './types';
 import { getDisplacement } from './utils';
 
+import { grafanaStructuredLogger } from '@grafana/runtime';
 interface SymbolMaker extends RegistryItem {
   aliasIds: string[];
   make: StyleMaker;
@@ -297,7 +298,7 @@ async function prepareSVG(url: string, size?: number, backgroundOpacity?: number
       return `data:image/svg+xml,${svgURI}`;
     })
     .catch((error) => {
-      console.error(error); // eslint-disable-line no-console
+      grafanaStructuredLogger.logError(error instanceof Error ? error : new Error(String(error))); // eslint-disable-line no-console
       return '';
     });
 }

--- a/public/app/plugins/panel/geomap/style/utils.ts
+++ b/public/app/plugins/panel/geomap/style/utils.ts
@@ -13,6 +13,7 @@ import {
   type ColorValue,
 } from './types';
 
+import { grafanaStructuredLogger } from '@grafana/runtime';
 /** Indicate if the style wants to show text values */
 export function styleUsesText(config: StyleConfig): boolean {
   const text = config?.text;
@@ -106,7 +107,7 @@ export function getRGBValues(colorString: string): ColorValue | null {
 
   // Handle other color formats if needed
   else {
-    console.warn(`Unsupported color format: ${colorString}`);
+    grafanaStructuredLogger.logWarning(String(`Unsupported color format: ${colorString}`));
   }
   return null;
 }
@@ -142,10 +143,10 @@ function getRGBFromRGBString(rgbString: string): ColorValue | null {
         a: parseFloat(matches[3]), // Using parseFloat for alpha as it can be decimal (0-1)
       };
     } else {
-      console.warn(`Unsupported color format: ${rgbString}`);
+      grafanaStructuredLogger.logWarning(String(`Unsupported color format: ${rgbString}`));
     }
   } else {
-    console.warn(`Unsupported color format: ${rgbString}`);
+    grafanaStructuredLogger.logWarning(String(`Unsupported color format: ${rgbString}`));
   }
   return null;
 }

--- a/public/app/plugins/panel/geomap/utils/layers.ts
+++ b/public/app/plugins/panel/geomap/utils/layers.ts
@@ -15,6 +15,7 @@ import { type MapLayerState } from '../types';
 
 import { getNextLayerName } from './utils';
 
+import { grafanaStructuredLogger } from '@grafana/runtime';
 const layerStateMap = new WeakMap<BaseLayer, MapLayerState>();
 
 export const applyLayerFilter = (
@@ -91,7 +92,7 @@ export async function updateLayer(panel: GeomapPanel, uid: string, newOptions: M
     // initialize with new data
     applyLayerFilter(info.handler, newOptions, panel.props.data);
   } catch (err) {
-    console.warn('ERROR', err); // eslint-disable-line no-console
+    grafanaStructuredLogger.logWarning(String('ERROR'), { args: err }); // eslint-disable-line no-console
     return false;
   }
 

--- a/public/app/plugins/panel/heatmap/HeatmapPanel.tsx
+++ b/public/app/plugins/panel/heatmap/HeatmapPanel.tsx
@@ -30,6 +30,7 @@ import { quantizeScheme } from './palettes';
 import { type Options } from './panelcfg.gen';
 import { calculateYSizeDivisor, prepConfig } from './utils';
 
+import { grafanaStructuredLogger } from '@grafana/runtime';
 interface HeatmapPanelProps extends PanelProps<Options> {}
 
 type HeatmapDataForViz = Required<Pick<HeatmapData, 'heatmap'>> & Omit<HeatmapData, 'warning' | 'heatmap'>;
@@ -54,7 +55,7 @@ export const HeatmapPanel = (props: HeatmapPanelProps) => {
         timeRange,
       });
     } catch (ex) {
-      console.error(ex);
+      grafanaStructuredLogger.logError(ex instanceof Error ? ex : new Error(String(ex)));
       return { warning: `${ex}` };
     }
   }, [data.series, data.annotations, options, palette, theme, replaceVariables, timeRange]);

--- a/public/app/plugins/panel/live/LivePanel.tsx
+++ b/public/app/plugins/panel/live/LivePanel.tsx
@@ -27,6 +27,7 @@ import { TablePanel } from '../table/TablePanel';
 import { LivePublish } from './LivePublish';
 import { type LivePanelOptions, MessageDisplayMode, MessagePublishMode } from './types';
 
+import { grafanaStructuredLogger } from '@grafana/runtime';
 interface Props extends PanelProps<LivePanelOptions> {}
 
 interface State {
@@ -72,7 +73,7 @@ export class LivePanel extends PureComponent<Props, State> {
       } else if (isLiveChannelMessageEvent(event)) {
         this.setState({ message: event.message, changed: Date.now() });
       } else {
-        console.log('ignore', event);
+        grafanaStructuredLogger.logInfo(String('ignore'), { args: event });
       }
     },
   };
@@ -87,7 +88,7 @@ export class LivePanel extends PureComponent<Props, State> {
   async loadChannel() {
     const addr = this.props.options?.channel;
     if (!isValidLiveChannelAddress(addr)) {
-      console.log('INVALID', addr);
+      grafanaStructuredLogger.logInfo(String('INVALID'), { args: addr });
       this.unsubscribe();
       this.setState({
         addr: undefined,
@@ -96,13 +97,13 @@ export class LivePanel extends PureComponent<Props, State> {
     }
 
     if (isEqual(addr, this.state.addr)) {
-      console.log('Same channel', this.state.addr);
+      grafanaStructuredLogger.logInfo(String('Same channel'), { args: this.state.addr });
       return;
     }
 
     const live = getGrafanaLiveSrv();
     if (!live) {
-      console.log('INVALID', addr);
+      grafanaStructuredLogger.logInfo(String('INVALID'), { args: addr });
       this.unsubscribe();
       this.setState({
         addr: undefined,
@@ -111,7 +112,7 @@ export class LivePanel extends PureComponent<Props, State> {
     }
     this.unsubscribe();
 
-    console.log('LOAD', addr);
+    grafanaStructuredLogger.logInfo(String('LOAD'), { args: addr });
 
     // Subscribe to new events
     try {

--- a/public/app/plugins/panel/live/LivePublish.tsx
+++ b/public/app/plugins/panel/live/LivePublish.tsx
@@ -7,6 +7,7 @@ import { CodeEditor, Button } from '@grafana/ui';
 
 import { MessagePublishMode } from './types';
 
+import { grafanaStructuredLogger } from '@grafana/runtime';
 interface Props {
   height: number;
   addr?: LiveChannelAddress;
@@ -46,7 +47,7 @@ export function LivePublish({ height, mode, body, addr, onSave }: Props) {
     }
 
     const rsp = await getGrafanaLiveSrv().publish(addr, body);
-    console.log('onPublishClicked (response from publish)', rsp);
+    grafanaStructuredLogger.logInfo(String('onPublishClicked (response from publish)'), { args: rsp });
   };
 
   return (

--- a/public/app/plugins/panel/logs/LogsPanel.tsx
+++ b/public/app/plugins/panel/logs/LogsPanel.tsx
@@ -71,6 +71,7 @@ import {
 } from './types';
 import { useDatasourcesFromTargets } from './useDatasourcesFromTargets';
 
+import { grafanaStructuredLogger } from '@grafana/runtime';
 interface LogsPanelProps extends PanelProps<Options> {
   /**
    * Adds a key => value filter to the query referenced by the provided DataFrame refId. Used by Log details and Logs table.
@@ -488,7 +489,7 @@ export const LogsPanel = ({ data, timeZone, fieldConfig, options, onOptionsChang
           newSeries = await lastValueFrom(transformDataFrame(panel?.transformations, newSeries));
         }
       } catch (e) {
-        console.error(e);
+        grafanaStructuredLogger.logError(e instanceof Error ? e : new Error(String(e)));
       } finally {
         setInfiniteScrolling(false);
         loadingRef.current = false;
@@ -851,7 +852,7 @@ export async function requestMoreLogs(
   for (const uid in targetGroups) {
     const dataSource = dataSourcesMap.get(panelData.request.targets[0].refId);
     if (!dataSource) {
-      console.warn(`Could not resolve data source for target ${panelData.request.targets[0].refId}`);
+      grafanaStructuredLogger.logWarning(String(`Could not resolve data source for target ${panelData.request.targets[0].refId}`));
       continue;
     }
     dataRequests.push(

--- a/public/app/plugins/panel/logstable/fieldSelector/buildColumnsWithMeta.ts
+++ b/public/app/plugins/panel/logstable/fieldSelector/buildColumnsWithMeta.ts
@@ -1,4 +1,5 @@
 import { type DataFrame, type FieldWithIndex, getFieldDisplayName } from '@grafana/data';
+import { grafanaStructuredLogger } from '@grafana/runtime';
 import { type FieldNameMeta, type FieldNameMetaStore } from 'app/features/explore/Logs/LogsTableWrap';
 import { LOG_LINE_BODY_FIELD_NAME } from 'app/features/logs/components/fieldSelector/logFields';
 
@@ -104,7 +105,10 @@ export const buildColumnsWithMeta = (
       pendingLabelState[logsFrameFields.bodyField?.name].active = true;
       pendingLabelState[logsFrameFields.bodyField?.name].index = idx;
     } else {
-      console.error(`Unknown field ${fieldName}`, { pendingLabelState, displayedFields });
+      grafanaStructuredLogger.logError(new Error(`Unknown field ${fieldName}`), {
+        pendingLabelState,
+        displayedFields,
+      });
     }
   });
 

--- a/public/app/plugins/panel/logstable/hooks/useExtractFields.ts
+++ b/public/app/plugins/panel/logstable/hooks/useExtractFields.ts
@@ -16,6 +16,7 @@ import { replaceVariables } from '@grafana-plugins/loki/querybuilder/parsingUtil
 
 import { extractLogsFieldsTransform } from '../transforms/extractLogsFieldsTransform';
 
+import { grafanaStructuredLogger } from '@grafana/runtime';
 interface Props {
   rawTableFrame: DataFrame | null;
   fieldConfig?: FieldConfigSource;
@@ -56,7 +57,7 @@ export function useExtractFields({ rawTableFrame, fieldConfig, timeZone }: Props
         }
       })
       .catch((err) => {
-        console.error('LogsTable: Extract fields transform error', err);
+        grafanaStructuredLogger.logError(err instanceof Error ? err : new Error(String(err)), { message: String('LogsTable: Extract fields transform error') });
       });
     // @todo hook re-renders unexpectedly when data frame isn't changing if we add `rawTableFrame` as dependency, so we check for changes in the timestamps instead
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/public/app/plugins/panel/logstable/hooks/useOrganizeFields.tsx
+++ b/public/app/plugins/panel/logstable/hooks/useOrganizeFields.tsx
@@ -17,6 +17,7 @@ import type { Options as LogsTableOptions } from '../panelcfg.gen';
 import { organizeLogsFieldsTransform } from '../transforms/organizeLogsFieldsTransform';
 import { type BuildLinkToLogLine, isBuildLinkToLogLine } from '../types';
 
+import { grafanaStructuredLogger } from '@grafana/runtime';
 interface Props {
   extractedFrame: DataFrame | null;
   timeFieldName: string;
@@ -68,7 +69,7 @@ export function useOrganizeFields({
         }
       })
       .catch((err) => {
-        console.error('LogsTable: Organize fields transform error', err);
+        grafanaStructuredLogger.logError(err instanceof Error ? err : new Error(String(err)), { message: String('LogsTable: Organize fields transform error') });
       });
   }, [
     bodyFieldName,

--- a/public/app/plugins/panel/logstable/rows/LogsTableRowActionButtons.tsx
+++ b/public/app/plugins/panel/logstable/rows/LogsTableRowActionButtons.tsx
@@ -15,6 +15,7 @@ import { type LogsFrame } from 'app/features/logs/logsFrame';
 
 import { type BuildLinkToLogLine } from '../types';
 
+import { grafanaStructuredLogger } from '@grafana/runtime';
 interface Props extends CustomCellRendererProps {
   buildLinkToLog?: BuildLinkToLogLine;
   showInspectLogLine: boolean;
@@ -71,7 +72,7 @@ export function LogsTableRowActionButtons(props: Props) {
                 if (logId) {
                   return buildLinkToLog(logId) ?? '';
                 } else {
-                  console.error('failed to copy log line link!');
+                  grafanaStructuredLogger.logError(new Error('failed to copy log line link!'));
                 }
                 return '';
               }}

--- a/public/app/plugins/panel/news/utils.ts
+++ b/public/app/plugins/panel/news/utils.ts
@@ -2,6 +2,7 @@ import { FieldType, type DataFrame, dateTime } from '@grafana/data';
 
 import { type Feed } from './types';
 
+import { grafanaStructuredLogger } from '@grafana/runtime';
 export function feedToDataFrame(feed: Feed): DataFrame {
   const date: number[] = [];
   const title: string[] = [];
@@ -23,7 +24,7 @@ export function feedToDataFrame(feed: Feed): DataFrame {
         content.push(body);
       }
     } catch (err) {
-      console.warn('Error reading news item:', err, item);
+      grafanaStructuredLogger.logWarning(String('Error reading news item:'), { args: err, item });
     }
   }
 

--- a/public/app/plugins/panel/table/migrations.ts
+++ b/public/app/plugins/panel/table/migrations.ts
@@ -15,6 +15,7 @@ import { type ReduceTransformerOptions } from '@grafana/data/internal';
 
 import { type Options } from './panelcfg.gen';
 
+import { grafanaStructuredLogger } from '@grafana/runtime';
 /**
  * At 7.0, the `table` panel was swapped from an angular implementation to a react one.
  * The models do not match, so this process will delegate to the old implementation when
@@ -23,7 +24,7 @@ import { type Options } from './panelcfg.gen';
 export const tableMigrationHandler = (panel: PanelModel<Options>): Partial<Options> => {
   // Table was saved as an angular table, lets just swap to the 'table-old' panel
   if (!panel.pluginVersion && 'columns' in panel) {
-    console.log('Was angular table', panel);
+    grafanaStructuredLogger.logInfo(String('Was angular table'), { args: panel });
   }
 
   // ensure overrides array exists before applying rest of overrides

--- a/public/app/plugins/panel/timeseries/NullsThresholdInput.tsx
+++ b/public/app/plugins/panel/timeseries/NullsThresholdInput.tsx
@@ -4,6 +4,7 @@ import { rangeUtil } from '@grafana/data';
 import { t } from '@grafana/i18n';
 import { Input } from '@grafana/ui';
 
+import { grafanaStructuredLogger } from '@grafana/runtime';
 export enum InputPrefix {
   LessThan = 'lessthan',
   GreaterThan = 'greaterthan',
@@ -31,7 +32,7 @@ export const NullsThresholdInput = ({ value, onChange, inputPrefix, isTime }: Pr
           val = Number(txt);
         }
       } catch (err) {
-        console.warn('ERROR', err);
+        grafanaStructuredLogger.logWarning(String('ERROR'), { args: err });
       }
     }
     onChange(val);

--- a/public/app/plugins/panel/timeseries/migrations.ts
+++ b/public/app/plugins/panel/timeseries/migrations.ts
@@ -45,6 +45,7 @@ import { type GrafanaQuery, GrafanaQueryType } from 'app/plugins/datasource/graf
 import { defaultGraphConfig } from './config';
 import { type Options } from './panelcfg.gen';
 
+import { grafanaStructuredLogger } from '@grafana/runtime';
 let dashboardRefreshDebouncer: ReturnType<typeof setTimeout> | null = null;
 
 /**
@@ -283,7 +284,7 @@ export function graphToTimeseriesOptions(angular: any): {
             });
             break;
           default:
-            console.log('Ignore override migration:', seriesOverride.alias, p, v);
+            grafanaStructuredLogger.logInfo(String('Ignore override migration:'), { args: seriesOverride.alias, p, v });
         }
       }
       if (dashOverride) {

--- a/public/app/plugins/panel/timeseries/plugins/annotations2-cluster/useAnnotationClustering.tsx
+++ b/public/app/plugins/panel/timeseries/plugins/annotations2-cluster/useAnnotationClustering.tsx
@@ -7,6 +7,7 @@ import { type TimeRange2 } from '@grafana/ui/internal';
 
 import { DEFAULT_CLUSTERING_ANNOTATION_SPACING } from './constants';
 
+import { grafanaStructuredLogger } from '@grafana/runtime';
 interface Props {
   annotations: DataFrame[];
   clusteringMode: ClusteringMode | null;
@@ -120,7 +121,7 @@ export const useAnnotationClustering = ({ annotations, clusteringMode, plotWidth
       }
     } else if (clusteringMode === ClusteringMode.Hover) {
       // Have the tooltip be clustered, but not the annotations: https://github.com/grafana/grafana/issues/119436
-      console.warn('Hover mode not implemented');
+      grafanaStructuredLogger.logWarning(String('Hover mode not implemented'));
     }
 
     // Sort clustered frames

--- a/scripts/migrate-console-to-structured.mjs
+++ b/scripts/migrate-console-to-structured.mjs
@@ -1,0 +1,303 @@
+#!/usr/bin/env node
+/** Console.* → Grafana structured helpers. */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { execSync } from 'node:child_process';
+import ts from 'typescript';
+
+const ROOT = path.resolve(path.dirname(new URL(import.meta.url).pathname), '..');
+
+const SKIP_SUB = [
+  'structuredBrowserLog.ts',
+  `${path.sep}utils${path.sep}logging.ts`,
+  '.test.',
+  '.spec.',
+  '.story.',
+  '/scripts/',
+];
+
+function hasRuntime(pkgRoot) {
+  try {
+    const j = JSON.parse(fs.readFileSync(path.join(pkgRoot, 'package.json'), 'utf8'));
+    const d = { ...(j.dependencies ?? {}), ...(j.peerDependencies ?? {}) };
+    return d['@grafana/runtime'] !== undefined;
+  } catch {
+    return false;
+  }
+}
+
+function findPkgRoot(fp) {
+  let d = path.dirname(fp);
+  while (d.startsWith(ROOT)) {
+    if (fs.existsSync(path.join(d, 'package.json'))) {
+      return d;
+    }
+    const u = path.dirname(d);
+    if (u === d) {
+      break;
+    }
+    d = u;
+  }
+  return null;
+}
+
+function structuredRel(fromFile) {
+  let rel = path
+    .relative(path.dirname(fromFile), path.join(ROOT, 'packages/grafana-data/src/utils/structuredBrowserLog'))
+    .replace(/\\/g, '/');
+  if (!rel.startsWith('.')) {
+    rel = './' + rel;
+  }
+  return rel.replace(/\.tsx?$/, '');
+}
+
+function consumeClosingParen(openParen, src) {
+  let depth = 0;
+  for (let idx = openParen; idx < src.length; idx++) {
+    const c = src[idx];
+    if (c === '(') {
+      depth++;
+    } else if (c === ')') {
+      depth--;
+      if (depth === 0) {
+        return { inner: src.slice(openParen + 1, idx), closeIdx: idx };
+      }
+    }
+  }
+  return null;
+}
+
+function normErr(expr) {
+  const t = expr.trim();
+  if (t.startsWith('`') || t.startsWith("'") || t.startsWith('"')) {
+    return `new Error(${t})`;
+  }
+  return `${t} instanceof Error ? ${t} : new Error(String(${t}))`;
+}
+
+function trailingNewlines(full, posAfterStmt) {
+  let out = '';
+  for (let i = posAfterStmt; i < full.length && (full[i] === '\n' || full[i] === '\r'); i++) {
+    out += full[i];
+  }
+  return out;
+}
+
+function ensureImport(full, importSnippet) {
+  const line = importSnippet.trim();
+  if (full.includes(line)) {
+    return full;
+  }
+
+  const sf = ts.createSourceFile('_f.tsx', full, ts.ScriptTarget.Latest, true, ts.ScriptKind.TSX);
+  let importEnd = 0;
+  for (const st of sf.statements) {
+    if (ts.isImportDeclaration(st) || ts.isImportEqualsDeclaration(st)) {
+      importEnd = st.end;
+    } else {
+      break;
+    }
+  }
+  const lb = trailingNewlines(full, importEnd);
+  const cut = importEnd + lb.length;
+  return `${full.slice(0, importEnd)}${lb || '\n'}${importSnippet}\n${full.slice(cut)}`;
+}
+
+function replacementsFor(full, mode, logRef) {
+  const methods = ['error', 'warn', 'log', 'info', 'debug'];
+  const marks = [];
+  const src = full;
+
+  for (const m of methods) {
+    const pre = `console.${m}`;
+    let p = 0;
+    while (p < src.length) {
+      const ix = src.indexOf(pre + '(', p);
+      if (ix === -1) {
+        break;
+      }
+      if (ix > 0 && /\w/.test(src[ix - 1])) {
+        p = ix + 2;
+        continue;
+      }
+      marks.push({ ix, m, open: ix + pre.length });
+      p = ix + pre.length + 2;
+    }
+  }
+
+  marks.sort((a, b) => a.ix - b.ix);
+
+  /** @type { { start:number,end:number,str:string }[] } */
+  const picked = [];
+  let maxRight = -1;
+
+  for (const h of marks) {
+    const ext = consumeClosingParen(h.open, src);
+    if (!ext) {
+      continue;
+    }
+    const start = h.ix;
+    const end = ext.closeIdx + 1;
+    if (start < maxRight) {
+      continue;
+    }
+
+    const lineStart = src.lastIndexOf('\n', start);
+    const prefix = src.slice(lineStart + 1, start).trimStart();
+    if (prefix.startsWith('//') || prefix.startsWith('*')) {
+      continue;
+    }
+
+    const args = ext.inner.trim();
+    let str = '';
+
+    if (mode === 'runtime') {
+      if (h.m === 'error') {
+        if (!args) {
+          continue;
+        }
+        str = !args.includes(',')
+          ? `${logRef}.logError(${normErr(args)})`
+          : (() => {
+              const lc = args.lastIndexOf(',');
+              return `${logRef}.logError(${normErr(args.slice(lc + 1).trim())}, { message: String(${args.slice(0, lc).trim()}) })`;
+            })();
+      } else {
+        const cap = h.m === 'log' || h.m === 'info' ? 'Info' : h.m === 'debug' ? 'Debug' : 'Warning';
+        if (!args) {
+          continue;
+        }
+        str = !args.includes(',')
+          ? `${logRef}.log${cap}(String(${args}))`
+          : (() => {
+              const fc = args.indexOf(',');
+              return `${logRef}.log${cap}(String(${args.slice(0, fc).trim()}), { args: ${args.slice(fc + 1).trim()} })`;
+            })();
+      }
+    } else {
+      if (h.m === 'error') {
+        if (!args) {
+          continue;
+        }
+        str = !args.includes(',')
+          ? `emitStructuredBrowserError(${normErr(args)})`
+          : (() => {
+              const lc = args.lastIndexOf(',');
+              return `emitStructuredBrowserError(${normErr(args.slice(lc + 1).trim())}, { message: String(${args.slice(0, lc).trim()}) })`;
+            })();
+      } else {
+        const lvl = h.m === 'log' || h.m === 'info' ? 'info' : h.m === 'debug' ? 'debug' : 'warn';
+        if (!args) {
+          continue;
+        }
+        str = !args.includes(',')
+          ? `emitStructuredBrowserLog('${lvl}', String(${args}))`
+          : (() => {
+              const fc = args.indexOf(',');
+              return `emitStructuredBrowserLog('${lvl}', String(${args.slice(0, fc).trim()}), { args: ${args.slice(fc + 1).trim()} })`;
+            })();
+      }
+    }
+
+    picked.push({ start, end, str });
+    maxRight = Math.max(maxRight, end);
+  }
+
+  return picked.sort((a, b) => b.start - a.start);
+}
+
+function patchOne(file) {
+  if (SKIP_SUB.some((s) => file.includes(s))) {
+    return false;
+  }
+
+  let text = fs.readFileSync(file, 'utf8');
+  if (!/console\.(log|warn|error|info|debug)\s*\(/.test(text)) {
+    return false;
+  }
+
+  const orig = text;
+  const norm = file.replace(/\\/g, '/');
+  const isRuntimeConfig = norm.endsWith('packages/grafana-runtime/src/config.ts');
+  const inGrafanaData = norm.includes('packages/grafana-data/');
+  const pkg = findPkgRoot(file);
+  const runtimeMode = !isRuntimeConfig && !inGrafanaData && pkg && hasRuntime(pkg);
+
+  const importLine = runtimeMode
+    ? `import { grafanaStructuredLogger } from '@grafana/runtime';`
+    : `import { emitStructuredBrowserError, emitStructuredBrowserLog } from '${
+        inGrafanaData ? structuredRel(file) : '@grafana/data'
+      }';`;
+
+  text = text.replace(
+    /\.catch\(\s*console\.error\s*\)/g,
+    runtimeMode
+      ? '.catch((err: unknown) => grafanaStructuredLogger.logError(err instanceof Error ? err : new Error(String(err))))'
+      : '.catch((err: unknown) => emitStructuredBrowserError(err instanceof Error ? err : new Error(String(err))))'
+  );
+
+  const reps = replacementsFor(text, runtimeMode ? 'runtime' : 'emit', 'grafanaStructuredLogger');
+  for (const r of reps) {
+    text = text.slice(0, r.start) + r.str + text.slice(r.end);
+  }
+
+  /** throw console.error — convert to log + throw */
+  {
+    const pre = 'throw console.error(';
+    let search = 0;
+    while (true) {
+      const i = text.indexOf(pre, search);
+      if (i < 0) {
+        break;
+      }
+      const openParenIdx = i + 'throw console.error('.length - 1;
+      const ext = consumeClosingParen(openParenIdx, text);
+      if (!ext) {
+        search = i + pre.length;
+        continue;
+      }
+      const args = ext.inner.trim();
+      const errExpr = !args.includes(',') ? normErr(args) : normErr(args.slice(args.lastIndexOf(',') + 1).trim());
+      const rep = `{ const _err = ${errExpr}; ${
+        runtimeMode ? 'grafanaStructuredLogger.logError(_err)' : 'emitStructuredBrowserError(_err)'
+      }; throw _err; }`;
+      text = text.slice(0, i) + rep + text.slice(ext.closeIdx + 1);
+      search = i + rep.length;
+    }
+  }
+
+  if (text === orig) {
+    return false;
+  }
+
+  text = ensureImport(text, importLine);
+
+  fs.writeFileSync(file, text);
+  return true;
+}
+
+function listTargets() {
+  const out = execSync(
+    `grep -rl "console\\\\.\\\\(log\\\\|warn\\\\|error\\\\|info\\\\|debug\\\\)" --exclude-dir=node_modules --exclude-dir=.yarn --include='*.ts' --include='*.tsx' public/app packages 2>/dev/null || true`,
+    { cwd: ROOT, encoding: 'utf8', maxBuffer: 64 * 1024 * 1024 }
+  );
+  return out
+    .split('\n')
+    .map((l) => l.trim())
+    .filter(Boolean)
+    .map((p) => path.join(ROOT, p));
+}
+
+let n = 0;
+for (const f of listTargets()) {
+  try {
+    if (patchOne(f)) {
+      n++;
+      console.log('patched', path.relative(ROOT, f));
+    }
+  } catch (e) {
+    console.error('failed', f, e);
+  }
+}
+console.log('done, files:', n);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
**What is this feature?**

Replaces ad-hoc `console.*` usage in the Grafana frontend and shared packages with structured logging: `grafanaStructuredLogger` from `@grafana/runtime` in app code, and `emitStructuredBrowserLog` / `emitStructuredBrowserError` from `@grafana/data` where depending on runtime would be wrong. When the Grafana JavaScript Agent is disabled, logs still emit as structured `[Grafana]` records to the browser console.

**Implementation notes**

- `GrafanaStructuredLogContext` (`Record<string, unknown>`) is normalized to Faro’s string-only contexts when the agent is on.
- Regression fixes after automated migration: `ScopesApiClient` imports, Trusted Types CSP report-only warnings, corrupted Loki/Graphite calls, plugin loader mock AMD string (still uses `console.log` inside synthesized module JS), Lezer `String` shadowing in Loki parsing.
- Adds optional `scripts/migrate-console-to-structured.mjs` helper for bulk migration.

**Why do we need this feature?**

Consistent, parseable frontend logs aligned with observability (Faro) and fewer ambiguous multi-argument console dumps.

**Who is this feature for?**

Users and engineers debugging the Grafana UI; operators ingesting frontend logs.

**Verification**

- `yarn exec tsc --noEmit` passes.
- `yarn jest --no-watch public/app/features/scopes/ScopesApiClient.test.ts` passes.

Node CLIs, Storybook stories, e2e harnesses, and the structured console sink in `structuredBrowserLog.ts` still use or reference `console` by design.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-30533005-07ba-4c10-92bf-0e8f1feb38b7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-30533005-07ba-4c10-92bf-0e8f1feb38b7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

