### PR TITLE
Top bar: move Help button before search

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -180,6 +180,7 @@ pkg/services/quota/quotaimpl/storage/storage.json
 
 # Ignore frontend build manifest
 manifest.json
+manifest-react19.json
 /packages/grafana-data/src/themes/schema.generated.json
 
 # Ignore go local build dependencies

--- a/public/app/core/components/AppChrome/TopBar/SingleTopBar.tsx
+++ b/public/app/core/components/AppChrome/TopBar/SingleTopBar.tsx
@@ -93,9 +93,9 @@ export const SingleTopBar = memo(function SingleTopBar({
           data-testid={!showToolbarLevel ? Components.NavToolbar.container : undefined}
         >
           <TopBarExtensionPoint />
+          <HelpTopBarButton isSmallScreen={isSmallScreen} />
           <TopSearchBarCommandPaletteTrigger />
           {!isSmallScreen && <QuickAdd />}
-          <HelpTopBarButton isSmallScreen={isSmallScreen} />
           <NavToolbarSeparator />
           {!isSmallScreen && <ExtensionToolbarItem compact={isSmallScreen} />}
           {!showToolbarLevel && actions}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Reorders the right-side top toolbar so the Help control (question icon) appears immediately after extension toolbar items and **before** the search command palette trigger and Quick add. This is a small placement change only; behavior is unchanged.

Also ignores `manifest-react19.json` at the repo root (webpack prod output when building with React 19), matching existing `manifest.json` ignore behavior.

## Before vs after (toolbar fragment, left to right)

**Before:** … Extension slot → Search → Quick add → Help → separator → …

**After:** … Extension slot → **Help** → Search → Quick add → separator → …

```mermaid
flowchart LR
  subgraph before ["Before"]
    direction LR
    Ext1[Extensions] --> Search1[Search] --> Quick1[Quick add] --> Help1[Help]
  end
  subgraph after ["After"]
    direction LR
    Ext2[Extensions] --> Help2[Help] --> Search2[Search] --> Quick2[Quick add]
  end
```

## How to verify

1. Run backend (`make run`) and frontend (`yarn start`), sign in.
2. On a typical page with the standard chrome, compare the icon order on the top-right; Help sits closer to the left end of that cluster than before.

## Testing

- `yarn jest --no-watch --testPathPattern=AppChrome.test`
- ESLint on `SingleTopBar.tsx`
- `yarn build` (completed successfully in CI/dev verification)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e89cb181-43c5-4ec3-a62a-edaedfb63533"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e89cb181-43c5-4ec3-a62a-edaedfb63533"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

