### PR TITLE
feat(chrome): toolbar light/dark theme toggle (GRF-6)

### DIFF
--- a/packages/grafana-e2e-selectors/src/selectors/components.ts
+++ b/packages/grafana-e2e-selectors/src/selectors/components.ts
@@ -1069,6 +1069,9 @@ export const versionedComponents = {
     container: {
       '9.4.0': 'data-testid Nav toolbar',
     },
+    themeToggle: {
+      '13.0.0': 'data-testid Theme toggle',
+    },
     commandPaletteTrigger: {
       '11.5.0': 'data-testid Command palette trigger',
     },

--- a/public/app/core/components/AppChrome/TopBar/SingleTopBar.tsx
+++ b/public/app/core/components/AppChrome/TopBar/SingleTopBar.tsx
@@ -26,6 +26,7 @@ import { InviteUserButton } from './InviteUserButton';
 import { ProfileButton } from './ProfileButton';
 import { SignInLink } from './SignInLink';
 import { SingleTopBarActions } from './SingleTopBarActions';
+import { ThemeToggleButton } from './ThemeToggleButton';
 import { TopBarExtensionPoint } from './TopBarExtensionPoint';
 import { TopSearchBarCommandPaletteTrigger } from './TopSearchBarCommandPaletteTrigger';
 import { getChromeHeaderLevelHeight } from './useChromeHeaderHeight';
@@ -95,6 +96,7 @@ export const SingleTopBar = memo(function SingleTopBar({
           <TopBarExtensionPoint />
           <TopSearchBarCommandPaletteTrigger />
           {!isSmallScreen && <QuickAdd />}
+          <ThemeToggleButton />
           <HelpTopBarButton isSmallScreen={isSmallScreen} />
           <NavToolbarSeparator />
           {!isSmallScreen && <ExtensionToolbarItem compact={isSmallScreen} />}

--- a/public/app/core/components/AppChrome/TopBar/ThemeToggleButton.test.tsx
+++ b/public/app/core/components/AppChrome/TopBar/ThemeToggleButton.test.tsx
@@ -1,0 +1,40 @@
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { render } from 'test/test-utils';
+
+import { reportInteraction } from '@grafana/runtime';
+import * as themeService from 'app/core/services/theme';
+
+import { ThemeToggleButton } from './ThemeToggleButton';
+
+jest.mock('@grafana/runtime', () => ({
+  ...jest.requireActual('@grafana/runtime'),
+  reportInteraction: jest.fn(),
+}));
+
+jest.mock('app/core/services/theme', () => ({
+  toggleTheme: jest.fn(),
+}));
+
+const mockToggleTheme = jest.mocked(themeService.toggleTheme);
+const mockReportInteraction = jest.mocked(reportInteraction);
+
+describe('ThemeToggleButton', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('calls toggleTheme(false) when clicked', async () => {
+    const user = userEvent.setup();
+    render(<ThemeToggleButton />);
+
+    await user.click(screen.getByRole('button', { name: /switch to (light|dark) theme/i }));
+
+    expect(mockToggleTheme).toHaveBeenCalledTimes(1);
+    expect(mockToggleTheme).toHaveBeenCalledWith(false);
+    expect(mockReportInteraction).toHaveBeenCalledWith(
+      'navigation_theme_toggle_clicked',
+      expect.objectContaining({ fromMode: expect.stringMatching(/^(dark|light)$/) })
+    );
+  });
+});

--- a/public/app/core/components/AppChrome/TopBar/ThemeToggleButton.tsx
+++ b/public/app/core/components/AppChrome/TopBar/ThemeToggleButton.tsx
@@ -1,0 +1,37 @@
+import { memo, useCallback } from 'react';
+
+import { type IconName } from '@grafana/data';
+import { Components } from '@grafana/e2e-selectors';
+import { t } from '@grafana/i18n';
+import { reportInteraction } from '@grafana/runtime';
+import { ToolbarButton, useTheme2 } from '@grafana/ui';
+import { toggleTheme } from 'app/core/services/theme';
+
+export const ThemeToggleButton = memo(function ThemeToggleButton() {
+  const grafanaTheme = useTheme2();
+  const isDark = grafanaTheme.isDark;
+
+  const label = isDark
+    ? t('navigation.theme-toggle.switch-to-light', 'Switch to light theme')
+    : t('navigation.theme-toggle.switch-to-dark', 'Switch to dark theme');
+
+  const icon: IconName = isDark ? 'lightbulb-alt' : 'laptop-cloud';
+
+  const onClick = useCallback(() => {
+    reportInteraction('navigation_theme_toggle_clicked', {
+      fromMode: isDark ? 'dark' : 'light',
+    });
+    void toggleTheme(false);
+  }, [isDark]);
+
+  return (
+    <ToolbarButton
+      iconOnly
+      icon={icon}
+      tooltip={label}
+      aria-label={label}
+      onClick={onClick}
+      data-testid={Components.NavToolbar.themeToggle}
+    />
+  );
+});

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -12230,7 +12230,11 @@
       "aria-label": "New",
       "new-template-dashboard-button": "Dashboard from template"
     },
-    "rss-button": "Latest from the blog"
+    "rss-button": "Latest from the blog",
+    "theme-toggle": {
+      "switch-to-dark": "Switch to dark theme",
+      "switch-to-light": "Switch to light theme"
+    }
   },
   "news": {
     "category-news": "News",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements **GRF-6** by adding a dedicated theme control to the main app chrome top bar.

- New `ThemeToggleButton` uses existing `toggleTheme(false)` ([`public/app/core/services/theme.ts`](public/app/core/services/theme.ts)) so the UI updates immediately and signed-in users get the same user preference persistence as the `c t` shortcut.
- Placed in [`SingleTopBar.tsx`](public/app/core/components/AppChrome/TopBar/SingleTopBar.tsx) before **Help**, visible on all breakpoints (same as Help).
- E2E: `Components.NavToolbar.themeToggle` in [`packages/grafana-e2e-selectors`](packages/grafana-e2e-selectors/src/selectors/components.ts).
- Analytics: `navigation_theme_toggle_clicked` with `fromMode`.
- i18n: `navigation.theme-toggle.switch-to-light` / `switch-to-dark` in `public/locales/en-US/grafana.json`.
- Unit test mocks `toggleTheme` and asserts click behavior.

## How to verify

1. Sign in, open any page with chrome.
2. Use the new toolbar button (lightbulb in dark mode, laptop-cloud in light mode) and confirm theme flips and survives reload.
3. `yarn jest public/app/core/components/AppChrome/TopBar/ThemeToggleButton.test.tsx --no-watch --watchAll=false`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4691dde1-d518-452a-84e2-f8f0be77ae1e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4691dde1-d518-452a-84e2-f8f0be77ae1e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

