### PR TITLE
feat(chrome): theme toggle on main toolbar (dark ↔ light)

### DIFF
--- a/packages/grafana-e2e-selectors/src/selectors/components.ts
+++ b/packages/grafana-e2e-selectors/src/selectors/components.ts
@@ -1018,6 +1018,9 @@ export const versionedComponents = {
     commandPaletteTrigger: {
       '11.5.0': 'data-testid Command palette trigger',
     },
+    themeToggle: {
+      '13.0.0': 'data-testid Theme toggle',
+    },
     shareDashboard: {
       '11.1.0': 'data-testid Share dashboard',
     },

--- a/packages/grafana-runtime/src/config.ts
+++ b/packages/grafana-runtime/src/config.ts
@@ -26,6 +26,7 @@ import {
   UnifiedAlertingConfig,
   GrafanaConfig,
   CurrentUserDTO,
+  store,
 } from '@grafana/data';
 
 /**
@@ -75,6 +76,30 @@ export type PreinstalledPlugin = {
   id: string;
   version: string;
 };
+
+/**
+ * Browser localStorage key for persisted dark/light theme when no signed-in user exists.
+ * Written by the application theme service when anonymous users change theme.
+ */
+export const GRAFANA_ANONYMOUS_THEME_STORAGE_KEY = 'grafana.theme.color-scheme';
+
+function readAnonymousThemePreference(serverTheme: string, isSignedIn: boolean | undefined): string {
+  if (isSignedIn) {
+    return serverTheme;
+  }
+  if (typeof window === 'undefined') {
+    return serverTheme;
+  }
+  try {
+    const stored = store.get(GRAFANA_ANONYMOUS_THEME_STORAGE_KEY);
+    if (stored === 'dark' || stored === 'light') {
+      return stored;
+    }
+  } catch {
+    // Storage can be unavailable (private mode, disabled cookies, etc.)
+  }
+  return serverTheme;
+}
 
 /**
  * Use to access Grafana config settings in application code.
@@ -292,7 +317,14 @@ export class GrafanaBootConfig {
     this.bootData.settings.featureToggles = this.featureToggles;
 
     // Creating theme after applying feature toggle overrides in case we need to toggle anything
-    this.theme2 = getThemeById(this.bootData.user.theme);
+    const resolvedTheme = readAnonymousThemePreference(
+      this.bootData.user.theme || 'dark',
+      this.bootData.user.isSignedIn
+    );
+    this.theme2 = getThemeById(resolvedTheme);
+    if (!this.bootData.user.isSignedIn) {
+      this.bootData.user.theme = resolvedTheme;
+    }
     this.bootData.user.lightTheme = this.theme2.isLight;
     this.theme = this.theme2.v1;
     this.regionalFormat = options.bootData.user.regionalFormat;
@@ -304,7 +336,7 @@ export class GrafanaBootConfig {
 function overrideFeatureTogglesFromLocalStorage(config: GrafanaBootConfig) {
   const featureToggles = config.featureToggles;
   const localStorageKey = 'grafana.featureToggles';
-  const localStorageValue = window.localStorage.getItem(localStorageKey);
+  const localStorageValue = store.get(localStorageKey);
   if (localStorageValue) {
     const features = localStorageValue.split(',');
     for (const feature of features) {

--- a/public/app/core/components/AppChrome/TopBar/SingleTopBar.tsx
+++ b/public/app/core/components/AppChrome/TopBar/SingleTopBar.tsx
@@ -26,6 +26,7 @@ import { InviteUserButton } from './InviteUserButton';
 import { ProfileButton } from './ProfileButton';
 import { SignInLink } from './SignInLink';
 import { SingleTopBarActions } from './SingleTopBarActions';
+import { ThemeToolbarToggle } from './ThemeToolbarToggle';
 import { TopBarExtensionPoint } from './TopBarExtensionPoint';
 import { TopSearchBarCommandPaletteTrigger } from './TopSearchBarCommandPaletteTrigger';
 import { getChromeHeaderLevelHeight } from './useChromeHeaderHeight';
@@ -94,6 +95,7 @@ export const SingleTopBar = memo(function SingleTopBar({
         >
           <TopBarExtensionPoint />
           <TopSearchBarCommandPaletteTrigger />
+          <ThemeToolbarToggle />
           {!isSmallScreen && <QuickAdd />}
           <HelpTopBarButton isSmallScreen={isSmallScreen} />
           <NavToolbarSeparator />

--- a/public/app/core/components/AppChrome/TopBar/ThemeToolbarToggle.test.tsx
+++ b/public/app/core/components/AppChrome/TopBar/ThemeToolbarToggle.test.tsx
@@ -1,0 +1,33 @@
+import { Components } from '@grafana/e2e-selectors';
+import { render, screen, userEvent } from 'test/test-utils';
+
+import { toggleTheme } from 'app/core/services/theme';
+
+import { ThemeToolbarToggle } from './ThemeToolbarToggle';
+
+jest.mock('app/core/services/theme', () => ({
+  toggleTheme: jest.fn(),
+}));
+
+describe('ThemeToolbarToggle', () => {
+  beforeEach(() => {
+    jest.mocked(toggleTheme).mockClear();
+  });
+
+  it('exposes a toolbar test id and an accessible switch', () => {
+    render(<ThemeToolbarToggle />);
+
+    expect(screen.getByTestId(Components.NavToolbar.themeToggle)).toBeInTheDocument();
+    expect(screen.getByRole('switch')).toBeInTheDocument();
+  });
+
+  it('invokes theme toggle when the switch is activated', async () => {
+    const user = userEvent.setup();
+    render(<ThemeToolbarToggle />);
+
+    await user.click(screen.getByRole('switch'));
+
+    expect(toggleTheme).toHaveBeenCalledTimes(1);
+    expect(toggleTheme).toHaveBeenCalledWith(false);
+  });
+});

--- a/public/app/core/components/AppChrome/TopBar/ThemeToolbarToggle.tsx
+++ b/public/app/core/components/AppChrome/TopBar/ThemeToolbarToggle.tsx
@@ -1,0 +1,36 @@
+import { memo, useCallback } from 'react';
+
+import { Components } from '@grafana/e2e-selectors';
+import { t } from '@grafana/i18n';
+import { reportInteraction } from '@grafana/runtime';
+import { InlineSwitch, Stack, useTheme2 } from '@grafana/ui';
+import { useMediaQueryMinWidth } from 'app/core/hooks/useMediaQueryMinWidth';
+import { toggleTheme } from 'app/core/services/theme';
+
+export const ThemeToolbarToggle = memo(function ThemeToolbarToggle() {
+  const theme = useTheme2();
+  const isLargeScreen = useMediaQueryMinWidth('sm');
+
+  const onToggle = useCallback(() => {
+    reportInteraction('grafana_preferences_theme_changed', {
+      toTheme: theme.isDark ? 'light' : 'dark',
+      preferenceType: 'toolbar_toggle',
+    });
+    void toggleTheme(false);
+  }, [theme.isDark]);
+
+  const label = t('navigation.theme.dark-interface-label', 'Dark interface');
+
+  return (
+    <Stack alignItems="center" data-testid={Components.NavToolbar.themeToggle}>
+      <InlineSwitch
+        transparent
+        id="toolbar-theme-toggle"
+        value={theme.isDark}
+        onChange={onToggle}
+        showLabel={isLargeScreen}
+        label={label}
+      />
+    </Stack>
+  );
+});

--- a/public/app/core/services/theme.ts
+++ b/public/app/core/services/theme.ts
@@ -1,5 +1,6 @@
+import { store } from '@grafana/data';
 import { getThemeById } from '@grafana/data/internal';
-import { config, ThemeChangedEvent } from '@grafana/runtime';
+import { config, GRAFANA_ANONYMOUS_THEME_STORAGE_KEY, ThemeChangedEvent } from '@grafana/runtime';
 
 import { appEvents } from '../app_events';
 import { contextSrv } from '../services/context_srv';
@@ -40,6 +41,11 @@ export async function changeTheme(themeId: string, runtimeOnly?: boolean) {
   }
 
   if (!contextSrv.isSignedIn) {
+    try {
+      store.set(GRAFANA_ANONYMOUS_THEME_STORAGE_KEY, themeId);
+    } catch {
+      // Ignore unavailable storage
+    }
     return;
   }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a **dark/light theme toggle** to the main application chrome (top navigation bar) so users can switch interface color mode without opening profile preferences.

## Behavior

- **Toolbar control**: `InlineSwitch` with `role="switch"`, optional visible label on wider viewports, and `data-testid` for automation (`Components.NavToolbar.themeToggle`).
- **Immediate update**: Uses existing `toggleTheme` / `changeTheme` flow (`ThemeChangedEvent`, CSS swap) so the UI updates right away.
- **Persistence**:
  - **Signed-in users**: unchanged — preferences PATCH (`/api/user/preferences`) as before.
  - **Anonymous users**: stores `dark` or `light` in the Grafana `store` (localStorage) under `GRAFANA_ANONYMOUS_THEME_STORAGE_KEY`, and `GrafanaBootConfig` reads that key on startup so the choice survives reloads.

## Tests

- `yarn jest public/app/core/components/AppChrome/TopBar/ThemeToolbarToggle.test.tsx --no-watch --watchAll=false`

## Notes

- `overrideFeatureTogglesFromLocalStorage` now uses `store.get` instead of raw `localStorage` to satisfy lint rules in the same file.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b1c6c973-de93-4f34-967c-cbd320489d50"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b1c6c973-de93-4f34-967c-cbd320489d50"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

