### PR TITLE
Theme: Add Beach preset (CURSOR-26)

### DIFF
--- a/packages/grafana-data/src/themes/createTheme.test.ts
+++ b/packages/grafana-data/src/themes/createTheme.test.ts
@@ -1,6 +1,19 @@
-import { createTheme } from './createTheme';
+import beach from './themeDefinitions/beach.json';
+import { createTheme, NewThemeOptionsSchema } from './createTheme';
 
 describe('createTheme', () => {
+  it('loads beach theme definition from JSON', () => {
+    const parsed = NewThemeOptionsSchema.safeParse(beach);
+    expect(parsed.success).toBe(true);
+    if (!parsed.success) {
+      return;
+    }
+    const theme = createTheme(parsed.data);
+    expect(theme.isLight).toBe(true);
+    expect(theme.name).toBe('Beach');
+    expect(theme.colors.background.canvas).toBe('#efe6d9');
+  });
+
   it('create custom theme', () => {
     const custom = createTheme({
       colors: {

--- a/packages/grafana-data/src/themes/registry.ts
+++ b/packages/grafana-data/src/themes/registry.ts
@@ -2,6 +2,7 @@ import { Registry, type RegistryItem } from '../utils/Registry';
 
 import { createTheme, NewThemeOptionsSchema } from './createTheme';
 import aubergine from './themeDefinitions/aubergine.json';
+import beach from './themeDefinitions/beach.json';
 import debug from './themeDefinitions/debug.json';
 import desertbloom from './themeDefinitions/desertbloom.json';
 import deuteranopia_protanopia_dark from './themeDefinitions/deuteranopia_protanopia_dark.json';
@@ -26,6 +27,7 @@ export interface ThemeRegistryItem extends RegistryItem {
 
 const extraThemes: { [key: string]: unknown } = {
   aubergine,
+  beach,
   debug,
   desertbloom,
   deuteranopia_protanopia_dark,

--- a/packages/grafana-data/src/themes/themeDefinitions/beach.json
+++ b/packages/grafana-data/src/themes/themeDefinitions/beach.json
@@ -1,0 +1,71 @@
+{
+  "name": "Beach",
+  "id": "beach",
+  "colors": {
+    "mode": "light",
+    "border": {
+      "weak": "rgba(30, 77, 95, 0.12)",
+      "medium": "rgba(30, 77, 95, 0.22)",
+      "strong": "rgba(30, 77, 95, 0.35)"
+    },
+    "text": {
+      "primary": "#1c3d4b",
+      "secondary": "#3d6272",
+      "disabled": "rgba(28, 61, 75, 0.45)",
+      "link": "#0a6f8c",
+      "maxContrast": "#081f28"
+    },
+    "primary": {
+      "main": "#d45a3e",
+      "text": "#b84a31",
+      "border": "#a83d29",
+      "name": "primary",
+      "shade": "#a83d29",
+      "transparent": "#d45a3e26",
+      "contrastText": "#fffdf8",
+      "borderTransparent": "#d45a3e40"
+    },
+    "secondary": {
+      "main": "#e8f4f8",
+      "text": "#2f5f6f",
+      "border": "#b5d9e5",
+      "name": "secondary",
+      "shade": "#c8dfe8",
+      "transparent": "#e8f4f826",
+      "contrastText": "#194a58",
+      "borderTransparent": "#b5d9e566"
+    },
+    "info": {
+      "main": "#0a6f8c"
+    },
+    "success": {
+      "main": "#1f8f7a"
+    },
+    "warning": {
+      "main": "#c77d12"
+    },
+    "background": {
+      "canvas": "#efe6d9",
+      "primary": "#fffcf5",
+      "secondary": "#e4dbd0",
+      "elevated": "#ffffff"
+    },
+    "action": {
+      "hover": "rgba(10, 111, 140, 0.10)",
+      "selected": "rgba(10, 111, 140, 0.18)",
+      "selectedBorder": "#d45a3e",
+      "focus": "rgba(10, 111, 140, 0.26)",
+      "hoverOpacity": 0.08,
+      "disabledText": "rgba(61, 98, 114, 0.45)",
+      "disabledBackground": "rgba(10, 111, 140, 0.06)",
+      "disabledOpacity": 0.38
+    },
+    "gradients": {
+      "brandHorizontal": "linear-gradient(270deg, #f29f5f 0%, #f06b5a 50%, #d45a3e 100%)",
+      "brandVertical": "linear-gradient(0deg, #4aabd4 0%, #f06b5a 65%, #f29f5f 100%)"
+    },
+    "contrastThreshold": 3,
+    "hoverFactor": 0.03,
+    "tonalOffset": 0.15
+  }
+}

--- a/packages/grafana-flamegraph/.storybook/preview.ts
+++ b/packages/grafana-flamegraph/.storybook/preview.ts
@@ -9,6 +9,7 @@ const allowedExtraThemes: string[] = [];
 
 if (process.env.NODE_ENV === 'development') {
   allowedExtraThemes.push('debug');
+  allowedExtraThemes.push('beach');
   allowedExtraThemes.push('desertbloom');
   allowedExtraThemes.push('gildedgrove');
   allowedExtraThemes.push('gloom');

--- a/packages/grafana-ui/.storybook/preview.ts
+++ b/packages/grafana-ui/.storybook/preview.ts
@@ -42,6 +42,7 @@ const allowedExtraThemes: string[] = [
 
 if (process.env.NODE_ENV === 'development') {
   allowedExtraThemes.push('debug');
+  allowedExtraThemes.push('beach');
   allowedExtraThemes.push('desertbloom');
   allowedExtraThemes.push('gildedgrove');
   allowedExtraThemes.push('gloom');

--- a/public/app/core/components/ThemeSelector/getSelectableThemes.ts
+++ b/public/app/core/components/ThemeSelector/getSelectableThemes.ts
@@ -12,6 +12,7 @@ export function getSelectableThemes() {
   }
 
   if (config.featureToggles.grafanaconThemes) {
+    allowedExtraThemes.push('beach');
     allowedExtraThemes.push('desertbloom');
     allowedExtraThemes.push('gildedgrove');
     allowedExtraThemes.push('sapphiredusk');

--- a/public/app/features/theme-playground/ThemePlayground.tsx
+++ b/public/app/features/theme-playground/ThemePlayground.tsx
@@ -4,6 +4,7 @@ import { useId, useState } from 'react';
 import { createTheme, type GrafanaTheme2, type NewThemeOptions } from '@grafana/data';
 import { NewThemeOptionsSchema } from '@grafana/data/internal';
 import aubergine from '@grafana/data/themes/definitions/aubergine.json';
+import beach from '@grafana/data/themes/definitions/beach.json';
 import debug from '@grafana/data/themes/definitions/debug.json';
 import desertbloom from '@grafana/data/themes/definitions/desertbloom.json';
 import deuteranopia_protanopia_dark from '@grafana/data/themes/definitions/deuteranopia_protanopia_dark.json';
@@ -52,6 +53,7 @@ const themeMap: Record<string, NewThemeOptions> = {
 
 const experimentalDefinitions: Record<string, unknown> = {
   aubergine,
+  beach,
   debug,
   desertbloom,
   deuteranopia_protanopia_dark,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
**What is this feature?**

Adds a new optional **Beach** light theme preset (sand canvases, ocean blues, coral sunset accent) using the existing `createTheme` JSON pipeline and Grafanacon extra-themes toggle.

**Why do we need this feature?**

Delivers CURSOR-26: a highly visible demo theme that exercises tokens and parity with other Grafanacon presets without changing default light/dark.

**Who is this feature for?**

Operators and Grafana developers previewing alternate palettes; surfaced in Theme playground always, and in the profile theme picker when `grafanaconThemes` is enabled (same path as Desert bloom).

**Which issue(s) does this PR fix?**

Fixes #(internal CURSOR-26)

**Verification**

- `yarn jest packages/grafana-data/src/themes/createTheme.test.ts --watchAll=false`
- Preview Beach from **Theme playground** (base theme dropdown) without toggles.
- With `grafanaconThemes`, select Beach from profile theme drawer alongside other Grafanacon themes.

Palette reference (screenshot artifact):

![Beach theme palette preview](https://cursor.com/artifacts/c/art-33539a3b-d870-4fa7-99ff-a7b8fe8cc277)

**Special notes for your reviewer:**

Please check that Beach applies cleanly on core surfaces when selected, Grafanacon toggle behavior matches sibling themes, and default light/dark are unchanged.

- [ ] It works as expected from a user's perspective.
- [x] Grafanacon extra themes remain behind `grafanaconThemes` where applicable (playground previews all presets without the toggle).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-97b18222-e802-4027-b79b-4ad4a4b85059"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-97b18222-e802-4027-b79b-4ad4a4b85059"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

