### PR TITLE
Docker: Fix Railway Metal builder Dockerfile build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -83,15 +83,15 @@ COPY .citools .citools
 # Uses --parents to preserve directory structure with fewer COPY directives.
 COPY --parents **/go.mod **/go.sum ./
 
-RUN --mount=type=cache,id=grafana-gomod,target=/go/pkg/mod \
-    go mod download
+RUN go mod download
 
 # Copy full source
 COPY embed.go Makefile package.json ./
 COPY cue.mod cue.mod
 COPY kinds kinds
 COPY kindsv2 kindsv2
-COPY local local
+# `local/` is gitignored (dev overrides); ensure it exists when not in build context (e.g. Railway).
+RUN mkdir -p local
 COPY packages/grafana-schema packages/grafana-schema
 COPY packages/grafana-data/src/themes/themeDefinitions packages/grafana-data/src/themes/themeDefinitions
 COPY public/app/plugins public/app/plugins
@@ -105,9 +105,7 @@ COPY .github .github
 ENV COMMIT_SHA=${COMMIT_SHA}
 ENV BUILD_BRANCH=${BUILD_BRANCH}
 
-RUN --mount=type=cache,id=grafana-gomod,target=/go/pkg/mod \
-    --mount=type=cache,id=grafana-gobuild,target=/root/.cache/go-build \
-    make build-go GO_BUILD_TAGS=${GO_BUILD_TAGS} WIRE_TAGS=${WIRE_TAGS}
+RUN make build-go GO_BUILD_TAGS=${GO_BUILD_TAGS} WIRE_TAGS=${WIRE_TAGS}
 
 RUN mkdir -p data/plugins-bundled
 

--- a/deploy/railway/README.md
+++ b/deploy/railway/README.md
@@ -9,14 +9,30 @@ Target repo: [fieldsphere/grafana](https://github.com/fieldsphere/grafana).
 1. Create a [Railway](https://railway.com) project (Hobby or Pro).
 2. **New → GitHub Repo** → `fieldsphere/grafana`, branch `main`.
 3. Railway detects the root `Dockerfile` and `railway.toml` (health check `/api/health`, long timeout for cold builds).
-4. **Add a volume** (if using SQLite): mount at `/var/lib/grafana` on the Grafana service.
-5. **Variables**: copy from [`env.example`](./env.example). Minimum: `GF_SERVER_ROOT_URL`, `GF_SECURITY_ADMIN_PASSWORD`, and disable anonymous/signup (already in the example).
-6. **Networking**: generate a public domain; set `GF_SERVER_ROOT_URL` to `https://<that-domain>`.
-7. **PR environments**: Project Settings → **Environments** → enable **PR Environments** (and optionally **Focused PR Environments** so only this service rebuilds).
+4. **Postgres (recommended):** add a Postgres database in the project, then on the **grafana** service set variables from [`env.example`](./env.example) using `${{Postgres.PGHOST}}` (and related) references. Railway does not auto-inject DB creds; you must add the references explicitly.
+5. **Or SQLite:** attach a volume at `/var/lib/grafana` and use the SQLite block in `env.example`.
+6. **Variables:** copy [`env.example`](./env.example). At minimum set:
+   - `GF_SERVER_ROOT_URL` (must match the public HTTPS URL)
+   - `GF_SECURITY_ADMIN_PASSWORD` (and `GF_SECURITY_SECRET_KEY` — not optional for a public deploy)
+   - Postgres `GF_DATABASE_*` **or** SQLite + volume
+   - `GF_AUTH_ANONYMOUS_ENABLED=false`, `GF_USERS_ALLOW_SIGN_UP=false`
+7. **Networking:** generate a public domain; confirm `GF_SERVER_ROOT_URL` matches it.
+8. **PR environments**: Project Settings → **Environments** → enable **PR Environments** (and optionally **Focused PR Environments** so only this service rebuilds).
 
 Auth is **Grafana’s own login page** (admin user + password you set in Railway). Railway does not sit in front with a separate login wall.
 
-For a public demo, you only need a strong `GF_SECURITY_ADMIN_PASSWORD` plus `GF_AUTH_ANONYMOUS_ENABLED=false` and `GF_USERS_ALLOW_SIGN_UP=false` so strangers cannot browse without logging in or create accounts.
+For a public demo you need Grafana’s own auth configured in Railway:
+
+| Variable                           | Why                                                                 |
+| ---------------------------------- | ------------------------------------------------------------------- |
+| `GF_SECURITY_ADMIN_PASSWORD`       | Login password (not `admin` / `admin`)                              |
+| `GF_SECURITY_SECRET_KEY`           | Session signing; never leave the sample.ini default on the internet |
+| `GF_SECURITY_ADMIN_EMAIL`          | Admin profile email on first boot                                   |
+| `GF_DATABASE_*` or volume + SQLite | Persist users/settings; Postgres refs `${{Postgres.*}}`             |
+| `GF_AUTH_ANONYMOUS_ENABLED=false`  | No anonymous browsing                                               |
+| `GF_USERS_ALLOW_SIGN_UP=false`     | No public account creation                                          |
+
+Admin password env vars only apply on **first** startup. If Grafana already created an admin with defaults, change the password in the UI or reset the database before expecting env changes to take effect.
 
 ### Optional: GitHub on the Grafana login page
 
@@ -56,11 +72,11 @@ Dashboard UI + datasource queries from the preview count toward egress (usually 
 
 ### Practical guidance
 
-| Pattern | Build cost | Run cost | Good for |
-|---------|------------|----------|----------|
-| PR preview on **every** commit | High | Medium while PR open | Proving “deploy my branch” in demos |
-| PR preview only with label / manual Railway deploy | Lower | Lower | Day-to-day dev |
-| **Main only** auto-deploy; PRs use local `make run` | Lowest | One stable instance | Most internal work |
+| Pattern                                             | Build cost | Run cost             | Good for                            |
+| --------------------------------------------------- | ---------- | -------------------- | ----------------------------------- |
+| PR preview on **every** commit                      | High       | Medium while PR open | Proving “deploy my branch” in demos |
+| PR preview only with label / manual Railway deploy  | Lower      | Lower                | Day-to-day dev                      |
+| **Main only** auto-deploy; PRs use local `make run` | Lowest     | One stable instance  | Most internal work                  |
 
 For coding-tool demos, a common compromise is: **auto-deploy `main`**, enable PR environments for **release demos**, and accept **one long first build** per PR.
 
@@ -82,12 +98,12 @@ railway up
 
 ## Suggested resources
 
-| Setting | Suggestion |
-|---------|------------|
-| RAM | ≥ 1 GB (2 GB if dashboards + alerting feel tight) |
-| Volume | 1–5 GB for SQLite demos |
-| Health check | `/healthz` (configured in `railway.toml`) |
-| Service RAM | ≥ 2 GB recommended for runtime |
+| Setting      | Suggestion                                        |
+| ------------ | ------------------------------------------------- |
+| RAM          | ≥ 1 GB (2 GB if dashboards + alerting feel tight) |
+| Volume       | 1–5 GB for SQLite demos                           |
+| Health check | `/healthz` (configured in `railway.toml`)         |
+| Service RAM  | ≥ 2 GB recommended for runtime                    |
 
 Push `railway.toml` to GitHub so Railway picks up config-as-code (a dashboard-only deploy won't get these settings).
 

--- a/deploy/railway/TROUBLESHOOTING.md
+++ b/deploy/railway/TROUBLESHOOTING.md
@@ -42,12 +42,12 @@ If it still fails, use a larger Railway plan or build the image in GitHub Action
 
 **Causes:**
 
-| Cause | Fix |
-|-------|-----|
-| Health check hits `/api/health` before DB is ready | Use `/healthz` in `railway.toml` (committed config) |
-| Cold Docker build + DB migrations exceed timeout | Raise `healthcheckTimeout` in `railway.toml` (600–900s) |
+| Cause                                              | Fix                                                                                                      |
+| -------------------------------------------------- | -------------------------------------------------------------------------------------------------------- |
+| Health check hits `/api/health` before DB is ready | Use `/healthz` in `railway.toml` (committed config)                                                      |
+| Cold Docker build + DB migrations exceed timeout   | Raise `healthcheckTimeout` in `railway.toml` (600–900s)                                                  |
 | Grafana listens on 3000, Railway routes to `$PORT` | Set `GF_SERVER_HTTP_PORT=${{PORT}}` or use updated `packaging/docker/run.sh` (maps `PORT` automatically) |
-| First image build still running | Wait; full Grafana image builds often take 20–45+ minutes |
+| First image build still running                    | Wait; full Grafana image builds often take 20–45+ minutes                                                |
 
 ### 4. Running but 502 Bad Gateway
 

--- a/deploy/railway/env.example
+++ b/deploy/railway/env.example
@@ -1,30 +1,84 @@
-# Railway → Service → Variables
-# Railway injects PORT; Grafana must listen on it.
+# Copy into Railway → grafana service → Variables.
+# Use "Add variable" / raw editor; Railway expands ${{...}} references at deploy time.
+#
+# Generate secrets locally:
+#   openssl rand -base64 24    # admin password
+#   openssl rand -base64 44    # secret_key
 
-# --- Deploy / networking (required) ---
-# Optional if using packaging/docker/run.sh (maps Railway PORT automatically).
+# =============================================================================
+# Required — networking (Railway)
+# =============================================================================
+# Railway sets PORT; run.sh maps it if GF_SERVER_HTTP_PORT is unset.
 GF_SERVER_HTTP_PORT=${{PORT}}
-# After first deploy: your public HTTPS URL, no trailing slash.
-# PR envs: https://${{RAILWAY_PUBLIC_DOMAIN}}
+
+# Public URL of this service (HTTPS, no trailing slash).
+# Production: your generated Railway domain.
+# PR previews: GF_SERVER_ROOT_URL=https://${{RAILWAY_PUBLIC_DOMAIN}}
 GF_SERVER_ROOT_URL=https://YOUR-SERVICE.up.railway.app
 
-# --- Grafana login (required for a public URL) ---
-# Auth is the normal Grafana login screen — set a strong admin password (not admin/admin).
+# Trust proxy headers from Railway's edge (recommended behind HTTPS).
+GF_SERVER_SERVE_FROM_SUB_PATH=false
+GF_SERVER_ENFORCE_DOMAIN=false
+
+# =============================================================================
+# Required — Grafana admin login (first startup only)
+# =============================================================================
+# These apply when the database has no admin user yet. If you already booted with
+# defaults, reset the password in the UI or wipe the DB volume before redeploying.
 GF_SECURITY_ADMIN_USER=admin
 GF_SECURITY_ADMIN_PASSWORD=
+GF_SECURITY_ADMIN_EMAIL=admin@example.com
 
-# Don't leave a public demo wide open: no anonymous dashboards, no self-signup.
+# Required for production: signing key for sessions/cookies (do NOT use the sample.ini default).
+GF_SECURITY_SECRET_KEY=
+
+# =============================================================================
+# Required — lock down a public demo URL
+# =============================================================================
 GF_AUTH_ANONYMOUS_ENABLED=false
 GF_USERS_ALLOW_SIGN_UP=false
+GF_USERS_DEFAULT_THEME=dark
 
-# --- Optional: GitHub sign-in on the Grafana login page (org-restricted) ---
-# Only if you want "Sign in with GitHub" in addition to admin login.
-# Callback URL: {GF_SERVER_ROOT_URL}/login/github
+# =============================================================================
+# Required — database (pick ONE block)
+# =============================================================================
+
+# --- Option A: Railway Postgres (recommended; you have a Postgres service) ---
+# In the grafana service, reference the Postgres plugin (service name must match).
+GF_DATABASE_TYPE=postgres
+GF_DATABASE_HOST=${{Postgres.PGHOST}}
+GF_DATABASE_PORT=${{Postgres.PGPORT}}
+GF_DATABASE_USER=${{Postgres.PGUSER}}
+GF_DATABASE_PASSWORD=${{Postgres.PGPASSWORD}}
+GF_DATABASE_NAME=${{Postgres.PGDATABASE}}
+GF_DATABASE_SSL_MODE=require
+
+# Alternative single URL (comment out the GF_DATABASE_* lines above if you use this):
+# GF_DATABASE_URL=${{Postgres.DATABASE_URL}}
+
+# --- Option B: SQLite on a Railway volume ---
+# Attach a volume mounted at /var/lib/grafana, then use:
+# GF_DATABASE_TYPE=sqlite3
+# (paths default to GF_PATHS_DATA=/var/lib/grafana; DB file grafana.db)
+
+# =============================================================================
+# Recommended — runtime / demo
+# =============================================================================
+GF_DEFAULT_INSTANCE_NAME=fieldsphere-demo
+GF_LOG_LEVEL=info
+GF_ANALYTICS_REPORTING_ENABLED=false
+GF_ANALYTICS_CHECK_FOR_UPDATES=false
+
+# =============================================================================
+# Optional — GitHub button on Grafana login page
+# =============================================================================
+# Callback: {GF_SERVER_ROOT_URL}/login/github
 # GF_AUTH_GITHUB_ENABLED=true
 # GF_AUTH_GITHUB_CLIENT_ID=
 # GF_AUTH_GITHUB_CLIENT_SECRET=
 # GF_AUTH_GITHUB_ALLOWED_ORGANIZATIONS=fieldsphere
 
-# --- Database (pick one) ---
-# SQLite: attach a Railway volume at /var/lib/grafana
-# Postgres: attach Railway Postgres, then set GF_DATABASE_TYPE=postgres and PG* refs
+# =============================================================================
+# Optional — Docker build (Railway Settings → Docker → build args)
+# =============================================================================
+# If yarn build OOMs (exit 137): JS_NODE_MAX_OLD_SPACE=4096


### PR DESCRIPTION
**What is this feature?**

Dockerfile changes so `fieldsphere/grafana` can build on Railway's Metal builder: drop Go BuildKit cache mounts Railway rejects, and create `local/` at build time when the gitignored directory is missing from context.

**Why do we need this feature?**

Railway demo deploys were failing at Dockerfile parse (`cacheKey prefix`) and at `COPY local local` (`/local` not found). This unblocks the Docker build through those stages.

**Who is this feature for?**

Anyone deploying this fork to Railway (or similar hosts with the same constraints).

**Which issue(s) does this PR fix?**:

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.

---

Target repo: `fieldsphere/grafana`

**Test plan**

- [ ] Merge and let Railway rebuild from `main` (or redeploy service)
- [ ] Confirm build passes Dockerfile validation and `go-builder` stages

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to Dockerfile build compatibility and Railway documentation/example env vars; no application auth or data-path logic is modified in Go/TS code.
> 
> **Overview**
> **Docker** changes unblock Railway’s Metal builder: Go build steps no longer use BuildKit `--mount=type=cache` (which Railway rejects), and the gitignored `local/` directory is created with `mkdir -p` instead of `COPY local local` when it’s missing from the build context.
> 
> **Railway deploy docs** are expanded to match a real public demo: `deploy/railway/env.example` is reorganized with required networking, admin credentials, `GF_SECURITY_SECRET_KEY`, Postgres `${{Postgres.*}}` references (or SQLite + volume), and lock-down flags. `README.md` walks through Postgres vs SQLite, explicit security variables, and notes that admin password env vars only apply on first boot.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7fd974f5d176db8eb20eb8fc29d2b5c7f8f8d33b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->