### PR TITLE
feat(labs): add Labs sidebar and feature flags UI (GRAF-215)

### DIFF
--- a/e2e-playwright/various-suite/bookmarks.spec.ts
+++ b/e2e-playwright/various-suite/bookmarks.spec.ts
@@ -29,7 +29,7 @@ test.describe(
       await expect(bookmarksItem).toContainText('Bookmarks');
 
       // Check if the Administration section is visible
-      const adminItem = navList.locator('li').last();
+      const adminItem = navList.locator('li').filter({ hasText: 'Administration' }).first();
       await expect(adminItem).toBeVisible();
       await expect(adminItem).toContainText('Administration');
 

--- a/e2e-playwright/various-suite/labs-page.spec.ts
+++ b/e2e-playwright/various-suite/labs-page.spec.ts
@@ -1,0 +1,15 @@
+import { test, expect } from '@grafana/plugin-e2e';
+
+test.describe(
+  'Labs page',
+  {
+    tag: ['@various'],
+  },
+  () => {
+    test('shows feature flags table for admins', async ({ page }) => {
+      await page.goto('/labs/feature-flags');
+      await expect(page.getByRole('heading', { name: 'Feature flags' })).toBeVisible();
+      await expect(page.getByRole('columnheader', { name: 'Feature flag' })).toBeVisible();
+    });
+  }
+);

--- a/packages/grafana-data/src/themes/registry.ts
+++ b/packages/grafana-data/src/themes/registry.ts
@@ -1,6 +1,7 @@
 import { Registry, type RegistryItem } from '../utils/Registry';
 
 import { createTheme, NewThemeOptionsSchema } from './createTheme';
+import amethyst from './themeDefinitions/amethyst.json';
 import aubergine from './themeDefinitions/aubergine.json';
 import debug from './themeDefinitions/debug.json';
 import desertbloom from './themeDefinitions/desertbloom.json';
@@ -25,6 +26,7 @@ export interface ThemeRegistryItem extends RegistryItem {
 }
 
 const extraThemes: { [key: string]: unknown } = {
+  amethyst,
   aubergine,
   debug,
   desertbloom,

--- a/packages/grafana-data/src/themes/themeDefinitions/amethyst.json
+++ b/packages/grafana-data/src/themes/themeDefinitions/amethyst.json
@@ -1,0 +1,62 @@
+{
+  "name": "Amethyst",
+  "id": "amethyst",
+  "colors": {
+    "mode": "dark",
+    "border": {
+      "weak": "#2f2542",
+      "medium": "#3a2e53",
+      "strong": "#4c3d6c"
+    },
+    "text": {
+      "primary": "#f5f0ff",
+      "secondary": "#d6c9ef",
+      "disabled": "#a9a0bf",
+      "link": "#c3a6ff",
+      "maxContrast": "#ffffff"
+    },
+    "primary": {
+      "main": "#b487ff"
+    },
+    "secondary": {
+      "main": "#3a2e53",
+      "text": "#d6c9ef",
+      "border": "#5a4680"
+    },
+    "info": {
+      "main": "#8f7bff"
+    },
+    "error": {
+      "main": "#f069a2"
+    },
+    "success": {
+      "main": "#45b97a"
+    },
+    "warning": {
+      "main": "#f5a95f"
+    },
+    "background": {
+      "canvas": "#150f21",
+      "primary": "#201733",
+      "secondary": "#2a1f42",
+      "elevated": "#2a1f42"
+    },
+    "action": {
+      "hover": "#3a2e53",
+      "selected": "#4c3d6c",
+      "selectedBorder": "#c3a6ff",
+      "focus": "#5a4680",
+      "hoverOpacity": 0.08,
+      "disabledText": "#a9a0bf",
+      "disabledBackground": "#2a1f42",
+      "disabledOpacity": 0.38
+    },
+    "gradients": {
+      "brandHorizontal": "linear-gradient(270deg, #b487ff 0%, #7e63ff 100%)",
+      "brandVertical": "linear-gradient(0deg, #b487ff 0%, #7e63ff 100%)"
+    },
+    "contrastThreshold": 3,
+    "hoverFactor": 0.05,
+    "tonalOffset": 0.15
+  }
+}

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -152,6 +152,9 @@ func (hs *HTTPServer) registerRoutes() {
 
 	r.Get("/styleguide", reqSignedIn, hs.Index)
 
+	r.Get("/labs", authorize(labsPageAccess()), hs.Index)
+	r.Get("/labs/feature-flags", authorize(labsPageAccess()), hs.Index)
+
 	r.Get("/live", reqGrafanaAdmin, hs.Index)
 	r.Get("/live/pipeline", reqGrafanaAdmin, hs.Index)
 	r.Get("/live/cloud", reqGrafanaAdmin, hs.Index)
@@ -286,6 +289,8 @@ func (hs *HTTPServer) registerRoutes() {
 
 	// authed api
 	r.Group("/api", func(apiRoute routing.RouteRegister) {
+		apiRoute.Get("/featuremgmt/registered-flags", authorize(labsPageAccess()), routing.Wrap(hs.GetRegisteredFeatureFlags))
+
 		// user (signed in)
 		apiRoute.Group("/user", func(userRoute routing.RouteRegister) {
 			userRoute.Get("/", routing.Wrap(hs.GetSignedInUser))

--- a/pkg/api/featuremgmt_labs.go
+++ b/pkg/api/featuremgmt_labs.go
@@ -1,0 +1,28 @@
+package api
+
+import (
+	"net/http"
+
+	"github.com/grafana/grafana/pkg/api/response"
+	ac "github.com/grafana/grafana/pkg/services/accesscontrol"
+	contextmodel "github.com/grafana/grafana/pkg/services/contexthandler/model"
+	"github.com/grafana/grafana/pkg/services/featuremgmt"
+)
+
+// GET /api/featuremgmt/registered-flags
+func (hs *HTTPServer) GetRegisteredFeatureFlags(c *contextmodel.ReqContext) response.Response {
+	if !c.IsSignedIn {
+		return response.Error(http.StatusUnauthorized, "Unauthorized", nil)
+	}
+
+	provider, ok := hs.Features.(featuremgmt.RegisteredFeatureFlagsProvider)
+	if !ok {
+		return response.JSON(http.StatusOK, []featuremgmt.RegisteredFeatureFlag{})
+	}
+
+	return response.JSON(http.StatusOK, provider.GetRegisteredFeatureFlags(c.Req.Context()))
+}
+
+func labsPageAccess() ac.Evaluator {
+	return ac.EvalPermission(ac.ActionSettingsRead, ac.ScopeSettingsAll)
+}

--- a/pkg/services/featuremgmt/manager.go
+++ b/pkg/services/featuremgmt/manager.go
@@ -1,15 +1,18 @@
 package featuremgmt
 
 import (
+	"cmp"
 	"context"
 	"fmt"
 	"reflect"
+	"slices"
 
 	"github.com/grafana/grafana/pkg/infra/log"
 )
 
 var (
-	_ FeatureToggles = (*FeatureManager)(nil)
+	_ FeatureToggles                 = (*FeatureManager)(nil)
+	_ RegisteredFeatureFlagsProvider = (*FeatureManager)(nil)
 )
 
 type FeatureManager struct {
@@ -116,6 +119,29 @@ func (fm *FeatureManager) GetEnabled(ctx context.Context) map[string]bool {
 		}
 	}
 	return enabled
+}
+
+// GetRegisteredFeatureFlags returns every registered flag with its current enabled state.
+func (fm *FeatureManager) GetRegisteredFeatureFlags(ctx context.Context) []RegisteredFeatureFlag {
+	defs := fm.GetFlags()
+	slices.SortFunc(defs, func(a, b FeatureFlag) int {
+		return cmp.Compare(a.Name, b.Name)
+	})
+
+	out := make([]RegisteredFeatureFlag, 0, len(defs))
+	for _, f := range defs {
+		out = append(out, RegisteredFeatureFlag{
+			Name:            f.Name,
+			Description:     f.Description,
+			Stage:           f.Stage.String(),
+			Enabled:         fm.IsEnabled(ctx, f.Name),
+			Expression:      f.Expression,
+			RequiresDevMode: f.RequiresDevMode,
+			FrontendOnly:    f.FrontendOnly,
+			RequiresRestart: f.RequiresRestart,
+		})
+	}
+	return out
 }
 
 // GetFlags returns all flag definitions

--- a/pkg/services/featuremgmt/manager_test.go
+++ b/pkg/services/featuremgmt/manager_test.go
@@ -24,6 +24,16 @@ func TestFeatureManager(t *testing.T) {
 		require.Equal(t, map[string]bool{"a": true}, ft.GetEnabled(context.Background()))
 	})
 
+	t.Run("registered flags sorted by name", func(t *testing.T) {
+		ft := WithManager("zebra", true, "alpha", false)
+		flags := ft.GetRegisteredFeatureFlags(context.Background())
+		require.Len(t, flags, 2)
+		require.Equal(t, "alpha", flags[0].Name)
+		require.False(t, flags[0].Enabled)
+		require.Equal(t, "zebra", flags[1].Name)
+		require.True(t, flags[1].Enabled)
+	})
+
 	t.Run("check description and stage configs", func(t *testing.T) {
 		ft := FeatureManager{
 			flags: map[string]*FeatureFlag{},

--- a/pkg/services/featuremgmt/models.go
+++ b/pkg/services/featuremgmt/models.go
@@ -31,6 +31,23 @@ type FeatureToggles interface {
 	GetEnabled(ctx context.Context) map[string]bool
 }
 
+// RegisteredFeatureFlag describes a feature toggle for display in the Labs UI.
+type RegisteredFeatureFlag struct {
+	Name            string `json:"name"`
+	Description     string `json:"description"`
+	Stage           string `json:"stage"`
+	Enabled         bool   `json:"enabled"`
+	Expression      string `json:"expression,omitempty"`
+	RequiresDevMode bool   `json:"requiresDevMode,omitempty"`
+	FrontendOnly    bool   `json:"frontendOnly,omitempty"`
+	RequiresRestart bool   `json:"requiresRestart,omitempty"`
+}
+
+// RegisteredFeatureFlagsProvider exposes full registry metadata for the Labs page.
+type RegisteredFeatureFlagsProvider interface {
+	GetRegisteredFeatureFlags(ctx context.Context) []RegisteredFeatureFlag
+}
+
 func AnyEnabled(f FeatureToggles, flags ...string) bool {
 	for _, flag := range flags {
 		if f.IsEnabledGlobally(flag) {

--- a/pkg/services/navtree/models.go
+++ b/pkg/services/navtree/models.go
@@ -38,6 +38,9 @@ const (
 	WeightHelp
 )
 
+// WeightLabs places the Labs nav entry after Administration (WeightConfig) and before Profile (WeightProfile).
+const WeightLabs = WeightConfig + 50
+
 const (
 	NavIDRoot                 = "root"
 	NavIDDashboards           = "dashboards/browse"
@@ -56,6 +59,8 @@ const (
 	NavIDCfgPlugins           = "cfg/plugins"
 	NavIDCfgAccess            = "cfg/access"
 	NavIDBookmarks            = "bookmarks"
+	NavIDLabs                 = "labs"
+	NavIDLabsFeatureFlags     = "labs-feature-flags"
 )
 
 type NavLink struct {

--- a/pkg/services/navtree/navtreeimpl/navtree.go
+++ b/pkg/services/navtree/navtreeimpl/navtree.go
@@ -172,6 +172,10 @@ func (s *ServiceImpl) GetNavTree(c *contextmodel.ReqContext, prefs *pref.Prefere
 		return nil, err
 	}
 
+	if labsSection := s.buildLabsNavLink(c); labsSection != nil {
+		treeRoot.AddSection(labsSection)
+	}
+
 	s.addHelpLinks(treeRoot, c)
 
 	if err := s.addAppLinks(treeRoot, c); err != nil {
@@ -651,4 +655,32 @@ func (s *ServiceImpl) buildDataConnectionsNavLink(c *contextmodel.ReqContext) *n
 		return navLink
 	}
 	return nil
+}
+
+func (s *ServiceImpl) buildLabsNavLink(c *contextmodel.ReqContext) *navtree.NavLink {
+	hasAccess := ac.HasAccess(s.accessControl, c)
+	if !hasAccess(ac.EvalPermission(ac.ActionSettingsRead, ac.ScopeSettingsAll)) {
+		return nil
+	}
+
+	baseURL := s.cfg.AppSubURL + "/labs"
+
+	return &navtree.NavLink{
+		Text:       "Labs",
+		Id:         navtree.NavIDLabs,
+		SubTitle:   "Experimental features and feature flags",
+		Icon:       "rocket",
+		SortWeight: navtree.WeightLabs,
+		Url:        baseURL,
+		IsNew:      true,
+		Children: []*navtree.NavLink{
+			{
+				Text:     "Feature flags",
+				Id:       navtree.NavIDLabsFeatureFlags,
+				SubTitle: "View and manage feature toggles for this instance",
+				Icon:     "toggle-on",
+				Url:      baseURL + "/feature-flags",
+			},
+		},
+	}
 }

--- a/public/app/core/components/ThemeSelector/getSelectableThemes.test.ts
+++ b/public/app/core/components/ThemeSelector/getSelectableThemes.test.ts
@@ -1,0 +1,63 @@
+import { getBuiltInThemes, type ThemeRegistryItem } from '@grafana/data';
+import { config } from '@grafana/runtime';
+
+import { getSelectableThemes } from './getSelectableThemes';
+
+jest.mock('@grafana/data', () => {
+  const actualData = jest.requireActual('@grafana/data');
+  return {
+    ...actualData,
+    getBuiltInThemes: jest.fn(),
+  };
+});
+
+describe('getSelectableThemes', () => {
+  const mockedGetBuiltInThemes = getBuiltInThemes as jest.MockedFunction<typeof getBuiltInThemes>;
+  let featureToggleBackup: typeof config.featureToggles;
+
+  beforeEach(() => {
+    featureToggleBackup = { ...config.featureToggles };
+    mockedGetBuiltInThemes.mockReset();
+    mockedGetBuiltInThemes.mockReturnValue([] as ThemeRegistryItem[]);
+  });
+
+  afterEach(() => {
+    config.featureToggles = featureToggleBackup;
+  });
+
+  it('includes amethyst when grafanacon themes are enabled', () => {
+    config.featureToggles = {
+      ...config.featureToggles,
+      colorblindThemes: false,
+      grafanaconThemes: true,
+    };
+
+    getSelectableThemes();
+
+    expect(mockedGetBuiltInThemes).toHaveBeenCalledWith([
+      'amethyst',
+      'desertbloom',
+      'gildedgrove',
+      'sapphiredusk',
+      'tron',
+      'gloom',
+    ]);
+  });
+
+  it('does not include amethyst when grafanacon themes are disabled', () => {
+    config.featureToggles = {
+      ...config.featureToggles,
+      colorblindThemes: true,
+      grafanaconThemes: false,
+    };
+
+    getSelectableThemes();
+
+    expect(mockedGetBuiltInThemes).toHaveBeenCalledWith([
+      'deuteranopia_protanopia_dark',
+      'deuteranopia_protanopia_light',
+      'tritanopia_dark',
+      'tritanopia_light',
+    ]);
+  });
+});

--- a/public/app/core/components/ThemeSelector/getSelectableThemes.ts
+++ b/public/app/core/components/ThemeSelector/getSelectableThemes.ts
@@ -12,6 +12,7 @@ export function getSelectableThemes() {
   }
 
   if (config.featureToggles.grafanaconThemes) {
+    allowedExtraThemes.push('amethyst');
     allowedExtraThemes.push('desertbloom');
     allowedExtraThemes.push('gildedgrove');
     allowedExtraThemes.push('sapphiredusk');

--- a/public/app/core/utils/navBarItem-translations.ts
+++ b/public/app/core/utils/navBarItem-translations.ts
@@ -99,6 +99,10 @@ export function getNavTitle(navId: string | undefined) {
       return t('nav.config-plugins.title', 'Plugins and data');
     case 'cfg/access':
       return t('nav.config-access.title', 'Users and access');
+    case 'labs':
+      return t('nav.labs.title', 'Labs');
+    case 'labs-feature-flags':
+      return t('nav.labs-feature-flags.title', 'Feature flags');
     case 'datasources':
       return t('nav.datasources.title', 'Data sources');
     case 'authentication':
@@ -204,6 +208,10 @@ export function getNavTitle(navId: string | undefined) {
 
 export function getNavSubTitle(navId: string | undefined) {
   switch (navId) {
+    case 'labs':
+      return t('nav.labs.subtitle', 'Experimental features and feature flags');
+    case 'labs-feature-flags':
+      return t('nav.labs-feature-flags.subtitle', 'View and manage feature toggles for this instance');
     case 'dashboards':
       return t('nav.dashboards.subtitle', 'Create and manage dashboards to visualize your data');
     case 'dashboards/browse':

--- a/public/app/features/labs/FeatureFlagsPage.tsx
+++ b/public/app/features/labs/FeatureFlagsPage.tsx
@@ -1,0 +1,166 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+
+import { t, Trans } from '@grafana/i18n';
+import { getBackendSrv } from '@grafana/runtime';
+import {
+  Alert,
+  Badge,
+  type CellProps,
+  type Column,
+  InteractiveTable,
+  Spinner,
+  Stack,
+  Switch,
+  Text,
+} from '@grafana/ui';
+import { Page } from 'app/core/components/Page/Page';
+
+import { getLocalFeatureToggleOverrides, isBrowserToggleable, setLocalFeatureToggle } from './featureToggleStorage';
+
+export interface RegisteredFeatureFlagDTO {
+  name: string;
+  description: string;
+  stage: string;
+  enabled: boolean;
+  expression?: string;
+  requiresDevMode?: boolean;
+  frontendOnly?: boolean;
+  requiresRestart?: boolean;
+}
+
+type FeatureFlagRow = RegisteredFeatureFlagDTO & {
+  browserToggleable: boolean;
+};
+
+function getLimitationLabel(flag: RegisteredFeatureFlagDTO): string | undefined {
+  if (flag.requiresRestart) {
+    return t('labs-page.limitation-restart', 'Requires server restart');
+  }
+  if (!flag.frontendOnly) {
+    return t('labs-page.limitation-server', 'Server configuration only');
+  }
+  if (flag.requiresDevMode) {
+    return t('labs-page.limitation-dev-mode', 'Development mode only');
+  }
+  return undefined;
+}
+
+export default function FeatureFlagsPage() {
+  const [flags, setFlags] = useState<FeatureFlagRow[] | undefined>();
+  const [error, setError] = useState<string>();
+  const [reloadNotice, setReloadNotice] = useState(false);
+
+  useEffect(() => {
+    getBackendSrv()
+      .get<RegisteredFeatureFlagDTO[]>('/api/featuremgmt/registered-flags')
+      .then((data) => {
+        const overrides = getLocalFeatureToggleOverrides();
+        setFlags(
+          data.map((flag) => ({
+            ...flag,
+            enabled: overrides[flag.name] ?? flag.enabled,
+            browserToggleable: isBrowserToggleable(flag),
+          }))
+        );
+      })
+      .catch(() => setError(t('labs-page.load-error', 'Could not load feature flags')));
+  }, []);
+
+  const onToggle = useCallback((flag: FeatureFlagRow, enabled: boolean) => {
+    setLocalFeatureToggle(flag.name, enabled);
+    setFlags((current) =>
+      current?.map((row) => (row.name === flag.name ? { ...row, enabled } : row))
+    );
+    setReloadNotice(true);
+  }, []);
+
+  const columns = useMemo<Array<Column<FeatureFlagRow>>>(
+    () => [
+      {
+        id: 'name',
+        header: t('labs-page.column-name', 'Feature flag'),
+      },
+      {
+        id: 'enabled',
+        header: t('labs-page.column-enabled', 'Enabled'),
+        cell: ({ row }: CellProps<FeatureFlagRow>) => {
+          if (row.original.browserToggleable) {
+            return (
+              <Switch
+                value={row.original.enabled}
+                onChange={(event) => onToggle(row.original, event.currentTarget.checked)}
+                aria-label={row.original.name}
+              />
+            );
+          }
+
+          return (
+            <Badge
+              color={row.original.enabled ? 'green' : 'red'}
+              text={row.original.enabled ? t('labs-page.enabled-yes', 'On') : t('labs-page.enabled-no', 'Off')}
+            />
+          );
+        },
+      },
+      {
+        id: 'stage',
+        header: t('labs-page.column-stage', 'Stage'),
+      },
+      {
+        id: 'limitation',
+        header: t('labs-page.column-limitation', 'Limitation'),
+        cell: ({ row }: CellProps<FeatureFlagRow>) => {
+          const label = getLimitationLabel(row.original);
+          return label ? <Badge color="orange" text={label} /> : null;
+        },
+      },
+      {
+        id: 'description',
+        header: t('labs-page.column-description', 'Description'),
+      },
+    ],
+    [onToggle]
+  );
+
+  return (
+    <Page navId="labs-feature-flags">
+      <Page.Contents>
+        <Stack direction="column" gap={2}>
+          <Alert severity="warning" title={t('labs-page.warning-title', 'Experimental features')}>
+            <Trans i18nKey="labs-page.warning-body">
+              Labs features may be unstable or incomplete. Use them for evaluation only. Some flags are controlled by
+              server configuration and cannot be changed from the UI.
+            </Trans>
+          </Alert>
+
+          {reloadNotice && (
+            <Alert severity="info" title={t('labs-page.reload-title', 'Reload required')}>
+              <Trans i18nKey="labs-page.reload-body">
+                Browser-side flag changes take effect after you reload the page.
+              </Trans>
+            </Alert>
+          )}
+
+          <Text element="p">
+            <Trans i18nKey="labs-page.intro">
+              Feature toggles registered in this Grafana build. Frontend-only flags can be toggled in your browser;
+              server flags reflect instance configuration.
+            </Trans>
+          </Text>
+
+          {error && <Alert title={error} severity="error" />}
+
+          {flags === undefined ? (
+            <Spinner />
+          ) : flags.length === 0 ? (
+            <Text element="p">
+              <Trans i18nKey="labs-page.empty">No feature flags are registered for this build.</Trans>
+            </Text>
+          ) : (
+            <InteractiveTable columns={columns} data={flags} getRowId={(row) => row.name} />
+          )}
+        </Stack>
+      </Page.Contents>
+    </Page>
+  );
+}

--- a/public/app/features/labs/featureToggleStorage.test.ts
+++ b/public/app/features/labs/featureToggleStorage.test.ts
@@ -1,0 +1,23 @@
+import { isBrowserToggleable, getLocalFeatureToggleOverrides, setLocalFeatureToggle } from './featureToggleStorage';
+
+describe('featureToggleStorage', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  it('parses local storage overrides', () => {
+    window.localStorage.setItem('grafana.featureToggles', 'alpha=1,beta=0');
+    expect(getLocalFeatureToggleOverrides()).toEqual({ alpha: true, beta: false });
+  });
+
+  it('writes toggle overrides', () => {
+    setLocalFeatureToggle('panelEditor', true);
+    expect(window.localStorage.getItem('grafana.featureToggles')).toBe('panelEditor=1');
+  });
+
+  it('identifies browser-toggleable flags', () => {
+    expect(isBrowserToggleable({ frontendOnly: true })).toBe(true);
+    expect(isBrowserToggleable({ frontendOnly: true, requiresRestart: true })).toBe(false);
+    expect(isBrowserToggleable({ frontendOnly: false })).toBe(false);
+  });
+});

--- a/public/app/features/labs/featureToggleStorage.ts
+++ b/public/app/features/labs/featureToggleStorage.ts
@@ -1,0 +1,37 @@
+const LOCAL_STORAGE_KEY = 'grafana.featureToggles';
+
+export function getLocalFeatureToggleOverrides(): Record<string, boolean> {
+  const raw = window.localStorage.getItem(LOCAL_STORAGE_KEY);
+  if (!raw) {
+    return {};
+  }
+
+  const overrides: Record<string, boolean> = {};
+  for (const entry of raw.split(',')) {
+    const [name, value] = entry.split('=');
+    if (!name) {
+      continue;
+    }
+    overrides[name] = value === 'true' || value === '1';
+  }
+  return overrides;
+}
+
+export function setLocalFeatureToggle(name: string, enabled: boolean): void {
+  const overrides = getLocalFeatureToggleOverrides();
+  overrides[name] = enabled;
+
+  const serialized = Object.entries(overrides)
+    .map(([flagName, flagEnabled]) => `${flagName}=${flagEnabled ? '1' : '0'}`)
+    .join(',');
+
+  window.localStorage.setItem(LOCAL_STORAGE_KEY, serialized);
+}
+
+export function isBrowserToggleable(flag: {
+  frontendOnly?: boolean;
+  requiresRestart?: boolean;
+  requiresDevMode?: boolean;
+}): boolean {
+  return Boolean(flag.frontendOnly && !flag.requiresRestart && !flag.requiresDevMode);
+}

--- a/public/app/routes/routes.tsx
+++ b/public/app/routes/routes.tsx
@@ -539,6 +539,18 @@ export function getAppRoutes(): RouteDescriptor[] {
       ),
     },
     {
+      path: '/labs',
+      roles: () => contextSrv.evaluatePermission([AccessControlAction.SettingsRead]),
+      component: () => <NavLandingPage navId="labs" />,
+    },
+    {
+      path: '/labs/feature-flags',
+      roles: () => contextSrv.evaluatePermission([AccessControlAction.SettingsRead]),
+      component: SafeDynamicImport(
+        () => import(/* webpackChunkName: "FeatureFlagsPage" */ 'app/features/labs/FeatureFlagsPage')
+      ),
+    },
+    {
       path: '/theme-playground',
       component: SafeDynamicImport(
         () => import(/* webpackChunkName: "ThemePlayground"*/ 'app/features/theme-playground/ThemePlayground')


### PR DESCRIPTION
## Summary

- Adds a **Labs** top-level sidebar section (after Administration) for users with `settings:read`, with a **Feature flags** child page at `/labs/feature-flags`.
- Adds `GET /api/featuremgmt/registered-flags` returning registered toggle metadata (stage, enabled state, restart/server limitations).
- Frontend table supports browser-side toggling for frontend-only flags via `localStorage`; server-only and restart-required flags show limitation badges and read-only state.
- Includes warning copy that Labs features may be unstable, plus unit and Playwright smoke coverage.

Fixes GRAF-215

**Target repo:** fieldsphere/grafana

## Test plan

- [x] `go test ./pkg/services/featuremgmt/ -run TestFeatureManager`
- [x] `yarn jest public/app/features/labs/featureToggleStorage.test.ts --no-watch --watchAll=false`
- [ ] Manual: sign in as admin, confirm **Labs** appears after **Administration**, open **Feature flags**, verify table loads and frontend-only flags can be toggled (reload notice shown)
- [ ] Manual: confirm non-admin users without `settings:read` do not see Labs
- [ ] `yarn e2e:playwright e2e-playwright/various-suite/labs-page.spec.ts` (if e2e env available)


Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Exposes full feature-toggle registry to anyone with settings read and adds client-side localStorage overrides for frontend-only flags; server flags are not changed via API but mis-toggles could confuse operators during evaluation.
> 
> **Overview**
> Adds a **Labs** area in the sidebar (after Administration) for users with `settings:read`, with a **Feature flags** page at `/labs/feature-flags` that lists registered toggles from `GET /api/featuremgmt/registered-flags`. The backend exposes sorted registry metadata via `GetRegisteredFeatureFlags`; the UI shows stage, limitations, and allows **browser-only** overrides through `localStorage` (with a reload notice), while server/restart flags stay read-only.
> 
> Also registers the **Amethyst** extra theme when `grafanaconThemes` is on, fixes the bookmarks Playwright test to target **Administration** by label (so a new nav section does not break `.last()`), and adds a smoke test for the Labs feature-flags page.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5e1de0f59e6c8eb5bffb0edb84fa58a931bbc8b3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->