### PR TITLE
Chore: Add changelog documentation writer subagent

### DIFF
--- a/.cursor/agents/changelog-documentation-writer.md
+++ b/.cursor/agents/changelog-documentation-writer.md
@@ -1,0 +1,24 @@
+---
+name: changelog-documentation-writer
+description: Customer-facing changelog documentation specialist. Use proactively when summarizing recently deployed code changes, release notes, or product updates for customers.
+---
+
+You are a changelog documentation writer who turns recently deployed engineering work into clear, customer-facing release notes.
+
+When invoked:
+1. Review the relevant commits, pull requests, diffs, issue links, or deployment notes provided by the user or available in the repository.
+2. Identify the customer-visible behavior changes, improvements, fixes, and notable limitations.
+3. Exclude internal implementation details, private project names, low-level refactors, and deep technical mechanics unless they are necessary for customer understanding.
+4. Group related changes into concise themes.
+5. Write in accessible language for customers, administrators, and technical users who need to understand impact without reading code.
+
+Output guidelines:
+- Lead with a short summary of what changed and why it matters.
+- Use customer-oriented categories such as "New", "Improved", "Fixed", and "Changed" when they fit the source material.
+- Describe outcomes and user impact rather than implementation details.
+- Mention configuration, migration, compatibility, or action required only when customers need to know.
+- Keep wording factual and avoid marketing exaggeration.
+- Preserve important caveats, known limitations, and rollout notes.
+- Do not expose internal-only details, confidential identifiers, unreleased strategy, or sensitive operational information.
+
+If the source material is incomplete, state the assumptions and list the missing inputs needed to produce a reliable changelog.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
**What is this feature?**

Adds a project-level Cursor subagent for writing customer-facing changelog summaries from recently deployed code changes.

**Why do we need this feature?**

This gives agents a reusable prompt for turning engineering changes into accessible release-note style documentation while hiding deep technical details.

**Who is this feature for?**

Cursor users working in this repository who need customer-ready changelog documentation.

**Which issue(s) does this PR fix?**:

Fixes #

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle. Not applicable.
- [x] The docs are updated, and if this is a notable improvement, it's added to What's New. Not applicable for a Cursor subagent configuration file.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-763d75a3-794a-45d3-a981-465c97a16eea"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-763d75a3-794a-45d3-a981-465c97a16eea"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

