### PR TITLE
Navigation: add toolbar theme toggle

### DIFF
--- a/public/app/core/components/AppChrome/TopBar/SingleTopBar.tsx
+++ b/public/app/core/components/AppChrome/TopBar/SingleTopBar.tsx
@@ -26,6 +26,7 @@ import { InviteUserButton } from './InviteUserButton';
 import { ProfileButton } from './ProfileButton';
 import { SignInLink } from './SignInLink';
 import { SingleTopBarActions } from './SingleTopBarActions';
+import { ThemeToggleButton } from './ThemeToggleButton';
 import { TopBarExtensionPoint } from './TopBarExtensionPoint';
 import { TopSearchBarCommandPaletteTrigger } from './TopSearchBarCommandPaletteTrigger';
 import { getChromeHeaderLevelHeight } from './useChromeHeaderHeight';
@@ -95,6 +96,7 @@ export const SingleTopBar = memo(function SingleTopBar({
           <TopBarExtensionPoint />
           <TopSearchBarCommandPaletteTrigger />
           {!isSmallScreen && <QuickAdd />}
+          <ThemeToggleButton />
           <HelpTopBarButton isSmallScreen={isSmallScreen} />
           <NavToolbarSeparator />
           {!isSmallScreen && <ExtensionToolbarItem compact={isSmallScreen} />}

--- a/public/app/core/components/AppChrome/TopBar/ThemeToggleButton.test.tsx
+++ b/public/app/core/components/AppChrome/TopBar/ThemeToggleButton.test.tsx
@@ -1,0 +1,52 @@
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { render } from 'test/test-utils';
+
+import { createTheme, ThemeContext } from '@grafana/data';
+import { changeTheme } from 'app/core/services/theme';
+
+import { ThemeToggleButton } from './ThemeToggleButton';
+
+jest.mock('app/core/services/theme', () => ({
+  changeTheme: jest.fn(),
+}));
+
+describe('ThemeToggleButton', () => {
+  const user = userEvent.setup();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('switches from dark to light and persists the preference', async () => {
+    render(
+      <ThemeContext.Provider value={createTheme({ colors: { mode: 'dark' } })}>
+        <ThemeToggleButton />
+      </ThemeContext.Provider>
+    );
+
+    const toggle = screen.getByRole('switch', { name: 'Dark theme' });
+
+    expect(toggle).toHaveAttribute('aria-checked', 'true');
+
+    await user.click(toggle);
+
+    expect(changeTheme).toHaveBeenCalledWith('light', false);
+  });
+
+  it('switches from light to dark and persists the preference', async () => {
+    render(
+      <ThemeContext.Provider value={createTheme({ colors: { mode: 'light' } })}>
+        <ThemeToggleButton />
+      </ThemeContext.Provider>
+    );
+
+    const toggle = screen.getByRole('switch', { name: 'Dark theme' });
+
+    expect(toggle).toHaveAttribute('aria-checked', 'false');
+
+    await user.click(toggle);
+
+    expect(changeTheme).toHaveBeenCalledWith('dark', false);
+  });
+});

--- a/public/app/core/components/AppChrome/TopBar/ThemeToggleButton.tsx
+++ b/public/app/core/components/AppChrome/TopBar/ThemeToggleButton.tsx
@@ -1,0 +1,22 @@
+import { t } from '@grafana/i18n';
+import { ToolbarButton, useTheme2 } from '@grafana/ui';
+import { changeTheme } from 'app/core/services/theme';
+
+export function ThemeToggleButton() {
+  const theme = useTheme2();
+  const targetThemeId = theme.isDark ? 'light' : 'dark';
+  const tooltip = theme.isDark
+    ? t('navigation.theme-toggle.switch-to-light', 'Switch to light theme')
+    : t('navigation.theme-toggle.switch-to-dark', 'Switch to dark theme');
+
+  return (
+    <ToolbarButton
+      aria-checked={theme.isDark}
+      aria-label={t('navigation.theme-toggle.aria-label', 'Dark theme')}
+      icon={theme.isDark ? 'toggle-on' : 'toggle-off'}
+      onClick={() => changeTheme(targetThemeId, false)}
+      role="switch"
+      tooltip={tooltip}
+    />
+  );
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
**What is this feature?**

Adds an accessible dark theme switch to the main application toolbar.

**Why do we need this feature?**

Users can switch between dark and light themes without opening profile preferences, and the existing preferences API persists the selection.

**Who is this feature for?**

Grafana users who want fast access to theme changes from the main toolbar.

**Which issue(s) does this PR fix?**:

Fixes #

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle. N/A: this exposes existing dark/light preference behavior in the toolbar.
- [ ] The docs are updated, and if this is a notable improvement, it's added to our What's New doc.

**Verification**

- `yarn jest --no-watch public/app/core/components/AppChrome/TopBar/ThemeToggleButton.test.tsx`
- `yarn eslint public/app/core/components/AppChrome/TopBar/SingleTopBar.tsx public/app/core/components/AppChrome/TopBar/ThemeToggleButton.tsx public/app/core/components/AppChrome/TopBar/ThemeToggleButton.test.tsx --no-error-on-unmatched-pattern`
- `curl -I http://localhost:3000/`
- Manual browser test: toggled dark -> light, reloaded to confirm light theme persisted, toggled light -> dark.

<a href="https://cursor.com/agents/bc-ba3243f4-92e0-4b61-af6d-d3bebb362260/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ftheme_toggle_toolbar_flow.mp4"><img src="https://cursor.com/artifacts/c/art-90e3ba06-9269-40b2-9ae4-ed7427ccba8a" alt="theme_toggle_toolbar_flow.mp4" /></a>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ba3243f4-92e0-4b61-af6d-d3bebb362260"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ba3243f4-92e0-4b61-af6d-d3bebb362260"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

