### PR TITLE
AppChrome: Add top bar light/dark theme toggle

### DIFF
--- a/public/app/core/components/AppChrome/TopBar/SingleTopBar.tsx
+++ b/public/app/core/components/AppChrome/TopBar/SingleTopBar.tsx
@@ -26,6 +26,7 @@ import { InviteUserButton } from './InviteUserButton';
 import { ProfileButton } from './ProfileButton';
 import { SignInLink } from './SignInLink';
 import { SingleTopBarActions } from './SingleTopBarActions';
+import { ThemeToggleButton } from './ThemeToggleButton';
 import { TopBarExtensionPoint } from './TopBarExtensionPoint';
 import { TopSearchBarCommandPaletteTrigger } from './TopSearchBarCommandPaletteTrigger';
 import { getChromeHeaderLevelHeight } from './useChromeHeaderHeight';
@@ -96,6 +97,7 @@ export const SingleTopBar = memo(function SingleTopBar({
           <TopSearchBarCommandPaletteTrigger />
           {!isSmallScreen && <QuickAdd />}
           <HelpTopBarButton isSmallScreen={isSmallScreen} />
+          <ThemeToggleButton />
           <NavToolbarSeparator />
           {!isSmallScreen && <ExtensionToolbarItem compact={isSmallScreen} />}
           {!showToolbarLevel && actions}

--- a/public/app/core/components/AppChrome/TopBar/ThemeToggleButton.test.tsx
+++ b/public/app/core/components/AppChrome/TopBar/ThemeToggleButton.test.tsx
@@ -1,0 +1,47 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import { createTheme, ThemeContext } from '@grafana/data';
+import * as themeService from 'app/core/services/theme';
+
+import { ThemeToggleButton } from './ThemeToggleButton';
+
+jest.mock('app/core/services/theme', () => ({
+  changeTheme: jest.fn(),
+}));
+
+function renderToggle(mode: 'dark' | 'light') {
+  const theme = createTheme({ colors: { mode } });
+
+  const ui = render(
+    <ThemeContext.Provider value={theme}>
+      <ThemeToggleButton />
+    </ThemeContext.Provider>
+  );
+
+  return { ...ui, user: userEvent.setup() };
+}
+
+describe('ThemeToggleButton', () => {
+  beforeEach(() => {
+    jest.mocked(themeService.changeTheme).mockClear();
+  });
+
+  it('calls changeTheme with light when the current theme is dark', async () => {
+    const { user } = renderToggle('dark');
+
+    const btn = screen.getByRole('button', { name: /switch to light theme/i });
+    await user.click(btn);
+
+    expect(themeService.changeTheme).toHaveBeenCalledWith('light', false);
+  });
+
+  it('calls changeTheme with dark when the current theme is light', async () => {
+    const { user } = renderToggle('light');
+
+    const btn = screen.getByRole('button', { name: /switch to dark theme/i });
+    await user.click(btn);
+
+    expect(themeService.changeTheme).toHaveBeenCalledWith('dark', false);
+  });
+});

--- a/public/app/core/components/AppChrome/TopBar/ThemeToggleButton.tsx
+++ b/public/app/core/components/AppChrome/TopBar/ThemeToggleButton.tsx
@@ -1,0 +1,28 @@
+import { memo, useCallback } from 'react';
+
+import { t } from '@grafana/i18n';
+import { ToolbarButton, useTheme2 } from '@grafana/ui';
+import { changeTheme } from 'app/core/services/theme';
+
+export const ThemeToggleButton = memo(function ThemeToggleButton() {
+  const theme = useTheme2();
+  const isDark = theme.isDark;
+
+  const label = isDark
+    ? t('navigation.theme.switch-to-light', 'Switch to light theme')
+    : t('navigation.theme.switch-to-dark', 'Switch to dark theme');
+
+  const onToggle = useCallback(() => {
+    void changeTheme(isDark ? 'light' : 'dark', false);
+  }, [isDark]);
+
+  return (
+    <ToolbarButton
+      iconOnly
+      icon="palette"
+      aria-label={label}
+      tooltip={label}
+      onClick={onToggle}
+    />
+  );
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
**What is this feature?**

Adds a global theme toggle (palette icon) to the main top bar, next to Help. It switches between light and dark themes using the existing `changeTheme` helper so the UI updates immediately and signed-in users persist the choice via user preferences.

**Why do we need this feature?**

Implements [GRF-6](https://fe-anysphere-demo.atlassian.net/browse/GRF-6): quick access to theme switching from the toolbar without opening profile or settings.

**Who is this feature for?**

Anyone using Grafana who prefers to switch between dark and light themes from the main chrome.

**Which issue(s) does this PR fix?**:

Fixes external ticket GRF-6 (Jira GrafanaDev).

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective (toggle label, immediate theme change; signed-in persistence via existing `PATCH` behavior in `changeTheme`).
- [ ] If this is a pre-GA feature, it is behind a feature toggle (not behind a toggle; small chrome addition).
- [ ] The docs are updated, and if this is a notable improvement, it's added to What's New (skipped: small UX tweak; can add docs if desired).

**Verification**

- `yarn jest --no-watch public/app/core/components/AppChrome/TopBar/ThemeToggleButton.test.tsx`
- `yarn eslint` on touched files
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-77d0feca-47e7-4a8f-a5b1-846fd372bd9e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-77d0feca-47e7-4a8f-a5b1-846fd372bd9e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

