### PR TITLE
API: Migrate annotations to generated API spec

### DIFF
--- a/apps/annotation/kinds/manifest.cue
+++ b/apps/annotation/kinds/manifest.cue
@@ -16,6 +16,12 @@ v0alpha1: {
 			"/tags": {
 				"GET": {
 					name: "getTags"
+					request: {
+						query: {
+							prefix?: string
+							limit?:  int64 | 100
+						}
+					}
 					response: {
 						tags: [...{
 							tag:   string
@@ -27,6 +33,22 @@ v0alpha1: {
 			"/search": {
 				"GET": {
 					name: "getSearch"
+					request: {
+						query: {
+							from?:           int64
+							to?:             int64
+							limit?:          int64 | 100
+							continue?:       string
+							dashboardUID?:   string
+							panelID?:        int64
+							tag?:            [...string]
+							tagsMatchAny?:   bool
+							scope?:          [...string]
+							scopesMatchAny?: bool
+							createdBy?:      string
+							legacyID?:       int64
+						}
+					}
 					response: {
 						apiVersion: string
 						kind:       string

--- a/apps/annotation/pkg/apis/annotation/v0alpha1/annotation_schema_gen.go
+++ b/apps/annotation/pkg/apis/annotation/v0alpha1/annotation_schema_gen.go
@@ -14,7 +14,7 @@ import (
 // schema is unexported to prevent accidental overwrites
 var (
 	schemaAnnotation = resource.NewSimpleSchema("annotation.grafana.app", "v0alpha1", NewAnnotation(), &AnnotationList{}, resource.WithKind("Annotation"),
-		resource.WithPlural("annotations"), resource.WithScope(resource.NamespacedScope), resource.WithSelectableFields([]resource.SelectableField{{
+		resource.WithPlural("annotations"), resource.WithScope(resource.NamespacedScope), resource.WithSelectableFields([]resource.SelectableField{resource.SelectableField{
 			FieldSelector: "spec.time",
 			FieldValueFunc: func(o resource.Object) (string, error) {
 				cast, ok := o.(*Annotation)
@@ -25,7 +25,7 @@ var (
 				return fmt.Sprintf("%d", cast.Spec.Time), nil
 			},
 		},
-			{
+			resource.SelectableField{
 				FieldSelector: "spec.timeEnd",
 				FieldValueFunc: func(o resource.Object) (string, error) {
 					cast, ok := o.(*Annotation)
@@ -39,7 +39,7 @@ var (
 					return fmt.Sprintf("%d", *cast.Spec.TimeEnd), nil
 				},
 			},
-			{
+			resource.SelectableField{
 				FieldSelector: "spec.dashboardUID",
 				FieldValueFunc: func(o resource.Object) (string, error) {
 					cast, ok := o.(*Annotation)
@@ -53,7 +53,7 @@ var (
 					return string(*cast.Spec.DashboardUID), nil
 				},
 			},
-			{
+			resource.SelectableField{
 				FieldSelector: "spec.panelID",
 				FieldValueFunc: func(o resource.Object) (string, error) {
 					cast, ok := o.(*Annotation)

--- a/apps/annotation/pkg/apis/annotation/v0alpha1/client_gen.go
+++ b/apps/annotation/pkg/apis/annotation/v0alpha1/client_gen.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"net/url"
 
 	"github.com/grafana/grafana-app-sdk/resource"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -30,13 +31,16 @@ func NewCustomRouteClientFromGenerator(generator resource.ClientGenerator, defau
 }
 
 type GetSearchRequest struct {
+	Params  GetSearchRequestParams
 	Headers http.Header
 }
 
 func (c *CustomRouteClient) GetSearch(ctx context.Context, namespace string, request GetSearchRequest) (*GetSearchResponse, error) {
+	params := url.Values{}
 	resp, err := c.NamespacedRequest(ctx, namespace, resource.CustomRouteRequestOptions{
 		Path:    "/search",
 		Verb:    "GET",
+		Query:   params,
 		Headers: request.Headers,
 	})
 	if err != nil {
@@ -51,13 +55,16 @@ func (c *CustomRouteClient) GetSearch(ctx context.Context, namespace string, req
 }
 
 type GetTagsRequest struct {
+	Params  GetTagsRequestParams
 	Headers http.Header
 }
 
 func (c *CustomRouteClient) GetTags(ctx context.Context, namespace string, request GetTagsRequest) (*GetTagsResponse, error) {
+	params := url.Values{}
 	resp, err := c.NamespacedRequest(ctx, namespace, resource.CustomRouteRequestOptions{
 		Path:    "/tags",
 		Verb:    "GET",
+		Query:   params,
 		Headers: request.Headers,
 	})
 	if err != nil {

--- a/apps/annotation/pkg/apis/annotation/v0alpha1/getsearch_request_params_object_gen.go
+++ b/apps/annotation/pkg/apis/annotation/v0alpha1/getsearch_request_params_object_gen.go
@@ -1,0 +1,37 @@
+// Code generated - EDITING IS FUTILE. DO NOT EDIT.
+
+package v0alpha1
+
+import (
+	"github.com/grafana/grafana-app-sdk/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+type GetSearchRequestParamsObject struct {
+	metav1.TypeMeta        `json:",inline"`
+	GetSearchRequestParams `json:",inline"`
+}
+
+func NewGetSearchRequestParamsObject() *GetSearchRequestParamsObject {
+	return &GetSearchRequestParamsObject{}
+}
+
+func (o *GetSearchRequestParamsObject) DeepCopyObject() runtime.Object {
+	dst := NewGetSearchRequestParamsObject()
+	o.DeepCopyInto(dst)
+	return dst
+}
+
+func (o *GetSearchRequestParamsObject) DeepCopyInto(dst *GetSearchRequestParamsObject) {
+	dst.TypeMeta.APIVersion = o.TypeMeta.APIVersion
+	dst.TypeMeta.Kind = o.TypeMeta.Kind
+	dstGetSearchRequestParams := GetSearchRequestParams{}
+	_ = resource.CopyObjectInto(&dstGetSearchRequestParams, &o.GetSearchRequestParams)
+}
+
+func (GetSearchRequestParamsObject) OpenAPIModelName() string {
+	return "com.github.grafana.grafana.apps.annotation.pkg.apis.annotation.v0alpha1.GetSearchRequestParamsObject"
+}
+
+var _ runtime.Object = NewGetSearchRequestParamsObject()

--- a/apps/annotation/pkg/apis/annotation/v0alpha1/getsearch_request_params_types_gen.go
+++ b/apps/annotation/pkg/apis/annotation/v0alpha1/getsearch_request_params_types_gen.go
@@ -1,0 +1,28 @@
+// Code generated - EDITING IS FUTILE. DO NOT EDIT.
+
+package v0alpha1
+
+type GetSearchRequestParams struct {
+	From           *int64   `json:"from,omitempty"`
+	To             *int64   `json:"to,omitempty"`
+	Limit          int64    `json:"limit,omitempty"`
+	Continue       *string  `json:"continue,omitempty"`
+	DashboardUID   *string  `json:"dashboardUID,omitempty"`
+	PanelID        *int64   `json:"panelID,omitempty"`
+	Tag            []string `json:"tag,omitempty"`
+	TagsMatchAny   *bool    `json:"tagsMatchAny,omitempty"`
+	Scope          []string `json:"scope,omitempty"`
+	ScopesMatchAny *bool    `json:"scopesMatchAny,omitempty"`
+	CreatedBy      *string  `json:"createdBy,omitempty"`
+	LegacyID       *int64   `json:"legacyID,omitempty"`
+}
+
+// NewGetSearchRequestParams creates a new GetSearchRequestParams object.
+func NewGetSearchRequestParams() *GetSearchRequestParams {
+	return &GetSearchRequestParams{}
+}
+
+// OpenAPIModelName returns the OpenAPI model name for GetSearchRequestParams.
+func (GetSearchRequestParams) OpenAPIModelName() string {
+	return "com.github.grafana.grafana.apps.annotation.pkg.apis.annotation.v0alpha1.GetSearchRequestParams"
+}

--- a/apps/annotation/pkg/apis/annotation/v0alpha1/gettags_request_params_object_gen.go
+++ b/apps/annotation/pkg/apis/annotation/v0alpha1/gettags_request_params_object_gen.go
@@ -1,0 +1,37 @@
+// Code generated - EDITING IS FUTILE. DO NOT EDIT.
+
+package v0alpha1
+
+import (
+	"github.com/grafana/grafana-app-sdk/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+type GetTagsRequestParamsObject struct {
+	metav1.TypeMeta      `json:",inline"`
+	GetTagsRequestParams `json:",inline"`
+}
+
+func NewGetTagsRequestParamsObject() *GetTagsRequestParamsObject {
+	return &GetTagsRequestParamsObject{}
+}
+
+func (o *GetTagsRequestParamsObject) DeepCopyObject() runtime.Object {
+	dst := NewGetTagsRequestParamsObject()
+	o.DeepCopyInto(dst)
+	return dst
+}
+
+func (o *GetTagsRequestParamsObject) DeepCopyInto(dst *GetTagsRequestParamsObject) {
+	dst.TypeMeta.APIVersion = o.TypeMeta.APIVersion
+	dst.TypeMeta.Kind = o.TypeMeta.Kind
+	dstGetTagsRequestParams := GetTagsRequestParams{}
+	_ = resource.CopyObjectInto(&dstGetTagsRequestParams, &o.GetTagsRequestParams)
+}
+
+func (GetTagsRequestParamsObject) OpenAPIModelName() string {
+	return "com.github.grafana.grafana.apps.annotation.pkg.apis.annotation.v0alpha1.GetTagsRequestParamsObject"
+}
+
+var _ runtime.Object = NewGetTagsRequestParamsObject()

--- a/apps/annotation/pkg/apis/annotation/v0alpha1/gettags_request_params_types_gen.go
+++ b/apps/annotation/pkg/apis/annotation/v0alpha1/gettags_request_params_types_gen.go
@@ -1,0 +1,18 @@
+// Code generated - EDITING IS FUTILE. DO NOT EDIT.
+
+package v0alpha1
+
+type GetTagsRequestParams struct {
+	Prefix *string `json:"prefix,omitempty"`
+	Limit  int64   `json:"limit,omitempty"`
+}
+
+// NewGetTagsRequestParams creates a new GetTagsRequestParams object.
+func NewGetTagsRequestParams() *GetTagsRequestParams {
+	return &GetTagsRequestParams{}
+}
+
+// OpenAPIModelName returns the OpenAPI model name for GetTagsRequestParams.
+func (GetTagsRequestParams) OpenAPIModelName() string {
+	return "com.github.grafana.grafana.apps.annotation.pkg.apis.annotation.v0alpha1.GetTagsRequestParams"
+}

--- a/apps/annotation/pkg/apis/annotation_manifest.go
+++ b/apps/annotation/pkg/apis/annotation_manifest.go
@@ -57,6 +57,163 @@ var appManifestData = app.ManifestData{
 
 								OperationId: "getSearch",
 
+								Parameters: []*spec3.Parameter{
+
+									{
+										ParameterProps: spec3.ParameterProps{
+											Name: "continue",
+											In:   "query",
+											Schema: &spec.Schema{
+												SchemaProps: spec.SchemaProps{
+													Type: []string{"string"},
+												},
+											},
+										},
+									},
+
+									{
+										ParameterProps: spec3.ParameterProps{
+											Name: "createdBy",
+											In:   "query",
+											Schema: &spec.Schema{
+												SchemaProps: spec.SchemaProps{
+													Type: []string{"string"},
+												},
+											},
+										},
+									},
+
+									{
+										ParameterProps: spec3.ParameterProps{
+											Name: "dashboardUID",
+											In:   "query",
+											Schema: &spec.Schema{
+												SchemaProps: spec.SchemaProps{
+													Type: []string{"string"},
+												},
+											},
+										},
+									},
+
+									{
+										ParameterProps: spec3.ParameterProps{
+											Name: "from",
+											In:   "query",
+											Schema: &spec.Schema{
+												SchemaProps: spec.SchemaProps{
+													Type: []string{"integer"},
+												},
+											},
+										},
+									},
+
+									{
+										ParameterProps: spec3.ParameterProps{
+											Name: "legacyID",
+											In:   "query",
+											Schema: &spec.Schema{
+												SchemaProps: spec.SchemaProps{
+													Type: []string{"integer"},
+												},
+											},
+										},
+									},
+
+									{
+										ParameterProps: spec3.ParameterProps{
+											Name: "limit",
+											In:   "query",
+											Schema: &spec.Schema{
+												SchemaProps: spec.SchemaProps{},
+											},
+										},
+									},
+
+									{
+										ParameterProps: spec3.ParameterProps{
+											Name: "panelID",
+											In:   "query",
+											Schema: &spec.Schema{
+												SchemaProps: spec.SchemaProps{
+													Type: []string{"integer"},
+												},
+											},
+										},
+									},
+
+									{
+										ParameterProps: spec3.ParameterProps{
+											Name: "scope",
+											In:   "query",
+											Schema: &spec.Schema{
+												SchemaProps: spec.SchemaProps{
+													Type: []string{"array"},
+													Items: &spec.SchemaOrArray{
+														Schema: &spec.Schema{
+															SchemaProps: spec.SchemaProps{
+																Type: []string{"string"},
+															}},
+													},
+												},
+											},
+										},
+									},
+
+									{
+										ParameterProps: spec3.ParameterProps{
+											Name: "scopesMatchAny",
+											In:   "query",
+											Schema: &spec.Schema{
+												SchemaProps: spec.SchemaProps{
+													Type: []string{"boolean"},
+												},
+											},
+										},
+									},
+
+									{
+										ParameterProps: spec3.ParameterProps{
+											Name: "tag",
+											In:   "query",
+											Schema: &spec.Schema{
+												SchemaProps: spec.SchemaProps{
+													Type: []string{"array"},
+													Items: &spec.SchemaOrArray{
+														Schema: &spec.Schema{
+															SchemaProps: spec.SchemaProps{
+																Type: []string{"string"},
+															}},
+													},
+												},
+											},
+										},
+									},
+
+									{
+										ParameterProps: spec3.ParameterProps{
+											Name: "tagsMatchAny",
+											In:   "query",
+											Schema: &spec.Schema{
+												SchemaProps: spec.SchemaProps{
+													Type: []string{"boolean"},
+												},
+											},
+										},
+									},
+
+									{
+										ParameterProps: spec3.ParameterProps{
+											Name: "to",
+											In:   "query",
+											Schema: &spec.Schema{
+												SchemaProps: spec.SchemaProps{
+													Type: []string{"integer"},
+												},
+											},
+										},
+									},
+								},
+
 								Responses: &spec3.Responses{
 									ResponsesProps: spec3.ResponsesProps{
 										Default: &spec3.Response{
@@ -119,6 +276,31 @@ var appManifestData = app.ManifestData{
 							OperationProps: spec3.OperationProps{
 
 								OperationId: "getTags",
+
+								Parameters: []*spec3.Parameter{
+
+									{
+										ParameterProps: spec3.ParameterProps{
+											Name: "limit",
+											In:   "query",
+											Schema: &spec.Schema{
+												SchemaProps: spec.SchemaProps{},
+											},
+										},
+									},
+
+									{
+										ParameterProps: spec3.ParameterProps{
+											Name: "prefix",
+											In:   "query",
+											Schema: &spec.Schema{
+												SchemaProps: spec.SchemaProps{
+													Type: []string{"string"},
+												},
+											},
+										},
+									},
+								},
 
 								Responses: &spec3.Responses{
 									ResponsesProps: spec3.ResponsesProps{

--- a/packages/grafana-api-clients/package.json
+++ b/packages/grafana-api-clients/package.json
@@ -55,6 +55,12 @@
       "import": "./dist/esm/clients/rtkq/advisor/v0alpha1/index.mjs",
       "require": "./dist/cjs/clients/rtkq/advisor/v0alpha1/index.cjs"
     },
+    "./rtkq/annotation/v0alpha1": {
+      "@grafana-app/source": "./src/clients/rtkq/annotation/v0alpha1/index.ts",
+      "types": "./dist/types/clients/rtkq/annotation/v0alpha1/index.d.ts",
+      "import": "./dist/esm/clients/rtkq/annotation/v0alpha1/index.mjs",
+      "require": "./dist/cjs/clients/rtkq/annotation/v0alpha1/index.cjs"
+    },
     "./rtkq/collections/v1alpha1": {
       "@grafana-app/source": "./src/clients/rtkq/collections/v1alpha1/index.ts",
       "types": "./dist/types/clients/rtkq/collections/v1alpha1/index.d.ts",

--- a/packages/grafana-api-clients/src/clients/rtkq/annotation/v0alpha1/baseAPI.ts
+++ b/packages/grafana-api-clients/src/clients/rtkq/annotation/v0alpha1/baseAPI.ts
@@ -1,0 +1,16 @@
+import { createApi } from '@reduxjs/toolkit/query/react';
+
+import { getAPIBaseURL } from '../../../../utils/utils';
+import { createBaseQuery } from '../../createBaseQuery';
+
+export const API_GROUP = 'annotation.grafana.app' as const;
+export const API_VERSION = 'v0alpha1' as const;
+export const BASE_URL = getAPIBaseURL(API_GROUP, API_VERSION);
+
+export const api = createApi({
+  reducerPath: 'annotationAPIv0alpha1',
+  baseQuery: createBaseQuery({
+    baseURL: BASE_URL,
+  }),
+  endpoints: () => ({}),
+});

--- a/packages/grafana-api-clients/src/clients/rtkq/annotation/v0alpha1/endpoints.gen.ts
+++ b/packages/grafana-api-clients/src/clients/rtkq/annotation/v0alpha1/endpoints.gen.ts
@@ -1,0 +1,576 @@
+import { api } from './baseAPI';
+export const addTagTypes = ['API Discovery', 'Annotation'] as const;
+const injectedRtkApi = api
+  .enhanceEndpoints({
+    addTagTypes,
+  })
+  .injectEndpoints({
+    endpoints: (build) => ({
+      getApiResources: build.query<GetApiResourcesApiResponse, GetApiResourcesApiArg>({
+        query: () => ({ url: `/` }),
+        providesTags: ['API Discovery'],
+      }),
+      listAnnotation: build.query<ListAnnotationApiResponse, ListAnnotationApiArg>({
+        query: (queryArg) => ({
+          url: `/annotations`,
+          params: {
+            pretty: queryArg.pretty,
+            continue: queryArg['continue'],
+            fieldSelector: queryArg.fieldSelector,
+            labelSelector: queryArg.labelSelector,
+            limit: queryArg.limit,
+            resourceVersion: queryArg.resourceVersion,
+            timeoutSeconds: queryArg.timeoutSeconds,
+            watch: queryArg.watch,
+          },
+        }),
+        providesTags: ['Annotation'],
+      }),
+      createAnnotation: build.mutation<CreateAnnotationApiResponse, CreateAnnotationApiArg>({
+        query: (queryArg) => ({
+          url: `/annotations`,
+          method: 'POST',
+          body: queryArg.annotation,
+          params: {
+            pretty: queryArg.pretty,
+            dryRun: queryArg.dryRun,
+            fieldManager: queryArg.fieldManager,
+            fieldValidation: queryArg.fieldValidation,
+          },
+        }),
+        invalidatesTags: ['Annotation'],
+      }),
+      getAnnotation: build.query<GetAnnotationApiResponse, GetAnnotationApiArg>({
+        query: (queryArg) => ({
+          url: `/annotations/${queryArg.name}`,
+          params: {
+            pretty: queryArg.pretty,
+          },
+        }),
+        providesTags: ['Annotation'],
+      }),
+      replaceAnnotation: build.mutation<ReplaceAnnotationApiResponse, ReplaceAnnotationApiArg>({
+        query: (queryArg) => ({
+          url: `/annotations/${queryArg.name}`,
+          method: 'PUT',
+          body: queryArg.annotation,
+          params: {
+            pretty: queryArg.pretty,
+            dryRun: queryArg.dryRun,
+            fieldManager: queryArg.fieldManager,
+            fieldValidation: queryArg.fieldValidation,
+          },
+        }),
+        invalidatesTags: ['Annotation'],
+      }),
+      deleteAnnotation: build.mutation<DeleteAnnotationApiResponse, DeleteAnnotationApiArg>({
+        query: (queryArg) => ({
+          url: `/annotations/${queryArg.name}`,
+          method: 'DELETE',
+          params: {
+            pretty: queryArg.pretty,
+            dryRun: queryArg.dryRun,
+            gracePeriodSeconds: queryArg.gracePeriodSeconds,
+            ignoreStoreReadErrorWithClusterBreakingPotential: queryArg.ignoreStoreReadErrorWithClusterBreakingPotential,
+            orphanDependents: queryArg.orphanDependents,
+            propagationPolicy: queryArg.propagationPolicy,
+          },
+        }),
+        invalidatesTags: ['Annotation'],
+      }),
+      updateAnnotation: build.mutation<UpdateAnnotationApiResponse, UpdateAnnotationApiArg>({
+        query: (queryArg) => ({
+          url: `/annotations/${queryArg.name}`,
+          method: 'PATCH',
+          body: queryArg.patch,
+          params: {
+            pretty: queryArg.pretty,
+            dryRun: queryArg.dryRun,
+            fieldManager: queryArg.fieldManager,
+            fieldValidation: queryArg.fieldValidation,
+            force: queryArg.force,
+          },
+        }),
+        invalidatesTags: ['Annotation'],
+      }),
+      getAnnotationStatus: build.query<GetAnnotationStatusApiResponse, GetAnnotationStatusApiArg>({
+        query: (queryArg) => ({
+          url: `/annotations/${queryArg.name}/status`,
+          params: {
+            pretty: queryArg.pretty,
+          },
+        }),
+        providesTags: ['Annotation'],
+      }),
+      replaceAnnotationStatus: build.mutation<ReplaceAnnotationStatusApiResponse, ReplaceAnnotationStatusApiArg>({
+        query: (queryArg) => ({
+          url: `/annotations/${queryArg.name}/status`,
+          method: 'PUT',
+          body: queryArg.annotation,
+          params: {
+            pretty: queryArg.pretty,
+            dryRun: queryArg.dryRun,
+            fieldManager: queryArg.fieldManager,
+            fieldValidation: queryArg.fieldValidation,
+          },
+        }),
+        invalidatesTags: ['Annotation'],
+      }),
+      updateAnnotationStatus: build.mutation<UpdateAnnotationStatusApiResponse, UpdateAnnotationStatusApiArg>({
+        query: (queryArg) => ({
+          url: `/annotations/${queryArg.name}/status`,
+          method: 'PATCH',
+          body: queryArg.patch,
+          params: {
+            pretty: queryArg.pretty,
+            dryRun: queryArg.dryRun,
+            fieldManager: queryArg.fieldManager,
+            fieldValidation: queryArg.fieldValidation,
+            force: queryArg.force,
+          },
+        }),
+        invalidatesTags: ['Annotation'],
+      }),
+      getSearch: build.query<GetSearchApiResponse, GetSearchApiArg>({
+        query: (queryArg) => ({
+          url: `/search`,
+          params: {
+            continue: queryArg['continue'],
+            createdBy: queryArg.createdBy,
+            dashboardUID: queryArg.dashboardUid,
+            from: queryArg['from'],
+            legacyID: queryArg.legacyId,
+            limit: queryArg.limit,
+            panelID: queryArg.panelId,
+            scope: queryArg.scope,
+            scopesMatchAny: queryArg.scopesMatchAny,
+            tag: queryArg.tag,
+            tagsMatchAny: queryArg.tagsMatchAny,
+            to: queryArg.to,
+          },
+        }),
+      }),
+      getTags: build.query<GetTagsApiResponse, GetTagsApiArg>({
+        query: (queryArg) => ({
+          url: `/tags`,
+          params: {
+            limit: queryArg.limit,
+            prefix: queryArg.prefix,
+          },
+        }),
+      }),
+    }),
+    overrideExisting: false,
+  });
+export { injectedRtkApi as generatedAPI };
+export type GetApiResourcesApiResponse = /** status 200 OK */ ApiResourceList;
+export type GetApiResourcesApiArg = void;
+export type ListAnnotationApiResponse = /** status 200 OK */ AnnotationList;
+export type ListAnnotationApiArg = {
+  /** If 'true', then the output is pretty printed. Defaults to 'false' unless the user-agent indicates a browser or command-line HTTP tool (curl and wget). */
+  pretty?: string;
+  /** The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the "next key".
+    
+    This field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications. */
+  continue?: string;
+  /** A selector to restrict the list of returned objects by their fields. Defaults to everything. */
+  fieldSelector?: string;
+  /** A selector to restrict the list of returned objects by their labels. Defaults to everything. */
+  labelSelector?: string;
+  /** limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.
+    
+    The server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned. */
+  limit?: number;
+  /** resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.
+    
+    Defaults to unset */
+  resourceVersion?: string;
+  /** Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity. */
+  timeoutSeconds?: number;
+  /** Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion. */
+  watch?: boolean;
+};
+export type CreateAnnotationApiResponse = /** status 200 OK */
+  | Annotation
+  | /** status 201 Created */ Annotation
+  | /** status 202 Accepted */ Annotation;
+export type CreateAnnotationApiArg = {
+  /** If 'true', then the output is pretty printed. Defaults to 'false' unless the user-agent indicates a browser or command-line HTTP tool (curl and wget). */
+  pretty?: string;
+  /** When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed */
+  dryRun?: string;
+  /** fieldManager is a name associated with the actor or entity that is making these changes. The value must be less than or 128 characters long, and only contain printable characters, as defined by https://golang.org/pkg/unicode/#IsPrint. */
+  fieldManager?: string;
+  /** fieldValidation instructs the server on how to handle objects in the request (POST/PUT/PATCH) containing unknown or duplicate fields. Valid values are: - Ignore: This will ignore any unknown fields that are silently dropped from the object, and will ignore all but the last duplicate field that the decoder encounters. This is the default behavior prior to v1.23. - Warn: This will send a warning via the standard warning response header for each unknown field that is dropped from the object, and for each duplicate field that is encountered. The request will still succeed if there are no other errors, and will only persist the last of any duplicate fields. This is the default in v1.23+ - Strict: This will fail the request with a BadRequest error if any unknown fields would be dropped from the object, or if any duplicate fields are present. The error returned from the server will contain all unknown and duplicate fields encountered. */
+  fieldValidation?: string;
+  annotation: Annotation;
+};
+export type GetAnnotationApiResponse = /** status 200 OK */ Annotation;
+export type GetAnnotationApiArg = {
+  /** name of the Annotation */
+  name: string;
+  /** If 'true', then the output is pretty printed. Defaults to 'false' unless the user-agent indicates a browser or command-line HTTP tool (curl and wget). */
+  pretty?: string;
+};
+export type ReplaceAnnotationApiResponse = /** status 200 OK */ Annotation | /** status 201 Created */ Annotation;
+export type ReplaceAnnotationApiArg = {
+  /** name of the Annotation */
+  name: string;
+  /** If 'true', then the output is pretty printed. Defaults to 'false' unless the user-agent indicates a browser or command-line HTTP tool (curl and wget). */
+  pretty?: string;
+  /** When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed */
+  dryRun?: string;
+  /** fieldManager is a name associated with the actor or entity that is making these changes. The value must be less than or 128 characters long, and only contain printable characters, as defined by https://golang.org/pkg/unicode/#IsPrint. */
+  fieldManager?: string;
+  /** fieldValidation instructs the server on how to handle objects in the request (POST/PUT/PATCH) containing unknown or duplicate fields. Valid values are: - Ignore: This will ignore any unknown fields that are silently dropped from the object, and will ignore all but the last duplicate field that the decoder encounters. This is the default behavior prior to v1.23. - Warn: This will send a warning via the standard warning response header for each unknown field that is dropped from the object, and for each duplicate field that is encountered. The request will still succeed if there are no other errors, and will only persist the last of any duplicate fields. This is the default in v1.23+ - Strict: This will fail the request with a BadRequest error if any unknown fields would be dropped from the object, or if any duplicate fields are present. The error returned from the server will contain all unknown and duplicate fields encountered. */
+  fieldValidation?: string;
+  annotation: Annotation;
+};
+export type DeleteAnnotationApiResponse = /** status 200 OK */ Status | /** status 202 Accepted */ Status;
+export type DeleteAnnotationApiArg = {
+  /** name of the Annotation */
+  name: string;
+  /** If 'true', then the output is pretty printed. Defaults to 'false' unless the user-agent indicates a browser or command-line HTTP tool (curl and wget). */
+  pretty?: string;
+  /** When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed */
+  dryRun?: string;
+  /** The duration in seconds before the object should be deleted. Value must be non-negative integer. The value zero indicates delete immediately. If this value is nil, the default grace period for the specified type will be used. Defaults to a per object value if not specified. zero means delete immediately. */
+  gracePeriodSeconds?: number;
+  /** if set to true, it will trigger an unsafe deletion of the resource in case the normal deletion flow fails with a corrupt object error. A resource is considered corrupt if it can not be retrieved from the underlying storage successfully because of a) its data can not be transformed e.g. decryption failure, or b) it fails to decode into an object. NOTE: unsafe deletion ignores finalizer constraints, skips precondition checks, and removes the object from the storage. WARNING: This may potentially break the cluster if the workload associated with the resource being unsafe-deleted relies on normal deletion flow. Use only if you REALLY know what you are doing. The default value is false, and the user must opt in to enable it */
+  ignoreStoreReadErrorWithClusterBreakingPotential?: boolean;
+  /** Deprecated: please use the PropagationPolicy, this field will be deprecated in 1.7. Should the dependent objects be orphaned. If true/false, the "orphan" finalizer will be added to/removed from the object's finalizers list. Either this field or PropagationPolicy may be set, but not both. */
+  orphanDependents?: boolean;
+  /** Whether and how garbage collection will be performed. Either this field or OrphanDependents may be set, but not both. The default policy is decided by the existing finalizer set in the metadata.finalizers and the resource-specific default policy. Acceptable values are: 'Orphan' - orphan the dependents; 'Background' - allow the garbage collector to delete the dependents in the background; 'Foreground' - a cascading policy that deletes all dependents in the foreground. */
+  propagationPolicy?: string;
+};
+export type UpdateAnnotationApiResponse = /** status 200 OK */ Annotation | /** status 201 Created */ Annotation;
+export type UpdateAnnotationApiArg = {
+  /** name of the Annotation */
+  name: string;
+  /** If 'true', then the output is pretty printed. Defaults to 'false' unless the user-agent indicates a browser or command-line HTTP tool (curl and wget). */
+  pretty?: string;
+  /** When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed */
+  dryRun?: string;
+  /** fieldManager is a name associated with the actor or entity that is making these changes. The value must be less than or 128 characters long, and only contain printable characters, as defined by https://golang.org/pkg/unicode/#IsPrint. This field is required for apply requests (application/apply-patch) but optional for non-apply patch types (JsonPatch, MergePatch, StrategicMergePatch). */
+  fieldManager?: string;
+  /** fieldValidation instructs the server on how to handle objects in the request (POST/PUT/PATCH) containing unknown or duplicate fields. Valid values are: - Ignore: This will ignore any unknown fields that are silently dropped from the object, and will ignore all but the last duplicate field that the decoder encounters. This is the default behavior prior to v1.23. - Warn: This will send a warning via the standard warning response header for each unknown field that is dropped from the object, and for each duplicate field that is encountered. The request will still succeed if there are no other errors, and will only persist the last of any duplicate fields. This is the default in v1.23+ - Strict: This will fail the request with a BadRequest error if any unknown fields would be dropped from the object, or if any duplicate fields are present. The error returned from the server will contain all unknown and duplicate fields encountered. */
+  fieldValidation?: string;
+  /** Force is going to "force" Apply requests. It means user will re-acquire conflicting fields owned by other people. Force flag must be unset for non-apply patch requests. */
+  force?: boolean;
+  patch: Patch;
+};
+export type GetAnnotationStatusApiResponse = /** status 200 OK */ Annotation;
+export type GetAnnotationStatusApiArg = {
+  /** name of the Annotation */
+  name: string;
+  /** If 'true', then the output is pretty printed. Defaults to 'false' unless the user-agent indicates a browser or command-line HTTP tool (curl and wget). */
+  pretty?: string;
+};
+export type ReplaceAnnotationStatusApiResponse = /** status 200 OK */ Annotation | /** status 201 Created */ Annotation;
+export type ReplaceAnnotationStatusApiArg = {
+  /** name of the Annotation */
+  name: string;
+  /** If 'true', then the output is pretty printed. Defaults to 'false' unless the user-agent indicates a browser or command-line HTTP tool (curl and wget). */
+  pretty?: string;
+  /** When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed */
+  dryRun?: string;
+  /** fieldManager is a name associated with the actor or entity that is making these changes. The value must be less than or 128 characters long, and only contain printable characters, as defined by https://golang.org/pkg/unicode/#IsPrint. */
+  fieldManager?: string;
+  /** fieldValidation instructs the server on how to handle objects in the request (POST/PUT/PATCH) containing unknown or duplicate fields. Valid values are: - Ignore: This will ignore any unknown fields that are silently dropped from the object, and will ignore all but the last duplicate field that the decoder encounters. This is the default behavior prior to v1.23. - Warn: This will send a warning via the standard warning response header for each unknown field that is dropped from the object, and for each duplicate field that is encountered. The request will still succeed if there are no other errors, and will only persist the last of any duplicate fields. This is the default in v1.23+ - Strict: This will fail the request with a BadRequest error if any unknown fields would be dropped from the object, or if any duplicate fields are present. The error returned from the server will contain all unknown and duplicate fields encountered. */
+  fieldValidation?: string;
+  annotation: Annotation;
+};
+export type UpdateAnnotationStatusApiResponse = /** status 200 OK */ Annotation | /** status 201 Created */ Annotation;
+export type UpdateAnnotationStatusApiArg = {
+  /** name of the Annotation */
+  name: string;
+  /** If 'true', then the output is pretty printed. Defaults to 'false' unless the user-agent indicates a browser or command-line HTTP tool (curl and wget). */
+  pretty?: string;
+  /** When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed */
+  dryRun?: string;
+  /** fieldManager is a name associated with the actor or entity that is making these changes. The value must be less than or 128 characters long, and only contain printable characters, as defined by https://golang.org/pkg/unicode/#IsPrint. This field is required for apply requests (application/apply-patch) but optional for non-apply patch types (JsonPatch, MergePatch, StrategicMergePatch). */
+  fieldManager?: string;
+  /** fieldValidation instructs the server on how to handle objects in the request (POST/PUT/PATCH) containing unknown or duplicate fields. Valid values are: - Ignore: This will ignore any unknown fields that are silently dropped from the object, and will ignore all but the last duplicate field that the decoder encounters. This is the default behavior prior to v1.23. - Warn: This will send a warning via the standard warning response header for each unknown field that is dropped from the object, and for each duplicate field that is encountered. The request will still succeed if there are no other errors, and will only persist the last of any duplicate fields. This is the default in v1.23+ - Strict: This will fail the request with a BadRequest error if any unknown fields would be dropped from the object, or if any duplicate fields are present. The error returned from the server will contain all unknown and duplicate fields encountered. */
+  fieldValidation?: string;
+  /** Force is going to "force" Apply requests. It means user will re-acquire conflicting fields owned by other people. Force flag must be unset for non-apply patch requests. */
+  force?: boolean;
+  patch: Patch;
+};
+export type GetSearchApiResponse = /** status 200 OK */ GetSearchResponse;
+export type GetSearchApiArg = {
+  continue?: string;
+  createdBy?: string;
+  dashboardUid?: string;
+  from?: string;
+  legacyId?: string;
+  limit?: string;
+  panelId?: string;
+  scope?: string;
+  scopesMatchAny?: string;
+  tag?: string;
+  tagsMatchAny?: string;
+  to?: string;
+};
+export type GetTagsApiResponse = /** status 200 OK */ GetTagsResponse;
+export type GetTagsApiArg = {
+  limit?: string;
+  prefix?: string;
+};
+export type ApiResource = {
+  /** categories is a list of the grouped resources this resource belongs to (e.g. 'all') */
+  categories?: string[];
+  /** group is the preferred group of the resource.  Empty implies the group of the containing resource list. For subresources, this may have a different value, for example: Scale". */
+  group?: string;
+  /** kind is the kind for the resource (e.g. 'Foo' is the kind for a resource 'foo') */
+  kind: string;
+  /** name is the plural name of the resource. */
+  name: string;
+  /** namespaced indicates if a resource is namespaced or not. */
+  namespaced: boolean;
+  /** shortNames is a list of suggested short names of the resource. */
+  shortNames?: string[];
+  /** singularName is the singular name of the resource.  This allows clients to handle plural and singular opaquely. The singularName is more correct for reporting status on a single item and both singular and plural are allowed from the kubectl CLI interface. */
+  singularName: string;
+  /** The hash value of the storage version, the version this resource is converted to when written to the data store. Value must be treated as opaque by clients. Only equality comparison on the value is valid. This is an alpha feature and may change or be removed in the future. The field is populated by the apiserver only if the StorageVersionHash feature gate is enabled. This field will remain optional even if it graduates. */
+  storageVersionHash?: string;
+  /** verbs is a list of supported kube verbs (this includes get, list, watch, create, update, patch, delete, deletecollection, and proxy) */
+  verbs: string[];
+  /** version is the preferred version of the resource.  Empty implies the version of the containing resource list For subresources, this may have a different value, for example: v1 (while inside a v1beta1 version of the core resource's group)". */
+  version?: string;
+};
+export type ApiResourceList = {
+  /** APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources */
+  apiVersion?: string;
+  /** groupVersion is the group and version this APIResourceList is for. */
+  groupVersion: string;
+  /** Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds */
+  kind?: string;
+  /** resources contains the name of the resources and if they are namespaced. */
+  resources: ApiResource[];
+};
+export type Time = string;
+export type FieldsV1 = object;
+export type ManagedFieldsEntry = {
+  /** APIVersion defines the version of this resource that this field set applies to. The format is "group/version" just like the top-level APIVersion field. It is necessary to track the version of a field set because it cannot be automatically converted. */
+  apiVersion?: string;
+  /** FieldsType is the discriminator for the different fields format and version. There is currently only one possible value: "FieldsV1" */
+  fieldsType?: string;
+  /** FieldsV1 holds the first JSON version format as described in the "FieldsV1" type. */
+  fieldsV1?: FieldsV1;
+  /** Manager is an identifier of the workflow managing these fields. */
+  manager?: string;
+  /** Operation is the type of operation which lead to this ManagedFieldsEntry being created. The only valid values for this field are 'Apply' and 'Update'. */
+  operation?: string;
+  /** Subresource is the name of the subresource used to update that object, or empty string if the object was updated through the main resource. The value of this field is used to distinguish between managers, even if they share the same name. For example, a status update will be distinct from a regular update using the same manager name. Note that the APIVersion field is not related to the Subresource field and it always corresponds to the version of the main resource. */
+  subresource?: string;
+  /** Time is the timestamp of when the ManagedFields entry was added. The timestamp will also be updated if a field is added, the manager changes any of the owned fields value or removes a field. The timestamp does not update when a field is removed from the entry because another manager took it over. */
+  time?: Time;
+};
+export type OwnerReference = {
+  /** API version of the referent. */
+  apiVersion: string;
+  /** If true, AND if the owner has the "foregroundDeletion" finalizer, then the owner cannot be deleted from the key-value store until this reference is removed. See https://kubernetes.io/docs/concepts/architecture/garbage-collection/#foreground-deletion for how the garbage collector interacts with this field and enforces the foreground deletion. Defaults to false. To set this field, a user needs "delete" permission of the owner, otherwise 422 (Unprocessable Entity) will be returned. */
+  blockOwnerDeletion?: boolean;
+  /** If true, this reference points to the managing controller. */
+  controller?: boolean;
+  /** Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds */
+  kind: string;
+  /** Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names#names */
+  name: string;
+  /** UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names#uids */
+  uid: string;
+};
+export type ObjectMeta = {
+  /** Annotations is an unstructured key value map stored with a resource that may be set by external tools to store and retrieve arbitrary metadata. They are not queryable and should be preserved when modifying objects. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations */
+  annotations?: {
+    [key: string]: string;
+  };
+  /** CreationTimestamp is a timestamp representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations. Clients may not set this value. It is represented in RFC3339 form and is in UTC.
+    
+    Populated by the system. Read-only. Null for lists. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata */
+  creationTimestamp?: Time;
+  /** Number of seconds allowed for this object to gracefully terminate before it will be removed from the system. Only set when deletionTimestamp is also set. May only be shortened. Read-only. */
+  deletionGracePeriodSeconds?: number;
+  /** DeletionTimestamp is RFC 3339 date and time at which this resource will be deleted. This field is set by the server when a graceful deletion is requested by the user, and is not directly settable by a client. The resource is expected to be deleted (no longer visible from resource lists, and not reachable by name) after the time in this field, once the finalizers list is empty. As long as the finalizers list contains items, deletion is blocked. Once the deletionTimestamp is set, this value may not be unset or be set further into the future, although it may be shortened or the resource may be deleted prior to this time. For example, a user may request that a pod is deleted in 30 seconds. The Kubelet will react by sending a graceful termination signal to the containers in the pod. After that 30 seconds, the Kubelet will send a hard termination signal (SIGKILL) to the container and after cleanup, remove the pod from the API. In the presence of network partitions, this object may still exist after this timestamp, until an administrator or automated process can determine the resource is fully terminated. If not set, graceful deletion of the object has not been requested.
+    
+    Populated by the system when a graceful deletion is requested. Read-only. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata */
+  deletionTimestamp?: Time;
+  /** Must be empty before the object is deleted from the registry. Each entry is an identifier for the responsible component that will remove the entry from the list. If the deletionTimestamp of the object is non-nil, entries in this list can only be removed. Finalizers may be processed and removed in any order.  Order is NOT enforced because it introduces significant risk of stuck finalizers. finalizers is a shared field, any actor with permission can reorder it. If the finalizer list is processed in order, then this can lead to a situation in which the component responsible for the first finalizer in the list is waiting for a signal (field value, external system, or other) produced by a component responsible for a finalizer later in the list, resulting in a deadlock. Without enforced ordering finalizers are free to order amongst themselves and are not vulnerable to ordering changes in the list. */
+  finalizers?: string[];
+  /** GenerateName is an optional prefix, used by the server, to generate a unique name ONLY IF the Name field has not been provided. If this field is used, the name returned to the client will be different than the name passed. This value will also be combined with a unique suffix. The provided value has the same validation rules as the Name field, and may be truncated by the length of the suffix required to make the value unique on the server.
+    
+    If this field is specified and the generated name exists, the server will return a 409.
+    
+    Applied only if Name is not specified. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#idempotency */
+  generateName?: string;
+  /** A sequence number representing a specific generation of the desired state. Populated by the system. Read-only. */
+  generation?: number;
+  /** Map of string keys and values that can be used to organize and categorize (scope and select) objects. May match selectors of replication controllers and services. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels */
+  labels?: {
+    [key: string]: string;
+  };
+  /** ManagedFields maps workflow-id and version to the set of fields that are managed by that workflow. This is mostly for internal housekeeping, and users typically shouldn't need to set or understand this field. A workflow can be the user's name, a controller's name, or the name of a specific apply path like "ci-cd". The set of fields is always in the version that the workflow used when modifying the object. */
+  managedFields?: ManagedFieldsEntry[];
+  /** Name must be unique within a namespace. Is required when creating resources, although some resources may allow a client to request the generation of an appropriate name automatically. Name is primarily intended for creation idempotence and configuration definition. Cannot be updated. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names#names */
+  name?: string;
+  /** Namespace defines the space within which each name must be unique. An empty namespace is equivalent to the "default" namespace, but "default" is the canonical representation. Not all objects are required to be scoped to a namespace - the value of this field for those objects will be empty.
+    
+    Must be a DNS_LABEL. Cannot be updated. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces */
+  namespace?: string;
+  /** List of objects depended by this object. If ALL objects in the list have been deleted, this object will be garbage collected. If this object is managed by a controller, then an entry in this list will point to this controller, with the controller field set to true. There cannot be more than one managing controller. */
+  ownerReferences?: OwnerReference[];
+  /** An opaque value that represents the internal version of this object that can be used by clients to determine when objects have changed. May be used for optimistic concurrency, change detection, and the watch operation on a resource or set of resources. Clients must treat these values as opaque and passed unmodified back to the server. They may only be valid for a particular resource or set of resources.
+    
+    Populated by the system. Read-only. Value must be treated as opaque by clients and . More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency */
+  resourceVersion?: string;
+  /** Deprecated: selfLink is a legacy read-only field that is no longer populated by the system. */
+  selfLink?: string;
+  /** UID is the unique in time and space value for this object. It is typically generated by the server on successful creation of a resource and is not allowed to change on PUT operations.
+    
+    Populated by the system. Read-only. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names#uids */
+  uid?: string;
+};
+export type AnnotationSpec = {
+  dashboardUID?: string;
+  panelID?: number;
+  scopes?: string[];
+  tags?: string[];
+  text: string;
+  time: number;
+  timeEnd?: number;
+};
+export type AnnotationOperatorState = {
+  /** descriptiveState is an optional more descriptive state field which has no requirements on format */
+  descriptiveState?: string;
+  /** details contains any extra information that is operator-specific */
+  details?: {
+    [key: string]: any;
+  };
+  /** lastEvaluation is the ResourceVersion last evaluated */
+  lastEvaluation: string;
+  /** state describes the state of the lastEvaluation.
+    It is limited to three possible states for machine evaluation. */
+  state: 'success' | 'in_progress' | 'failed';
+};
+export type AnnotationStatus = {
+  /** additionalFields is reserved for future use */
+  additionalFields?: {
+    [key: string]: any;
+  };
+  /** operatorStates is a map of operator ID to operator state evaluations.
+    Any operator which consumes this kind SHOULD add its state evaluation information to this field. */
+  operatorStates?: {
+    [key: string]: AnnotationOperatorState;
+  };
+};
+export type Annotation = {
+  /** APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources */
+  apiVersion: string;
+  /** Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds */
+  kind: string;
+  metadata: ObjectMeta;
+  spec: AnnotationSpec;
+  status?: AnnotationStatus;
+};
+export type ListMeta = {
+  /** continue may be set if the user set a limit on the number of items returned, and indicates that the server has more data available. The value is opaque and may be used to issue another request to the endpoint that served this list to retrieve the next set of available objects. Continuing a consistent list may not be possible if the server configuration has changed or more than a few minutes have passed. The resourceVersion field returned when using this continue value will be identical to the value in the first response, unless you have received this token from an error message. */
+  continue?: string;
+  /** remainingItemCount is the number of subsequent items in the list which are not included in this list response. If the list request contained label or field selectors, then the number of remaining items is unknown and the field will be left unset and omitted during serialization. If the list is complete (either because it is not chunking or because this is the last chunk), then there are no more remaining items and this field will be left unset and omitted during serialization. Servers older than v1.15 do not set this field. The intended use of the remainingItemCount is *estimating* the size of a collection. Clients should not rely on the remainingItemCount to be set or to be exact. */
+  remainingItemCount?: number;
+  /** String that identifies the server's internal version of this object that can be used by clients to determine when objects have changed. Value must be treated as opaque by clients and passed unmodified back to the server. Populated by the system. Read-only. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency */
+  resourceVersion?: string;
+  /** Deprecated: selfLink is a legacy read-only field that is no longer populated by the system. */
+  selfLink?: string;
+};
+export type AnnotationList = {
+  /** APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources */
+  apiVersion?: string;
+  items: Annotation[];
+  /** Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds */
+  kind?: string;
+  metadata: ListMeta;
+};
+export type StatusCause = {
+  /** The field of the resource that has caused this error, as named by its JSON serialization. May include dot and postfix notation for nested attributes. Arrays are zero-indexed.  Fields may appear more than once in an array of causes due to fields having multiple errors. Optional.
+    
+    Examples:
+      "name" - the field "name" on the current resource
+      "items[0].name" - the field "name" on the first array entry in "items" */
+  field?: string;
+  /** A human-readable description of the cause of the error.  This field may be presented as-is to a reader. */
+  message?: string;
+  /** A machine-readable description of the cause of the error. If this value is empty there is no information available. */
+  reason?: string;
+};
+export type StatusDetails = {
+  /** The Causes array includes more details associated with the StatusReason failure. Not all StatusReasons may provide detailed causes. */
+  causes?: StatusCause[];
+  /** The group attribute of the resource associated with the status StatusReason. */
+  group?: string;
+  /** The kind attribute of the resource associated with the status StatusReason. On some operations may differ from the requested resource Kind. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds */
+  kind?: string;
+  /** The name attribute of the resource associated with the status StatusReason (when there is a single name which can be described). */
+  name?: string;
+  /** If specified, the time in seconds before the operation should be retried. Some errors may indicate the client must take an alternate action - for those errors this field may indicate how long to wait before taking the alternate action. */
+  retryAfterSeconds?: number;
+  /** UID of the resource. (when there is a single resource which can be described). More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names#uids */
+  uid?: string;
+};
+export type Status = {
+  /** APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources */
+  apiVersion?: string;
+  /** Suggested HTTP return code for this status, 0 if not set. */
+  code?: number;
+  /** Extended data associated with the reason.  Each reason may define its own extended details. This field is optional and the data returned is not guaranteed to conform to any schema except that defined by the reason type. */
+  details?: StatusDetails;
+  /** Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds */
+  kind?: string;
+  /** A human-readable description of the status of this operation. */
+  message?: string;
+  /** Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds */
+  metadata?: ListMeta;
+  /** A machine-readable description of why this operation is in the "Failure" status. If this value is empty there is no information available. A Reason clarifies an HTTP status code but does not override it. */
+  reason?: string;
+  /** Status of the operation. One of: "Success" or "Failure". More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status */
+  status?: string;
+};
+export type Patch = object;
+export type GetSearchResponse = {
+  /** APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources */
+  apiVersion: string;
+  items: {
+    [key: string]: any;
+  }[];
+  /** Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds */
+  kind: string;
+};
+export type GetTagsResponse = {
+  /** APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources */
+  apiVersion: string;
+  /** Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds */
+  kind: string;
+  tags: {
+    count: number;
+    tag: string;
+  }[];
+};
+export const {
+  useGetApiResourcesQuery,
+  useLazyGetApiResourcesQuery,
+  useListAnnotationQuery,
+  useLazyListAnnotationQuery,
+  useCreateAnnotationMutation,
+  useGetAnnotationQuery,
+  useLazyGetAnnotationQuery,
+  useReplaceAnnotationMutation,
+  useDeleteAnnotationMutation,
+  useUpdateAnnotationMutation,
+  useGetAnnotationStatusQuery,
+  useLazyGetAnnotationStatusQuery,
+  useReplaceAnnotationStatusMutation,
+  useUpdateAnnotationStatusMutation,
+  useGetSearchQuery,
+  useLazyGetSearchQuery,
+  useGetTagsQuery,
+  useLazyGetTagsQuery,
+} = injectedRtkApi;

--- a/packages/grafana-api-clients/src/clients/rtkq/annotation/v0alpha1/index.ts
+++ b/packages/grafana-api-clients/src/clients/rtkq/annotation/v0alpha1/index.ts
@@ -1,0 +1,5 @@
+export { BASE_URL, API_GROUP, API_VERSION } from './baseAPI';
+import { generatedAPI as rawAPI } from './endpoints.gen';
+
+export * from './endpoints.gen';
+export const generatedAPI = rawAPI.enhanceEndpoints({});

--- a/packages/grafana-api-clients/src/clients/rtkq/index.ts
+++ b/packages/grafana-api-clients/src/clients/rtkq/index.ts
@@ -2,6 +2,7 @@
  * Don't manually add to this file! Use the `generate:api-client` command to add new API clients.
  */
 import { generatedAPI as advisorAPIv0alpha1 } from './advisor/v0alpha1';
+import { generatedAPI as annotationAPIv0alpha1 } from './annotation/v0alpha1';
 import { generatedAPI as collectionsAPIv1alpha1 } from './collections/v1alpha1';
 import { generatedAPI as correlationsAPIv0alpha1 } from './correlations/v0alpha1';
 import { generatedAPI as dashboardAPIv0alpha1 } from './dashboard/v0alpha1';
@@ -28,6 +29,7 @@ import { generatedAPI as shortURLAPIv1beta1 } from './shorturl/v1beta1';
 /** RTK Query middleware for all API clients  */
 export const allMiddleware = [
   advisorAPIv0alpha1.middleware,
+  annotationAPIv0alpha1.middleware,
   dashboardAPIv0alpha1.middleware,
   folderAPIv1beta1.middleware,
   iamAPIv0alpha1.middleware,
@@ -55,6 +57,7 @@ export const allMiddleware = [
 /** RTK Query reducers for all API clients  */
 export const allReducers = {
   [advisorAPIv0alpha1.reducerPath]: advisorAPIv0alpha1.reducer,
+  [annotationAPIv0alpha1.reducerPath]: annotationAPIv0alpha1.reducer,
   [dashboardAPIv0alpha1.reducerPath]: dashboardAPIv0alpha1.reducer,
   [folderAPIv1beta1.reducerPath]: folderAPIv1beta1.reducer,
   [iamAPIv0alpha1.reducerPath]: iamAPIv0alpha1.reducer,

--- a/packages/grafana-api-clients/src/scripts/generate-rtk-apis.ts
+++ b/packages/grafana-api-clients/src/scripts/generate-rtk-apis.ts
@@ -111,6 +111,7 @@ const config: ConfigFile = {
       filterEndpoints: ['starDashboardByUid', 'unstarDashboardByUid'],
     },
     ...createAPIConfig('advisor', 'v0alpha1'),
+    ...createAPIConfig('annotation', 'v0alpha1'),
     ...createAPIConfig('correlations', 'v0alpha1'),
     ...createAPIConfig('dashboard', 'v0alpha1'),
     ...createAPIConfig('dashboard', 'v1beta1'),

--- a/packages/grafana-openapi/src/apis/annotation.grafana.app-v0alpha1.json
+++ b/packages/grafana-openapi/src/apis/annotation.grafana.app-v0alpha1.json
@@ -4,11 +4,9 @@
     "title": "annotation.grafana.app/v0alpha1"
   },
   "paths": {
-    "/apis/annotation.grafana.app/v0alpha1/": {
+    "/": {
       "get": {
-        "tags": [
-          "API Discovery"
-        ],
+        "tags": ["API Discovery"],
         "description": "Describe the available kubernetes resources",
         "operationId": "getAPIResources",
         "responses": {
@@ -17,12 +15,12 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.APIResourceList"
+                  "$ref": "#/components/schemas/APIResourceList"
                 }
               },
               "application/yaml": {
                 "schema": {
-                  "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.APIResourceList"
+                  "$ref": "#/components/schemas/APIResourceList"
                 }
               }
             }
@@ -30,11 +28,9 @@
         }
       }
     },
-    "/apis/annotation.grafana.app/v0alpha1/namespaces/{namespace}/annotations": {
+    "/annotations": {
       "get": {
-        "tags": [
-          "Annotation"
-        ],
+        "tags": ["Annotation"],
         "description": "list objects of kind Annotation",
         "operationId": "listAnnotation",
         "parameters": [
@@ -108,17 +104,17 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/com.github.grafana.grafana.apps.annotation.pkg.apis.annotation.v0alpha1.AnnotationList"
+                  "$ref": "#/components/schemas/AnnotationList"
                 }
               },
               "application/json;stream=watch": {
                 "schema": {
-                  "$ref": "#/components/schemas/com.github.grafana.grafana.apps.annotation.pkg.apis.annotation.v0alpha1.AnnotationList"
+                  "$ref": "#/components/schemas/AnnotationList"
                 }
               },
               "application/yaml": {
                 "schema": {
-                  "$ref": "#/components/schemas/com.github.grafana.grafana.apps.annotation.pkg.apis.annotation.v0alpha1.AnnotationList"
+                  "$ref": "#/components/schemas/AnnotationList"
                 }
               }
             }
@@ -132,9 +128,7 @@
         }
       },
       "post": {
-        "tags": [
-          "Annotation"
-        ],
+        "tags": ["Annotation"],
         "description": "create an Annotation",
         "operationId": "createAnnotation",
         "parameters": [
@@ -170,12 +164,12 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/com.github.grafana.grafana.apps.annotation.pkg.apis.annotation.v0alpha1.Annotation"
+                "$ref": "#/components/schemas/Annotation"
               }
             },
             "application/yaml": {
               "schema": {
-                "$ref": "#/components/schemas/com.github.grafana.grafana.apps.annotation.pkg.apis.annotation.v0alpha1.Annotation"
+                "$ref": "#/components/schemas/Annotation"
               }
             }
           },
@@ -187,12 +181,12 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/com.github.grafana.grafana.apps.annotation.pkg.apis.annotation.v0alpha1.Annotation"
+                  "$ref": "#/components/schemas/Annotation"
                 }
               },
               "application/yaml": {
                 "schema": {
-                  "$ref": "#/components/schemas/com.github.grafana.grafana.apps.annotation.pkg.apis.annotation.v0alpha1.Annotation"
+                  "$ref": "#/components/schemas/Annotation"
                 }
               }
             }
@@ -202,12 +196,12 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/com.github.grafana.grafana.apps.annotation.pkg.apis.annotation.v0alpha1.Annotation"
+                  "$ref": "#/components/schemas/Annotation"
                 }
               },
               "application/yaml": {
                 "schema": {
-                  "$ref": "#/components/schemas/com.github.grafana.grafana.apps.annotation.pkg.apis.annotation.v0alpha1.Annotation"
+                  "$ref": "#/components/schemas/Annotation"
                 }
               }
             }
@@ -217,12 +211,12 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/com.github.grafana.grafana.apps.annotation.pkg.apis.annotation.v0alpha1.Annotation"
+                  "$ref": "#/components/schemas/Annotation"
                 }
               },
               "application/yaml": {
                 "schema": {
-                  "$ref": "#/components/schemas/com.github.grafana.grafana.apps.annotation.pkg.apis.annotation.v0alpha1.Annotation"
+                  "$ref": "#/components/schemas/Annotation"
                 }
               }
             }
@@ -237,16 +231,6 @@
       },
       "parameters": [
         {
-          "name": "namespace",
-          "in": "path",
-          "description": "object name and auth scope, such as for teams and projects",
-          "required": true,
-          "schema": {
-            "type": "string",
-            "uniqueItems": true
-          }
-        },
-        {
           "name": "pretty",
           "in": "query",
           "description": "If 'true', then the output is pretty printed. Defaults to 'false' unless the user-agent indicates a browser or command-line HTTP tool (curl and wget).",
@@ -257,11 +241,9 @@
         }
       ]
     },
-    "/apis/annotation.grafana.app/v0alpha1/namespaces/{namespace}/annotations/{name}": {
+    "/annotations/{name}": {
       "get": {
-        "tags": [
-          "Annotation"
-        ],
+        "tags": ["Annotation"],
         "description": "read the specified Annotation",
         "operationId": "getAnnotation",
         "responses": {
@@ -270,12 +252,12 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/com.github.grafana.grafana.apps.annotation.pkg.apis.annotation.v0alpha1.Annotation"
+                  "$ref": "#/components/schemas/Annotation"
                 }
               },
               "application/yaml": {
                 "schema": {
-                  "$ref": "#/components/schemas/com.github.grafana.grafana.apps.annotation.pkg.apis.annotation.v0alpha1.Annotation"
+                  "$ref": "#/components/schemas/Annotation"
                 }
               }
             }
@@ -289,9 +271,7 @@
         }
       },
       "put": {
-        "tags": [
-          "Annotation"
-        ],
+        "tags": ["Annotation"],
         "description": "replace the specified Annotation",
         "operationId": "replaceAnnotation",
         "parameters": [
@@ -327,12 +307,12 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/com.github.grafana.grafana.apps.annotation.pkg.apis.annotation.v0alpha1.Annotation"
+                "$ref": "#/components/schemas/Annotation"
               }
             },
             "application/yaml": {
               "schema": {
-                "$ref": "#/components/schemas/com.github.grafana.grafana.apps.annotation.pkg.apis.annotation.v0alpha1.Annotation"
+                "$ref": "#/components/schemas/Annotation"
               }
             }
           },
@@ -344,12 +324,12 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/com.github.grafana.grafana.apps.annotation.pkg.apis.annotation.v0alpha1.Annotation"
+                  "$ref": "#/components/schemas/Annotation"
                 }
               },
               "application/yaml": {
                 "schema": {
-                  "$ref": "#/components/schemas/com.github.grafana.grafana.apps.annotation.pkg.apis.annotation.v0alpha1.Annotation"
+                  "$ref": "#/components/schemas/Annotation"
                 }
               }
             }
@@ -359,12 +339,12 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/com.github.grafana.grafana.apps.annotation.pkg.apis.annotation.v0alpha1.Annotation"
+                  "$ref": "#/components/schemas/Annotation"
                 }
               },
               "application/yaml": {
                 "schema": {
-                  "$ref": "#/components/schemas/com.github.grafana.grafana.apps.annotation.pkg.apis.annotation.v0alpha1.Annotation"
+                  "$ref": "#/components/schemas/Annotation"
                 }
               }
             }
@@ -378,9 +358,7 @@
         }
       },
       "delete": {
-        "tags": [
-          "Annotation"
-        ],
+        "tags": ["Annotation"],
         "description": "delete an Annotation",
         "operationId": "deleteAnnotation",
         "parameters": [
@@ -436,12 +414,12 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+                  "$ref": "#/components/schemas/Status"
                 }
               },
               "application/yaml": {
                 "schema": {
-                  "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+                  "$ref": "#/components/schemas/Status"
                 }
               }
             }
@@ -451,12 +429,12 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+                  "$ref": "#/components/schemas/Status"
                 }
               },
               "application/yaml": {
                 "schema": {
-                  "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Status"
+                  "$ref": "#/components/schemas/Status"
                 }
               }
             }
@@ -470,9 +448,7 @@
         }
       },
       "patch": {
-        "tags": [
-          "Annotation"
-        ],
+        "tags": ["Annotation"],
         "description": "partially update the specified Annotation",
         "operationId": "updateAnnotation",
         "parameters": [
@@ -517,22 +493,22 @@
           "content": {
             "application/apply-patch+yaml": {
               "schema": {
-                "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+                "$ref": "#/components/schemas/Patch"
               }
             },
             "application/json-patch+json": {
               "schema": {
-                "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+                "$ref": "#/components/schemas/Patch"
               }
             },
             "application/merge-patch+json": {
               "schema": {
-                "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+                "$ref": "#/components/schemas/Patch"
               }
             },
             "application/strategic-merge-patch+json": {
               "schema": {
-                "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+                "$ref": "#/components/schemas/Patch"
               }
             }
           },
@@ -544,12 +520,12 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/com.github.grafana.grafana.apps.annotation.pkg.apis.annotation.v0alpha1.Annotation"
+                  "$ref": "#/components/schemas/Annotation"
                 }
               },
               "application/yaml": {
                 "schema": {
-                  "$ref": "#/components/schemas/com.github.grafana.grafana.apps.annotation.pkg.apis.annotation.v0alpha1.Annotation"
+                  "$ref": "#/components/schemas/Annotation"
                 }
               }
             }
@@ -559,12 +535,12 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/com.github.grafana.grafana.apps.annotation.pkg.apis.annotation.v0alpha1.Annotation"
+                  "$ref": "#/components/schemas/Annotation"
                 }
               },
               "application/yaml": {
                 "schema": {
-                  "$ref": "#/components/schemas/com.github.grafana.grafana.apps.annotation.pkg.apis.annotation.v0alpha1.Annotation"
+                  "$ref": "#/components/schemas/Annotation"
                 }
               }
             }
@@ -589,16 +565,6 @@
           }
         },
         {
-          "name": "namespace",
-          "in": "path",
-          "description": "object name and auth scope, such as for teams and projects",
-          "required": true,
-          "schema": {
-            "type": "string",
-            "uniqueItems": true
-          }
-        },
-        {
           "name": "pretty",
           "in": "query",
           "description": "If 'true', then the output is pretty printed. Defaults to 'false' unless the user-agent indicates a browser or command-line HTTP tool (curl and wget).",
@@ -609,11 +575,9 @@
         }
       ]
     },
-    "/apis/annotation.grafana.app/v0alpha1/namespaces/{namespace}/annotations/{name}/status": {
+    "/annotations/{name}/status": {
       "get": {
-        "tags": [
-          "Annotation"
-        ],
+        "tags": ["Annotation"],
         "description": "read status of the specified Annotation",
         "operationId": "getAnnotationStatus",
         "responses": {
@@ -622,12 +586,12 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/com.github.grafana.grafana.apps.annotation.pkg.apis.annotation.v0alpha1.Annotation"
+                  "$ref": "#/components/schemas/Annotation"
                 }
               },
               "application/yaml": {
                 "schema": {
-                  "$ref": "#/components/schemas/com.github.grafana.grafana.apps.annotation.pkg.apis.annotation.v0alpha1.Annotation"
+                  "$ref": "#/components/schemas/Annotation"
                 }
               }
             }
@@ -641,9 +605,7 @@
         }
       },
       "put": {
-        "tags": [
-          "Annotation"
-        ],
+        "tags": ["Annotation"],
         "description": "replace status of the specified Annotation",
         "operationId": "replaceAnnotationStatus",
         "parameters": [
@@ -679,12 +641,12 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/com.github.grafana.grafana.apps.annotation.pkg.apis.annotation.v0alpha1.Annotation"
+                "$ref": "#/components/schemas/Annotation"
               }
             },
             "application/yaml": {
               "schema": {
-                "$ref": "#/components/schemas/com.github.grafana.grafana.apps.annotation.pkg.apis.annotation.v0alpha1.Annotation"
+                "$ref": "#/components/schemas/Annotation"
               }
             }
           },
@@ -696,12 +658,12 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/com.github.grafana.grafana.apps.annotation.pkg.apis.annotation.v0alpha1.Annotation"
+                  "$ref": "#/components/schemas/Annotation"
                 }
               },
               "application/yaml": {
                 "schema": {
-                  "$ref": "#/components/schemas/com.github.grafana.grafana.apps.annotation.pkg.apis.annotation.v0alpha1.Annotation"
+                  "$ref": "#/components/schemas/Annotation"
                 }
               }
             }
@@ -711,12 +673,12 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/com.github.grafana.grafana.apps.annotation.pkg.apis.annotation.v0alpha1.Annotation"
+                  "$ref": "#/components/schemas/Annotation"
                 }
               },
               "application/yaml": {
                 "schema": {
-                  "$ref": "#/components/schemas/com.github.grafana.grafana.apps.annotation.pkg.apis.annotation.v0alpha1.Annotation"
+                  "$ref": "#/components/schemas/Annotation"
                 }
               }
             }
@@ -730,9 +692,7 @@
         }
       },
       "patch": {
-        "tags": [
-          "Annotation"
-        ],
+        "tags": ["Annotation"],
         "description": "partially update status of the specified Annotation",
         "operationId": "updateAnnotationStatus",
         "parameters": [
@@ -777,22 +737,22 @@
           "content": {
             "application/apply-patch+yaml": {
               "schema": {
-                "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+                "$ref": "#/components/schemas/Patch"
               }
             },
             "application/json-patch+json": {
               "schema": {
-                "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+                "$ref": "#/components/schemas/Patch"
               }
             },
             "application/merge-patch+json": {
               "schema": {
-                "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+                "$ref": "#/components/schemas/Patch"
               }
             },
             "application/strategic-merge-patch+json": {
               "schema": {
-                "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Patch"
+                "$ref": "#/components/schemas/Patch"
               }
             }
           },
@@ -804,12 +764,12 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/com.github.grafana.grafana.apps.annotation.pkg.apis.annotation.v0alpha1.Annotation"
+                  "$ref": "#/components/schemas/Annotation"
                 }
               },
               "application/yaml": {
                 "schema": {
-                  "$ref": "#/components/schemas/com.github.grafana.grafana.apps.annotation.pkg.apis.annotation.v0alpha1.Annotation"
+                  "$ref": "#/components/schemas/Annotation"
                 }
               }
             }
@@ -819,12 +779,12 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/com.github.grafana.grafana.apps.annotation.pkg.apis.annotation.v0alpha1.Annotation"
+                  "$ref": "#/components/schemas/Annotation"
                 }
               },
               "application/yaml": {
                 "schema": {
-                  "$ref": "#/components/schemas/com.github.grafana.grafana.apps.annotation.pkg.apis.annotation.v0alpha1.Annotation"
+                  "$ref": "#/components/schemas/Annotation"
                 }
               }
             }
@@ -849,16 +809,6 @@
           }
         },
         {
-          "name": "namespace",
-          "in": "path",
-          "description": "object name and auth scope, such as for teams and projects",
-          "required": true,
-          "schema": {
-            "type": "string",
-            "uniqueItems": true
-          }
-        },
-        {
           "name": "pretty",
           "in": "query",
           "description": "If 'true', then the output is pretty printed. Defaults to 'false' unless the user-agent indicates a browser or command-line HTTP tool (curl and wget).",
@@ -869,7 +819,7 @@
         }
       ]
     },
-    "/apis/annotation.grafana.app/v0alpha1/namespaces/{namespace}/search": {
+    "/search": {
       "get": {
         "operationId": "getSearch",
         "responses": {
@@ -878,17 +828,17 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/com.github.grafana.grafana.apps.annotation.pkg.apis.annotation.v0alpha1.GetSearchResponse"
+                  "$ref": "#/components/schemas/GetSearchResponse"
                 }
               },
               "application/json;stream=watch": {
                 "schema": {
-                  "$ref": "#/components/schemas/com.github.grafana.grafana.apps.annotation.pkg.apis.annotation.v0alpha1.GetSearchResponse"
+                  "$ref": "#/components/schemas/GetSearchResponse"
                 }
               },
               "application/yaml": {
                 "schema": {
-                  "$ref": "#/components/schemas/com.github.grafana.grafana.apps.annotation.pkg.apis.annotation.v0alpha1.GetSearchResponse"
+                  "$ref": "#/components/schemas/GetSearchResponse"
                 }
               }
             }
@@ -945,16 +895,6 @@
           }
         },
         {
-          "name": "namespace",
-          "in": "path",
-          "description": "object name and auth scope, such as for teams and projects",
-          "required": true,
-          "schema": {
-            "type": "string",
-            "uniqueItems": true
-          }
-        },
-        {
           "name": "panelID",
           "in": "query",
           "schema": {
@@ -1004,7 +944,7 @@
         }
       ]
     },
-    "/apis/annotation.grafana.app/v0alpha1/namespaces/{namespace}/tags": {
+    "/tags": {
       "get": {
         "operationId": "getTags",
         "responses": {
@@ -1013,17 +953,17 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/com.github.grafana.grafana.apps.annotation.pkg.apis.annotation.v0alpha1.GetTagsResponse"
+                  "$ref": "#/components/schemas/GetTagsResponse"
                 }
               },
               "application/json;stream=watch": {
                 "schema": {
-                  "$ref": "#/components/schemas/com.github.grafana.grafana.apps.annotation.pkg.apis.annotation.v0alpha1.GetTagsResponse"
+                  "$ref": "#/components/schemas/GetTagsResponse"
                 }
               },
               "application/yaml": {
                 "schema": {
-                  "$ref": "#/components/schemas/com.github.grafana.grafana.apps.annotation.pkg.apis.annotation.v0alpha1.GetTagsResponse"
+                  "$ref": "#/components/schemas/GetTagsResponse"
                 }
               }
             }
@@ -1034,16 +974,6 @@
         {
           "name": "limit",
           "in": "query",
-          "schema": {
-            "type": "string",
-            "uniqueItems": true
-          }
-        },
-        {
-          "name": "namespace",
-          "in": "path",
-          "description": "object name and auth scope, such as for teams and projects",
-          "required": true,
           "schema": {
             "type": "string",
             "uniqueItems": true
@@ -1062,14 +992,9 @@
   },
   "components": {
     "schemas": {
-      "com.github.grafana.grafana.apps.annotation.pkg.apis.annotation.v0alpha1.Annotation": {
+      "Annotation": {
         "type": "object",
-        "required": [
-          "kind",
-          "apiVersion",
-          "metadata",
-          "spec"
-        ],
+        "required": ["kind", "apiVersion", "metadata", "spec"],
         "properties": {
           "apiVersion": {
             "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
@@ -1083,15 +1008,15 @@
             "default": {},
             "allOf": [
               {
-                "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta"
+                "$ref": "#/components/schemas/ObjectMeta"
               }
             ]
           },
           "spec": {
-            "$ref": "#/components/schemas/com.github.grafana.grafana.apps.annotation.pkg.apis.annotation.v0alpha1.AnnotationSpec"
+            "$ref": "#/components/schemas/AnnotationSpec"
           },
           "status": {
-            "$ref": "#/components/schemas/com.github.grafana.grafana.apps.annotation.pkg.apis.annotation.v0alpha1.AnnotationStatus"
+            "$ref": "#/components/schemas/AnnotationStatus"
           }
         },
         "x-kubernetes-group-version-kind": [
@@ -1102,12 +1027,9 @@
           }
         ]
       },
-      "com.github.grafana.grafana.apps.annotation.pkg.apis.annotation.v0alpha1.AnnotationList": {
+      "AnnotationList": {
         "type": "object",
-        "required": [
-          "metadata",
-          "items"
-        ],
+        "required": ["metadata", "items"],
         "properties": {
           "apiVersion": {
             "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
@@ -1119,7 +1041,7 @@
               "default": {},
               "allOf": [
                 {
-                  "$ref": "#/components/schemas/com.github.grafana.grafana.apps.annotation.pkg.apis.annotation.v0alpha1.Annotation"
+                  "$ref": "#/components/schemas/Annotation"
                 }
               ]
             }
@@ -1132,7 +1054,7 @@
             "default": {},
             "allOf": [
               {
-                "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta"
+                "$ref": "#/components/schemas/ListMeta"
               }
             ]
           }
@@ -1145,12 +1067,9 @@
           }
         ]
       },
-      "com.github.grafana.grafana.apps.annotation.pkg.apis.annotation.v0alpha1.AnnotationOperatorState": {
+      "AnnotationOperatorState": {
         "type": "object",
-        "required": [
-          "lastEvaluation",
-          "state"
-        ],
+        "required": ["lastEvaluation", "state"],
         "properties": {
           "descriptiveState": {
             "description": "descriptiveState is an optional more descriptive state field which has no requirements on format",
@@ -1168,21 +1087,14 @@
           "state": {
             "description": "state describes the state of the lastEvaluation.\nIt is limited to three possible states for machine evaluation.",
             "type": "string",
-            "enum": [
-              "success",
-              "in_progress",
-              "failed"
-            ]
+            "enum": ["success", "in_progress", "failed"]
           }
         },
         "additionalProperties": false
       },
-      "com.github.grafana.grafana.apps.annotation.pkg.apis.annotation.v0alpha1.AnnotationSpec": {
+      "AnnotationSpec": {
         "type": "object",
-        "required": [
-          "text",
-          "time"
-        ],
+        "required": ["text", "time"],
         "properties": {
           "dashboardUID": {
             "type": "string"
@@ -1214,7 +1126,7 @@
         },
         "additionalProperties": false
       },
-      "com.github.grafana.grafana.apps.annotation.pkg.apis.annotation.v0alpha1.AnnotationStatus": {
+      "AnnotationStatus": {
         "type": "object",
         "properties": {
           "additionalFields": {
@@ -1226,21 +1138,15 @@
             "description": "operatorStates is a map of operator ID to operator state evaluations.\nAny operator which consumes this kind SHOULD add its state evaluation information to this field.",
             "type": "object",
             "additionalProperties": {
-              "$ref": "#/components/schemas/com.github.grafana.grafana.apps.annotation.pkg.apis.annotation.v0alpha1.AnnotationOperatorState"
+              "$ref": "#/components/schemas/AnnotationOperatorState"
             }
           }
         },
         "additionalProperties": false
       },
-      "com.github.grafana.grafana.apps.annotation.pkg.apis.annotation.v0alpha1.GetSearchResponse": {
+      "GetSearchResponse": {
         "type": "object",
-        "required": [
-          "apiVersion",
-          "kind",
-          "items",
-          "apiVersion",
-          "kind"
-        ],
+        "required": ["apiVersion", "kind", "items", "apiVersion", "kind"],
         "properties": {
           "apiVersion": {
             "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
@@ -1259,13 +1165,9 @@
           }
         }
       },
-      "com.github.grafana.grafana.apps.annotation.pkg.apis.annotation.v0alpha1.GetTagsResponse": {
+      "GetTagsResponse": {
         "type": "object",
-        "required": [
-          "tags",
-          "apiVersion",
-          "kind"
-        ],
+        "required": ["tags", "apiVersion", "kind"],
         "properties": {
           "apiVersion": {
             "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
@@ -1279,10 +1181,7 @@
             "type": "array",
             "items": {
               "type": "object",
-              "required": [
-                "tag",
-                "count"
-              ],
+              "required": ["tag", "count"],
               "properties": {
                 "count": {
                   "type": "number"
@@ -1295,16 +1194,10 @@
           }
         }
       },
-      "io.k8s.apimachinery.pkg.apis.meta.v1.APIResource": {
+      "APIResource": {
         "description": "APIResource specifies the name of a resource and whether it is namespaced.",
         "type": "object",
-        "required": [
-          "name",
-          "singularName",
-          "namespaced",
-          "kind",
-          "verbs"
-        ],
+        "required": ["name", "singularName", "namespaced", "kind", "verbs"],
         "properties": {
           "categories": {
             "description": "categories is a list of the grouped resources this resource belongs to (e.g. 'all')",
@@ -1366,13 +1259,10 @@
           }
         }
       },
-      "io.k8s.apimachinery.pkg.apis.meta.v1.APIResourceList": {
+      "APIResourceList": {
         "description": "APIResourceList is a list of APIResource, it is used to expose the name of the resources supported in a specific group and version, and if the resource is namespaced.",
         "type": "object",
-        "required": [
-          "groupVersion",
-          "resources"
-        ],
+        "required": ["groupVersion", "resources"],
         "properties": {
           "apiVersion": {
             "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
@@ -1394,7 +1284,7 @@
               "default": {},
               "allOf": [
                 {
-                  "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.APIResource"
+                  "$ref": "#/components/schemas/APIResource"
                 }
               ]
             },
@@ -1402,7 +1292,7 @@
           }
         }
       },
-      "io.k8s.apimachinery.pkg.apis.meta.v1.DeleteOptions": {
+      "DeleteOptions": {
         "description": "DeleteOptions may be provided when deleting an API object.",
         "type": "object",
         "properties": {
@@ -1440,7 +1330,7 @@
             "description": "Must be fulfilled before a deletion is carried out. If not possible, a 409 Conflict status will be returned.",
             "allOf": [
               {
-                "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Preconditions"
+                "$ref": "#/components/schemas/Preconditions"
               }
             ]
           },
@@ -1450,11 +1340,11 @@
           }
         }
       },
-      "io.k8s.apimachinery.pkg.apis.meta.v1.FieldsV1": {
-        "description": "FieldsV1 stores a set of fields in a data structure like a Trie, in JSON format.\n\nEach key is either a '.' representing the field itself, and will always map to an empty set, or a string representing a sub-field or item. The string will follow one of these four formats: 'f:\u003cname\u003e', where \u003cname\u003e is the name of a field in a struct, or key in a map 'v:\u003cvalue\u003e', where \u003cvalue\u003e is the exact json formatted value of a list item 'i:\u003cindex\u003e', where \u003cindex\u003e is position of a item in a list 'k:\u003ckeys\u003e', where \u003ckeys\u003e is a map of  a list item's key fields to their unique values If a key maps to an empty Fields value, the field that key represents is part of the set.\n\nThe exact format is defined in sigs.k8s.io/structured-merge-diff",
+      "FieldsV1": {
+        "description": "FieldsV1 stores a set of fields in a data structure like a Trie, in JSON format.\n\nEach key is either a '.' representing the field itself, and will always map to an empty set, or a string representing a sub-field or item. The string will follow one of these four formats: 'f:<name>', where <name> is the name of a field in a struct, or key in a map 'v:<value>', where <value> is the exact json formatted value of a list item 'i:<index>', where <index> is position of a item in a list 'k:<keys>', where <keys> is a map of  a list item's key fields to their unique values If a key maps to an empty Fields value, the field that key represents is part of the set.\n\nThe exact format is defined in sigs.k8s.io/structured-merge-diff",
         "type": "object"
       },
-      "io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta": {
+      "ListMeta": {
         "description": "ListMeta describes metadata that synthetic resources must have, including lists and various status objects. A resource may have only one of {ObjectMeta, ListMeta}.",
         "type": "object",
         "properties": {
@@ -1477,7 +1367,7 @@
           }
         }
       },
-      "io.k8s.apimachinery.pkg.apis.meta.v1.ManagedFieldsEntry": {
+      "ManagedFieldsEntry": {
         "description": "ManagedFieldsEntry is a workflow-id, a FieldSet and the group version of the resource that the fieldset applies to.",
         "type": "object",
         "properties": {
@@ -1493,7 +1383,7 @@
             "description": "FieldsV1 holds the first JSON version format as described in the \"FieldsV1\" type.",
             "allOf": [
               {
-                "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.FieldsV1"
+                "$ref": "#/components/schemas/FieldsV1"
               }
             ]
           },
@@ -1513,13 +1403,13 @@
             "description": "Time is the timestamp of when the ManagedFields entry was added. The timestamp will also be updated if a field is added, the manager changes any of the owned fields value or removes a field. The timestamp does not update when a field is removed from the entry because another manager took it over.",
             "allOf": [
               {
-                "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Time"
+                "$ref": "#/components/schemas/Time"
               }
             ]
           }
         }
       },
-      "io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta": {
+      "ObjectMeta": {
         "description": "ObjectMeta is metadata that all persisted resources must have, which includes all objects users must create.",
         "type": "object",
         "properties": {
@@ -1535,7 +1425,7 @@
             "description": "CreationTimestamp is a timestamp representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations. Clients may not set this value. It is represented in RFC3339 form and is in UTC.\n\nPopulated by the system. Read-only. Null for lists. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata",
             "allOf": [
               {
-                "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Time"
+                "$ref": "#/components/schemas/Time"
               }
             ]
           },
@@ -1548,7 +1438,7 @@
             "description": "DeletionTimestamp is RFC 3339 date and time at which this resource will be deleted. This field is set by the server when a graceful deletion is requested by the user, and is not directly settable by a client. The resource is expected to be deleted (no longer visible from resource lists, and not reachable by name) after the time in this field, once the finalizers list is empty. As long as the finalizers list contains items, deletion is blocked. Once the deletionTimestamp is set, this value may not be unset or be set further into the future, although it may be shortened or the resource may be deleted prior to this time. For example, a user may request that a pod is deleted in 30 seconds. The Kubelet will react by sending a graceful termination signal to the containers in the pod. After that 30 seconds, the Kubelet will send a hard termination signal (SIGKILL) to the container and after cleanup, remove the pod from the API. In the presence of network partitions, this object may still exist after this timestamp, until an administrator or automated process can determine the resource is fully terminated. If not set, graceful deletion of the object has not been requested.\n\nPopulated by the system when a graceful deletion is requested. Read-only. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata",
             "allOf": [
               {
-                "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Time"
+                "$ref": "#/components/schemas/Time"
               }
             ]
           },
@@ -1586,7 +1476,7 @@
               "default": {},
               "allOf": [
                 {
-                  "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.ManagedFieldsEntry"
+                  "$ref": "#/components/schemas/ManagedFieldsEntry"
                 }
               ]
             },
@@ -1607,13 +1497,11 @@
               "default": {},
               "allOf": [
                 {
-                  "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.OwnerReference"
+                  "$ref": "#/components/schemas/OwnerReference"
                 }
               ]
             },
-            "x-kubernetes-list-map-keys": [
-              "uid"
-            ],
+            "x-kubernetes-list-map-keys": ["uid"],
             "x-kubernetes-list-type": "map",
             "x-kubernetes-patch-merge-key": "uid",
             "x-kubernetes-patch-strategy": "merge"
@@ -1632,15 +1520,10 @@
           }
         }
       },
-      "io.k8s.apimachinery.pkg.apis.meta.v1.OwnerReference": {
+      "OwnerReference": {
         "description": "OwnerReference contains enough information to let you identify an owning object. An owning object must be in the same namespace as the dependent, or be cluster-scoped, so there is no namespace field.",
         "type": "object",
-        "required": [
-          "apiVersion",
-          "kind",
-          "name",
-          "uid"
-        ],
+        "required": ["apiVersion", "kind", "name", "uid"],
         "properties": {
           "apiVersion": {
             "description": "API version of the referent.",
@@ -1673,11 +1556,11 @@
         },
         "x-kubernetes-map-type": "atomic"
       },
-      "io.k8s.apimachinery.pkg.apis.meta.v1.Patch": {
+      "Patch": {
         "description": "Patch is provided to give a concrete name and type to the Kubernetes PATCH request body.",
         "type": "object"
       },
-      "io.k8s.apimachinery.pkg.apis.meta.v1.Preconditions": {
+      "Preconditions": {
         "description": "Preconditions must be fulfilled before an operation (update, delete, etc.) is carried out.",
         "type": "object",
         "properties": {
@@ -1691,7 +1574,7 @@
           }
         }
       },
-      "io.k8s.apimachinery.pkg.apis.meta.v1.Status": {
+      "Status": {
         "description": "Status is a return value for calls that don't return other objects.",
         "type": "object",
         "properties": {
@@ -1708,7 +1591,7 @@
             "description": "Extended data associated with the reason.  Each reason may define its own extended details. This field is optional and the data returned is not guaranteed to conform to any schema except that defined by the reason type.",
             "allOf": [
               {
-                "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.StatusDetails"
+                "$ref": "#/components/schemas/StatusDetails"
               }
             ]
           },
@@ -1725,7 +1608,7 @@
             "default": {},
             "allOf": [
               {
-                "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta"
+                "$ref": "#/components/schemas/ListMeta"
               }
             ]
           },
@@ -1739,7 +1622,7 @@
           }
         }
       },
-      "io.k8s.apimachinery.pkg.apis.meta.v1.StatusCause": {
+      "StatusCause": {
         "description": "StatusCause provides more information about an api.Status failure, including cases when multiple errors are encountered.",
         "type": "object",
         "properties": {
@@ -1757,7 +1640,7 @@
           }
         }
       },
-      "io.k8s.apimachinery.pkg.apis.meta.v1.StatusDetails": {
+      "StatusDetails": {
         "description": "StatusDetails is a set of additional properties that MAY be set by the server to provide additional information about a response. The Reason field of a Status object defines what attributes will be set. Clients must ignore fields that do not match the defined type of each attribute, and should assume that any attribute may be empty, invalid, or under defined.",
         "type": "object",
         "properties": {
@@ -1768,7 +1651,7 @@
               "default": {},
               "allOf": [
                 {
-                  "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.StatusCause"
+                  "$ref": "#/components/schemas/StatusCause"
                 }
               ]
             },
@@ -1797,7 +1680,7 @@
           }
         }
       },
-      "io.k8s.apimachinery.pkg.apis.meta.v1.Time": {
+      "Time": {
         "description": "Time is a wrapper around time.Time which supports correct marshaling to YAML and JSON.  Wrappers are provided for many of the factory methods that the time package offers.",
         "type": "string",
         "format": "date-time"

--- a/pkg/tests/apis/openapi_test.go
+++ b/pkg/tests/apis/openapi_test.go
@@ -24,8 +24,9 @@ func TestIntegrationOpenAPIs(t *testing.T) {
 	testutil.SkipIntegrationTestInShortMode(t)
 
 	h := NewK8sTestHelper(t, testinfra.GrafanaOpts{
-		AppModeProduction:      false, // required for experimental APIs
-		RBACSingleOrganization: true,  // required for the Users API
+		AppModeProduction:           false, // required for experimental APIs
+		RBACSingleOrganization:      true,  // required for the Users API
+		EnableAnnotationAppPlatform: true,
 		EnableFeatureToggles: []string{
 			featuremgmt.FlagQueryService, // Query Library
 			featuremgmt.FlagProvisioning,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
**What is this feature?**

Adds the annotation App Platform API to the generated OpenAPI and RTK Query client pipeline. The annotation spec now includes `/search` and `/tags` custom routes with legacy-compatible query parameters, and the OpenAPI snapshot test enables the annotation App Platform installer so the served spec is validated.

**Why do we need this feature?**

Annotation APIs were partially migrated to App Platform but missing from `@grafana/openapi` and `@grafana/api-clients`. This makes the new API spec and generated client available alongside the existing correlations generated client path.

**Who is this feature for?**

Developers and frontend code using generated Grafana App Platform API specs and clients for annotations and correlations.

**Which issue(s) does this PR fix?**:

Fixes #

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle or app-platform config.
- [ ] The docs are updated, and if this is a notable improvement, it's added to What's New.

Tested with:
- `go test ./pkg/tests/apis -run TestIntegrationOpenAPIs`
- `go test ./pkg/tests/apis/annotations -run 'TestIntegrationAnnotation(Search|Tags)' -v`
- `go test ./pkg/registry/apps/annotation -run 'Test(SearchHandler|TagsHandler)'`
- `yarn jest --no-watch public/app/api/clients/annotation/v0alpha1/index.test.ts`
- `yarn eslint packages/grafana-api-clients/src/clients/rtkq/index.ts packages/grafana-api-clients/src/scripts/generate-rtk-apis.ts packages/grafana-api-clients/src/clients/rtkq/annotation/v0alpha1/baseAPI.ts packages/grafana-api-clients/src/clients/rtkq/annotation/v0alpha1/index.ts packages/grafana-api-clients/src/clients/rtkq/annotation/v0alpha1/endpoints.gen.ts`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5d8cabd1-f2be-4a61-9652-21ce3649abbe"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5d8cabd1-f2be-4a61-9652-21ce3649abbe"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

