### PR TITLE
fix(api): correct SSO login redirect handling with app sub-URL

### DIFF
--- a/pkg/api/frontendsettings.go
+++ b/pkg/api/frontendsettings.go
@@ -46,7 +46,8 @@ func (hs *HTTPServer) GetBootdata(c *contextmodel.ReqContext) {
 
 	ofClient := openfeature.NewDefaultClient()
 	autoLoginFlagEnabled := ofClient.Boolean(c.Req.Context(), featuremgmt.FlagFrontendServiceSSOAutoLogin, false, openfeature.TransactionContext(c.Req.Context()))
-	if autoLoginFlagEnabled && !c.IsSignedIn {
+	_, disableAutoLogin := c.Req.URL.Query()["disableAutoLogin"]
+	if autoLoginFlagEnabled && !c.IsSignedIn && !disableAutoLogin {
 		data.AutoLoginRedirectURL = hs.getAutoLoginRedirectURL(c)
 	}
 

--- a/pkg/services/frontend/index.html
+++ b/pkg/services/frontend/index.html
@@ -306,7 +306,24 @@
 
           // Handle SSO auto-login redirection from /bootdata.
           // Only redirect if there's no login error to avoid redirect loops.
-          const hasLoginError = rawBootData.settings?.loginError || window.grafanaBootData.settings.loginError;
+          const hasLoginError = rawBootData.settings?.loginError || window.grafanaBootData.settings?.loginError;
+          const appPathname = (() => {
+            const pathname = window.location.pathname;
+            const base = document.querySelector('base');
+            if (!base) {
+              return pathname;
+            }
+            try {
+              const basePath = new URL(base.href, window.location.origin).pathname.replace(/\/$/, '') || '';
+              if (basePath && pathname.startsWith(basePath)) {
+                const remaining = pathname.slice(basePath.length);
+                return remaining || '/';
+              }
+            } catch (e) {
+              // ignore invalid base URL
+            }
+            return pathname;
+          })();
           const annonAccessPages = [
             /\/dashboard\/snapshot\/.*$/,
             /\/invite$/,
@@ -315,11 +332,11 @@
             /\/user\/password\/reset$/,
             /\/public-dashboards\/.*$/,
           ]
-          const isAllowedAnonPage = annonAccessPages.some((regex) => regex.test(window.location.pathname));
+          const isAllowedAnonPage = annonAccessPages.some((regex) => regex.test(appPathname));
+          const isLoginPage = appPathname === '/login';
           if (rawBootData.autoLoginRedirectURL && !hasLoginError && !queryParams.has('disableAutoLogin') && !isAllowedAnonPage) {
             // Copied from context_srv.setRedirectToUrl
-            const redirectPath = window.location.href.substring(window.location.origin.length)
-            if (redirectPath !== "/login") {
+            if (!isLoginPage) {
               window.sessionStorage.setItem(
                 'redirectTo',
                 encodeURIComponent(window.location.href.substring(window.location.origin.length))


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes a login redirect bug in the backend-api boot flow used by the frontend-service stack.

When Grafana is served under an app sub-URL (for example `/grafana`), SSO auto-login logic compared paths against `/login` literally. That caused:

- `redirectTo` session storage to be set while already on the login page, which could send users back to `/grafana/login` after SSO instead of the home page
- Anonymous routes like `/invite` not matching, triggering unwanted SSO redirects

## Changes

- **`pkg/api/frontendsettings.go`**: `GetBootdata` now honors the `disableAutoLogin` query parameter and omits `autoLoginRedirectURL` when it is set (aligned with `LoginView` and the frontend boot script).
- **`pkg/services/frontend/index.html`**: Normalize the pathname using the `<base href>` before checking login and anonymous-access routes.

## Testing

- `go test -run TestLogin ./pkg/api/ -count=1`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-cbd54c2a-ff69-489c-9e69-5d640b240af5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-cbd54c2a-ff69-489c-9e69-5d640b240af5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

