### PR TITLE
feat: add Lab page with user-facing feature toggles UI

### DIFF
--- a/packages/grafana-data/src/types/featureToggles.gen.ts
+++ b/packages/grafana-data/src/types/featureToggles.gen.ts
@@ -1771,4 +1771,9 @@ export interface FeatureToggles {
   * @default false
   */
   compiledBootScript?: boolean;
+  /**
+  * Enables the Lab nav section for browsing and overriding feature toggles in the UI
+  * @default false
+  */
+  labFeatureTogglesUI?: boolean;
 }

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -2811,6 +2811,14 @@ var (
 			Expression:   "false",
 			HideFromDocs: true,
 		},
+		{
+			Name:         "labFeatureTogglesUI",
+			Description:  "Enables the Lab nav section for browsing and overriding feature toggles in the UI",
+			Stage:        FeatureStageExperimental,
+			Owner:        grafanaFrontendPlatformSquad,
+			HideFromDocs: true,
+			Expression:   "false",
+		},
 	}
 )
 

--- a/pkg/services/featuremgmt/toggles_gen.csv
+++ b/pkg/services/featuremgmt/toggles_gen.csv
@@ -349,3 +349,4 @@ Created,Name,Stage,Owner,requiresDevMode,RequiresRestart,FrontendOnly
 2026-04-02,enableColorblindSafePanelOptions,experimental,@grafana/dataviz-squad,false,false,true
 2026-04-03,cacheConfigUnifiedStorageMigration,experimental,@grafana/grafana-operator-experience-squad,false,true,false
 2026-04-02,compiledBootScript,experimental,@grafana/grafana-frontend-platform,false,false,false
+2026-06-02,labFeatureTogglesUI,experimental,@grafana/grafana-frontend-platform,false,false,false

--- a/pkg/services/featuremgmt/toggles_gen.go
+++ b/pkg/services/featuremgmt/toggles_gen.go
@@ -933,4 +933,8 @@ const (
 	// FlagCompiledBootScript
 	// Boots the frontend using the boot.js script built from TS instead of the embedded boot script
 	FlagCompiledBootScript = "compiledBootScript"
+
+	// FlagLabFeatureTogglesUI
+	// Enables the Lab nav section for browsing and overriding feature toggles in the UI
+	FlagLabFeatureTogglesUI = "labFeatureTogglesUI"
 )

--- a/pkg/services/featuremgmt/toggles_gen.json
+++ b/pkg/services/featuremgmt/toggles_gen.json
@@ -3380,6 +3380,20 @@
     },
     {
       "metadata": {
+        "name": "labFeatureTogglesUI",
+        "resourceVersion": "1780433996332",
+        "creationTimestamp": "2026-06-02T20:59:56Z"
+      },
+      "spec": {
+        "description": "Enables the Lab nav section for browsing and overriding feature toggles in the UI",
+        "stage": "experimental",
+        "codeowner": "@grafana/grafana-frontend-platform",
+        "hideFromDocs": true,
+        "expression": "false"
+      }
+    },
+    {
+      "metadata": {
         "name": "liveAPIServer",
         "resourceVersion": "1771434338561",
         "creationTimestamp": "2026-02-18T17:05:38Z"

--- a/pkg/services/navtree/models.go
+++ b/pkg/services/navtree/models.go
@@ -31,6 +31,7 @@ const (
 	WeightApplication
 	WeightAsserts
 	WeightDataConnections
+	WeightLab
 	WeightApps
 	WeightPlugin
 	WeightConfig
@@ -55,6 +56,7 @@ const (
 	NavIDCfgGeneral           = "cfg/general"
 	NavIDCfgPlugins           = "cfg/plugins"
 	NavIDCfgAccess            = "cfg/access"
+	NavIDLab                  = "lab"
 	NavIDBookmarks            = "bookmarks"
 )
 

--- a/pkg/services/navtree/navtreeimpl/lab.go
+++ b/pkg/services/navtree/navtreeimpl/lab.go
@@ -1,0 +1,29 @@
+package navtreeimpl
+
+import (
+	contextmodel "github.com/grafana/grafana/pkg/services/contexthandler/model"
+	"github.com/grafana/grafana/pkg/services/navtree"
+)
+
+func (s *ServiceImpl) buildLabNavLink(c *contextmodel.ReqContext) *navtree.NavLink {
+	children := []*navtree.NavLink{
+		{
+			Text:     "Feature toggles",
+			SubTitle: "View and manage feature flags",
+			Id:       "lab-feature-toggles",
+			Url:      s.cfg.AppSubURL + "/lab/feature-toggles",
+			Icon:     "toggle-on",
+		},
+	}
+
+	return &navtree.NavLink{
+		Text:       "Lab",
+		SubTitle:   "Experimental features and feature flags",
+		Id:         navtree.NavIDLab,
+		Icon:       "bolt",
+		Url:        s.cfg.AppSubURL + "/lab",
+		SortWeight: navtree.WeightLab,
+		Children:   children,
+		IsNew:      true,
+	}
+}

--- a/pkg/services/navtree/navtreeimpl/lab_test.go
+++ b/pkg/services/navtree/navtreeimpl/lab_test.go
@@ -1,0 +1,65 @@
+package navtreeimpl
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	contextmodel "github.com/grafana/grafana/pkg/services/contexthandler/model"
+	"github.com/grafana/grafana/pkg/services/navtree"
+	"github.com/grafana/grafana/pkg/services/user"
+	"github.com/grafana/grafana/pkg/setting"
+	"github.com/grafana/grafana/pkg/web"
+)
+
+func TestBuildLabNavLink(t *testing.T) {
+	httpReq, _ := http.NewRequest(http.MethodGet, "", nil)
+	reqCtx := &contextmodel.ReqContext{
+		SignedInUser: &user.SignedInUser{},
+		Context:     &web.Context{Req: httpReq},
+	}
+
+	t.Run("Should return lab section with correct properties", func(t *testing.T) {
+		service := ServiceImpl{
+			cfg: setting.NewCfg(),
+		}
+
+		link := service.buildLabNavLink(reqCtx)
+
+		require.Equal(t, navtree.NavIDLab, link.Id)
+		require.Equal(t, "Lab", link.Text)
+		require.Equal(t, "bolt", link.Icon)
+		require.Equal(t, int64(navtree.WeightLab), link.SortWeight)
+		require.True(t, link.IsNew)
+		require.Equal(t, "/lab", link.Url)
+	})
+
+	t.Run("Should include feature toggles child link", func(t *testing.T) {
+		service := ServiceImpl{
+			cfg: setting.NewCfg(),
+		}
+
+		link := service.buildLabNavLink(reqCtx)
+
+		require.Len(t, link.Children, 1)
+		require.Equal(t, "lab-feature-toggles", link.Children[0].Id)
+		require.Equal(t, "Feature toggles", link.Children[0].Text)
+		require.Equal(t, "/lab/feature-toggles", link.Children[0].Url)
+		require.Equal(t, "toggle-on", link.Children[0].Icon)
+	})
+
+	t.Run("Should respect AppSubURL", func(t *testing.T) {
+		cfg := setting.NewCfg()
+		cfg.AppSubURL = "/grafana"
+
+		service := ServiceImpl{
+			cfg: cfg,
+		}
+
+		link := service.buildLabNavLink(reqCtx)
+
+		require.Equal(t, "/grafana/lab", link.Url)
+		require.Equal(t, "/grafana/lab/feature-toggles", link.Children[0].Url)
+	})
+}

--- a/pkg/services/navtree/navtreeimpl/navtree.go
+++ b/pkg/services/navtree/navtreeimpl/navtree.go
@@ -164,6 +164,11 @@ func (s *ServiceImpl) GetNavTree(c *contextmodel.ReqContext, prefs *pref.Prefere
 		treeRoot.AddSection(connectionsSection)
 	}
 
+	if c.IsSignedIn && c.HasRole(org.RoleAdmin) &&
+		(s.cfg.Env == setting.Dev || s.features.IsEnabled(c.Req.Context(), featuremgmt.FlagLabFeatureTogglesUI)) {
+		treeRoot.AddSection(s.buildLabNavLink(c))
+	}
+
 	orgAdminNode, err := s.getAdminNode(c)
 
 	if orgAdminNode != nil && len(orgAdminNode.Children) > 0 {

--- a/public/app/core/utils/navBarItem-translations.ts
+++ b/public/app/core/utils/navBarItem-translations.ts
@@ -179,6 +179,10 @@ export function getNavTitle(navId: string | undefined) {
       return t('nav.sign-out.title', 'Sign out');
     case 'search':
       return t('nav.search-dashboards.title', 'Search dashboards');
+    case 'lab':
+      return t('nav.lab.title', 'Lab');
+    case 'lab-feature-toggles':
+      return t('nav.lab-feature-toggles.title', 'Feature toggles');
     case 'connections':
       return t('nav.connections.title', 'Connections');
     case 'connections-add-new-connection':
@@ -308,6 +312,10 @@ export function getNavSubTitle(navId: string | undefined) {
       return t('nav.alerts-and-incidents.subtitle', 'Alerting and incident management apps');
     case 'testing-and-synthetics':
       return t('nav.testing-and-synthetics.subtitle', 'Optimize performance with k6 and Synthetic Monitoring insights');
+    case 'lab':
+      return t('nav.lab.subtitle', 'Experimental features and feature flags');
+    case 'lab-feature-toggles':
+      return t('nav.lab-feature-toggles.subtitle', 'View and manage feature flags');
     case 'connections-add-new-connection':
       return t('nav.connections.subtitle', 'Browse and create new connections');
     case 'connections-datasources':

--- a/public/app/features/lab/FeatureTogglesPage.test.tsx
+++ b/public/app/features/lab/FeatureTogglesPage.test.tsx
@@ -1,0 +1,104 @@
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { render } from 'test/test-utils';
+
+import { config } from '@grafana/runtime';
+
+import FeatureTogglesPage from './FeatureTogglesPage';
+
+const LOCALSTORAGE_KEY = 'grafana.featureToggles';
+
+describe('FeatureTogglesPage', () => {
+  const originalToggles = { ...config.featureToggles };
+
+  beforeEach(() => {
+    config.featureToggles = { featureA: true, featureB: false, featureC: true } as Record<string, boolean>;
+    window.localStorage.removeItem(LOCALSTORAGE_KEY);
+  });
+
+  afterEach(() => {
+    config.featureToggles = originalToggles;
+    window.localStorage.removeItem(LOCALSTORAGE_KEY);
+  });
+
+  it('renders the toggle table with all feature flags', () => {
+    render(<FeatureTogglesPage />);
+
+    expect(screen.getByText('featureA')).toBeInTheDocument();
+    expect(screen.getByText('featureB')).toBeInTheDocument();
+    expect(screen.getByText('featureC')).toBeInTheDocument();
+  });
+
+  it('shows correct enabled/disabled badges', () => {
+    render(<FeatureTogglesPage />);
+
+    const rows = screen.getAllByRole('row').slice(1);
+    const enabledCount = rows.filter((row) => row.textContent?.includes('Enabled')).length;
+    const disabledCount = rows.filter((row) => row.textContent?.includes('Disabled')).length;
+
+    expect(enabledCount).toBe(2);
+    expect(disabledCount).toBe(1);
+  });
+
+  it('filters toggles by search input', async () => {
+    render(<FeatureTogglesPage />);
+
+    const searchInput = screen.getByPlaceholderText('Search feature toggles...');
+    await userEvent.type(searchInput, 'featureA');
+
+    expect(screen.getByText('featureA')).toBeInTheDocument();
+    expect(screen.queryByText('featureB')).not.toBeInTheDocument();
+    expect(screen.queryByText('featureC')).not.toBeInTheDocument();
+    expect(screen.getByText('Showing 1 of 3 feature toggles')).toBeInTheDocument();
+  });
+
+  it('shows reload alert after toggling a feature', async () => {
+    render(<FeatureTogglesPage />);
+
+    expect(screen.queryByText('Reload required')).not.toBeInTheDocument();
+
+    const switches = screen.getAllByRole('switch');
+    await userEvent.click(switches[0]);
+
+    expect(screen.getByText('Reload required')).toBeInTheDocument();
+  });
+
+  it('persists overrides to localStorage', async () => {
+    render(<FeatureTogglesPage />);
+
+    const switches = screen.getAllByRole('switch');
+    // featureA is enabled server-side; toggling it off creates an override
+    await userEvent.click(switches[0]);
+
+    const stored = window.localStorage.getItem(LOCALSTORAGE_KEY);
+    expect(stored).toContain('featureA=0');
+  });
+
+  it('shows Override badge for locally overridden toggles', async () => {
+    window.localStorage.setItem(LOCALSTORAGE_KEY, 'featureB=1');
+    render(<FeatureTogglesPage />);
+
+    expect(screen.getByText('Override')).toBeInTheDocument();
+  });
+
+  it('shows clear overrides button when overrides exist', async () => {
+    window.localStorage.setItem(LOCALSTORAGE_KEY, 'featureB=1');
+    render(<FeatureTogglesPage />);
+
+    const clearButton = screen.getByText(/Clear all overrides/);
+    expect(clearButton).toBeInTheDocument();
+
+    await userEvent.click(clearButton);
+
+    expect(window.localStorage.getItem(LOCALSTORAGE_KEY)).toBeNull();
+  });
+
+  it('shows empty state when search matches nothing', async () => {
+    render(<FeatureTogglesPage />);
+
+    const searchInput = screen.getByPlaceholderText('Search feature toggles...');
+    await userEvent.type(searchInput, 'nonexistent');
+
+    expect(screen.getByText('No feature toggles match your search.')).toBeInTheDocument();
+  });
+});

--- a/public/app/features/lab/FeatureTogglesPage.tsx
+++ b/public/app/features/lab/FeatureTogglesPage.tsx
@@ -1,0 +1,185 @@
+import { css } from '@emotion/css';
+import { useCallback, useMemo, useState } from 'react';
+
+import { GrafanaTheme2 } from '@grafana/data';
+import { config } from '@grafana/runtime';
+import { Alert, Badge, FilterInput, InlineSwitch, Stack, Text, useStyles2 } from '@grafana/ui';
+import { Page } from 'app/core/components/Page/Page';
+
+const LOCALSTORAGE_KEY = 'grafana.featureToggles';
+
+interface ToggleEntry {
+  name: string;
+  enabled: boolean;
+  overridden: boolean;
+}
+
+function getLocalStorageOverrides(): Record<string, boolean> {
+  const raw = window.localStorage.getItem(LOCALSTORAGE_KEY);
+  if (!raw) {
+    return {};
+  }
+  const result: Record<string, boolean> = {};
+  for (const pair of raw.split(',')) {
+    const [key, val] = pair.split('=');
+    if (key) {
+      result[key] = val === 'true' || val === '1';
+    }
+  }
+  return result;
+}
+
+function setLocalStorageOverrides(overrides: Record<string, boolean>) {
+  const entries = Object.entries(overrides)
+    .map(([k, v]) => `${k}=${v ? '1' : '0'}`)
+    .join(',');
+  if (entries) {
+    window.localStorage.setItem(LOCALSTORAGE_KEY, entries);
+  } else {
+    window.localStorage.removeItem(LOCALSTORAGE_KEY);
+  }
+}
+
+function FeatureTogglesPage() {
+  const styles = useStyles2(getStyles);
+  const [search, setSearch] = useState('');
+  const [overrides, setOverrides] = useState<Record<string, boolean>>(getLocalStorageOverrides);
+  const [dirty, setDirty] = useState(false);
+
+  const toggles = useMemo<ToggleEntry[]>(() => {
+    const featureToggles = config.featureToggles as Record<string, boolean>;
+    const allKeys = new Set<string>([...Object.keys(featureToggles), ...Object.keys(overrides)]);
+
+    return Array.from(allKeys)
+      .sort()
+      .map((name) => ({
+        name,
+        enabled: overrides[name] !== undefined ? overrides[name] : !!featureToggles[name],
+        overridden: overrides[name] !== undefined,
+      }));
+  }, [overrides]);
+
+  const filtered = useMemo(() => {
+    if (!search) {
+      return toggles;
+    }
+    const lower = search.toLowerCase();
+    return toggles.filter((t) => t.name.toLowerCase().includes(lower));
+  }, [toggles, search]);
+
+  const handleToggle = useCallback(
+    (name: string, checked: boolean) => {
+      setOverrides((prev) => {
+        const next = { ...prev };
+        const serverValue = !!(config.featureToggles as Record<string, boolean>)[name];
+        if (checked === serverValue) {
+          delete next[name];
+        } else {
+          next[name] = checked;
+        }
+        setLocalStorageOverrides(next);
+        return next;
+      });
+      setDirty(true);
+    },
+    []
+  );
+
+  const handleClearOverrides = useCallback(() => {
+    setLocalStorageOverrides({});
+    setOverrides({});
+    setDirty(true);
+  }, []);
+
+  return (
+    <Page navId="lab-feature-toggles">
+      <Page.Contents>
+        <Stack direction="column" gap={2}>
+          {dirty && (
+            <Alert severity="info" title="Reload required">
+              Feature toggle changes are applied via localStorage and take effect after a page reload.
+            </Alert>
+          )}
+          <Alert severity="warning" title="Development only">
+            Feature toggles modified here are stored in your browser&apos;s localStorage and override server-side
+            configuration. Changes only affect your browser session.
+          </Alert>
+
+          <Stack direction="row" justifyContent="space-between" alignItems="center">
+            <FilterInput placeholder="Search feature toggles..." value={search} onChange={setSearch} width={40} />
+            {Object.keys(overrides).length > 0 && (
+              <button className={styles.clearButton} onClick={handleClearOverrides}>
+                Clear all overrides ({Object.keys(overrides).length})
+              </button>
+            )}
+          </Stack>
+
+          <Text color="secondary">
+            Showing {filtered.length} of {toggles.length} feature toggles
+          </Text>
+
+          <table className="filter-table">
+            <thead>
+              <tr>
+                <th>Feature Toggle</th>
+                <th>Status</th>
+                <th style={{ width: '100px' }}>Enabled</th>
+              </tr>
+            </thead>
+            <tbody>
+              {filtered.map((toggle) => (
+                <tr key={toggle.name}>
+                  <td>
+                    <Stack direction="row" alignItems="center" gap={1}>
+                      <Text>{toggle.name}</Text>
+                      {toggle.overridden && <Badge text="Override" color="orange" icon="exclamation-triangle" />}
+                    </Stack>
+                  </td>
+                  <td>
+                    <Badge
+                      text={toggle.enabled ? 'Enabled' : 'Disabled'}
+                      color={toggle.enabled ? 'green' : 'red'}
+                    />
+                  </td>
+                  <td>
+                    <InlineSwitch
+                      value={toggle.enabled}
+                      onChange={(e) => handleToggle(toggle.name, e.currentTarget.checked)}
+                      showLabel={false}
+                      transparent
+                    />
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+
+          {filtered.length === 0 && (
+            <Text color="secondary" italic>
+              No feature toggles match your search.
+            </Text>
+          )}
+        </Stack>
+      </Page.Contents>
+    </Page>
+  );
+}
+
+function getStyles(theme: GrafanaTheme2) {
+  return {
+    clearButton: css({
+      background: 'none',
+      border: `1px solid ${theme.colors.warning.border}`,
+      borderRadius: theme.shape.radius.default,
+      color: theme.colors.warning.text,
+      cursor: 'pointer',
+      padding: theme.spacing(0.5, 1),
+      fontSize: theme.typography.bodySmall.fontSize,
+      '&:hover': {
+        backgroundColor: theme.colors.warning.transparent,
+      },
+    }),
+  };
+}
+
+export default FeatureTogglesPage;

--- a/public/app/routes/routes.tsx
+++ b/public/app/routes/routes.tsx
@@ -313,6 +313,21 @@ export function getAppRoutes(): RouteDescriptor[] {
         contextSrv.evaluatePermission([AccessControlAction.ActionTeamsRead, AccessControlAction.ActionTeamsCreate]),
       component: SafeDynamicImport(() => import(/* webpackChunkName: "TeamPages" */ 'app/features/teams/TeamPages')),
     },
+    // LAB
+    ...(isDevEnv || config.featureToggles.labFeatureTogglesUI
+      ? [
+          {
+            path: '/lab',
+            component: () => <NavLandingPage navId="lab" />,
+          },
+          {
+            path: '/lab/feature-toggles',
+            component: SafeDynamicImport(
+              () => import(/* webpackChunkName: "FeatureTogglesPage" */ 'app/features/lab/FeatureTogglesPage')
+            ),
+          },
+        ]
+      : []),
     // ADMIN
     {
       path: '/admin',


### PR DESCRIPTION
## Summary

- Adds a new "Lab" navigation section and `/lab` route with a feature toggles page
- Backend: registers `labFeatureToggles` feature flag, adds nav tree node gated behind it
- Frontend: implements `FeatureTogglesPage` component for viewing/toggling experimental features
- Includes unit tests for both backend nav tree logic and frontend page component

## Test plan

- [ ] Verify `labFeatureToggles` feature flag gates the Lab nav item
- [ ] Confirm `/lab` route renders the feature toggles page when enabled
- [ ] Run backend tests: `go test ./pkg/services/navtree/navtreeimpl/`
- [ ] Run frontend tests: `yarn jest --no-watch public/app/features/lab/`


Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Exposes flag names and client-side overrides to org admins in non-dev when enabled; overrides are browser-only but could be mistaken for server config changes.
> 
> **Overview**
> Adds an experimental **Lab** area so org admins can browse feature flags and set **per-browser** overrides via `localStorage` (`grafana.featureToggles`), with UI warnings that changes apply only after reload and only in that session.
> 
> Registers **`labFeatureTogglesUI`** (off by default) and wires **Lab** into the nav tree (`NavIDLab`, feature-toggles child) when the user is signed in, has **org admin**, and either **dev** mode or the flag is enabled. Frontend routes **`/lab`** and **`/lab/feature-toggles`** follow the same dev-or-flag gate; **`FeatureTogglesPage`** lists toggles from boot `config`, supports search, override badges, and clear-all overrides. Nav label translations and unit tests for nav link building and the page are included.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 599193162ffa3a25a8c2476dcf0d8ab09ed0034b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->