### PR TITLE
docs: Cursor Cloud dev environment notes in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -138,7 +138,7 @@ Build a specific plugin: `yarn workspace @grafana-plugins/<name> dev`
 
 ### Prerequisites
 
-- **Node.js v24.x** (see `.nvmrc` for exact version). Use `nvm install` / `nvm use` to match.
+- **Node.js v24.x** (see `.nvmrc` for exact version). Use `nvm install` / `nvm use` to match. On Cursor Cloud VMs, `/exec-daemon/node` may appear earlier on `PATH` than nvm’s binary (wrong version for `node -v`); prepend nvm’s bin directory after `nvm use`, e.g. `export PATH="$NVM_DIR/versions/node/$(cat .nvmrc | tr -d v)/bin:$PATH"`.
 - **Go 1.25.7** (see `go.mod`). Pre-installed in the VM.
 - **Yarn 4.11.0** via corepack (bundled in `.yarn/releases/`). Run `corepack enable` if `yarn` is not found.
 - **GCC** required for CGo/SQLite compilation of the backend.
@@ -146,7 +146,8 @@ Build a specific plugin: `yarn workspace @grafana-plugins/<name> dev`
 ### Running services
 
 - **Backend**: `make run` — builds and starts Grafana backend with hot-reload (air) on `localhost:3000`. Default login: `admin`/`admin`. First build takes ~3 minutes due to debug symbols (`-gcflags all=-N -l`); subsequent hot-reload rebuilds are faster.
-- **Frontend**: `yarn start` — starts webpack dev server that watches for changes. The backend proxies to it. First compile takes ~45s.
+- **Frontend**: `yarn start` — webpack watch build into `public/build` (required for UI). First compile takes ~45s; wait for `Compiled successfully` before relying on the UI.
+- Run backend and frontend in separate long-lived terminals (e.g. tmux sessions `grafana-backend` / `grafana-frontend`).
 - No external databases required — Grafana uses embedded SQLite by default.
 
 ### Testing gotchas


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Clarifies Cursor Cloud VM setup for Grafana development:

- **Node PATH**: `/exec-daemon/node` can shadow nvm; document prepending nvm's bin after `nvm use`.
- **Frontend dev**: `yarn start` builds into `public/build` (not a separate proxy port); wait for webpack `Compiled successfully`.
- **tmux**: Suggested session names for long-running backend/frontend processes.

No application code changes.

## Test plan

- [x] Cloud agent verified `yarn install --immutable`, `make run`, `yarn start`, health API, login, and dashboard creation.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2c2b0ea4-972e-4baa-82bd-ddc100b38e63"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2c2b0ea4-972e-4baa-82bd-ddc100b38e63"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

