### PR TITLE
feat: add Labs page with open feature flags

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -166,6 +166,7 @@ func (hs *HTTPServer) registerRoutes() {
 	r.Get("/connections/datasources/edit/*", authorize(datasources.EditPageAccess), hs.Index)
 	r.Get("/connections", authorize(datasources.ConfigurationPageAccess), hs.Index)
 	r.Get("/connections/add-new-connection", authorize(datasources.ConfigurationPageAccess), hs.Index)
+	r.Get("/labs", reqOrgAdmin, hs.Index)
 	// Plugin details pages
 	r.Get("/connections/datasources/:id", middleware.CanAdminPlugins(hs.Cfg, hs.AccessControl), hs.Index)
 	r.Get("/connections/datasources/:id/page/:page", middleware.CanAdminPlugins(hs.Cfg, hs.AccessControl), hs.Index)
@@ -507,6 +508,8 @@ func (hs *HTTPServer) registerRoutes() {
 
 		// Playlist
 		hs.registerPlaylistAPI(apiRoute)
+
+		apiRoute.Get("/feature-toggles/open", reqOrgAdmin, routing.Wrap(hs.GetOpenFeatureToggles))
 
 		// Search
 		apiRoute.Get("/search/sorting", routing.Wrap(hs.ListSortOptions))

--- a/pkg/api/feature_toggles.go
+++ b/pkg/api/feature_toggles.go
@@ -1,0 +1,69 @@
+package api
+
+import (
+	"net/http"
+	"sort"
+
+	"github.com/grafana/grafana/pkg/api/response"
+	"github.com/grafana/grafana/pkg/services/featuremgmt"
+	contextmodel "github.com/grafana/grafana/pkg/services/contexthandler/model"
+)
+
+// OpenFeatureToggleDTO describes a non-GA feature flag and its current state.
+type OpenFeatureToggleDTO struct {
+	Name            string `json:"name"`
+	Description     string `json:"description"`
+	Stage           string `json:"stage"`
+	Enabled         bool   `json:"enabled"`
+	RequiresDevMode bool   `json:"requiresDevMode,omitempty"`
+}
+
+func isOpenFeatureStage(stage string) bool {
+	switch stage {
+	case "GA", "deprecated":
+		return false
+	default:
+		return true
+	}
+}
+
+// GetOpenFeatureToggles returns feature flags that are not generally available.
+// swagger:response openFeatureTogglesResponse
+// in:body
+// type OpenFeatureToggleDTO
+//
+// swagger:route GET /feature-toggles/open feature_toggles getOpenFeatureToggles
+//
+// Get open (non-GA) feature toggles.
+//
+// Responses:
+//   200: openFeatureTogglesResponse
+func (hs *HTTPServer) GetOpenFeatureToggles(c *contextmodel.ReqContext) response.Response {
+	featureList, err := featuremgmt.GetEmbeddedFeatureList()
+	if err != nil {
+		return response.Error(http.StatusInternalServerError, "Failed to load feature toggles", err)
+	}
+
+	enabled := hs.Features.GetEnabled(c.Req.Context())
+	openToggles := make([]OpenFeatureToggleDTO, 0)
+
+	for _, feature := range featureList.Items {
+		if feature.Spec.HideFromDocs || !isOpenFeatureStage(feature.Spec.Stage) {
+			continue
+		}
+
+		openToggles = append(openToggles, OpenFeatureToggleDTO{
+			Name:            feature.Name,
+			Description:     feature.Spec.Description,
+			Stage:           feature.Spec.Stage,
+			Enabled:         enabled[feature.Name],
+			RequiresDevMode: feature.Spec.RequiresDevMode,
+		})
+	}
+
+	sort.Slice(openToggles, func(i, j int) bool {
+		return openToggles[i].Name < openToggles[j].Name
+	})
+
+	return response.JSON(http.StatusOK, openToggles)
+}

--- a/pkg/api/feature_toggles_test.go
+++ b/pkg/api/feature_toggles_test.go
@@ -1,0 +1,94 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/grafana/pkg/services/featuremgmt"
+	contextmodel "github.com/grafana/grafana/pkg/services/contexthandler/model"
+	"github.com/grafana/grafana/pkg/services/org"
+	"github.com/grafana/grafana/pkg/services/user"
+	"github.com/grafana/grafana/pkg/web"
+)
+
+func TestGetOpenFeatureToggles(t *testing.T) {
+	hs := setupSimpleHTTPServer(featuremgmt.WithFeatures())
+
+	req, err := http.NewRequest(http.MethodGet, "/api/feature-toggles/open", nil)
+	require.NoError(t, err)
+
+	recorder := httptest.NewRecorder()
+	c := &contextmodel.ReqContext{
+		Context: &web.Context{
+			Resp: web.NewResponseWriter(http.MethodGet, recorder),
+			Req:  req,
+		},
+		SignedInUser: &user.SignedInUser{
+			UserID:  1,
+			OrgID:   1,
+			OrgRole: org.RoleAdmin,
+		},
+	}
+
+	resp := hs.GetOpenFeatureToggles(c)
+	require.Equal(t, http.StatusOK, resp.Status())
+
+	var toggles []OpenFeatureToggleDTO
+	err = json.Unmarshal(resp.Body(), &toggles)
+	require.NoError(t, err)
+	require.NotEmpty(t, toggles)
+
+	for _, toggle := range toggles {
+		require.True(t, isOpenFeatureStage(toggle.Stage), "toggle %s should be open", toggle.Name)
+		require.NotEmpty(t, toggle.Name)
+	}
+}
+
+func TestGetOpenFeatureToggles_IncludesEnabledState(t *testing.T) {
+	hs := setupSimpleHTTPServer(featuremgmt.WithFeatures("panelTitleSearch"))
+
+	req, err := http.NewRequest(http.MethodGet, "/api/feature-toggles/open", nil)
+	require.NoError(t, err)
+
+	recorder := httptest.NewRecorder()
+	c := &contextmodel.ReqContext{
+		Context: &web.Context{
+			Resp: web.NewResponseWriter(http.MethodGet, recorder),
+			Req:  req,
+		},
+		SignedInUser: &user.SignedInUser{
+			UserID:  1,
+			OrgID:   1,
+			OrgRole: org.RoleAdmin,
+		},
+	}
+
+	resp := hs.GetOpenFeatureToggles(c)
+	require.Equal(t, http.StatusOK, resp.Status())
+
+	var toggles []OpenFeatureToggleDTO
+	err = json.Unmarshal(resp.Body(), &toggles)
+	require.NoError(t, err)
+
+	var panelTitleSearch *OpenFeatureToggleDTO
+	for i := range toggles {
+		if toggles[i].Name == "panelTitleSearch" {
+			panelTitleSearch = &toggles[i]
+			break
+		}
+	}
+
+	require.NotNil(t, panelTitleSearch)
+	require.True(t, panelTitleSearch.Enabled)
+}
+
+func TestIsOpenFeatureStage(t *testing.T) {
+	require.False(t, isOpenFeatureStage("GA"))
+	require.False(t, isOpenFeatureStage("deprecated"))
+	require.True(t, isOpenFeatureStage("preview"))
+	require.True(t, isOpenFeatureStage("experimental"))
+}

--- a/pkg/services/navtree/navtreeimpl/labs.go
+++ b/pkg/services/navtree/navtreeimpl/labs.go
@@ -1,0 +1,23 @@
+package navtreeimpl
+
+import (
+	contextmodel "github.com/grafana/grafana/pkg/services/contexthandler/model"
+	"github.com/grafana/grafana/pkg/services/navtree"
+	"github.com/grafana/grafana/pkg/services/org"
+)
+
+func (s *ServiceImpl) buildLabsNavLink(c *contextmodel.ReqContext) *navtree.NavLink {
+	if !c.IsSignedIn || !c.HasRole(org.RoleAdmin) {
+		return nil
+	}
+
+	return &navtree.NavLink{
+		Text:       "Labs",
+		Id:         "labs",
+		SubTitle:   "Preview and experimental feature flags",
+		Icon:       "flask",
+		Url:        s.cfg.AppSubURL + "/labs",
+		SortWeight: navtree.WeightDataConnections + 50,
+		IsNew:      true,
+	}
+}

--- a/pkg/services/navtree/navtreeimpl/navtree.go
+++ b/pkg/services/navtree/navtreeimpl/navtree.go
@@ -164,6 +164,10 @@ func (s *ServiceImpl) GetNavTree(c *contextmodel.ReqContext, prefs *pref.Prefere
 		treeRoot.AddSection(connectionsSection)
 	}
 
+	if labsSection := s.buildLabsNavLink(c); labsSection != nil {
+		treeRoot.AddSection(labsSection)
+	}
+
 	orgAdminNode, err := s.getAdminNode(c)
 
 	if orgAdminNode != nil && len(orgAdminNode.Children) > 0 {

--- a/public/app/core/utils/navBarItem-translations.ts
+++ b/public/app/core/utils/navBarItem-translations.ts
@@ -179,6 +179,8 @@ export function getNavTitle(navId: string | undefined) {
       return t('nav.sign-out.title', 'Sign out');
     case 'search':
       return t('nav.search-dashboards.title', 'Search dashboards');
+    case 'labs':
+      return t('nav.labs.title', 'Labs');
     case 'connections':
       return t('nav.connections.title', 'Connections');
     case 'connections-add-new-connection':
@@ -308,6 +310,8 @@ export function getNavSubTitle(navId: string | undefined) {
       return t('nav.alerts-and-incidents.subtitle', 'Alerting and incident management apps');
     case 'testing-and-synthetics':
       return t('nav.testing-and-synthetics.subtitle', 'Optimize performance with k6 and Synthetic Monitoring insights');
+    case 'labs':
+      return t('nav.labs.subtitle', 'Preview and experimental feature flags');
     case 'connections-add-new-connection':
       return t('nav.connections.subtitle', 'Browse and create new connections');
     case 'connections-datasources':

--- a/public/app/features/labs/LabsPage.test.tsx
+++ b/public/app/features/labs/LabsPage.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen, waitFor } from 'test/test-utils';
 
-import { getOpenFeatureToggles } from './api';
 import LabsPage from './LabsPage';
+import { getOpenFeatureToggles } from './api';
 
 jest.mock('./api', () => ({
   getOpenFeatureToggles: jest.fn(),

--- a/public/app/features/labs/LabsPage.test.tsx
+++ b/public/app/features/labs/LabsPage.test.tsx
@@ -1,0 +1,42 @@
+import { render, screen, waitFor } from 'test/test-utils';
+
+import { getOpenFeatureToggles } from './api';
+import LabsPage from './LabsPage';
+
+jest.mock('./api', () => ({
+  getOpenFeatureToggles: jest.fn(),
+}));
+
+const mockGetOpenFeatureToggles = jest.mocked(getOpenFeatureToggles);
+
+describe('LabsPage', () => {
+  beforeEach(() => {
+    mockGetOpenFeatureToggles.mockResolvedValue([
+      {
+        name: 'panelTitleSearch',
+        description: 'Search for dashboards using panel title',
+        stage: 'preview',
+        enabled: true,
+      },
+      {
+        name: 'lokiExperimentalStreaming',
+        description: 'Support new streaming approach for loki',
+        stage: 'experimental',
+        enabled: false,
+        requiresDevMode: false,
+      },
+    ]);
+  });
+
+  it('renders open feature flags', async () => {
+    render(<LabsPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText('panelTitleSearch')).toBeInTheDocument();
+    });
+
+    expect(screen.getByText('lokiExperimentalStreaming')).toBeInTheDocument();
+    expect(screen.getByText('Enabled')).toBeInTheDocument();
+    expect(screen.getByText('Disabled')).toBeInTheDocument();
+  });
+});

--- a/public/app/features/labs/LabsPage.tsx
+++ b/public/app/features/labs/LabsPage.tsx
@@ -1,0 +1,157 @@
+import { css } from '@emotion/css';
+import { useMemo } from 'react';
+import { useAsync } from 'react-use';
+
+import { FeatureState, type GrafanaTheme2 } from '@grafana/data';
+import { Trans, t } from '@grafana/i18n';
+import { Alert, FeatureBadge, Spinner, Stack, Text, useStyles2 } from '@grafana/ui';
+import { Page } from 'app/core/components/Page/Page';
+
+import { getOpenFeatureToggles, type OpenFeatureToggle } from './api';
+
+function stageToFeatureState(stage: string): FeatureState | undefined {
+  switch (stage) {
+    case 'experimental':
+    case 'alpha':
+      return FeatureState.experimental;
+    case 'preview':
+    case 'beta':
+      return FeatureState.preview;
+    case 'privatePreview':
+      return FeatureState.privatePreview;
+    default:
+      return undefined;
+  }
+}
+
+function getStyles(theme: GrafanaTheme2) {
+  return {
+    table: css({
+      width: '100%',
+      borderCollapse: 'collapse',
+      marginTop: theme.spacing(2),
+    }),
+    headerCell: css({
+      textAlign: 'left',
+      padding: theme.spacing(1, 2),
+      borderBottom: `1px solid ${theme.colors.border.weak}`,
+      color: theme.colors.text.secondary,
+      fontWeight: theme.typography.fontWeightMedium,
+    }),
+    cell: css({
+      padding: theme.spacing(1.5, 2),
+      borderBottom: `1px solid ${theme.colors.border.weak}`,
+      verticalAlign: 'top',
+    }),
+    nameCell: css({
+      fontFamily: theme.typography.fontFamilyMonospace,
+      fontSize: theme.typography.bodySmall.fontSize,
+    }),
+    enabled: css({
+      color: theme.colors.success.text,
+      fontWeight: theme.typography.fontWeightMedium,
+    }),
+    disabled: css({
+      color: theme.colors.text.secondary,
+    }),
+  };
+}
+
+function FeatureToggleRow({ toggle, styles }: { toggle: OpenFeatureToggle; styles: ReturnType<typeof getStyles> }) {
+  const featureState = stageToFeatureState(toggle.stage);
+
+  return (
+    <tr>
+      <td className={styles.cell}>
+        <Stack direction="row" gap={1} alignItems="center">
+          <span className={styles.nameCell}>{toggle.name}</span>
+          {featureState && <FeatureBadge featureState={featureState} />}
+          {toggle.requiresDevMode && (
+            <FeatureBadge
+              featureState={FeatureState.experimental}
+              tooltip={t('labs.feature-toggles.requires-dev-mode', 'Requires app_mode = development')}
+            />
+          )}
+        </Stack>
+      </td>
+      <td className={styles.cell}>
+        <Text variant="bodySmall" color="secondary">
+          {toggle.description}
+        </Text>
+      </td>
+      <td className={styles.cell}>
+        <span className={toggle.enabled ? styles.enabled : styles.disabled}>
+          {toggle.enabled
+            ? t('labs.feature-toggles.enabled', 'Enabled')
+            : t('labs.feature-toggles.disabled', 'Disabled')}
+        </span>
+      </td>
+    </tr>
+  );
+}
+
+export default function LabsPage() {
+  const styles = useStyles2(getStyles);
+  const { loading, value: toggles, error } = useAsync(() => getOpenFeatureToggles(), []);
+
+  const enabledCount = useMemo(() => toggles?.filter((toggle) => toggle.enabled).length ?? 0, [toggles]);
+
+  return (
+    <Page navId="labs">
+      <Page.Contents>
+        <Text element="h1">
+          <Trans i18nKey="labs.title">Labs</Trans>
+        </Text>
+        <Text color="secondary">
+          <Trans i18nKey="labs.description">
+            Open feature flags are preview and experimental toggles that are not yet generally available. Enable them in
+            your Grafana configuration to try new functionality.
+          </Trans>
+        </Text>
+
+        {loading && (
+          <Stack direction="row" alignItems="center" gap={1}>
+            <Spinner />
+            <Trans i18nKey="labs.loading">Loading feature flags...</Trans>
+          </Stack>
+        )}
+
+        {error && (
+          <Alert severity="error" title={t('labs.error-title', 'Failed to load feature flags')}>
+            <Trans i18nKey="labs.error-message">Could not load open feature flags. Please try again later.</Trans>
+          </Alert>
+        )}
+
+        {toggles && (
+          <>
+            <Text color="secondary">
+              <Trans i18nKey="labs.summary" values={{ total: toggles.length, enabled: enabledCount }}>
+                {'{{enabled}} of {{total}} open feature flags are enabled'}
+              </Trans>
+            </Text>
+            <table className={styles.table}>
+              <thead>
+                <tr>
+                  <th className={styles.headerCell}>
+                    <Trans i18nKey="labs.table.name">Name</Trans>
+                  </th>
+                  <th className={styles.headerCell}>
+                    <Trans i18nKey="labs.table.description">Description</Trans>
+                  </th>
+                  <th className={styles.headerCell}>
+                    <Trans i18nKey="labs.table.status">Status</Trans>
+                  </th>
+                </tr>
+              </thead>
+              <tbody>
+                {toggles.map((toggle) => (
+                  <FeatureToggleRow key={toggle.name} toggle={toggle} styles={styles} />
+                ))}
+              </tbody>
+            </table>
+          </>
+        )}
+      </Page.Contents>
+    </Page>
+  );
+}

--- a/public/app/features/labs/api.ts
+++ b/public/app/features/labs/api.ts
@@ -1,0 +1,13 @@
+import { getBackendSrv } from '@grafana/runtime';
+
+export interface OpenFeatureToggle {
+  name: string;
+  description: string;
+  stage: string;
+  enabled: boolean;
+  requiresDevMode?: boolean;
+}
+
+export function getOpenFeatureToggles(): Promise<OpenFeatureToggle[]> {
+  return getBackendSrv().get<OpenFeatureToggle[]>('/api/feature-toggles/open');
+}

--- a/public/app/features/labs/routes.tsx
+++ b/public/app/features/labs/routes.tsx
@@ -1,0 +1,11 @@
+import { SafeDynamicImport } from 'app/core/components/DynamicImports/SafeDynamicImport';
+import { type RouteDescriptor } from 'app/core/navigation/types';
+
+export function getLabsRoutes(): RouteDescriptor[] {
+  return [
+    {
+      path: '/labs',
+      component: SafeDynamicImport(() => import(/* webpackChunkName: "LabsPage" */ 'app/features/labs/LabsPage')),
+    },
+  ];
+}

--- a/public/app/routes/routes.tsx
+++ b/public/app/routes/routes.tsx
@@ -11,10 +11,10 @@ import { isAdmin, isLocalDevEnv, isOpenSourceEdition } from 'app/features/alerti
 import { ConnectionsRedirectNotice } from 'app/features/connections/components/ConnectionsRedirectNotice/ConnectionsRedirectNotice';
 import { ROUTES as CONNECTIONS_ROUTES } from 'app/features/connections/constants';
 import { getRoutes as getDataConnectionsRoutes } from 'app/features/connections/routes';
-import { getLabsRoutes } from 'app/features/labs/routes';
 import { DASHBOARD_LIBRARY_ROUTES } from 'app/features/dashboard/dashgrid/types';
 import { DATASOURCES_ROUTES } from 'app/features/datasources/constants';
 import { ConfigureIRM } from 'app/features/gops/configuration-tracker/components/ConfigureIRM';
+import { getLabsRoutes } from 'app/features/labs/routes';
 import { getRoutes as getPluginCatalogRoutes } from 'app/features/plugins/admin/routes';
 import { getAppPluginRoutes } from 'app/features/plugins/routes';
 import { getProfileRoutes } from 'app/features/profile/routes';

--- a/public/app/routes/routes.tsx
+++ b/public/app/routes/routes.tsx
@@ -11,6 +11,7 @@ import { isAdmin, isLocalDevEnv, isOpenSourceEdition } from 'app/features/alerti
 import { ConnectionsRedirectNotice } from 'app/features/connections/components/ConnectionsRedirectNotice/ConnectionsRedirectNotice';
 import { ROUTES as CONNECTIONS_ROUTES } from 'app/features/connections/constants';
 import { getRoutes as getDataConnectionsRoutes } from 'app/features/connections/routes';
+import { getLabsRoutes } from 'app/features/labs/routes';
 import { DASHBOARD_LIBRARY_ROUTES } from 'app/features/dashboard/dashgrid/types';
 import { DATASOURCES_ROUTES } from 'app/features/datasources/constants';
 import { ConfigureIRM } from 'app/features/gops/configuration-tracker/components/ConfigureIRM';
@@ -562,6 +563,7 @@ export function getAppRoutes(): RouteDescriptor[] {
     ...extraRoutes,
     ...getPublicDashboardRoutes(),
     ...getDataConnectionsRoutes(),
+    ...getLabsRoutes(),
     ...getProvisioningRoutes(),
     {
       path: '/goto/*',


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a **Labs** entry to the left navigation (between Connections and Administration) with a **New!** badge. The Labs page lists open (non-GA) feature flags with their stage, description, and whether each toggle is currently enabled.

## Changes

- **Navigation**: New top-level Labs nav item (`flask` icon, `isNew` badge) visible to org admins, positioned after Connections.
- **API**: `GET /api/feature-toggles/open` returns preview/experimental/private-preview flags from the embedded feature toggle registry with current enabled state.
- **Frontend**: `/labs` route and page with a table of open feature flags.

## Demo

<a href="https://cursor.com/agents/bc-4718fd01-1d34-4dfa-aae1-605a0e762639/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Flabs-feature-flags-page-demo.mp4"><img src="https://cursor.com/artifacts/c/art-289a4bc6-efb2-4837-95a8-b3e9eb30404a" alt="labs-feature-flags-page-demo.mp4" /></a>

## Testing

- `go test -run TestGetOpenFeatureToggles ./pkg/api/`
- `yarn jest public/app/features/labs/LabsPage.test.tsx --no-watch --watchAll=false`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4718fd01-1d34-4dfa-aae1-605a0e762639"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4718fd01-1d34-4dfa-aae1-605a0e762639"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

