### PR TITLE
Admin: Add server-persisted Feature Flag Lab

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -114,6 +114,7 @@ func (hs *HTTPServer) registerRoutes() {
 	r.Get("/configuration", reqGrafanaAdmin, hs.Index)
 	r.Get("/admin", reqOrgAdmin, hs.Index)
 	r.Get("/admin/settings", authorize(ac.EvalPermission(ac.ActionSettingsRead, ac.ScopeSettingsAll)), hs.Index)
+	r.Get("/admin/feature-toggles", authorize(ac.EvalPermission(ac.ActionFeatureManagementRead)), hs.Index)
 	r.Get("/admin/users", authorize(ac.EvalAny(ac.EvalPermission(ac.ActionOrgUsersRead), ac.EvalPermission(ac.ActionUsersRead, ac.ScopeGlobalUsersAll))), hs.Index)
 	r.Get("/admin/users/create", authorize(ac.EvalPermission(ac.ActionUsersCreate)), hs.Index)
 	r.Get("/admin/users/edit/:id", authorize(ac.EvalPermission(ac.ActionUsersRead)), hs.Index)
@@ -550,6 +551,9 @@ func (hs *HTTPServer) registerRoutes() {
 		adminRoute.Get("/settings", authorize(ac.EvalPermission(ac.ActionSettingsRead)), routing.Wrap(hs.AdminGetSettings))
 		adminRoute.Get("/settings-verbose", authorize(ac.EvalPermission(ac.ActionSettingsRead)), routing.Wrap(hs.AdminGetVerboseSettings))
 		adminRoute.Get("/stats", authorize(ac.EvalPermission(ac.ActionServerStatsRead)), routing.Wrap(hs.AdminGetStats))
+		adminRoute.Get("/feature-toggles", authorize(ac.EvalPermission(ac.ActionFeatureManagementRead)), routing.Wrap(hs.AdminGetFeatureToggles))
+		adminRoute.Put("/feature-toggles/:name", authorize(ac.EvalPermission(ac.ActionFeatureManagementWrite)), routing.Wrap(hs.AdminSetFeatureToggle))
+		adminRoute.Delete("/feature-toggles/:name", authorize(ac.EvalPermission(ac.ActionFeatureManagementWrite)), routing.Wrap(hs.AdminDeleteFeatureToggle))
 
 		adminRoute.Post("/encryption/rotate-data-keys", reqGrafanaAdmin, routing.Wrap(hs.AdminRotateDataEncryptionKeys))
 		adminRoute.Post("/encryption/reencrypt-data-keys", reqGrafanaAdmin, routing.Wrap(hs.AdminReEncryptEncryptionKeys))

--- a/pkg/api/feature_toggles.go
+++ b/pkg/api/feature_toggles.go
@@ -1,0 +1,87 @@
+package api
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+
+	"github.com/grafana/grafana/pkg/api/response"
+	ac "github.com/grafana/grafana/pkg/services/accesscontrol"
+	contextmodel "github.com/grafana/grafana/pkg/services/contexthandler/model"
+	"github.com/grafana/grafana/pkg/services/featuremgmt"
+	"github.com/grafana/grafana/pkg/web"
+)
+
+type setFeatureToggleRequest struct {
+	Enabled bool `json:"enabled"`
+}
+
+func (hs *HTTPServer) AdminGetFeatureToggles(c *contextmodel.ReqContext) response.Response {
+	if hs.FeatureToggleAdmin == nil {
+		return response.Error(http.StatusInternalServerError, "Feature toggle admin is unavailable", nil)
+	}
+
+	canWrite, err := hs.AccessControl.Evaluate(c.Req.Context(), c.SignedInUser, ac.EvalPermission(ac.ActionFeatureManagementWrite))
+	if err != nil {
+		return response.Error(http.StatusInternalServerError, "Failed to evaluate permissions", err)
+	}
+
+	return response.JSON(http.StatusOK, hs.FeatureToggleAdmin.GetResolvedState(c.Req.Context(), canWrite))
+}
+
+func (hs *HTTPServer) AdminSetFeatureToggle(c *contextmodel.ReqContext) response.Response {
+	if hs.FeatureToggleAdmin == nil {
+		return response.Error(http.StatusInternalServerError, "Feature toggle admin is unavailable", nil)
+	}
+
+	name := web.Params(c.Req)[":name"]
+	var req setFeatureToggleRequest
+	if err := json.NewDecoder(c.Req.Body).Decode(&req); err != nil {
+		return response.Error(http.StatusBadRequest, "Invalid request body", err)
+	}
+
+	actor := c.GetLogin()
+	if actor == "" {
+		actor = "unknown"
+	}
+
+	if err := hs.FeatureToggleAdmin.SetOverride(c.Req.Context(), name, req.Enabled, actor); err != nil {
+		switch {
+		case errors.Is(err, featuremgmt.ErrUnknownFeatureFlag):
+			return response.Error(http.StatusNotFound, "Feature flag not found", err)
+		case errors.Is(err, featuremgmt.ErrFeatureFlagReadOnly):
+			return response.Error(http.StatusConflict, "Feature flag is configured in grafana.ini and cannot be changed", err)
+		case errors.Is(err, featuremgmt.ErrFeatureFlagNotWriteable):
+			return response.Error(http.StatusConflict, "Feature flag is not writeable", err)
+		default:
+			return response.Error(http.StatusInternalServerError, "Failed to update feature flag", err)
+		}
+	}
+
+	return response.JSON(http.StatusOK, hs.FeatureToggleAdmin.GetResolvedState(c.Req.Context(), true))
+}
+
+func (hs *HTTPServer) AdminDeleteFeatureToggle(c *contextmodel.ReqContext) response.Response {
+	if hs.FeatureToggleAdmin == nil {
+		return response.Error(http.StatusInternalServerError, "Feature toggle admin is unavailable", nil)
+	}
+
+	name := web.Params(c.Req)[":name"]
+	actor := c.GetLogin()
+	if actor == "" {
+		actor = "unknown"
+	}
+
+	if err := hs.FeatureToggleAdmin.DeleteOverride(c.Req.Context(), name, actor); err != nil {
+		switch {
+		case errors.Is(err, featuremgmt.ErrUnknownFeatureFlag):
+			return response.Error(http.StatusNotFound, "Feature flag not found", err)
+		case errors.Is(err, featuremgmt.ErrFeatureFlagReadOnly):
+			return response.Error(http.StatusConflict, "Feature flag is configured in grafana.ini and cannot be changed", err)
+		default:
+			return response.Error(http.StatusInternalServerError, "Failed to delete feature flag override", err)
+		}
+	}
+
+	return response.JSON(http.StatusOK, hs.FeatureToggleAdmin.GetResolvedState(c.Req.Context(), true))
+}

--- a/pkg/api/feature_toggles_test.go
+++ b/pkg/api/feature_toggles_test.go
@@ -1,0 +1,74 @@
+package api
+
+import (
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/grafana/pkg/services/accesscontrol"
+	"github.com/grafana/grafana/pkg/services/featuremgmt"
+	"github.com/grafana/grafana/pkg/services/featuremgmt/persist"
+	"github.com/grafana/grafana/pkg/services/featuretoggleadmin"
+	"github.com/grafana/grafana/pkg/setting"
+	"github.com/grafana/grafana/pkg/web/webtest"
+)
+
+func TestAPI_AdminFeatureToggles(t *testing.T) {
+	t.Run("read requires featuremgmt.read permission", func(t *testing.T) {
+		server := setupFeatureToggleAPIServer(t)
+
+		res, err := server.Send(webtest.RequestWithSignedInUser(server.NewGetRequest("/api/admin/feature-toggles"), userWithPermissions(1, []accesscontrol.Permission{
+			{Action: accesscontrol.ActionFeatureManagementRead},
+		})))
+		require.NoError(t, err)
+		assert.Equal(t, http.StatusOK, res.StatusCode)
+		require.NoError(t, res.Body.Close())
+	})
+
+	t.Run("read denied without permission", func(t *testing.T) {
+		server := setupFeatureToggleAPIServer(t)
+
+		res, err := server.Send(webtest.RequestWithSignedInUser(server.NewGetRequest("/api/admin/feature-toggles"), userWithPermissions(1, nil)))
+		require.NoError(t, err)
+		assert.Equal(t, http.StatusForbidden, res.StatusCode)
+		require.NoError(t, res.Body.Close())
+	})
+
+	t.Run("write updates non-restart flag", func(t *testing.T) {
+		server := setupFeatureToggleAPIServer(t)
+
+		res, err := server.Send(webtest.RequestWithSignedInUser(
+			server.NewRequest(http.MethodPut, "/api/admin/feature-toggles/panelTitleSearch", strings.NewReader(`{"enabled":true}`)),
+			userWithPermissions(1, []accesscontrol.Permission{
+				{Action: accesscontrol.ActionFeatureManagementWrite},
+			}),
+		))
+		require.NoError(t, err)
+		assert.Equal(t, http.StatusOK, res.StatusCode)
+		body, err := io.ReadAll(res.Body)
+		require.NoError(t, err)
+		assert.Contains(t, string(body), `"panelTitleSearch"`)
+		require.NoError(t, res.Body.Close())
+	})
+}
+
+func setupFeatureToggleAPIServer(t *testing.T) *webtest.Server {
+	t.Helper()
+
+	cfg := setting.NewCfg()
+	manager, err := featuremgmt.ProvideManagerService(cfg)
+	require.NoError(t, err)
+	store := persist.NewFakeStore()
+	admin, err := featuretoggleadmin.ProvideService(manager, store)
+	require.NoError(t, err)
+
+	return SetupAPITestServer(t, func(hs *HTTPServer) {
+		hs.Cfg = cfg
+		hs.Features = manager
+		hs.FeatureToggleAdmin = admin
+	})
+}

--- a/pkg/api/http_server.go
+++ b/pkg/api/http_server.go
@@ -68,6 +68,7 @@ import (
 	"github.com/grafana/grafana/pkg/services/datasources/guardian"
 	"github.com/grafana/grafana/pkg/services/encryption"
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
+	"github.com/grafana/grafana/pkg/services/featuretoggleadmin"
 	"github.com/grafana/grafana/pkg/services/folder"
 	"github.com/grafana/grafana/pkg/services/hooks"
 	"github.com/grafana/grafana/pkg/services/libraryelements"
@@ -132,6 +133,7 @@ type HTTPServer struct {
 	RenderService                rendering.Service
 	Cfg                          *setting.Cfg
 	Features                     featuremgmt.FeatureToggles
+	FeatureToggleAdmin           *featuretoggleadmin.Service
 	SettingsProvider             setting.Provider
 	HooksService                 *hooks.HooksService
 	navTreeService               navtree.Service
@@ -253,6 +255,7 @@ func ProvideHTTPServer(opts ServerOptions, cfg *setting.Cfg, routeRegister routi
 	accessControl accesscontrol.AccessControl, dataSourceProxy *datasourceproxy.DataSourceProxyService, searchService *search.SearchService,
 	live *live.GrafanaLive, livePushGateway *pushhttp.Gateway, plugCtxProvider *plugincontext.Provider,
 	contextHandler *contexthandler.ContextHandler, loggerMiddleware loggermw.Logger, features featuremgmt.FeatureToggles,
+	featureToggleAdmin *featuretoggleadmin.Service,
 	alertNG *ngalert.AlertNG, libraryPanelService librarypanels.Service, libraryElementService libraryelements.Service,
 	quotaService quota.Service, socialService social.Service, tracer tracing.Tracer,
 	encryptionService encryption.Internal, grafanaUpdateChecker *updatemanager.GrafanaService,
@@ -314,6 +317,7 @@ func ProvideHTTPServer(opts ServerOptions, cfg *setting.Cfg, routeRegister routi
 		QueryHistoryService:          queryHistoryService,
 		CorrelationsService:          correlationsService,
 		Features:                     features, // a read only view of the managers state
+		FeatureToggleAdmin:           featureToggleAdmin,
 		RemoteCacheService:           remoteCache,
 		ProvisioningService:          provisioningService,
 		AccessControl:                accessControl,

--- a/pkg/server/wire.go
+++ b/pkg/server/wire.go
@@ -107,6 +107,8 @@ import (
 	"github.com/grafana/grafana/pkg/services/extsvcauth"
 	extsvcreg "github.com/grafana/grafana/pkg/services/extsvcauth/registry"
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
+	featuremgmtpersist "github.com/grafana/grafana/pkg/services/featuremgmt/persist"
+	"github.com/grafana/grafana/pkg/services/featuretoggleadmin"
 	"github.com/grafana/grafana/pkg/services/folder"
 	"github.com/grafana/grafana/pkg/services/folder/folderimpl"
 	"github.com/grafana/grafana/pkg/services/grpcserver"
@@ -354,6 +356,8 @@ var wireBasicSet = wire.NewSet(
 	dsquerierclient.NewNullQSDatasourceClientBuilder,
 	expr.ProvideService,
 	featuremgmt.ProvideManagerService,
+	featuremgmtpersist.ProvideStore,
+	featuretoggleadmin.ProvideService,
 	featuremgmt.ProvideToggles,
 	dashboardservice.ProvideDashboardServiceImpl,
 	wire.Bind(new(dashboards.PermissionsRegistrationService), new(*dashboardservice.DashboardServiceImpl)),

--- a/pkg/server/wire_gen.go
+++ b/pkg/server/wire_gen.go
@@ -154,6 +154,8 @@ import (
 	"github.com/grafana/grafana/pkg/services/extsvcauth"
 	registry2 "github.com/grafana/grafana/pkg/services/extsvcauth/registry"
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
+	"github.com/grafana/grafana/pkg/services/featuretoggleadmin"
+	featuremgmtpersist "github.com/grafana/grafana/pkg/services/featuremgmt/persist"
 	"github.com/grafana/grafana/pkg/services/folder"
 	"github.com/grafana/grafana/pkg/services/folder/folderimpl"
 	"github.com/grafana/grafana/pkg/services/grpcserver"
@@ -334,6 +336,11 @@ func Initialize(ctx context.Context, cfg *setting.Cfg, opts Options, apiOpts api
 		return nil, err
 	}
 	kvStore := kvstore.ProvideService(sqlStore)
+	featureToggleOverrideStore := featuremgmtpersist.ProvideStore(kvStore)
+	featureToggleAdmin, err := featuretoggleadmin.ProvideService(featureManager, featureToggleOverrideStore)
+	if err != nil {
+		return nil, err
+	}
 	accessControl := acimpl.ProvideAccessControl(featureToggles)
 	bundleregistryService := bundleregistry.ProvideService()
 	usageStats, err := service.ProvideService(cfg, kvStore, routeRegisterImpl, tracingService, accessControl, bundleregistryService)
@@ -803,7 +810,7 @@ func Initialize(ctx context.Context, cfg *setting.Cfg, opts Options, apiOpts api
 	}
 	idimplService := idimpl.ProvideService(cfg, localSigner, remoteCache, authnService, registerer, tracer)
 	verifier := userimpl.ProvideVerifier(cfg, userimplService, tempuserService, notificationService, idimplService)
-	httpServer, err := api.ProvideHTTPServer(apiOpts, cfg, routeRegisterImpl, inProcBus, renderingService, ossLicensingService, hooksService, cacheService, sqlStore, ossDataSourceRequestValidator, pluginstoreService, service14, pluginstoreService, middlewareHandler, pluginerrsStore, pluginInstaller, ossImpl, cacheServiceImpl, userAuthTokenService, cleanUpService, shortURLService, queryHistoryService, correlationsService, remoteCache, provisioningServiceImpl, accessControl, dataSourceProxyService, searchService, grafanaLive, gateway, plugincontextProvider, contexthandlerContextHandler, logger, featureToggles, alertNG, libraryPanelService, libraryElementService, quotaService, socialService, tracingService, serviceService, grafanaService, pluginsService, ossService, service13, queryServiceImpl, filestoreService, serviceAccountsProxy, pluginassetsService, authinfoimplService, notificationService, dashboardService, dashboardProvisioningService, folderimplService, ossProvider, serviceImpl, service12, avatarCacheServer, prefService, k8sHandler, folderPermissionsService, dashboardPermissionsService, dashverService, starService, csrfCSRF, managedpluginsNoop, apikeyService, kvStore, secretsMigrator, secretsService, secretMigrationProviderImpl, secretsKVStore, v6, userimplService, tempuserService, loginattemptimplService, orgService, deletionService, teamimplService, acimplService, navtreeService, repositoryImpl, tagimplService, oauthtokenService, statsService, authnService, pluginscdnService, gatherer, apiAPI, registerer, anonDeviceService, eventualRestConfigProvider, clientGenerator, verifier, preinstallImpl, v4)
+	httpServer, err := api.ProvideHTTPServer(apiOpts, cfg, routeRegisterImpl, inProcBus, renderingService, ossLicensingService, hooksService, cacheService, sqlStore, ossDataSourceRequestValidator, pluginstoreService, service14, pluginstoreService, middlewareHandler, pluginerrsStore, pluginInstaller, ossImpl, cacheServiceImpl, userAuthTokenService, cleanUpService, shortURLService, queryHistoryService, correlationsService, remoteCache, provisioningServiceImpl, accessControl, dataSourceProxyService, searchService, grafanaLive, gateway, plugincontextProvider, contexthandlerContextHandler, logger, featureToggles, featureToggleAdmin, alertNG, libraryPanelService, libraryElementService, quotaService, socialService, tracingService, serviceService, grafanaService, pluginsService, ossService, service13, queryServiceImpl, filestoreService, serviceAccountsProxy, pluginassetsService, authinfoimplService, notificationService, dashboardService, dashboardProvisioningService, folderimplService, ossProvider, serviceImpl, service12, avatarCacheServer, prefService, k8sHandler, folderPermissionsService, dashboardPermissionsService, dashverService, starService, csrfCSRF, managedpluginsNoop, apikeyService, kvStore, secretsMigrator, secretsService, secretMigrationProviderImpl, secretsKVStore, v6, userimplService, tempuserService, loginattemptimplService, orgService, deletionService, teamimplService, acimplService, navtreeService, repositoryImpl, tagimplService, oauthtokenService, statsService, authnService, pluginscdnService, gatherer, apiAPI, registerer, anonDeviceService, eventualRestConfigProvider, clientGenerator, verifier, preinstallImpl, v4)
 	if err != nil {
 		return nil, err
 	}
@@ -1068,6 +1075,11 @@ func InitializeForTest(ctx context.Context, t sqlutil.ITestDB, testingT interfac
 		return nil, err
 	}
 	kvStore := kvstore.ProvideService(sqlStore)
+	featureToggleOverrideStore := featuremgmtpersist.ProvideStore(kvStore)
+	featureToggleAdmin, err := featuretoggleadmin.ProvideService(featureManager, featureToggleOverrideStore)
+	if err != nil {
+		return nil, err
+	}
 	accessControl := acimpl.ProvideAccessControl(featureToggles)
 	bundleregistryService := bundleregistry.ProvideService()
 	usageStats, err := service.ProvideService(cfg, kvStore, routeRegisterImpl, tracingService, accessControl, bundleregistryService)
@@ -1536,7 +1548,7 @@ func InitializeForTest(ctx context.Context, t sqlutil.ITestDB, testingT interfac
 	}
 	idimplService := idimpl.ProvideService(cfg, localSigner, remoteCache, authnService, registerer, tracer)
 	verifier := userimpl.ProvideVerifier(cfg, userimplService, tempuserService, notificationServiceMock, idimplService)
-	httpServer, err := api.ProvideHTTPServer(apiOpts, cfg, routeRegisterImpl, inProcBus, renderingService, ossLicensingService, hooksService, cacheService, sqlStore, ossDataSourceRequestValidator, pluginstoreService, service14, pluginstoreService, middlewareHandler, pluginerrsStore, pluginInstaller, ossImpl, cacheServiceImpl, userAuthTokenService, cleanUpService, shortURLService, queryHistoryService, correlationsService, remoteCache, provisioningServiceImpl, accessControl, dataSourceProxyService, searchService, grafanaLive, gateway, plugincontextProvider, contexthandlerContextHandler, logger, featureToggles, alertNG, libraryPanelService, libraryElementService, quotaService, socialService, tracingService, serviceService, grafanaService, pluginsService, ossService, service13, queryServiceImpl, filestoreService, serviceAccountsProxy, pluginassetsService, authinfoimplService, notificationServiceMock, dashboardService, dashboardProvisioningService, folderimplService, ossProvider, serviceImpl, service12, avatarCacheServer, prefService, k8sHandler, folderPermissionsService, dashboardPermissionsService, dashverService, starService, csrfCSRF, managedpluginsNoop, apikeyService, kvStore, secretsMigrator, secretsService, secretMigrationProviderImpl, secretsKVStore, v6, userimplService, tempuserService, loginattemptimplService, orgService, deletionService, teamimplService, acimplService, navtreeService, repositoryImpl, tagimplService, oauthtokentestService, statsService, authnService, pluginscdnService, gatherer, apiAPI, registerer, anonDeviceService, eventualRestConfigProvider, clientGenerator, verifier, preinstallImpl, v4)
+	httpServer, err := api.ProvideHTTPServer(apiOpts, cfg, routeRegisterImpl, inProcBus, renderingService, ossLicensingService, hooksService, cacheService, sqlStore, ossDataSourceRequestValidator, pluginstoreService, service14, pluginstoreService, middlewareHandler, pluginerrsStore, pluginInstaller, ossImpl, cacheServiceImpl, userAuthTokenService, cleanUpService, shortURLService, queryHistoryService, correlationsService, remoteCache, provisioningServiceImpl, accessControl, dataSourceProxyService, searchService, grafanaLive, gateway, plugincontextProvider, contexthandlerContextHandler, logger, featureToggles, featureToggleAdmin, alertNG, libraryPanelService, libraryElementService, quotaService, socialService, tracingService, serviceService, grafanaService, pluginsService, ossService, service13, queryServiceImpl, filestoreService, serviceAccountsProxy, pluginassetsService, authinfoimplService, notificationServiceMock, dashboardService, dashboardProvisioningService, folderimplService, ossProvider, serviceImpl, service12, avatarCacheServer, prefService, k8sHandler, folderPermissionsService, dashboardPermissionsService, dashverService, starService, csrfCSRF, managedpluginsNoop, apikeyService, kvStore, secretsMigrator, secretsService, secretMigrationProviderImpl, secretsKVStore, v6, userimplService, tempuserService, loginattemptimplService, orgService, deletionService, teamimplService, acimplService, navtreeService, repositoryImpl, tagimplService, oauthtokentestService, statsService, authnService, pluginscdnService, gatherer, apiAPI, registerer, anonDeviceService, eventualRestConfigProvider, clientGenerator, verifier, preinstallImpl, v4)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/server/wireexts_oss.go
+++ b/pkg/server/wireexts_oss.go
@@ -46,6 +46,8 @@ import (
 	"github.com/grafana/grafana/pkg/services/encryption"
 	encryptionprovider "github.com/grafana/grafana/pkg/services/encryption/provider"
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
+	featuremgmtpersist "github.com/grafana/grafana/pkg/services/featuremgmt/persist"
+	"github.com/grafana/grafana/pkg/services/featuretoggleadmin"
 	"github.com/grafana/grafana/pkg/services/hooks"
 	"github.com/grafana/grafana/pkg/services/kmsproviders"
 	"github.com/grafana/grafana/pkg/services/kmsproviders/osskmsproviders"
@@ -195,6 +197,8 @@ var wireExtsBaseCLISet = wire.NewSet(
 
 	metrics.WireSet,
 	featuremgmt.ProvideManagerService,
+	featuremgmtpersist.ProvideStore,
+	featuretoggleadmin.ProvideService,
 	featuremgmt.ProvideToggles,
 	hooks.ProvideService,
 	setting.ProvideProvider, wire.Bind(new(setting.Provider), new(*setting.OSSImpl)),

--- a/pkg/services/featuremgmt/admin_state.go
+++ b/pkg/services/featuremgmt/admin_state.go
@@ -1,0 +1,77 @@
+package featuremgmt
+
+import (
+	"sort"
+
+	common "github.com/grafana/grafana/pkg/apimachinery/apis/common/v0alpha1"
+	featuretoggleapi "github.com/grafana/grafana/pkg/services/featuremgmt/feature_toggle_api"
+)
+
+// ResolvedToggleState returns the current feature toggle state for admin APIs.
+func (fm *FeatureManager) ResolvedToggleState(allowEditing bool) *featuretoggleapi.ResolvedToggleState {
+	fm.mu.RLock()
+	defer fm.mu.RUnlock()
+
+	state := &featuretoggleapi.ResolvedToggleState{
+		AllowEditing: allowEditing,
+		Enabled:      make(map[string]bool),
+		Toggles:      make([]featuretoggleapi.ToggleStatus, 0, len(fm.flags)),
+	}
+
+	for _, flag := range fm.flags {
+		status := fm.buildToggleStatusLocked(flag, allowEditing)
+		if status.Enabled {
+			state.Enabled[flag.Name] = true
+		}
+		if status.PendingEnabled != nil && *status.PendingEnabled != status.Enabled {
+			state.RestartRequired = true
+		}
+		state.Toggles = append(state.Toggles, status)
+	}
+
+	sort.Slice(state.Toggles, func(i, j int) bool {
+		return state.Toggles[i].Name < state.Toggles[j].Name
+	})
+
+	return state
+}
+
+func (fm *FeatureManager) buildToggleStatusLocked(flag *FeatureFlag, allowEditing bool) featuretoggleapi.ToggleStatus {
+	status := featuretoggleapi.ToggleStatus{
+		Name:        flag.Name,
+		Description: flag.Description,
+		Stage:       flag.Stage.String(),
+		Enabled:     fm.enabled[flag.Name],
+	}
+
+	if warning, ok := fm.warnings[flag.Name]; ok {
+		status.Warning = warning
+	}
+
+	if _, configured := fm.startup[flag.Name]; configured {
+		status.Source = &common.ObjectReference{Kind: "configured"}
+		status.Writeable = false
+		return status
+	}
+
+	if override, ok := fm.overrides[flag.Name]; ok {
+		status.Source = &common.ObjectReference{Kind: "override"}
+		if flag.RequiresRestart {
+			pending := override
+			status.PendingEnabled = &pending
+		}
+	} else {
+		status.Source = &common.ObjectReference{Kind: "default"}
+	}
+
+	status.RequiresRestart = flag.RequiresRestart
+	status.Writeable = allowEditing && fm.isWriteableLocked(flag)
+	return status
+}
+
+func (fm *FeatureManager) FlagRequiresRestart(name string) bool {
+	fm.mu.RLock()
+	defer fm.mu.RUnlock()
+	flag, ok := fm.flags[name]
+	return ok && flag.RequiresRestart
+}

--- a/pkg/services/featuremgmt/errors.go
+++ b/pkg/services/featuremgmt/errors.go
@@ -1,0 +1,9 @@
+package featuremgmt
+
+import "errors"
+
+var (
+	ErrUnknownFeatureFlag      = errors.New("unknown feature flag")
+	ErrFeatureFlagNotWriteable = errors.New("feature flag is not writeable")
+	ErrFeatureFlagReadOnly     = errors.New("feature flag is configured in grafana.ini and cannot be changed")
+)

--- a/pkg/services/featuremgmt/feature_toggle_api/types.go
+++ b/pkg/services/featuremgmt/feature_toggle_api/types.go
@@ -110,6 +110,12 @@ type ToggleStatus struct {
 	// Can this flag be updated
 	Writeable bool `json:"writeable"`
 
+	// The flag requires a restart before changes take effect
+	RequiresRestart bool `json:"requiresRestart,omitempty"`
+
+	// Pending value saved but not yet effective until restart
+	PendingEnabled *bool `json:"pendingEnabled,omitempty"`
+
 	// Where was the value configured
 	// eg: startup | tenant|org | user | browser
 	// missing means default

--- a/pkg/services/featuremgmt/manager.go
+++ b/pkg/services/featuremgmt/manager.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"reflect"
+	"sync"
 
 	"github.com/grafana/grafana/pkg/infra/log"
 )
@@ -13,13 +14,17 @@ var (
 )
 
 type FeatureManager struct {
+	mu sync.RWMutex
+
 	isDevMod bool
 
-	flags    map[string]*FeatureFlag
-	enabled  map[string]bool   // only the "on" values
-	startup  map[string]bool   // the explicit values registered at startup
-	warnings map[string]string // potential warnings about the flag
-	log      log.Logger
+	flags             map[string]*FeatureFlag
+	enabled           map[string]bool   // only the "on" values
+	startup           map[string]bool   // the explicit values registered at startup
+	overrides         map[string]bool   // admin persisted overrides
+	appliedOverrides  map[string]bool   // overrides applied to runtime evaluation
+	warnings          map[string]string // potential warnings about the flag
+	log               log.Logger
 }
 
 // This will merge the flags with the current configuration
@@ -58,7 +63,6 @@ func (fm *FeatureManager) registerFlags(flags ...FeatureFlag) {
 		}
 	}
 
-	// This will evaluate all flags
 	fm.update()
 }
 
@@ -71,44 +75,144 @@ func (fm *FeatureManager) meetsRequirements(ff *FeatureFlag) (bool, string) {
 	return true, ""
 }
 
-// Update
 func (fm *FeatureManager) update() {
+	fm.mu.Lock()
+	defer fm.mu.Unlock()
+	fm.updateLocked()
+}
+
+func (fm *FeatureManager) updateLocked() {
 	enabled := make(map[string]bool)
 	for _, flag := range fm.flags {
-		// if grafana cannot run the feature, omit metrics around it
 		ok, reason := fm.meetsRequirements(flag)
 		if !ok {
 			fm.warnings[flag.Name] = reason
+			featureToggleInfo.WithLabelValues(flag.Name).Set(0)
 			continue
 		}
 
-		// Update the registry
-		track := 0.0
+		delete(fm.warnings, flag.Name)
 
-		startup, ok := fm.startup[flag.Name]
-		if startup || (!ok && flag.Expression == "true") {
+		isEnabled := fm.resolveEnabledLocked(flag)
+		track := 0.0
+		if isEnabled {
 			track = 1
 			enabled[flag.Name] = true
 		}
-
-		// Register value with prometheus metric
 		featureToggleInfo.WithLabelValues(flag.Name).Set(track)
 	}
 	fm.enabled = enabled
 }
 
+func (fm *FeatureManager) resolveEnabledLocked(flag *FeatureFlag) bool {
+	if configured, ok := fm.startup[flag.Name]; ok {
+		return configured
+	}
+
+	if applied, ok := fm.appliedOverrides[flag.Name]; ok {
+		return applied
+	}
+
+	return flag.Expression == "true"
+}
+
+func (fm *FeatureManager) isWriteableLocked(flag *FeatureFlag) bool {
+	if _, configured := fm.startup[flag.Name]; configured {
+		return false
+	}
+	ok, _ := fm.meetsRequirements(flag)
+	return ok
+}
+
+// LoadPersistedOverrides applies stored overrides during startup.
+func (fm *FeatureManager) LoadPersistedOverrides(overrides map[string]bool) {
+	fm.mu.Lock()
+	defer fm.mu.Unlock()
+
+	for name, enabled := range overrides {
+		if _, ok := fm.flags[name]; !ok {
+			continue
+		}
+		fm.overrides[name] = enabled
+		fm.appliedOverrides[name] = enabled
+	}
+	fm.updateLocked()
+}
+
+// SetOverrideRuntimeState updates in-memory override state.
+func (fm *FeatureManager) SetOverrideRuntimeState(name string, enabled bool, applyImmediately bool) (previousEnabled bool, err error) {
+	fm.mu.Lock()
+	defer fm.mu.Unlock()
+
+	flag, ok := fm.flags[name]
+	if !ok {
+		return false, ErrUnknownFeatureFlag
+	}
+	if _, configured := fm.startup[name]; configured {
+		return false, ErrFeatureFlagReadOnly
+	}
+	if !fm.isWriteableLocked(flag) {
+		return false, ErrFeatureFlagNotWriteable
+	}
+
+	previousEnabled = fm.enabled[name]
+	fm.overrides[name] = enabled
+	if applyImmediately {
+		fm.appliedOverrides[name] = enabled
+		fm.updateLocked()
+	}
+	return previousEnabled, nil
+}
+
+// RevertOverrideRuntimeState rolls back an in-memory override change.
+func (fm *FeatureManager) RevertOverrideRuntimeState(name string) {
+	fm.mu.Lock()
+	defer fm.mu.Unlock()
+	delete(fm.overrides, name)
+}
+
+// ClearOverrideRuntimeState removes an override from runtime evaluation.
+func (fm *FeatureManager) ClearOverrideRuntimeState(name string, applyImmediately bool) (previousEnabled bool, err error) {
+	fm.mu.Lock()
+	defer fm.mu.Unlock()
+
+	if _, ok := fm.flags[name]; !ok {
+		return false, ErrUnknownFeatureFlag
+	}
+	if _, configured := fm.startup[name]; configured {
+		return false, ErrFeatureFlagReadOnly
+	}
+	if _, ok := fm.overrides[name]; !ok {
+		return fm.enabled[name], nil
+	}
+
+	previousEnabled = fm.enabled[name]
+	delete(fm.overrides, name)
+	if applyImmediately {
+		delete(fm.appliedOverrides, name)
+		fm.updateLocked()
+	}
+	return previousEnabled, nil
+}
+
 // IsEnabled checks if a feature is enabled
 func (fm *FeatureManager) IsEnabled(ctx context.Context, flag string) bool {
+	fm.mu.RLock()
+	defer fm.mu.RUnlock()
 	return fm.enabled[flag]
 }
 
 // IsEnabledGlobally checks if a feature is for all tenants
 func (fm *FeatureManager) IsEnabledGlobally(flag string) bool {
+	fm.mu.RLock()
+	defer fm.mu.RUnlock()
 	return fm.enabled[flag]
 }
 
 // GetEnabled returns a map containing only the features that are enabled
 func (fm *FeatureManager) GetEnabled(ctx context.Context) map[string]bool {
+	fm.mu.RLock()
+	defer fm.mu.RUnlock()
 	enabled := make(map[string]bool, len(fm.enabled))
 	for key, val := range fm.enabled {
 		if val {
@@ -120,6 +224,8 @@ func (fm *FeatureManager) GetEnabled(ctx context.Context) map[string]bool {
 
 // GetFlags returns all flag definitions
 func (fm *FeatureManager) GetFlags() []FeatureFlag {
+	fm.mu.RLock()
+	defer fm.mu.RUnlock()
 	v := make([]FeatureFlag, 0, len(fm.flags))
 	for _, value := range fm.flags {
 		v = append(v, *value)
@@ -157,5 +263,12 @@ func WithManager(spec ...any) *FeatureManager {
 		}
 	}
 
-	return &FeatureManager{enabled: enabled, flags: features, startup: enabled, warnings: map[string]string{}}
+	return &FeatureManager{
+		enabled:          enabled,
+		flags:            features,
+		startup:          enabled,
+		overrides:        map[string]bool{},
+		appliedOverrides: map[string]bool{},
+		warnings:         map[string]string{},
+	}
 }

--- a/pkg/services/featuremgmt/persist/fake_store.go
+++ b/pkg/services/featuremgmt/persist/fake_store.go
@@ -1,0 +1,29 @@
+package persist
+
+import "context"
+
+type fakeStore struct {
+	values map[string]bool
+}
+
+func NewFakeStore() *fakeStore {
+	return &fakeStore{values: map[string]bool{}}
+}
+
+func (f *fakeStore) GetAll(_ context.Context) (map[string]bool, error) {
+	out := make(map[string]bool, len(f.values))
+	for key, value := range f.values {
+		out[key] = value
+	}
+	return out, nil
+}
+
+func (f *fakeStore) Set(_ context.Context, name string, enabled bool) error {
+	f.values[name] = enabled
+	return nil
+}
+
+func (f *fakeStore) Delete(_ context.Context, name string) error {
+	delete(f.values, name)
+	return nil
+}

--- a/pkg/services/featuremgmt/persist/store.go
+++ b/pkg/services/featuremgmt/persist/store.go
@@ -1,0 +1,54 @@
+package persist
+
+import (
+	"context"
+	"strconv"
+
+	"github.com/grafana/grafana/pkg/infra/kvstore"
+)
+
+const featureToggleOverridesNamespace = "featuremgmt.overrides"
+
+type Store interface {
+	GetAll(ctx context.Context) (map[string]bool, error)
+	Set(ctx context.Context, name string, enabled bool) error
+	Delete(ctx context.Context, name string) error
+}
+
+type store struct {
+	kv *kvstore.NamespacedKVStore
+}
+
+func ProvideStore(kv kvstore.KVStore) Store {
+	return &store{kv: kvstore.WithNamespace(kv, 0, featureToggleOverridesNamespace)}
+}
+
+func (s *store) GetAll(ctx context.Context) (map[string]bool, error) {
+	all, err := s.kv.GetAll(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	orgOverrides, ok := all[0]
+	if !ok {
+		return map[string]bool{}, nil
+	}
+
+	out := make(map[string]bool, len(orgOverrides))
+	for key, value := range orgOverrides {
+		enabled, err := strconv.ParseBool(value)
+		if err != nil {
+			continue
+		}
+		out[key] = enabled
+	}
+	return out, nil
+}
+
+func (s *store) Set(ctx context.Context, name string, enabled bool) error {
+	return s.kv.Set(ctx, name, strconv.FormatBool(enabled))
+}
+
+func (s *store) Delete(ctx context.Context, name string) error {
+	return s.kv.Del(ctx, name)
+}

--- a/pkg/services/featuremgmt/service.go
+++ b/pkg/services/featuremgmt/service.go
@@ -22,12 +22,14 @@ var (
 
 func ProvideManagerService(cfg *setting.Cfg) (*FeatureManager, error) {
 	mgmt := &FeatureManager{
-		isDevMod: cfg.Env != setting.Prod,
-		flags:    make(map[string]*FeatureFlag, 30),
-		enabled:  make(map[string]bool),
-		startup:  make(map[string]bool),
-		warnings: make(map[string]string),
-		log:      log.New("featuremgmt"),
+		isDevMod:         cfg.Env != setting.Prod,
+		flags:            make(map[string]*FeatureFlag, 30),
+		enabled:          make(map[string]bool),
+		startup:          make(map[string]bool),
+		overrides:        make(map[string]bool),
+		appliedOverrides: make(map[string]bool),
+		warnings:         make(map[string]string),
+		log:              log.New("featuremgmt"),
 	}
 
 	// Register the standard flags
@@ -53,8 +55,6 @@ func ProvideManagerService(cfg *setting.Cfg) (*FeatureManager, error) {
 
 	// update the values
 	mgmt.update()
-
-	// Log the enabled feature toggles at startup
 	enabled := slices.Sorted(maps.Keys(mgmt.enabled))
 	logctx := make([]any, len(enabled)*2)
 	for i, k := range enabled {

--- a/pkg/services/featuretoggleadmin/service.go
+++ b/pkg/services/featuretoggleadmin/service.go
@@ -1,0 +1,87 @@
+package featuretoggleadmin
+
+import (
+	"context"
+
+	"github.com/grafana/grafana/pkg/infra/log"
+	featuretoggleapi "github.com/grafana/grafana/pkg/services/featuremgmt/feature_toggle_api"
+	"github.com/grafana/grafana/pkg/services/featuremgmt"
+	"github.com/grafana/grafana/pkg/services/featuremgmt/persist"
+)
+
+// Service exposes server-persisted feature toggle management.
+type Service struct {
+	manager *featuremgmt.FeatureManager
+	store   persist.Store
+	log     log.Logger
+}
+
+func ProvideService(manager *featuremgmt.FeatureManager, store persist.Store) (*Service, error) {
+	service := &Service{
+		manager: manager,
+		store:   store,
+		log:     log.New("featuretoggleadmin"),
+	}
+	if err := service.loadOverrides(context.Background()); err != nil {
+		return nil, err
+	}
+	return service, nil
+}
+
+func (s *Service) loadOverrides(ctx context.Context) error {
+	overrides, err := s.store.GetAll(ctx)
+	if err != nil {
+		return err
+	}
+	s.manager.LoadPersistedOverrides(overrides)
+	return nil
+}
+
+func (s *Service) GetResolvedState(_ context.Context, allowEditing bool) *featuretoggleapi.ResolvedToggleState {
+	return s.manager.ResolvedToggleState(allowEditing)
+}
+
+func (s *Service) SetOverride(ctx context.Context, name string, enabled bool, actor string) error {
+	applyImmediately := !s.manager.FlagRequiresRestart(name)
+	previous, err := s.manager.SetOverrideRuntimeState(name, enabled, applyImmediately)
+	if err != nil {
+		return err
+	}
+
+	if err := s.store.Set(ctx, name, enabled); err != nil {
+		s.manager.RevertOverrideRuntimeState(name)
+		return err
+	}
+
+	if applyImmediately {
+		s.log.Info("Feature toggle override applied",
+			"flag", name, "enabled", enabled, "actor", actor, "previous", previous)
+		return nil
+	}
+
+	s.log.Info("Feature toggle override saved, restart required",
+		"flag", name, "enabled", enabled, "actor", actor, "previous", previous)
+	return nil
+}
+
+func (s *Service) DeleteOverride(ctx context.Context, name string, actor string) error {
+	applyImmediately := !s.manager.FlagRequiresRestart(name)
+	previous, err := s.manager.ClearOverrideRuntimeState(name, applyImmediately)
+	if err != nil {
+		return err
+	}
+
+	if err := s.store.Delete(ctx, name); err != nil {
+		return err
+	}
+
+	if applyImmediately {
+		s.log.Info("Feature toggle override removed",
+			"flag", name, "actor", actor, "previous", previous)
+		return nil
+	}
+
+	s.log.Info("Feature toggle override removed, restart required",
+		"flag", name, "actor", actor, "previous", previous)
+	return nil
+}

--- a/pkg/services/featuretoggleadmin/service_test.go
+++ b/pkg/services/featuretoggleadmin/service_test.go
@@ -1,0 +1,69 @@
+package featuretoggleadmin
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/grafana/pkg/services/featuremgmt"
+	"github.com/grafana/grafana/pkg/services/featuremgmt/persist"
+	"github.com/grafana/grafana/pkg/setting"
+)
+
+func TestServiceOverrides(t *testing.T) {
+	t.Run("configured flags are read-only", func(t *testing.T) {
+		cfg := setting.NewCfg()
+		section, err := cfg.Raw.NewSection("feature_toggles")
+		require.NoError(t, err)
+		_, err = section.NewKey("panelTitleSearch", "true")
+		require.NoError(t, err)
+
+		manager, err := featuremgmt.ProvideManagerService(cfg)
+		require.NoError(t, err)
+		service, err := ProvideService(manager, persist.NewFakeStore())
+		require.NoError(t, err)
+
+		err = service.SetOverride(context.Background(), "panelTitleSearch", false, "admin")
+		require.ErrorIs(t, err, featuremgmt.ErrFeatureFlagReadOnly)
+	})
+
+	t.Run("non-restart override applies immediately", func(t *testing.T) {
+		manager, err := featuremgmt.ProvideManagerService(setting.NewCfg())
+		require.NoError(t, err)
+		service, err := ProvideService(manager, persist.NewFakeStore())
+		require.NoError(t, err)
+
+		err = service.SetOverride(context.Background(), "panelTitleSearch", true, "admin")
+		require.NoError(t, err)
+		require.True(t, manager.IsEnabledGlobally("panelTitleSearch"))
+	})
+
+	t.Run("restart-required override is pending until restart", func(t *testing.T) {
+		manager, err := featuremgmt.ProvideManagerService(setting.NewCfg())
+		require.NoError(t, err)
+		service, err := ProvideService(manager, persist.NewFakeStore())
+		require.NoError(t, err)
+
+		err = service.SetOverride(context.Background(), "live.runAPIServer", true, "admin")
+		require.NoError(t, err)
+		require.False(t, manager.IsEnabledGlobally("live.runAPIServer"))
+
+		state := service.GetResolvedState(context.Background(), true)
+		require.True(t, state.RestartRequired)
+	})
+
+	t.Run("load overrides at startup", func(t *testing.T) {
+		cfg := setting.NewCfg()
+		manager, err := featuremgmt.ProvideManagerService(cfg)
+		require.NoError(t, err)
+
+		fakeStore := persist.NewFakeStore()
+		require.NoError(t, fakeStore.Set(context.Background(), "panelTitleSearch", true))
+
+		service, err := ProvideService(manager, fakeStore)
+		require.NoError(t, err)
+		require.NotNil(t, service)
+		require.True(t, manager.IsEnabledGlobally("panelTitleSearch"))
+	})
+}

--- a/pkg/services/navtree/navtreeimpl/admin.go
+++ b/pkg/services/navtree/navtreeimpl/admin.go
@@ -39,6 +39,11 @@ func (s *ServiceImpl) getAdminNode(c *contextmodel.ReqContext) (*navtree.NavLink
 			Text: "Settings", SubTitle: "View the settings defined in your Grafana config", Id: "server-settings", Url: s.cfg.AppSubURL + "/admin/settings", Icon: "sliders-v-alt",
 		})
 	}
+	if hasAccess(ac.EvalPermission(ac.ActionFeatureManagementRead)) {
+		generalNodeLinks = append(generalNodeLinks, &navtree.NavLink{
+			Text: "Feature Flag Lab", SubTitle: "View and manage feature flags for team development", Id: "feature-flag-lab", Url: s.cfg.AppSubURL + "/admin/feature-toggles", Icon: "flask",
+		})
+	}
 	if hasGlobalAccess(orgsAccessEvaluator) {
 		generalNodeLinks = append(generalNodeLinks, &navtree.NavLink{
 			Text: "Organizations", SubTitle: "Isolated instances of Grafana running on the same server", Id: "global-orgs", Url: s.cfg.AppSubURL + "/admin/orgs", Icon: "building",

--- a/public/app/core/utils/navBarItem-translations.ts
+++ b/public/app/core/utils/navBarItem-translations.ts
@@ -129,6 +129,8 @@ export function getNavTitle(navId: string | undefined) {
       return t('nav.global-orgs.title', 'Organizations');
     case 'server-settings':
       return t('nav.server-settings.title', 'Settings');
+    case 'feature-flag-lab':
+      return t('nav.feature-flag-lab.title', 'Feature Flag Lab');
     case 'storage':
       return t('nav.storage.title', 'Storage');
     case 'migrate-to-cloud':
@@ -281,6 +283,8 @@ export function getNavSubTitle(navId: string | undefined) {
       return t('nav.global-orgs.subtitle', 'Isolated instances of Grafana running on the same server');
     case 'server-settings':
       return t('nav.server-settings.subtitle', 'View the settings defined in your Grafana config');
+    case 'feature-flag-lab':
+      return t('nav.feature-flag-lab.subtitle', 'View and manage feature flags for team development');
     case 'storage':
       return t('nav.storage.subtitle', 'Manage file storage');
     case 'migrate-to-cloud':

--- a/public/app/features/admin/feature-toggles/FeatureTogglesPage.test.tsx
+++ b/public/app/features/admin/feature-toggles/FeatureTogglesPage.test.tsx
@@ -1,0 +1,66 @@
+import { render, screen } from '@testing-library/react';
+import FeatureTogglesPage from './FeatureTogglesPage';
+import { type FeatureToggleState } from './api';
+
+jest.mock('app/core/components/Page/Page', () => {
+  const Page = ({ children }: { children: React.ReactNode }) => <div>{children}</div>;
+  Page.Contents = ({ children }: { children: React.ReactNode }) => <div>{children}</div>;
+  return { Page };
+});
+
+const mockState: FeatureToggleState = {
+  allowEditing: true,
+  restartRequired: true,
+  toggles: [
+    {
+      name: 'panelTitleSearch',
+      description: 'Search for dashboards using panel title',
+      stage: 'preview',
+      enabled: false,
+      writeable: true,
+      source: { kind: 'default' },
+    },
+    {
+      name: 'live.runAPIServer',
+      description: 'Registers a live apiserver',
+      stage: 'experimental',
+      enabled: false,
+      writeable: true,
+      requiresRestart: true,
+      pendingEnabled: true,
+      source: { kind: 'override' },
+    },
+    {
+      name: 'cloudWatchCrossAccountQuerying',
+      description: 'Configured in grafana.ini',
+      stage: 'GA',
+      enabled: true,
+      writeable: false,
+      source: { kind: 'configured' },
+    },
+  ],
+};
+
+jest.mock('./api', () => ({
+  getFeatureToggles: jest.fn(async () => mockState),
+  setFeatureToggle: jest.fn(async () => mockState),
+  clearFeatureToggleOverride: jest.fn(async () => mockState),
+}));
+
+jest.mock('app/core/services/context_srv', () => ({
+  contextSrv: {
+    hasPermission: () => true,
+  },
+}));
+
+describe('FeatureTogglesPage', () => {
+  it('renders the lab header and team flags by default', async () => {
+    render(<FeatureTogglesPage />);
+
+    expect(await screen.findByRole('heading', { name: /feature flag lab/i })).toBeInTheDocument();
+    expect(await screen.findByTestId('feature-flag-row-panelTitleSearch')).toBeInTheDocument();
+    expect(screen.getByTestId('feature-flag-row-live.runAPIServer')).toBeInTheDocument();
+    expect(screen.queryByTestId('feature-flag-row-cloudWatchCrossAccountQuerying')).not.toBeInTheDocument();
+    expect(screen.getByText(/restart required/i)).toBeInTheDocument();
+  });
+});

--- a/public/app/features/admin/feature-toggles/FeatureTogglesPage.tsx
+++ b/public/app/features/admin/feature-toggles/FeatureTogglesPage.tsx
@@ -1,0 +1,315 @@
+import { css } from '@emotion/css';
+import { useCallback, useEffect, useMemo, useState } from 'react';
+
+import { type GrafanaTheme2 } from '@grafana/data';
+import { Trans, t } from '@grafana/i18n';
+import {
+  Alert,
+  Badge,
+  FilterInput,
+  Icon,
+  RadioButtonGroup,
+  Switch,
+  useStyles2,
+} from '@grafana/ui';
+import { Page } from 'app/core/components/Page/Page';
+import { contextSrv } from 'app/core/services/context_srv';
+import { AccessControlAction } from 'app/types/accessControl';
+
+import {
+  clearFeatureToggleOverride,
+  getFeatureToggles,
+  setFeatureToggle,
+  type FeatureToggleState,
+  type FeatureToggleStatus,
+} from './api';
+
+const TEAM_STAGES = new Set(['experimental', 'privatePreview', 'preview']);
+
+type StageFilter = 'team' | 'all';
+
+export default function FeatureTogglesPage() {
+  const styles = useStyles2(getStyles);
+  const canWrite = contextSrv.hasPermission(AccessControlAction.FeatureManagementWrite);
+  const [state, setState] = useState<FeatureToggleState | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [search, setSearch] = useState('');
+  const [stageFilter, setStageFilter] = useState<StageFilter>('team');
+  const [savingFlag, setSavingFlag] = useState<string | null>(null);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const response = await getFeatureToggles();
+      setState(response);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to load feature flags');
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  const filteredToggles = useMemo(() => {
+    const toggles = state?.toggles ?? [];
+    const query = search.trim().toLowerCase();
+
+    return toggles.filter((toggle) => {
+      if (stageFilter === 'team' && !TEAM_STAGES.has(toggle.stage)) {
+        return false;
+      }
+
+      if (!query) {
+        return true;
+      }
+
+      return (
+        toggle.name.toLowerCase().includes(query) ||
+        toggle.description?.toLowerCase().includes(query) ||
+        toggle.stage.toLowerCase().includes(query)
+      );
+    });
+  }, [search, stageFilter, state?.toggles]);
+
+  const onToggle = async (toggle: FeatureToggleStatus, enabled: boolean) => {
+    if (!toggle.writeable || !canWrite) {
+      return;
+    }
+
+    setSavingFlag(toggle.name);
+    setError(null);
+    try {
+      const response = await setFeatureToggle(toggle.name, enabled);
+      setState(response);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to update feature flag');
+    } finally {
+      setSavingFlag(null);
+    }
+  };
+
+  const onClearOverride = async (toggle: FeatureToggleStatus) => {
+    if (!toggle.writeable || !canWrite || toggle.source?.kind !== 'override') {
+      return;
+    }
+
+    setSavingFlag(toggle.name);
+    setError(null);
+    try {
+      const response = await clearFeatureToggleOverride(toggle.name);
+      setState(response);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to clear feature flag override');
+    } finally {
+      setSavingFlag(null);
+    }
+  };
+
+  return (
+    <Page navId="feature-flag-lab">
+      <Page.Contents isLoading={loading}>
+        <div className={styles.hero}>
+          <Icon name="flask" size="xxxl" className={styles.heroIcon} />
+          <div>
+            <h1 className={styles.heroTitle}>
+              <Trans i18nKey="admin.feature-toggles.title">Feature Flag Lab</Trans>
+            </h1>
+            <p className={styles.heroSubtitle}>
+              <Trans i18nKey="admin.feature-toggles.subtitle">
+                Turn team feature flags on or off for this Grafana instance. Changes are persisted on the server.
+              </Trans>
+            </p>
+          </div>
+        </div>
+
+        {state?.restartRequired && (
+          <Alert severity="warning" title={t('admin.feature-toggles.restart-required', 'Restart required')}>
+            <Trans i18nKey="admin.feature-toggles.restart-required-body">
+              Some feature flags require a Grafana restart before pending changes take effect.
+            </Trans>
+          </Alert>
+        )}
+
+        {error && (
+          <Alert severity="error" title={t('admin.feature-toggles.error', 'Unable to update feature flags')}>
+            {error}
+          </Alert>
+        )}
+
+        <div className={styles.controls}>
+          <FilterInput
+            placeholder={t('admin.feature-toggles.search-placeholder', 'Search feature flags')}
+            value={search}
+            onChange={setSearch}
+          />
+          <RadioButtonGroup
+            options={[
+              { label: t('admin.feature-toggles.filter-team', 'Team flags'), value: 'team' },
+              { label: t('admin.feature-toggles.filter-all', 'All flags'), value: 'all' },
+            ]}
+            value={stageFilter}
+            onChange={(value) => setStageFilter(value as StageFilter)}
+          />
+        </div>
+
+        <div className={styles.table}>
+          <div className={styles.headerRow}>
+            <span>
+              <Trans i18nKey="admin.feature-toggles.column-flag">Flag</Trans>
+            </span>
+            <span>
+              <Trans i18nKey="admin.feature-toggles.column-stage">Stage</Trans>
+            </span>
+            <span>
+              <Trans i18nKey="admin.feature-toggles.column-source">Source</Trans>
+            </span>
+            <span>
+              <Trans i18nKey="admin.feature-toggles.column-enabled">Enabled</Trans>
+            </span>
+          </div>
+
+          {filteredToggles.map((toggle) => {
+            const isSaving = savingFlag === toggle.name;
+            const isConfigured = toggle.source?.kind === 'configured';
+            const hasPending =
+              toggle.pendingEnabled !== undefined && toggle.pendingEnabled !== toggle.enabled;
+
+            return (
+              <div key={toggle.name} className={styles.row} data-testid={`feature-flag-row-${toggle.name}`}>
+                <div className={styles.flagCell}>
+                  <strong>{toggle.name}</strong>
+                  {toggle.description && <div className={styles.description}>{toggle.description}</div>}
+                  {toggle.warning && <div className={styles.warning}>{toggle.warning}</div>}
+                </div>
+                <div>{toggle.stage}</div>
+                <div className={styles.sourceCell}>
+                  <Badge text={toggle.source?.kind ?? 'default'} color="blue" />
+                  {toggle.requiresRestart && (
+                    <Badge
+                      text={t('admin.feature-toggles.restart-badge', 'Restart')}
+                      color="orange"
+                      className={styles.badgeSpacing}
+                    />
+                  )}
+                  {hasPending && (
+                    <Badge
+                      text={t('admin.feature-toggles.pending-badge', 'Pending: {{value}}', {
+                        value: String(toggle.pendingEnabled),
+                      })}
+                      color="purple"
+                      className={styles.badgeSpacing}
+                    />
+                  )}
+                </div>
+                <div className={styles.switchCell}>
+                  <Switch
+                    value={toggle.enabled}
+                    disabled={!toggle.writeable || !canWrite || isSaving || isConfigured}
+                    onChange={(event) => onToggle(toggle, event.currentTarget.checked)}
+                  />
+                  {toggle.source?.kind === 'override' && toggle.writeable && canWrite && (
+                    <button
+                      type="button"
+                      className={styles.clearButton}
+                      disabled={isSaving}
+                      onClick={() => onClearOverride(toggle)}
+                    >
+                      <Trans i18nKey="admin.feature-toggles.clear-override">Clear override</Trans>
+                    </button>
+                  )}
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      </Page.Contents>
+    </Page>
+  );
+}
+
+const getStyles = (theme: GrafanaTheme2) => ({
+  hero: css({
+    display: 'flex',
+    alignItems: 'center',
+    gap: theme.spacing(3),
+    marginBottom: theme.spacing(3),
+  }),
+  heroIcon: css({
+    color: theme.colors.warning.text,
+    flexShrink: 0,
+  }),
+  heroTitle: css({
+    margin: 0,
+    fontSize: theme.typography.h2.fontSize,
+  }),
+  heroSubtitle: css({
+    margin: `${theme.spacing(1)} 0 0`,
+    color: theme.colors.text.secondary,
+    maxWidth: '720px',
+  }),
+  controls: css({
+    display: 'flex',
+    flexWrap: 'wrap',
+    gap: theme.spacing(2),
+    marginBottom: theme.spacing(3),
+    alignItems: 'center',
+  }),
+  table: css({
+    display: 'grid',
+    gap: theme.spacing(1),
+  }),
+  headerRow: css({
+    display: 'grid',
+    gridTemplateColumns: '2fr 1fr 1fr 1fr',
+    gap: theme.spacing(2),
+    padding: theme.spacing(1, 2),
+    fontWeight: theme.typography.fontWeightMedium,
+    color: theme.colors.text.secondary,
+  }),
+  row: css({
+    display: 'grid',
+    gridTemplateColumns: '2fr 1fr 1fr 1fr',
+    gap: theme.spacing(2),
+    alignItems: 'center',
+    padding: theme.spacing(2),
+    borderRadius: theme.shape.radius.default,
+    background: theme.colors.background.secondary,
+  }),
+  flagCell: css({
+    minWidth: 0,
+  }),
+  description: css({
+    color: theme.colors.text.secondary,
+    marginTop: theme.spacing(0.5),
+  }),
+  warning: css({
+    color: theme.colors.warning.text,
+    marginTop: theme.spacing(0.5),
+  }),
+  sourceCell: css({
+    display: 'flex',
+    flexWrap: 'wrap',
+    gap: theme.spacing(0.5),
+  }),
+  badgeSpacing: css({
+    marginLeft: theme.spacing(0.5),
+  }),
+  switchCell: css({
+    display: 'flex',
+    alignItems: 'center',
+    gap: theme.spacing(1),
+  }),
+  clearButton: css({
+    background: 'none',
+    border: 'none',
+    color: theme.colors.text.link,
+    cursor: 'pointer',
+    padding: 0,
+    textDecoration: 'underline',
+  }),
+});

--- a/public/app/features/admin/feature-toggles/api.ts
+++ b/public/app/features/admin/feature-toggles/api.ts
@@ -1,0 +1,34 @@
+import { getBackendSrv } from '@grafana/runtime';
+
+export interface FeatureToggleStatus {
+  name: string;
+  description?: string;
+  stage: string;
+  enabled: boolean;
+  writeable: boolean;
+  requiresRestart?: boolean;
+  pendingEnabled?: boolean;
+  warning?: string;
+  source?: {
+    kind?: string;
+  };
+}
+
+export interface FeatureToggleState {
+  allowEditing?: boolean;
+  restartRequired?: boolean;
+  enabled?: Record<string, boolean>;
+  toggles?: FeatureToggleStatus[];
+}
+
+export async function getFeatureToggles(): Promise<FeatureToggleState> {
+  return getBackendSrv().get('/api/admin/feature-toggles');
+}
+
+export async function setFeatureToggle(name: string, enabled: boolean): Promise<FeatureToggleState> {
+  return getBackendSrv().put(`/api/admin/feature-toggles/${encodeURIComponent(name)}`, { enabled });
+}
+
+export async function clearFeatureToggleOverride(name: string): Promise<FeatureToggleState> {
+  return getBackendSrv().delete(`/api/admin/feature-toggles/${encodeURIComponent(name)}`);
+}

--- a/public/app/routes/routes.tsx
+++ b/public/app/routes/routes.tsx
@@ -343,6 +343,16 @@ export function getAppRoutes(): RouteDescriptor[] {
       ),
     },
     {
+      path: '/admin/feature-toggles',
+      roles: () => contextSrv.evaluatePermission([AccessControlAction.FeatureManagementRead]),
+      component: SafeDynamicImport(
+        () =>
+          import(
+            /* webpackChunkName: "FeatureTogglesPage" */ 'app/features/admin/feature-toggles/FeatureTogglesPage'
+          )
+      ),
+    },
+    {
       path: '/admin/upgrading',
       component: SafeDynamicImport(() => import('app/features/admin/UpgradePage')),
     },

--- a/public/app/types/accessControl.ts
+++ b/public/app/types/accessControl.ts
@@ -184,6 +184,9 @@ export enum AccessControlAction {
   SettingsRead = 'settings:read',
   SettingsWrite = 'settings:write',
 
+  FeatureManagementRead = 'featuremgmt.read',
+  FeatureManagementWrite = 'featuremgmt.write',
+
   // GroupSync
   GroupSyncMappingsRead = 'groupsync.mappings:read',
   GroupSyncMappingsWrite = 'groupsync.mappings:write',


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
**What is this feature?**

Adds a Feature Flag Lab admin page at `/admin/feature-toggles` under Administration > General. Authorized admins can search team feature flags, toggle them with server-persisted overrides, and see pending restart states for flags that require a restart.

**Why do we need this feature?**

Operators and developers need a supported way to enable/disable team feature flags without relying on local browser overrides or editing `grafana.ini` directly. Server-persisted overrides survive restarts and respect deployment config precedence.

**Who is this feature for?**

Grafana administrators with `featuremgmt.read` / `featuremgmt.write` permissions.

**Which issue(s) does this PR fix?**:

Fixes #

**Special notes for your reviewer:**

- Config-owned flags from `grafana.ini` / env are read-only in the UI.
- Restart-required flags persist overrides as pending until Grafana restarts.
- Admin API:
  - `GET /api/admin/feature-toggles`
  - `PUT /api/admin/feature-toggles/:name`
  - `DELETE /api/admin/feature-toggles/:name`
- Tests run:
  - `go test -v -short ./pkg/services/featuremgmt ./pkg/services/featuretoggleadmin ./pkg/api ./pkg/services/navtree/navtreeimpl`
  - `yarn jest --no-watch --runTestsByPath public/app/features/admin/feature-toggles/FeatureTogglesPage.test.tsx`

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a notable improvement, it's added to What's New.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-88375017-de8c-4a14-81e6-8310e10fa792"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-88375017-de8c-4a14-81e6-8310e10fa792"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

