### PR TITLE
Code health: demo quality dashboard page

### DIFF
--- a/e2e-playwright/various-suite/code-health-dashboard.spec.ts
+++ b/e2e-playwright/various-suite/code-health-dashboard.spec.ts
@@ -1,0 +1,41 @@
+import { expect, test } from '@grafana/plugin-e2e';
+
+/**
+ * Executable demo walkthrough for the Code health dashboard (CURSOR-27).
+ *
+ * Run (with Grafana reachable, default admin auth from plugin-e2e):
+ *   yarn playwright test e2e-playwright/various-suite/code-health-dashboard.spec.ts --project various
+ */
+test.describe(
+  'Code health dashboard',
+  {
+    tag: ['@various'],
+  },
+  () => {
+    test('demo: renders mock workspace metrics and updates when the reporting window changes', async ({ page }) => {
+      await page.goto('/code-health');
+
+      await expect(page.getByText(/mock signals for demos/i)).toBeVisible();
+      await expect(page.getByText(/reporting window/i)).toBeVisible();
+
+      await expect(page.getByTestId('code-health-card-lint')).toBeVisible();
+      await expect(page.getByTestId('code-health-card-typescript')).toBeVisible();
+      await expect(page.getByTestId('code-health-card-flaky')).toBeVisible();
+      await expect(page.getByTestId('code-health-card-coverage')).toBeVisible();
+      await expect(page.getByTestId('code-health-card-deps')).toBeVisible();
+      await expect(page.getByTestId('code-health-card-ci')).toBeVisible();
+
+      await expect(page.getByText(/lint backlog by tier/i)).toBeVisible();
+      await expect(page.getByText(/quality trend snapshot/i)).toBeVisible();
+      await expect(page.getByText(/prioritized recommendations/i)).toBeVisible();
+
+      const ciCard = page.getByTestId('code-health-card-ci');
+      await expect(ciCard).toContainText('96%');
+
+      await page.getByRole('radio', { name: /^7 days$/ }).click();
+
+      await expect(ciCard).toContainText('92%');
+      await expect(page.getByRole('radio', { name: /^7 days$/ })).toBeChecked();
+    });
+  }
+);

--- a/pkg/services/navtree/models.go
+++ b/pkg/services/navtree/models.go
@@ -56,7 +56,11 @@ const (
 	NavIDCfgPlugins           = "cfg/plugins"
 	NavIDCfgAccess            = "cfg/access"
 	NavIDBookmarks            = "bookmarks"
+	NavIDCodeHealth           = "code-health"
 )
+
+// WeightCodeHealthDemo places the Code health demo link between Drilldown and Assistant in the root nav.
+const WeightCodeHealthDemo int64 = -3450
 
 type NavLink struct {
 	Id             string     `json:"id,omitempty"`

--- a/pkg/services/navtree/navtreeimpl/navtree.go
+++ b/pkg/services/navtree/navtreeimpl/navtree.go
@@ -147,6 +147,17 @@ func (s *ServiceImpl) GetNavTree(c *contextmodel.ReqContext, prefs *pref.Prefere
 		})
 	}
 
+	if c.IsSignedIn {
+		treeRoot.AddSection(&navtree.NavLink{
+			Text:       "Code health",
+			Id:         navtree.NavIDCodeHealth,
+			SubTitle:   "Demo repository quality overview for Cursor agent workflows",
+			Icon:       "heart-rate",
+			SortWeight: navtree.WeightCodeHealthDemo,
+			Url:        s.cfg.AppSubURL + "/code-health",
+		})
+	}
+
 	if s.cfg.ProfileEnabled && c.IsSignedIn {
 		treeRoot.AddSection(s.getProfileNode(c))
 	}

--- a/public/app/core/utils/navBarItem-translations.ts
+++ b/public/app/core/utils/navBarItem-translations.ts
@@ -59,6 +59,8 @@ export function getNavTitle(navId: string | undefined) {
       return t('nav.explore.title', 'Explore');
     case 'drilldown':
       return t('nav.drilldown.title', 'Drilldown');
+    case 'code-health':
+      return t('nav.code-health.title', 'Code health');
     case 'alerting':
       return t('nav.alerting.title', 'Alerting');
     case 'plugin-page-grafana-oncall-app':
@@ -319,6 +321,11 @@ export function getNavSubTitle(navId: string | undefined) {
       );
     case 'plugin-page-grafana-ml-app':
       return t('nav.machine-learning.subtitle', 'Explore AI and machine learning features');
+    case 'code-health':
+      return t(
+        'nav.code-health.subtitle',
+        'Demo repository quality overview for Cursor agent workflows'
+      );
     default:
       return undefined;
   }

--- a/public/app/features/code-health/CodeHealthDashboardPage.test.tsx
+++ b/public/app/features/code-health/CodeHealthDashboardPage.test.tsx
@@ -1,0 +1,88 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { TestProvider } from 'test/helpers/TestProvider';
+import { getGrafanaContextMock } from 'test/mocks/getGrafanaContextMock';
+
+import { config } from '@grafana/runtime';
+import { HOME_NAV_ID } from 'app/core/reducers/navModel';
+
+import CodeHealthDashboardPage from './CodeHealthDashboardPage';
+import { __test_resetCodeHealthFetchState, __test_simulateFetchFailureOnce } from './codeHealthDashboardData';
+
+describe('CodeHealthDashboardPage', () => {
+  let navBackup: typeof config.bootData.navTree;
+
+  beforeEach(() => {
+    __test_resetCodeHealthFetchState();
+    navBackup = config.bootData.navTree;
+
+    config.bootData.navTree = [
+      {
+        id: HOME_NAV_ID,
+        text: 'Home',
+        url: '/',
+        icon: 'home-alt',
+      },
+      {
+        id: 'code-health',
+        text: 'Code health',
+        url: '/code-health',
+        icon: 'heart-rate',
+        subTitle: 'Demo overview',
+        sortWeight: -3450,
+      },
+    ];
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+    config.bootData.navTree = navBackup;
+  });
+
+  function renderPage() {
+    return render(
+      <TestProvider grafanaContext={getGrafanaContextMock()}>
+        <CodeHealthDashboardPage />
+      </TestProvider>
+    );
+  }
+
+  it('shows summary metrics once demo data resolves', async () => {
+    renderPage();
+
+    await waitFor(() => {
+      expect(screen.getByTestId('code-health-card-lint')).toBeInTheDocument();
+      expect(screen.getByTestId('code-health-card-coverage')).toBeInTheDocument();
+    });
+
+    expect(screen.getByText(/Lint backlog by tier/i)).toBeInTheDocument();
+    expect(screen.getByText(/Prioritized recommendations/i)).toBeInTheDocument();
+  });
+
+  it('reloads summaries when timeframe filter changes', async () => {
+    const user = userEvent.setup();
+    renderPage();
+
+    await waitFor(() => expect(screen.getByTestId('code-health-card-ci')).toHaveTextContent('96%'));
+
+    await user.click(screen.getByRole('radio', { name: /7 days/i }));
+
+    await waitFor(() => expect(screen.getByTestId('code-health-card-ci')).toHaveTextContent('92%'));
+  });
+
+  it('shows an alert when loading fails and recovers via retry', async () => {
+    __test_simulateFetchFailureOnce();
+    const user = userEvent.setup();
+
+    renderPage();
+
+    await waitFor(() => expect(screen.getByRole('alert', { name: /Could not refresh metrics/i })).toBeInTheDocument());
+
+    const retryBtn = screen.getByText('Retry').closest('button');
+    expect(retryBtn).not.toBeNull();
+
+    await user.click(retryBtn!);
+
+    await waitFor(() => expect(screen.getByTestId('code-health-card-lint')).toBeInTheDocument());
+  });
+});

--- a/public/app/features/code-health/CodeHealthDashboardPage.tsx
+++ b/public/app/features/code-health/CodeHealthDashboardPage.tsx
@@ -1,0 +1,390 @@
+import { css } from '@emotion/css';
+import { useCallback, useEffect, useMemo, useState } from 'react';
+
+import { type GrafanaTheme2 } from '@grafana/data';
+import { t } from '@grafana/i18n';
+import {
+  Alert,
+  Badge,
+  Button,
+  Field,
+  RadioButtonGroup,
+  Spinner,
+  Stack,
+  Text,
+  useStyles2,
+  useTheme2,
+} from '@grafana/ui';
+import { Page } from 'app/core/components/Page/Page';
+
+import {
+  type CodeHealthSummaryCard,
+  type CodeHealthTimeframe,
+  type CodeHealthTrendPoint,
+  type CodeHealthViewModel,
+  fetchCodeHealthSummary,
+} from './codeHealthDashboardData';
+
+const TIMEFRAME_OPTIONS: Array<{ label: string; value: CodeHealthTimeframe }> = [
+  { label: t('code-health.dashboard.timeframe.7d', '7 days'), value: '7d' },
+  { label: t('code-health.dashboard.timeframe.30d', '30 days'), value: '30d' },
+  { label: t('code-health.dashboard.timeframe.90d', '90 days'), value: '90d' },
+];
+
+export default function CodeHealthDashboardPage() {
+  const styles = useStyles2(getStyles);
+  const [timeframe, setTimeframe] = useState<CodeHealthTimeframe>('30d');
+  const [phase, setPhase] = useState<'loading' | 'ready' | 'error'>('loading');
+  const [model, setModel] = useState<CodeHealthViewModel | undefined>();
+
+  const load = useCallback(async () => {
+    setPhase('loading');
+    try {
+      const data = await fetchCodeHealthSummary(timeframe);
+      setModel(data);
+      setPhase('ready');
+    } catch {
+      setModel(undefined);
+      setPhase('error');
+    }
+  }, [timeframe]);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  const maxSeverity = useMemo(() => Math.max(...(model?.severityRows.map((r) => r.count) ?? [1])), [model]);
+
+  return (
+    <Page
+      navId="code-health"
+      pageNav={{ text: '', active: true }}
+      subTitle={t(
+        'code-health.dashboard.subtitle',
+        'Mock signals for demos of agents triaging lint, tests, coverage, dependencies, and CI—values are illustrative only.'
+      )}
+    >
+      <Page.Contents>
+        <Stack direction="column" gap={3}>
+          <Stack justifyContent="space-between" alignItems="flex-end" wrap="wrap">
+            <div className={styles.filterIntro}>
+              <Text element="h2" variant="body">
+                {t('code-health.dashboard.filters.heading', 'Reporting window')}
+              </Text>
+              <Text variant="bodySmall" color="secondary">
+                {t(
+                  'code-health.dashboard.filters.caption',
+                  'Agents can correlate longer windows when investigating regressions.'
+                )}
+              </Text>
+            </div>
+            <Field label={t('code-health.dashboard.timeframe.label', 'Window')}>
+              <RadioButtonGroup<CodeHealthTimeframe>
+                options={TIMEFRAME_OPTIONS}
+                value={timeframe}
+                onChange={setTimeframe}
+              />
+            </Field>
+          </Stack>
+
+          {phase === 'loading' && (
+            <Stack direction="column" gap={2} alignItems="center" justifyContent="center">
+              <Spinner />
+              <Text role="status" variant="body" color="secondary">
+                {t('code-health.dashboard.loading', 'Refreshing demo workspace metrics')}
+              </Text>
+            </Stack>
+          )}
+
+          {phase === 'error' && (
+            <Alert
+              severity="error"
+              title={t('code-health.dashboard.error.title', 'Could not refresh metrics')}
+              buttonContent={t('code-health.dashboard.error.retry', 'Retry')}
+              onRemove={load}
+            >
+              {t(
+                'code-health.dashboard.error.body',
+                'The demo datasource failed. Retry simulates requesting the workspace again.'
+              )}
+            </Alert>
+          )}
+
+          {phase === 'ready' && model && (
+            <>
+              <section aria-label={t('code-health.dashboard.metrics.region', 'Repository summary metrics')}>
+                <div className={styles.metricGrid}>
+                  {model.cards.map((card) => (
+                    <MetricCard key={card.id} card={card} styles={styles} />
+                  ))}
+                </div>
+              </section>
+
+              <section className={styles.split} aria-labelledby="code-health-breakdown-heading">
+                <Stack direction="column" gap={2} flex={1}>
+                  <Text variant="h3" id="code-health-breakdown-heading">
+                    {t('code-health.dashboard.severity.title', 'Lint backlog by tier')}
+                  </Text>
+                  <Text variant="bodySmall" color="secondary">
+                    {t(
+                      'code-health.dashboard.severity.helper',
+                      'Synthetic distribution for prioritizing agent-driven cleanups.'
+                    )}
+                  </Text>
+                  <Stack direction="column" gap={2}>
+                    {model.severityRows.map((row) => (
+                      <div key={row.id}>
+                        <Stack justifyContent="space-between">
+                          <Text variant="body">{row.label}</Text>
+                          <Badge text={String(row.count)} color="blue" />
+                        </Stack>
+                        <div className={styles.barTrack}>
+                          <div
+                            className={styles.barFill}
+                            style={{ width: `${Math.min(100, (row.count / maxSeverity) * 100)}%` }}
+                          />
+                        </div>
+                      </div>
+                    ))}
+                  </Stack>
+                </Stack>
+
+                <Stack direction="column" gap={2} flex={1}>
+                  <Text variant="h3">{t('code-health.dashboard.trend.title', 'Quality trend snapshot')}</Text>
+                  <Text variant="bodySmall" color="secondary">
+                    {t(
+                      'code-health.dashboard.trend.helper',
+                      'Compare lint backlog against coverage lifts without wiring to real CI payloads.'
+                    )}
+                  </Text>
+                  <TrendChart points={model.lintTrend} />
+                  <Stack direction="row" gap={3}>
+                    <Badge color="blue" icon="chart-line" text={t('code-health.dashboard.trend.legendLint', 'Lint')} />
+                    <Badge
+                      color="green"
+                      icon="bolt"
+                      text={t('code-health.dashboard.trend.legendCoverage', 'Coverage')}
+                    />
+                  </Stack>
+                </Stack>
+              </section>
+
+              <section aria-labelledby="code-health-actions-heading">
+                <Stack direction="column" gap={2}>
+                  <Text variant="h3" id="code-health-actions-heading">
+                    {t('code-health.dashboard.actions.title', 'Prioritized recommendations')}
+                  </Text>
+                  <ol className={styles.actionList}>
+                    {model.recommendations.map((rec) => (
+                      <li key={rec.id}>
+                        <div className={styles.actionCard}>
+                          <Stack direction="column" gap={1}>
+                            <Text variant="body">{rec.title}</Text>
+                            <Text variant="bodySmall" color="secondary">
+                              {rec.rationale}
+                            </Text>
+                          </Stack>
+                          <Badge
+                            icon="document-info"
+                            text={`#${rec.rank} · ${rec.suggestedTicket}`}
+                            color="purple"
+                          />
+                        </div>
+                      </li>
+                    ))}
+                  </ol>
+                  <Stack>
+                    <Button variant="secondary" size="sm" disabled>
+                      {t('code-health.dashboard.actions.export', 'Export mock findings (stub)')}
+                    </Button>
+                  </Stack>
+                </Stack>
+              </section>
+            </>
+          )}
+        </Stack>
+      </Page.Contents>
+    </Page>
+  );
+}
+
+function MetricCard({ card, styles }: { card: CodeHealthSummaryCard; styles: ReturnType<typeof getStyles> }) {
+  return (
+    <div className={styles.metricCard} data-testid={`code-health-card-${card.id}`}>
+      <Text variant="h5">{card.label}</Text>
+      <Text variant="h3">
+        {card.value}
+        {card.valueSuffix ?? ''}
+      </Text>
+      <SparkBars values={card.spark} />
+      <Text variant="bodySmall" color="secondary">
+        {card.helper}
+      </Text>
+    </div>
+  );
+}
+
+function SparkBars({ values }: { values: number[] }) {
+  const theme = useTheme2();
+  const rowStyle = css({
+    display: 'flex',
+    gap: theme.spacing(0.75),
+    height: theme.spacing(4),
+    alignItems: 'flex-end',
+    marginBottom: theme.spacing(1),
+  });
+  const barBase = css({
+    flex: '1',
+    borderRadius: theme.shape.radius.default,
+    minWidth: theme.spacing(0.75),
+  });
+
+  return (
+    <div className={rowStyle} aria-hidden>
+      {values.map((fraction, idx) => {
+        const clamped = Math.max(0.08, Math.min(fraction, 1));
+        return (
+          <div
+            // eslint-disable-next-line react/no-array-index-key -- static demo lengths
+            key={idx}
+            className={barBase}
+            style={{
+              flexGrow: clamped,
+              opacity: 0.4 + clamped / 2,
+              backgroundImage: `linear-gradient(180deg, ${theme.colors.primary.main}, transparent)`,
+            }}
+          />
+        );
+      })}
+    </div>
+  );
+}
+
+function TrendChart({ points }: { points: CodeHealthTrendPoint[] }) {
+  const styles = useStyles2(getTrendStyles);
+  const maxLint = Math.max(...points.map((p) => p.lintIssues), 1);
+  const maxCov = Math.max(...points.map((p) => p.coveragePct), 1);
+
+  return (
+    <div
+      className={styles.chart}
+      aria-label={t('code-health.dashboard.trend.aria', 'Weekly lint versus coverage')}
+      role="group"
+    >
+      {points.map((point) => (
+        <div key={point.week} className={styles.column}>
+          <div className={styles.bars}>
+            <div
+              className={styles.lintSeries}
+              style={{ height: `${(point.lintIssues / maxLint) * 100}%` }}
+              aria-label={t('code-health.dashboard.trend.lintValue', '{{count}} issues', { count: point.lintIssues })}
+            />
+            <div
+              className={styles.coverageSeries}
+              style={{ height: `${(point.coveragePct / maxCov) * 100}%` }}
+              aria-label={t('code-health.dashboard.trend.coverageValue', '{{pct}}% coverage', {
+                pct: point.coveragePct,
+              })}
+            />
+          </div>
+          <Text variant="caption" color="secondary">
+            {point.week}
+          </Text>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+const getTrendStyles = (theme: GrafanaTheme2) => ({
+  chart: css({
+    display: 'flex',
+    gap: theme.spacing(2),
+    justifyContent: 'space-between',
+    alignItems: 'flex-end',
+    padding: theme.spacing(2, 0),
+    flexWrap: 'wrap',
+  }),
+  column: css({
+    display: 'flex',
+    flexDirection: 'column',
+    alignItems: 'center',
+    gap: theme.spacing(1),
+    flex: '1 1 96px',
+  }),
+  bars: css({
+    display: 'flex',
+    gap: theme.spacing(1),
+    alignItems: 'flex-end',
+    height: theme.spacing(18),
+  }),
+  lintSeries: css({
+    width: theme.spacing(2.5),
+    borderRadius: theme.shape.radius.default,
+    backgroundColor: theme.colors.primary.main,
+    minHeight: theme.spacing(0.5),
+  }),
+  coverageSeries: css({
+    width: theme.spacing(2.5),
+    borderRadius: theme.shape.radius.default,
+    backgroundColor: theme.colors.success.main,
+    minHeight: theme.spacing(0.5),
+  }),
+});
+
+const getStyles = (theme: GrafanaTheme2) => ({
+  filterIntro: css({
+    maxWidth: '480px',
+  }),
+  metricGrid: css({
+    display: 'grid',
+    gridTemplateColumns: 'repeat(auto-fill, minmax(220px, 1fr))',
+    gap: theme.spacing(2),
+  }),
+  metricCard: css({
+    borderRadius: theme.shape.radius.default,
+    border: `1px solid ${theme.colors.border.weak}`,
+    background: theme.colors.background.secondary,
+    padding: theme.spacing(2),
+    display: 'flex',
+    flexDirection: 'column',
+    gap: theme.spacing(0.5),
+  }),
+  split: css({
+    display: 'flex',
+    flexWrap: 'wrap',
+    gap: theme.spacing(3),
+  }),
+  barTrack: css({
+    height: theme.spacing(0.75),
+    borderRadius: theme.shape.radius.default,
+    backgroundColor: theme.colors.border.weak,
+    marginTop: theme.spacing(1),
+    overflow: 'hidden',
+  }),
+  barFill: css({
+    height: '100%',
+    borderRadius: theme.shape.radius.default,
+    background: `linear-gradient(90deg, ${theme.colors.primary.main}, ${theme.colors.success.main})`,
+  }),
+  actionList: css({
+    margin: 0,
+    paddingLeft: theme.spacing(2),
+    display: 'flex',
+    flexDirection: 'column',
+    gap: theme.spacing(2),
+    listStyle: 'decimal',
+  }),
+  actionCard: css({
+    border: `1px solid ${theme.colors.border.medium}`,
+    borderRadius: theme.shape.radius.default,
+    padding: theme.spacing(2),
+    display: 'flex',
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    justifyContent: 'space-between',
+    gap: theme.spacing(2),
+    backgroundColor: theme.colors.background.primary,
+    boxShadow: theme.shadows.z1,
+  }),
+});

--- a/public/app/features/code-health/codeHealthDashboardData.ts
+++ b/public/app/features/code-health/codeHealthDashboardData.ts
@@ -1,0 +1,204 @@
+/** Demo-only aggregates for CURSOR-27; not connected to CI or tooling. */
+
+export type CodeHealthTimeframe = '7d' | '30d' | '90d';
+
+export interface CodeHealthSeverityBreakdownRow {
+  id: string;
+  label: string;
+  count: number;
+}
+
+export interface CodeHealthSummaryCard {
+  id: string;
+  /** Short label rendered as card title */
+  label: string;
+  /** Numeric or percentage main value */
+  value: number;
+  valueSuffix?: string;
+  helper: string;
+  /** Fractional trend for spark-style bars */
+  spark: number[];
+  /** "up" improves health (coverage), "down" improves health (lint) */
+  direction: 'higherBetter' | 'lowerBetter';
+}
+
+export interface CodeHealthTrendPoint {
+  week: string;
+  lintIssues: number;
+  coveragePct: number;
+}
+
+export interface RecommendedActionRow {
+  id: string;
+  rank: number;
+  title: string;
+  rationale: string;
+  suggestedTicket: string;
+}
+
+export interface CodeHealthViewModel {
+  cards: CodeHealthSummaryCard[];
+  severityRows: CodeHealthSeverityBreakdownRow[];
+  lintTrend: CodeHealthTrendPoint[];
+  recommendations: RecommendedActionRow[];
+}
+
+const WEEK_LABELS_BY_TF: Record<CodeHealthTimeframe, string[]> = {
+  '7d': ['Wk -4', 'Wk -3', 'Wk -2', 'Past week'],
+  '30d': ['Wk -8', 'Wk -6', 'Wk -4', 'Wk -2', 'Past 30 days'],
+  '90d': ['Q start', '+3 wks', '+6 wks', '+9 wks', 'Quarter end'],
+};
+
+function multiplier(tf: CodeHealthTimeframe): number {
+  switch (tf) {
+    case '7d':
+      return 1;
+    case '30d':
+      return 1.15;
+    case '90d':
+      return 1.35;
+    default:
+      return 1;
+  }
+}
+
+export function buildCodeHealthViewModel(timeframe: CodeHealthTimeframe): CodeHealthViewModel {
+  const m = multiplier(timeframe);
+  const weeks = WEEK_LABELS_BY_TF[timeframe];
+
+  const lintSeries = weeks.map((_, i) => Math.round((42 + i * 3) * m - i));
+  const coverageSeries = weeks.map((_, i) =>
+    Math.min(94, Math.round(72 + i * 2.5 + (timeframe === '90d' ? 8 : 0)))
+  );
+
+  const cards: CodeHealthSummaryCard[] = [
+    {
+      id: 'lint',
+      label: 'Lint issues',
+      value: Math.round(38 * m),
+      helper: 'OSS ESLint equivalents (demo)',
+      spark: lintSeries.map((v) => 1 - v / 80),
+      direction: 'lowerBetter',
+    },
+    {
+      id: 'typescript',
+      label: 'TypeScript errors',
+      value: Math.round(12 * m),
+      helper: 'Monorepo `yarn typecheck` concept',
+      spark: [0.2, 0.35, 0.42, 0.38, 0.33],
+      direction: 'lowerBetter',
+    },
+    {
+      id: 'flaky',
+      label: 'Flaky tests',
+      value: Math.round(5 + (timeframe === '90d' ? 2 : 0)),
+      helper: 'Last N main-branch runs',
+      spark: [0.5, 0.62, 0.55, 0.58, 0.48],
+      direction: 'lowerBetter',
+    },
+    {
+      id: 'coverage',
+      label: 'Est. coverage',
+      value: Math.round(73 + (timeframe === '90d' ? 6 : 2)),
+      valueSuffix: '%',
+      helper: 'Aggregate line coverage (mock)',
+      spark: coverageSeries.map((v) => v / 100),
+      direction: 'higherBetter',
+    },
+    {
+      id: 'deps',
+      label: 'Outdated deps',
+      value: Math.round(28 * (timeframe === '90d' ? 1.1 : 1)),
+      helper: 'Direct prod + dev (demo)',
+      spark: [0.7, 0.68, 0.71, 0.66],
+      direction: 'lowerBetter',
+    },
+    {
+      id: 'ci',
+      label: 'CI pass rate',
+      value: Math.min(
+        99,
+        Math.round(88 + (timeframe === '7d' ? 4 : timeframe === '30d' ? 8 : 11))
+      ),
+      valueSuffix: '%',
+      helper: 'Required checks over window',
+      spark: [0.82, 0.85, 0.87, 0.9, 0.91],
+      direction: 'higherBetter',
+    },
+  ];
+
+  const severityRows: CodeHealthSeverityBreakdownRow[] = [
+    { id: 'critical', label: 'Critical', count: Math.round(2 * m) },
+    { id: 'high', label: 'High', count: Math.round(9 * m) },
+    { id: 'medium', label: 'Medium', count: Math.round(24 * m) },
+    { id: 'low', label: 'Low / style', count: Math.round(18 * m) },
+  ];
+
+  const lintTrend: CodeHealthTrendPoint[] = weeks.map((week, i) => ({
+    week,
+    lintIssues: lintSeries[i] ?? lintSeries[lintSeries.length - 1],
+    coveragePct: coverageSeries[i] ?? coverageSeries[coverageSeries.length - 1],
+  }));
+
+  const recommendations: RecommendedActionRow[] = [
+    {
+      id: 'a11y-batch',
+      rank: 1,
+      title: 'Clear legacy `jsx-a11y` violations in alerting views',
+      rationale: `${cards[0].value} lint findings cluster in unified alerting; fixing the top bucket drops noise for agents.`,
+      suggestedTicket: `QUALITY-${timeframe}-101`,
+    },
+    {
+      id: 'tier2-types',
+      rank: 2,
+      title: 'Triage remaining TS errors in `public/app/features/plugins` workspace',
+      rationale: `${cards[1].value} TS errors block strict mode adoption; aligns with flaky-test hotspots.`,
+      suggestedTicket: `QUALITY-${timeframe}-204`,
+    },
+    {
+      id: 'quarantine-tests',
+      rank: 3,
+      title: 'Quarantine and rewrite top flaky Playwright journeys',
+      rationale: `${cards[2].value} flaky tests correlate with Explore + dashboards smoke paths.`,
+      suggestedTicket: `QUALITY-${timeframe}-318`,
+    },
+    {
+      id: 'coverage-gap',
+      rank: 4,
+      title: 'Backfill integration coverage for provisioning API adapters',
+      rationale: `Coverage at ${cards[3].value}${cards[3].valueSuffix} trails target; prioritized files listed in demo export.`,
+      suggestedTicket: `QUALITY-${timeframe}-442`,
+    },
+    {
+      id: 'dep-bump',
+      rank: 5,
+      title: 'Schedule Yarn major bumps for lodash + uPlot minors',
+      rationale: `${cards[4].value} outdated deps; batch upgrade reduces renovate churn.`,
+      suggestedTicket: `QUALITY-${timeframe}-519`,
+    },
+  ];
+
+  return { cards, severityRows, lintTrend, recommendations };
+}
+
+const FETCH_DELAY_MS = 280;
+
+export async function fetchCodeHealthSummary(timeframe: CodeHealthTimeframe): Promise<CodeHealthViewModel> {
+  if (failNextFetch) {
+    failNextFetch = false;
+    throw new Error('Simulated code health load failure');
+  }
+  await new Promise<void>((resolve) => setTimeout(resolve, FETCH_DELAY_MS));
+  return buildCodeHealthViewModel(timeframe);
+}
+
+/** Test hook: next call to `fetchCodeHealthSummary` rejects once. */
+let failNextFetch = false;
+
+export function __test_simulateFetchFailureOnce(): void {
+  failNextFetch = true;
+}
+
+export function __test_resetCodeHealthFetchState(): void {
+  failNextFetch = false;
+}

--- a/public/app/routes/routes.tsx
+++ b/public/app/routes/routes.tsx
@@ -533,6 +533,12 @@ export function getAppRoutes(): RouteDescriptor[] {
       ),
     },
     {
+      path: '/code-health',
+      component: SafeDynamicImport(
+        () => import(/* webpackChunkName: "CodeHealthDashboard" */ 'app/features/code-health/CodeHealthDashboardPage')
+      ),
+    },
+    {
       path: '/bookmarks',
       component: SafeDynamicImport(
         () => import(/* webpackChunkName: "BookmarksPage"*/ 'app/features/bookmarks/BookmarksPage')


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
**What is this feature?**

Adds a **Code health** sidebar entry (signed-in users) and a `/code-health` page with mock repository quality metrics: lint, TypeScript errors, flaky tests, coverage, outdated dependencies, CI pass rate, a severity breakdown, a lint vs coverage trend, and a prioritized recommendation list. Implements loading, error with retry, and a 7d/30d/90d reporting window filter using local demo data only.

**Why do we need this feature?**

Provides a reliable demo surface for agent workflows that investigate code quality without connecting to real CI or registry APIs.

**Who is this feature for?**

Developers and product demos; metrics are illustrative only.

**Demo / E2E**

- Playwright spec (runnable walkthrough): `e2e-playwright/various-suite/code-health-dashboard.spec.ts` (project **various**, tag **@various**).
- Narration checklist: see review environment artifact `CURSOR-27-code-health-demo-artifact.md` if present.

**Which issue(s) does this PR fix?**:

Internal ticket (no GitHub issue).

**Special notes for your reviewer:**

- Tests: `yarn jest public/app/features/code-health/CodeHealthDashboardPage.test.tsx --no-watch --watchAll=false`
- Go: `go test ./pkg/services/navtree/navtreeimpl/... -count=1`

Please check that:
- [ ] It works as expected from a user's perspective (`make run` + `yarn start`, then **Code health** in the sidebar).
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] Docs updated if required for notable improvements.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-21abc5da-6d19-4594-b6a2-aa68e71b482b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-21abc5da-6d19-4594-b6a2-aa68e71b482b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

