### PR TITLE
Frontend: Replace console logs with structured logging

### DIFF
--- a/packages/grafana-data/src/utils/LocalStorageValueProvider.tsx
+++ b/packages/grafana-data/src/utils/LocalStorageValueProvider.tsx
@@ -41,7 +41,7 @@ export const LocalStorageValueProvider = <T,>(props: Props<T>) => {
     try {
       store.delete(storageKey);
     } catch (error) {
-      console.log(error);
+      console.error(error);
     }
     setState({ value: defaultValue });
   };

--- a/packages/grafana-runtime/src/config.ts
+++ b/packages/grafana-runtime/src/config.ts
@@ -28,6 +28,8 @@ import {
   type CurrentUserDTO,
 } from '@grafana/data';
 
+import { logStructuredDebug } from './utils/structuredLogging';
+
 /**
  * @deprecated Use the type from `@grafana/data`
  */
@@ -309,7 +311,10 @@ function overrideFeatureTogglesFromLocalStorage(config: GrafanaBootConfig) {
       const toggleState = featureValue === 'true' || featureValue === '1';
       // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
       featureToggles[featureName as keyof FeatureToggles] = toggleState;
-      console.log(`Setting feature toggle ${featureName} = ${toggleState} via localstorage`);
+      logStructuredDebug('grafana/runtime.config', 'Setting feature toggle via localstorage', {
+        featureName,
+        toggleState,
+      });
     }
   }
 }
@@ -335,9 +340,11 @@ function overrideFeatureTogglesFromUrl(config: GrafanaBootConfig) {
       if (toggleState !== featureToggles[key]) {
         if (isDevelopment || safeRuntimeFeatureFlags.has(featureName)) {
           featureToggles[featureName] = toggleState;
-          console.log(`Setting feature toggle ${featureName} = ${toggleState} via url`);
+          logStructuredDebug('grafana/runtime.config', 'Setting feature toggle via url', { featureName, toggleState });
         } else {
-          console.log(`Unable to change feature toggle ${featureName} via url in production.`);
+          logStructuredDebug('grafana/runtime.config', 'Unable to change feature toggle via url in production', {
+            featureName,
+          });
         }
       }
     }

--- a/packages/grafana-runtime/src/index.ts
+++ b/packages/grafana-runtime/src/index.ts
@@ -25,6 +25,7 @@ export {
   logMeasurement,
   type MonitoringLogger,
 } from './utils/logging';
+export { logStructuredDebug } from './utils/structuredLogging';
 export {
   DataSourceWithBackend,
   HealthCheckError,

--- a/packages/grafana-runtime/src/utils/structuredLogging.ts
+++ b/packages/grafana-runtime/src/utils/structuredLogging.ts
@@ -1,0 +1,33 @@
+import { logDebug } from './logging';
+
+type StructuredLogContext = Record<string, string>;
+
+const serialize = (value: unknown): string => {
+  if (value instanceof Error) {
+    return value.message;
+  }
+
+  if (typeof value === 'string') {
+    return value;
+  }
+
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return String(value);
+  }
+};
+
+const createContext = (source: string, args: unknown[]): StructuredLogContext => {
+  const context: StructuredLogContext = { source };
+
+  args.forEach((arg, index) => {
+    context[`arg${index + 1}`] = serialize(arg);
+  });
+
+  return context;
+};
+
+export function logStructuredDebug(source: string, message: unknown, ...args: unknown[]) {
+  logDebug(serialize(message), createContext(source, args));
+}

--- a/public/app/core/services/FetchQueue.ts
+++ b/public/app/core/services/FetchQueue.ts
@@ -1,6 +1,6 @@
 import { type Observable, Subject } from 'rxjs';
 
-import { type BackendSrvRequest } from '@grafana/runtime';
+import { logStructuredDebug, type BackendSrvRequest } from '@grafana/runtime';
 
 export interface QueueState extends Record<string, { state: FetchStatus; options: BackendSrvRequest }> {}
 
@@ -90,8 +90,8 @@ export class FetchQueue {
       []
     );
 
-    console.log('FetchQueue noOfStarted', update.noOfInProgress);
-    console.log('FetchQueue noOfNotStarted', update.noOfPending);
-    console.log('FetchQueue state', entriesWithoutOptions);
+    logStructuredDebug('core.services', 'FetchQueue noOfStarted', update.noOfInProgress);
+    logStructuredDebug('core.services', 'FetchQueue noOfNotStarted', update.noOfPending);
+    logStructuredDebug('core.services', 'FetchQueue state', entriesWithoutOptions);
   };
 }

--- a/public/app/core/services/backend_srv.ts
+++ b/public/app/core/services/backend_srv.ts
@@ -27,9 +27,10 @@ import {
 
 import { AppEvents, DataQueryErrorType, deprecationWarning, generateUUID } from '@grafana/data';
 import {
+  config,
+  logStructuredDebug,
   type BackendSrv as BackendService,
   type BackendSrvRequest,
-  config,
   type FetchError,
   type FetchResponse,
 } from '@grafana/runtime';
@@ -240,7 +241,7 @@ export class BackendSrv implements BackendService {
             observer.complete();
           }) // runs in background
           .catch((e) => {
-            console.log(requestId, 'catch', e);
+            logStructuredDebug('core.services', requestId, 'catch', e);
             observer.error(e);
           }); // from abort
       },

--- a/public/app/core/services/echo/backends/analytics/BrowseConsoleBackend.ts
+++ b/public/app/core/services/echo/backends/analytics/BrowseConsoleBackend.ts
@@ -1,10 +1,11 @@
 /* eslint-disable no-console */
 import {
-  type EchoBackend,
   EchoEventType,
   isExperimentViewEvent,
   isInteractionEvent,
   isPageviewEvent,
+  logStructuredDebug,
+  type EchoBackend,
   type PageviewEchoEvent,
 } from '@grafana/runtime';
 
@@ -16,12 +17,12 @@ export class BrowserConsoleBackend implements EchoBackend<PageviewEchoEvent, unk
 
   addEvent = (e: PageviewEchoEvent) => {
     if (isPageviewEvent(e)) {
-      console.log('[EchoSrv:pageview]', e.payload.page);
+      logStructuredDebug('core.services', '[EchoSrv:pageview]', e.payload.page);
     }
 
     if (isInteractionEvent(e)) {
       const eventName = e.payload.interactionName;
-      console.log('[EchoSrv:event]', eventName, e.payload.properties);
+      logStructuredDebug('core.services', '[EchoSrv:event]', eventName, e.payload.properties);
 
       // Warn for non-scalar property values. We're not yet making this a hard a
       const invalidTypeProperties = Object.entries(e.payload.properties ?? {}).filter(([_, value]) => {
@@ -42,7 +43,7 @@ export class BrowserConsoleBackend implements EchoBackend<PageviewEchoEvent, unk
     }
 
     if (isExperimentViewEvent(e)) {
-      console.log('[EchoSrv:experiment]', e.payload);
+      logStructuredDebug('core.services', '[EchoSrv:experiment]', e.payload);
     }
   };
 

--- a/public/app/core/utils/debugLog.ts
+++ b/public/app/core/utils/debugLog.ts
@@ -1,4 +1,5 @@
 import { store } from '@grafana/data';
+import { logStructuredDebug } from '@grafana/runtime';
 
 /**
  * Creates a debug logger gated by a localStorage key.
@@ -11,7 +12,7 @@ export function createDebugLog(key: string, prefix: string) {
 
   return function debugLog(message: string, ...args: unknown[]) {
     if (store.get(storageKey) === 'true') {
-      console.log(`[${prefix}] ${message}`, ...args);
+      logStructuredDebug('core.utils', `[${prefix}] ${message}`, ...args);
     }
   };
 }

--- a/public/app/features/auth-config/FieldRenderer.tsx
+++ b/public/app/features/auth-config/FieldRenderer.tsx
@@ -3,6 +3,7 @@ import { useEffect, useState } from 'react';
 import { type UseFormReturn, Controller } from 'react-hook-form';
 
 import { type SelectableValue } from '@grafana/data';
+import { logStructuredDebug } from '@grafana/runtime';
 import { Checkbox, Field, Input, SecretInput, Select, Switch, useTheme2 } from '@grafana/ui';
 
 import { fieldMap } from './fields';
@@ -78,7 +79,7 @@ export const FieldRenderer = ({
   }, [isDisabled, disabledWhen?.disabledValue, name, setValue]);
 
   if (!field) {
-    console.log('missing field:', name);
+    logStructuredDebug('features.auth-config', 'missing field:', name);
     return null;
   }
 

--- a/public/app/features/auth-config/state/actions.ts
+++ b/public/app/features/auth-config/state/actions.ts
@@ -1,6 +1,6 @@
 import { lastValueFrom } from 'rxjs';
 
-import { getBackendSrv, isFetchError } from '@grafana/runtime';
+import { getBackendSrv, isFetchError, logStructuredDebug } from '@grafana/runtime';
 import { contextSrv } from 'app/core/services/context_srv';
 import { AccessControlAction } from 'app/types/accessControl';
 import { type Settings, type UpdateSettingsQuery } from 'app/types/settings';
@@ -78,7 +78,7 @@ export function saveSettings(data: UpdateSettingsQuery): ThunkResult<Promise<boo
         dispatch(resetError());
         return true;
       } catch (error) {
-        console.log(error);
+        logStructuredDebug('features.auth-config', error);
         if (isFetchError(error)) {
           error.isHandled = true;
           const updateErr: SettingsError = {

--- a/public/app/features/canvas/runtime/frame.tsx
+++ b/public/app/features/canvas/runtime/frame.tsx
@@ -1,5 +1,6 @@
 import { cloneDeep } from 'lodash';
 
+import { logStructuredDebug } from '@grafana/runtime';
 import { notFoundItem } from 'app/features/canvas/elements/notFound';
 import { type DimensionContext } from 'app/features/dimensions/context';
 import { HorizontalConstraint, type Placement, VerticalConstraint } from 'app/plugins/panel/canvas/panelcfg.gen';
@@ -129,7 +130,7 @@ export class FrameState extends ElementState {
         break;
       case LayerActionID.Duplicate:
         if (element.item.id === 'frame') {
-          console.log('Can not duplicate frames (yet)', action, element);
+          logStructuredDebug('features.canvas', 'Can not duplicate frames (yet)', action, element);
           return;
         }
         const opts = cloneDeep(element.options);
@@ -239,7 +240,7 @@ export class FrameState extends ElementState {
         break;
 
       default:
-        console.log('DO action', action, element);
+        logStructuredDebug('features.canvas', 'DO action', action, element);
         return;
     }
   };

--- a/public/app/features/dashboard-scene/inspect/HelpWizard/SupportSnapshotService.ts
+++ b/public/app/features/dashboard-scene/inspect/HelpWizard/SupportSnapshotService.ts
@@ -2,6 +2,7 @@ import saveAs from 'file-saver';
 
 import { dateTimeFormat, formattedValueToString, getValueFormat, type SelectableValue } from '@grafana/data';
 import { t } from '@grafana/i18n';
+import { logStructuredDebug } from '@grafana/runtime';
 import { sceneGraph, type SceneObject, type VizPanel } from '@grafana/scenes';
 import { StateManagerBase } from 'app/core/services/StateManagerBase';
 
@@ -84,7 +85,7 @@ export class SupportSnapshotService extends StateManagerBase<SupportSnapshotStat
         const dash = transformSaveModelToScene({ dashboard: snapshot, meta: { isEmbedded: true } });
         scene = dash.state.body; // skip the wrappers
       } catch (ex) {
-        console.log('Error creating scene:', ex);
+        logStructuredDebug('features.dashboard-scene', 'Error creating scene:', ex);
       }
     }
 

--- a/public/app/features/dashboard-scene/pages/DashboardScenePage.tsx
+++ b/public/app/features/dashboard-scene/pages/DashboardScenePage.tsx
@@ -3,7 +3,7 @@ import { type Params, useParams } from 'react-router-dom-v5-compat';
 import { usePrevious } from 'react-use';
 
 import { PageLayoutType } from '@grafana/data';
-import { locationService } from '@grafana/runtime';
+import { locationService, logStructuredDebug } from '@grafana/runtime';
 import { UrlSyncContextProvider } from '@grafana/scenes';
 import { Box } from '@grafana/ui';
 import { Page } from 'app/core/components/Page/Page';
@@ -132,7 +132,7 @@ export function DashboardScenePage({ route, queryParams, location }: Props) {
   // A bit tricky for transition to or from Home dashboard that does not have a uid in the url (but could have it in the dashboard model)
   // if prevMatch is undefined we are going from normal route to home route or vice versa
   if (type !== 'snapshot' && (!prevMatch || uid !== prevMatch?.params.uid)) {
-    console.log('skipping rendering');
+    logStructuredDebug('features.dashboard-scene', 'skipping rendering');
     return null;
   }
 

--- a/public/app/features/dashboard-scene/pages/DashboardScenePageStateManager.ts
+++ b/public/app/features/dashboard-scene/pages/DashboardScenePageStateManager.ts
@@ -1,6 +1,13 @@
 import { locationUtil, type UrlQueryMap } from '@grafana/data';
 import { t } from '@grafana/i18n';
-import { config, getBackendSrv, getDataSourceSrv, isFetchError, locationService } from '@grafana/runtime';
+import {
+  config,
+  getBackendSrv,
+  getDataSourceSrv,
+  isFetchError,
+  locationService,
+  logStructuredDebug,
+} from '@grafana/runtime';
 import { FlagKeys, getFeatureFlagClient, UserStorage } from '@grafana/runtime/internal';
 import { sceneGraph } from '@grafana/scenes';
 import {
@@ -874,7 +881,7 @@ export class DashboardScenePageStateManager extends DashboardScenePageStateManag
             ...locationService.getLocation(),
             pathname: dashboardUrl,
           });
-          console.log('not correct url correcting', dashboardUrl, currentPath);
+          logStructuredDebug('features.dashboard-scene', 'not correct url correcting', dashboardUrl, currentPath);
         }
       }
 
@@ -1138,7 +1145,7 @@ export class DashboardScenePageStateManagerV2 extends DashboardScenePageStateMan
             ...locationService.getLocation(),
             pathname: dashboardUrl,
           });
-          console.log('not correct url correcting', dashboardUrl, currentPath);
+          logStructuredDebug('features.dashboard-scene', 'not correct url correcting', dashboardUrl, currentPath);
         }
       }
       // Populate nav model in global store according to the folder

--- a/public/app/features/dashboard-scene/settings/VersionsEditView.tsx
+++ b/public/app/features/dashboard-scene/settings/VersionsEditView.tsx
@@ -4,6 +4,7 @@ import { useMemo } from 'react';
 
 import { PageLayoutType, dateTimeFormat, dateTimeFormatTimeAgo } from '@grafana/data';
 import { Trans } from '@grafana/i18n';
+import { logStructuredDebug } from '@grafana/runtime';
 import { type SceneComponentProps, SceneObjectBase, sceneGraph } from '@grafana/scenes';
 import { Alert, Spinner, Stack } from '@grafana/ui';
 import { useGetDisplayMappingQuery } from 'app/api/clients/iam/v0alpha1';
@@ -128,7 +129,7 @@ export class VersionsEditView extends SceneObjectBase<VersionsEditViewState> imp
         // Update the continueToken for the next request, if available
         this._continueToken = result.metadata.continue ?? '';
       })
-      .catch((err) => console.log(err))
+      .catch((err) => logStructuredDebug('features.dashboard-scene', err))
       .finally(() => this.setState({ isAppending: false }));
   };
 

--- a/public/app/features/dashboard/components/DashboardSettings/VersionsSettings.tsx
+++ b/public/app/features/dashboard/components/DashboardSettings/VersionsSettings.tsx
@@ -1,6 +1,7 @@
 import { PureComponent } from 'react';
 import * as React from 'react';
 
+import { logStructuredDebug } from '@grafana/runtime';
 import { Spinner, Stack } from '@grafana/ui';
 import { Page } from 'app/core/components/Page/Page';
 import { type Resource } from 'app/features/apiserver/types';
@@ -69,7 +70,7 @@ export class VersionsSettings extends PureComponent<Props, State> {
         // Update the continueToken for the next request, if available
         this.continueToken = result.metadata.continue ?? '';
       })
-      .catch((err) => console.log(err))
+      .catch((err) => logStructuredDebug('features.dashboard', err))
       .finally(() => this.setState({ isAppending: false }));
   };
 

--- a/public/app/features/dashboard/components/HelpWizard/SupportSnapshotService.ts
+++ b/public/app/features/dashboard/components/HelpWizard/SupportSnapshotService.ts
@@ -2,6 +2,7 @@ import saveAs from 'file-saver';
 
 import { dateTimeFormat, formattedValueToString, getValueFormat, type SelectableValue } from '@grafana/data';
 import { t } from '@grafana/i18n';
+import { logStructuredDebug } from '@grafana/runtime';
 import { type SceneObject } from '@grafana/scenes';
 import { StateManagerBase } from 'app/core/services/StateManagerBase';
 import { type Randomize } from 'app/features/dashboard-scene/inspect/HelpWizard/randomizer';
@@ -88,7 +89,7 @@ export class SupportSnapshotService extends StateManagerBase<SupportSnapshotStat
       const dash = createDashboardSceneFromDashboardModel(oldModel, snapshot);
       scene = dash.state.body; // skip the wrappers
     } catch (ex) {
-      console.log('Error creating scene:', ex);
+      logStructuredDebug('features.dashboard', 'Error creating scene:', ex);
     }
 
     this.setState({ snapshot, snapshotText, markdownText, snapshotSize, snapshotUpdate: snapshotUpdate + 1, scene });

--- a/public/app/features/dashboard/dashgrid/PanelStateWrapper.tsx
+++ b/public/app/features/dashboard/dashgrid/PanelStateWrapper.tsx
@@ -23,7 +23,7 @@ import {
   toDataFrameDTO,
   toUtc,
 } from '@grafana/data';
-import { RefreshEvent, ScopesContext, type ScopesContextValue } from '@grafana/runtime';
+import { logStructuredDebug, RefreshEvent, ScopesContext, type ScopesContextValue } from '@grafana/runtime';
 import { type VizLegendOptions } from '@grafana/schema';
 import {
   ErrorBoundary,
@@ -262,7 +262,7 @@ export class PanelStateWrapper extends PureComponent<Props, State> {
       const delta = liveTime.to.valueOf() - data.timeRange.to.valueOf();
       if (delta < 100) {
         // 10hz
-        console.log('Skip tick render', this.props.panel.title, delta);
+        logStructuredDebug('features.dashboard', 'Skip tick render', this.props.panel.title, delta);
         return;
       }
     }

--- a/public/app/features/dashboard/services/performanceUtils.ts
+++ b/public/app/features/dashboard/services/performanceUtils.ts
@@ -1,4 +1,5 @@
 import { store } from '@grafana/data';
+import { logStructuredDebug } from '@grafana/runtime';
 import { performanceUtils, writePerformanceLog } from '@grafana/scenes';
 
 /**
@@ -85,11 +86,9 @@ export function writePerformanceGroupStart(logger: string, message: string): voi
 export function writePerformanceGroupLog(logger: string, message: string, data?: unknown): void {
   if (isPerformanceLoggingEnabled()) {
     if (data) {
-      // eslint-disable-next-line no-console
-      console.log(message, data);
+      logStructuredDebug('features.dashboard', message, data);
     } else {
-      // eslint-disable-next-line no-console
-      console.log(message);
+      logStructuredDebug('features.dashboard', message);
     }
   }
 }

--- a/public/app/features/dashboard/state/DashboardModel.ts
+++ b/public/app/features/dashboard/state/DashboardModel.ts
@@ -18,7 +18,7 @@ import {
   type UrlQueryValue,
 } from '@grafana/data';
 import { type PromQuery } from '@grafana/prometheus';
-import { RefreshEvent, TimeRangeUpdatedEvent } from '@grafana/runtime';
+import { logStructuredDebug, RefreshEvent, TimeRangeUpdatedEvent } from '@grafana/runtime';
 import { type Dashboard, type DashboardLink, type VariableModel } from '@grafana/schema';
 import { DEFAULT_ANNOTATION_COLOR } from '@grafana/ui';
 import { GRID_CELL_HEIGHT, GRID_CELL_VMARGIN, GRID_COLUMN_COUNT, REPEAT_DIR_VERTICAL } from 'app/core/constants';
@@ -1113,13 +1113,13 @@ export class DashboardModel implements TimeModel {
 
   /** @deprecated */
   on<T>(event: AppEvent<T>, callback: (payload?: T) => void) {
-    console.log('DashboardModel.on is deprecated use events.subscribe');
+    logStructuredDebug('features.dashboard', 'DashboardModel.on is deprecated use events.subscribe');
     this.events.on(event, callback);
   }
 
   /** @deprecated */
   off<T>(event: AppEvent<T>, callback: (payload?: T) => void) {
-    console.log('DashboardModel.off is deprecated');
+    logStructuredDebug('features.dashboard', 'DashboardModel.off is deprecated');
     this.events.off(event, callback);
   }
 

--- a/public/app/features/explore/TraceView/components/CriticalPath/index.tsx
+++ b/public/app/features/explore/TraceView/components/CriticalPath/index.tsx
@@ -14,6 +14,8 @@
 
 import memoizeOne from 'memoize-one';
 
+import { logStructuredDebug } from '@grafana/runtime';
+
 import { type TraceSpan, type CriticalPathSection, type Trace } from '../types/trace';
 
 import findLastFinishingChildSpan from './utils/findLastFinishingChildSpan';
@@ -104,7 +106,7 @@ function criticalPathForTrace(trace: Trace) {
       criticalPath = computeCriticalPath(sanitizedSpanMap, rootSpanId, criticalPath);
     } catch (error) {
       /* eslint-disable no-console */
-      console.log('error while computing critical path for a trace', error);
+      logStructuredDebug('features.explore', 'error while computing critical path for a trace', error);
     }
   }
   return criticalPath;

--- a/public/app/features/explore/state/query.ts
+++ b/public/app/features/explore/state/query.ts
@@ -20,7 +20,7 @@ import {
   type SupplementaryQueryType,
 } from '@grafana/data';
 import { combinePanelData } from '@grafana/o11y-ds-frontend';
-import { config, getDataSourceSrv } from '@grafana/runtime';
+import { config, getDataSourceSrv, logStructuredDebug } from '@grafana/runtime';
 import { type DataQuery } from '@grafana/schema';
 import { notifyApp } from 'app/core/reducers/appNotification';
 import {
@@ -655,7 +655,7 @@ export const runQueries = createAsyncThunk<void, RunQueriesOptions>(
 
           // Keep scanning for results if this was the last scanning transaction
           if (exploreState!.scanning) {
-            console.log(data.series);
+            logStructuredDebug('features.explore', data.series);
             if (data.state === LoadingState.Done && data.series.length === 0) {
               const range = getShiftedTimeRange(-1, exploreState!.range);
               dispatch(updateTime({ exploreId, absoluteRange: range }));

--- a/public/app/features/live/centrifuge/LiveDataStream.ts
+++ b/public/app/features/live/centrifuge/LiveDataStream.ts
@@ -14,10 +14,11 @@ import {
 } from '@grafana/data';
 import { getStreamingFrameOptions } from '@grafana/data/internal';
 import {
-  type LiveDataStreamOptions,
+  logStructuredDebug,
   StreamingFrameAction,
-  type StreamingFrameOptions,
   toDataQueryError,
+  type LiveDataStreamOptions,
+  type StreamingFrameOptions,
 } from '@grafana/runtime';
 
 import { StreamingResponseDataType } from '../data/utils';
@@ -154,7 +155,7 @@ export class LiveDataStream<T = unknown> {
   };
 
   private onError = (err: unknown) => {
-    console.log('LiveQuery [error]', { err }, this.deps.channelId);
+    logStructuredDebug('features.live', 'LiveQuery [error]', { err }, this.deps.channelId);
     this.stream.next({
       type: InternalStreamMessageType.Error,
       error: toDataQueryError(err),
@@ -163,7 +164,7 @@ export class LiveDataStream<T = unknown> {
   };
 
   private onComplete = () => {
-    console.log('LiveQuery [complete]', this.deps.channelId);
+    logStructuredDebug('features.live', 'LiveQuery [complete]', this.deps.channelId);
     this.shutdown();
   };
 

--- a/public/app/features/live/centrifuge/channel.ts
+++ b/public/app/features/live/centrifuge/channel.ts
@@ -19,6 +19,7 @@ import {
   type DataFrameJSON,
   isValidLiveChannelAddress,
 } from '@grafana/data';
+import { logStructuredDebug } from '@grafana/runtime';
 
 /**
  * Internal class that maps Centrifuge support to GrafanaLive
@@ -81,7 +82,7 @@ export class CentrifugeLiveChannel<T = any> {
           this.sendStatus();
         }
       } catch (err) {
-        console.log('publish error', this.addr, err);
+        logStructuredDebug('features.live', 'publish error', this.addr, err);
         this.currentStatus.error = err;
         this.currentStatus.timestamp = Date.now();
         this.sendStatus();

--- a/public/app/features/live/centrifuge/service.ts
+++ b/public/app/features/live/centrifuge/service.ts
@@ -18,15 +18,16 @@ import {
   toLiveChannelId,
 } from '@grafana/data';
 import {
+  getBackendSrv,
+  logStructuredDebug,
+  StreamingFrameAction,
+  type BackendDataSourceResponse,
   type FetchResponse,
   type GrafanaLiveSrv,
   type LiveDataStreamOptions,
   type LivePublishOptions,
   type LiveQueryDataOptions,
-  StreamingFrameAction,
   type StreamingFrameOptions,
-  type BackendDataSourceResponse,
-  getBackendSrv,
 } from '@grafana/runtime';
 
 import { type StreamingResponseData } from '../data/utils';
@@ -126,7 +127,7 @@ export class CentrifugeService implements CentrifugeSrv {
   };
 
   private onServerSideMessage = (context: ServerPublicationContext) => {
-    console.log('Publication from server-side channel', context);
+    logStructuredDebug('features.live', 'Publication from server-side channel', context);
   };
 
   private onError = (context: ErrorContext) => {

--- a/public/app/features/live/dashboard/dashboardWatcher.ts
+++ b/public/app/features/live/dashboard/dashboardWatcher.ts
@@ -10,7 +10,7 @@ import {
   LiveChannelScope,
   generateUUID,
 } from '@grafana/data';
-import { getGrafanaLiveSrv, locationService } from '@grafana/runtime';
+import { getGrafanaLiveSrv, locationService, logStructuredDebug } from '@grafana/runtime';
 import { appEvents } from 'app/core/app_events';
 import { contextSrv } from 'app/core/services/context_srv';
 
@@ -137,7 +137,7 @@ class DashboardWatcher {
 
             const dash = getDashboardSrv().getCurrent();
             if (dash?.uid !== event.message.uid) {
-              console.log('dashboard event for different dashboard?', event, dash);
+              logStructuredDebug('features.live', 'dashboard event for different dashboard?', event, dash);
               return;
             }
 

--- a/public/app/features/panel/panellinks/linkSuppliers.ts
+++ b/public/app/features/panel/panellinks/linkSuppliers.ts
@@ -12,6 +12,7 @@ import {
   type ScopedVars,
 } from '@grafana/data';
 import { t } from '@grafana/i18n';
+import { logStructuredDebug } from '@grafana/runtime';
 import { type VizPanel } from '@grafana/scenes';
 import { type PanelModel } from 'app/features/dashboard/state/PanelModel';
 import { dashboardSceneGraph } from 'app/features/dashboard-scene/utils/dashboardSceneGraph';
@@ -124,7 +125,7 @@ export const getFieldLinksSupplier = (value: FieldDisplay): LinkModelSupplier<Fi
           };
         }
       } else {
-        console.log('VALUE', value);
+        logStructuredDebug('features.panel', 'VALUE', value);
       }
 
       const replace: InterpolateFunction = (value: string, vars: ScopedVars | undefined, fmt?: string | Function) => {

--- a/public/app/features/plugins/admin/state/actions.ts
+++ b/public/app/features/plugins/admin/state/actions.ts
@@ -2,7 +2,7 @@ import { createAction, createAsyncThunk, type Update } from '@reduxjs/toolkit';
 import { from, forkJoin, timeout, lastValueFrom, catchError, of } from 'rxjs';
 
 import { type PanelPlugin, type PluginError } from '@grafana/data';
-import { config, getBackendSrv, isFetchError } from '@grafana/runtime';
+import { config, getBackendSrv, isFetchError, logStructuredDebug } from '@grafana/runtime';
 import { refetchPanelPluginMetas } from '@grafana/runtime/internal';
 import { importPanelPlugin } from 'app/features/plugins/importPanelPlugin';
 import { type StoreState, type ThunkResult } from 'app/types/store';
@@ -121,7 +121,7 @@ export const fetchAll = createAsyncThunk(`${STATE_PREFIX}/fetchAll`, async (_, t
           }
         },
         (error) => {
-          console.log(error);
+          logStructuredDebug('features.plugins', error);
           thunkApi.dispatch({ type: `${STATE_PREFIX}/fetchLocal/rejected` });
           thunkApi.dispatch({ type: `${STATE_PREFIX}/fetchRemote/rejected` });
           return thunkApi.rejectWithValue('Unknown error.');

--- a/public/app/features/plugins/loader/utils.ts
+++ b/public/app/features/plugins/loader/utils.ts
@@ -1,4 +1,4 @@
-import { config } from '@grafana/runtime';
+import { config, logStructuredDebug } from '@grafana/runtime';
 
 import { sandboxPluginDependencies } from '../sandbox/pluginDependencies';
 
@@ -29,7 +29,7 @@ function addPreload(id: string, preload: (() => Promise<System.Module>) | System
   try {
     resolvedId = SystemJS.resolve(id);
   } catch (e) {
-    console.log(e);
+    logStructuredDebug('features.plugins', e);
   }
 
   if (resolvedId && SystemJS.has(resolvedId)) {

--- a/public/app/features/plugins/sandbox/distortions.ts
+++ b/public/app/features/plugins/sandbox/distortions.ts
@@ -2,6 +2,7 @@ import { type ProxyTarget } from '@locker/near-membrane-shared';
 import DOMPurify from 'dompurify';
 import { cloneDeep, isFunction } from 'lodash';
 
+import { logStructuredDebug } from '@grafana/runtime';
 import { type Monaco } from '@grafana/ui';
 
 import { loadScriptIntoSandbox } from './codeLoader';
@@ -140,7 +141,7 @@ function distortConsole(distortions: DistortionMap) {
       const pluginId = meta.id;
 
       function sandboxLog(...args: unknown[]) {
-        console.log(`[plugin ${pluginId}]`, ...args);
+        logStructuredDebug('features.plugins', `[plugin ${pluginId}]`, ...args);
       }
       return {
         log: sandboxLog,
@@ -170,7 +171,7 @@ function distortAlert(distortions: DistortionMap) {
     });
 
     return function (...args: unknown[]) {
-      console.log(`[plugin ${pluginId}]`, ...args);
+      logStructuredDebug('features.plugins', `[plugin ${pluginId}]`, ...args);
     };
   }
   const descriptor = Object.getOwnPropertyDescriptor(window, 'alert');

--- a/public/app/features/search/service/unified.ts
+++ b/public/app/features/search/service/unified.ts
@@ -14,7 +14,7 @@ import {
   type SelectableValue,
 } from '@grafana/data';
 import { t } from '@grafana/i18n';
-import { config, getBackendSrv } from '@grafana/runtime';
+import { config, getBackendSrv, logStructuredDebug } from '@grafana/runtime';
 import { generatedAPI, type ListStarsApiResponse } from 'app/api/clients/collections/v1alpha1';
 import { getAPIBaseURL } from 'app/api/utils';
 import { type TermCount } from 'app/core/components/TagFilter/TagFilter';
@@ -203,7 +203,7 @@ export class UnifiedSearcher implements GrafanaSearcher {
         const resp = await this.fetchResponse(nextPageUrl);
         const frame = toDashboardResults(resp, query.sort ?? '');
         if (!frame) {
-          console.log('no results', frame);
+          logStructuredDebug('features.search', 'no results', frame);
           return;
         }
 

--- a/public/app/plugins/datasource/grafana-testdata-datasource/components/RawFrameEditor.tsx
+++ b/public/app/plugins/datasource/grafana-testdata-datasource/components/RawFrameEditor.tsx
@@ -2,7 +2,7 @@ import { isArray } from 'lodash';
 import { useState } from 'react';
 
 import { dataFrameToJSON, toDataFrame, toDataFrameDTO } from '@grafana/data';
-import { toDataQueryResponse } from '@grafana/runtime';
+import { logStructuredDebug, toDataQueryResponse } from '@grafana/runtime';
 import { Alert, CodeEditor } from '@grafana/ui';
 
 import { type EditorProps } from '../QueryEditor';
@@ -35,8 +35,8 @@ export const RawFrameEditor = ({ onChange, query }: EditorProps) => {
       }
 
       if (data) {
-        console.log('Original', json);
-        console.log('Save', data);
+        logStructuredDebug('plugins.datasource.grafana-testdata-datasource', 'Original', json);
+        logStructuredDebug('plugins.datasource.grafana-testdata-datasource', 'Save', data);
         setError(undefined);
         setWarning('Converted to direct frame result');
         onChange({ ...query, rawFrameContent: JSON.stringify(data, null, 2) });
@@ -45,7 +45,7 @@ export const RawFrameEditor = ({ onChange, query }: EditorProps) => {
 
       setError('Unable to read dataframes in text');
     } catch (e) {
-      console.log('Error parsing json', e);
+      logStructuredDebug('plugins.datasource.grafana-testdata-datasource', 'Error parsing json', e);
       setError('Enter JSON array of data frames (or raw query results body)');
       setWarning(undefined);
     }

--- a/public/app/plugins/datasource/grafana-testdata-datasource/runStreams.ts
+++ b/public/app/plugins/datasource/grafana-testdata-datasource/runStreams.ts
@@ -18,7 +18,7 @@ import {
   createTheme,
   generateUUID,
 } from '@grafana/data';
-import { getBackendSrv } from '@grafana/runtime';
+import { getBackendSrv, logStructuredDebug } from '@grafana/runtime';
 
 import { getRandomLine } from './LogIpsum';
 import { type TestDataDataQuery, type StreamingQuery } from './dataquery';
@@ -125,7 +125,7 @@ function runSignalStream(
     setTimeout(pushNextEvent, 5);
 
     return () => {
-      console.log('unsubscribing to stream ' + streamId);
+      logStructuredDebug('plugins.datasource.grafana-testdata-datasource', 'unsubscribing to stream ' + streamId);
       clearTimeout(timeoutId);
     };
   });
@@ -171,7 +171,7 @@ function runLogsStream(
     setTimeout(pushNextEvent, 5);
 
     return () => {
-      console.log('unsubscribing to stream ' + streamId);
+      logStructuredDebug('plugins.datasource.grafana-testdata-datasource', 'unsubscribing to stream ' + streamId);
       clearTimeout(timeoutId);
     };
   });
@@ -254,7 +254,7 @@ function runWatchStream(
       });
 
     return () => {
-      console.log('unsubscribing to stream', streamId);
+      logStructuredDebug('plugins.datasource.grafana-testdata-datasource', 'unsubscribing to stream', streamId);
       sub.unsubscribe();
     };
   });
@@ -314,7 +314,7 @@ function runFetchStream(
       });
 
       if (value.done) {
-        console.log('Finished stream');
+        logStructuredDebug('plugins.datasource.grafana-testdata-datasource', 'Finished stream');
         subscriber.complete(); // necessary?
         return;
       }
@@ -335,7 +335,7 @@ function runFetchStream(
 
     return () => {
       // Cancel fetch?
-      console.log('unsubscribing to stream ' + streamId);
+      logStructuredDebug('plugins.datasource.grafana-testdata-datasource', 'unsubscribing to stream ' + streamId);
     };
   });
 }
@@ -368,7 +368,7 @@ function runTracesStream(
     setTimeout(pushNextEvent, 5);
 
     return () => {
-      console.log('unsubscribing to stream ' + streamId);
+      logStructuredDebug('plugins.datasource.grafana-testdata-datasource', 'unsubscribing to stream ' + streamId);
       clearTimeout(timeoutId);
     };
   });

--- a/public/app/plugins/datasource/loki/components/monaco-query-field/getOverrideServices.ts
+++ b/public/app/plugins/datasource/loki/components/monaco-query-field/getOverrideServices.ts
@@ -1,3 +1,4 @@
+import { logStructuredDebug } from '@grafana/runtime';
 import { type monacoTypes } from '@grafana/ui';
 
 // this thing here is a workaround in a way.
@@ -81,7 +82,7 @@ function makeStorageService() {
     },
 
     logStorage: (): void => {
-      console.log('logStorage: not implemented');
+      logStructuredDebug('plugins.datasource.loki', 'logStorage: not implemented');
     },
 
     migrate: (): Promise<void> => {

--- a/public/app/plugins/datasource/loki/shardQuerySplitting.test.ts
+++ b/public/app/plugins/datasource/loki/shardQuerySplitting.test.ts
@@ -13,11 +13,9 @@ import { type LokiQuery } from './types';
 
 const originalLokiQueryLimitsContextState = config.featureToggles.lokiQueryLimitsContext;
 
-const originalLog = console.log;
 const originalWarn = console.warn;
 const originalErr = console.error;
 beforeEach(() => {
-  jest.spyOn(console, 'log').mockImplementation(() => {});
   jest.spyOn(console, 'warn').mockImplementation(() => {});
   jest.spyOn(console, 'error').mockImplementation(() => {});
 });
@@ -25,7 +23,6 @@ beforeAll(() => {
   config.featureToggles.lokiQueryLimitsContext = true;
 });
 afterAll(() => {
-  console.log = originalLog;
   console.warn = originalWarn;
   console.error = originalErr;
   config.featureToggles.lokiQueryLimitsContext = originalLokiQueryLimitsContextState;

--- a/public/app/plugins/datasource/loki/shardQuerySplitting.ts
+++ b/public/app/plugins/datasource/loki/shardQuerySplitting.ts
@@ -8,7 +8,7 @@ import {
   type QueryResultMetaStat,
   generateUUID,
 } from '@grafana/data';
-import { config } from '@grafana/runtime';
+import { config, logStructuredDebug } from '@grafana/runtime';
 
 import { type LokiDatasource } from './datasource';
 import { combineResponses, replaceResponses } from './mergeResponses';
@@ -380,5 +380,5 @@ function debug(message: string) {
   if (!DEBUG_ENABLED) {
     return;
   }
-  console.log(message);
+  logStructuredDebug('plugins.datasource.loki', message);
 }

--- a/public/app/plugins/panel/canvas/components/connections/Connections.tsx
+++ b/public/app/plugins/panel/canvas/components/connections/Connections.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { BehaviorSubject } from 'rxjs';
 
-import { config } from '@grafana/runtime';
+import { config, logStructuredDebug } from '@grafana/runtime';
 import { type CanvasConnection, type ConnectionCoordinates, ConnectionPath } from 'app/features/canvas/element';
 import { type ElementState } from 'app/features/canvas/runtime/element';
 import { type Scene } from 'app/features/canvas/runtime/scene';
@@ -135,7 +135,7 @@ export class Connections {
     let element: ElementState | undefined = this.findElementTarget(event.target);
 
     if (!element) {
-      console.log('no element');
+      logStructuredDebug('plugins.panel.canvas', 'no element');
       return;
     }
 
@@ -144,7 +144,7 @@ export class Connections {
     } else {
       this.connectionSource = element;
       if (!this.connectionSource) {
-        console.log('no connection source');
+        logStructuredDebug('plugins.panel.canvas', 'no connection source');
         return;
       }
     }

--- a/public/app/plugins/panel/canvas/components/connections/Connections2.tsx
+++ b/public/app/plugins/panel/canvas/components/connections/Connections2.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { BehaviorSubject } from 'rxjs';
 
-import { config } from '@grafana/runtime';
+import { config, logStructuredDebug } from '@grafana/runtime';
 import { type CanvasConnection, type ConnectionCoordinates, ConnectionPath } from 'app/features/canvas/element';
 import { type ElementState } from 'app/features/canvas/runtime/element';
 import { type Scene } from 'app/features/canvas/runtime/scene';
@@ -128,7 +128,7 @@ export class Connections2 {
     let element: ElementState | undefined = this.findElementTarget(event.target);
 
     if (!element) {
-      console.log('no element');
+      logStructuredDebug('plugins.panel.canvas', 'no element');
       return;
     }
 
@@ -137,7 +137,7 @@ export class Connections2 {
     } else {
       this.connectionSource = element;
       if (!this.connectionSource) {
-        console.log('no connection source');
+        logStructuredDebug('plugins.panel.canvas', 'no connection source');
         return;
       }
     }

--- a/public/app/plugins/panel/live/LivePanel.tsx
+++ b/public/app/plugins/panel/live/LivePanel.tsx
@@ -19,7 +19,7 @@ import {
   StreamingDataFrame,
 } from '@grafana/data';
 import { Trans, t } from '@grafana/i18n';
-import { config, getGrafanaLiveSrv } from '@grafana/runtime';
+import { config, getGrafanaLiveSrv, logStructuredDebug } from '@grafana/runtime';
 import { Alert, stylesFactory, JSONFormatter, CustomScrollbar } from '@grafana/ui';
 
 import { TablePanel } from '../table/TablePanel';
@@ -72,7 +72,7 @@ export class LivePanel extends PureComponent<Props, State> {
       } else if (isLiveChannelMessageEvent(event)) {
         this.setState({ message: event.message, changed: Date.now() });
       } else {
-        console.log('ignore', event);
+        logStructuredDebug('plugins.panel.live', 'ignore', event);
       }
     },
   };
@@ -87,7 +87,7 @@ export class LivePanel extends PureComponent<Props, State> {
   async loadChannel() {
     const addr = this.props.options?.channel;
     if (!isValidLiveChannelAddress(addr)) {
-      console.log('INVALID', addr);
+      logStructuredDebug('plugins.panel.live', 'INVALID', addr);
       this.unsubscribe();
       this.setState({
         addr: undefined,
@@ -96,13 +96,13 @@ export class LivePanel extends PureComponent<Props, State> {
     }
 
     if (isEqual(addr, this.state.addr)) {
-      console.log('Same channel', this.state.addr);
+      logStructuredDebug('plugins.panel.live', 'Same channel', this.state.addr);
       return;
     }
 
     const live = getGrafanaLiveSrv();
     if (!live) {
-      console.log('INVALID', addr);
+      logStructuredDebug('plugins.panel.live', 'INVALID', addr);
       this.unsubscribe();
       this.setState({
         addr: undefined,
@@ -111,7 +111,7 @@ export class LivePanel extends PureComponent<Props, State> {
     }
     this.unsubscribe();
 
-    console.log('LOAD', addr);
+    logStructuredDebug('plugins.panel.live', 'LOAD', addr);
 
     // Subscribe to new events
     try {

--- a/public/app/plugins/panel/live/LivePublish.tsx
+++ b/public/app/plugins/panel/live/LivePublish.tsx
@@ -2,7 +2,7 @@ import { useMemo } from 'react';
 
 import { type LiveChannelAddress, isValidLiveChannelAddress } from '@grafana/data';
 import { Trans } from '@grafana/i18n';
-import { getBackendSrv, getGrafanaLiveSrv } from '@grafana/runtime';
+import { getBackendSrv, getGrafanaLiveSrv, logStructuredDebug } from '@grafana/runtime';
 import { CodeEditor, Button } from '@grafana/ui';
 
 import { MessagePublishMode } from './types';
@@ -46,7 +46,7 @@ export function LivePublish({ height, mode, body, addr, onSave }: Props) {
     }
 
     const rsp = await getGrafanaLiveSrv().publish(addr, body);
-    console.log('onPublishClicked (response from publish)', rsp);
+    logStructuredDebug('plugins.panel.live', 'onPublishClicked (response from publish)', rsp);
   };
 
   return (

--- a/public/app/plugins/panel/table/migrations.ts
+++ b/public/app/plugins/panel/table/migrations.ts
@@ -12,6 +12,7 @@ import {
   ByNamesMatcherMode,
 } from '@grafana/data';
 import { type ReduceTransformerOptions } from '@grafana/data/internal';
+import { logStructuredDebug } from '@grafana/runtime';
 
 import { type Options } from './panelcfg.gen';
 
@@ -23,7 +24,7 @@ import { type Options } from './panelcfg.gen';
 export const tableMigrationHandler = (panel: PanelModel<Options>): Partial<Options> => {
   // Table was saved as an angular table, lets just swap to the 'table-old' panel
   if (!panel.pluginVersion && 'columns' in panel) {
-    console.log('Was angular table', panel);
+    logStructuredDebug('plugins.panel.table', 'Was angular table', panel);
   }
 
   // ensure overrides array exists before applying rest of overrides

--- a/public/app/plugins/panel/timeseries/migrations.ts
+++ b/public/app/plugins/panel/timeseries/migrations.ts
@@ -16,6 +16,7 @@ import {
   type Threshold,
   ThresholdsMode,
 } from '@grafana/data';
+import { logStructuredDebug } from '@grafana/runtime';
 import {
   LegendDisplayMode,
   TooltipDisplayMode,
@@ -283,7 +284,7 @@ function graphToTimeseriesOptions(angular: any): {
             });
             break;
           default:
-            console.log('Ignore override migration:', seriesOverride.alias, p, v);
+            logStructuredDebug('plugins.panel.timeseries', 'Ignore override migration:', seriesOverride.alias, p, v);
         }
       }
       if (dashOverride) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
**What is this feature?**

Replaces shipped frontend `console.log` debug traces with a structured debug logging helper exported from `@grafana/runtime`.

**Why do we need this feature?**

Direct console logs are hard to filter, correlate, and route through Grafana's runtime logging pipeline. The new helper preserves debug messages while attaching a source and serialized arguments as structured context.

**Who is this feature for?**

Grafana frontend maintainers and operators who need cleaner client-side diagnostics.

**Which issue(s) does this PR fix?**:

Fixes #

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle. Not applicable.
- [x] The docs are updated, and if this is a notable improvement, it's added to What's New. Not applicable.

Validation:
- `yarn workspace @grafana-plugins/loki jest --runTestsByPath shardQuerySplitting.test.ts --runInBand --no-watch`
- `NODE_OPTIONS=--max-old-space-size=8192 yarn typecheck`
- `yarn eslint packages/grafana-runtime/src/utils/structuredLogging.ts $(git diff --name-only -- '*.ts' '*.tsx') --no-error-on-unmatched-pattern`
- `rg "\\bconsole\\.log\\b" public/app packages/grafana-runtime/src packages/grafana-data/src`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d66f3c59-5e69-4fca-b756-e1bb37f18941"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d66f3c59-5e69-4fca-b756-e1bb37f18941"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

