### PR TITLE
feat(alerting): highlight welcome header CTAs with success styling

### DIFF
--- a/public/app/features/alerting/unified/home/GettingStarted.tsx
+++ b/public/app/features/alerting/unified/home/GettingStarted.tsx
@@ -182,13 +182,18 @@ const getWelcomeHeaderStyles = (theme: GrafanaTheme2) => ({
     justifyContent: 'space-between',
     flexWrap: 'wrap',
 
+    '&&': {
+      backgroundColor: theme.colors.success.transparent,
+      border: `1px solid ${theme.colors.success.borderTransparent}`,
+    },
+
     [theme.breakpoints.down('lg')]: {
       flexDirection: 'column',
     },
   }),
   separator: css({
     width: '1px',
-    backgroundColor: theme.colors.border.medium,
+    backgroundColor: theme.colors.success.borderTransparent,
 
     [theme.breakpoints.down('lg')]: {
       display: 'none',
@@ -245,6 +250,14 @@ const getWelcomeCTAButtonStyles = (theme: GrafanaTheme2) => ({
     gridColumn: '2 / span 3',
     gridRow: 3,
     maxWidth: '240px',
+
+    '& a': {
+      color: theme.colors.success.text,
+
+      '&:hover': {
+        color: theme.colors.success.main,
+      },
+    },
   }),
 });
 


### PR DESCRIPTION
## Summary

- Apply Grafana success (green) theme tokens to the Alerting home quick-links card
- Style the Alert rules, Contact points, and Notification policies section with a green-tinted background, border, and link colors for better discoverability

## Test plan

- [ ] Open **Alerting** home page
- [ ] Confirm the top quick-links card uses a green-tinted background and border
- [ ] Confirm **Manage alert rules**, **Manage contact points**, and **Manage notification policies** links render in green
- [ ] Verify styling in both light and dark themes
- [ ] Confirm links still navigate to the correct Alerting pages


Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-only CSS on the Alerting home welcome header; no auth, data, or behavioral changes.
> 
> **Overview**
> The Alerting home **WelcomeHeader** quick-links strip is restyled so it stands out more: the shared CTA container gets a **success**-tinted background and border (via `theme.colors.success.transparent` / `borderTransparent`, with `&&` to override the default `ContentBox` look), vertical separators between sections use the same success border color instead of neutral border, and **Manage alert rules** / contact points / notification policies links use success text and hover colors.
> 
> No routing, copy, or layout logic changes—only Emotion styles in `GettingStarted.tsx`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 07b9a251879b39ef9cb344bde52fe3b79d4142b8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->