### PR TITLE
Cursor: Add demo pack

### DIFF
--- a/.cursor/hooks.json
+++ b/.cursor/hooks.json
@@ -5,6 +5,18 @@
       {
         "command": ".cursor/hooks/enforce-fieldsphere-gh.sh",
         "matcher": "(^|\\s)gh(\\s|$)"
+      },
+      {
+        "command": ".cursor/hooks/guard-git-push.sh",
+        "matcher": "(^|\\s)git\\s+push(\\s|$)"
+      },
+      {
+        "command": ".cursor/hooks/advise-jest-no-watch.sh",
+        "matcher": "(^|\\s)(yarn|npm|pnpm|npx)(\\s|$).*\\b(jest|test)\\b"
+      },
+      {
+        "command": ".cursor/hooks/protect-local-artifacts.sh",
+        "matcher": "(^|\\s)git\\s+(add|commit)(\\s|$)"
       }
     ]
   }

--- a/.cursor/hooks/README.md
+++ b/.cursor/hooks/README.md
@@ -1,0 +1,19 @@
+# Cursor Hook Demo Pack
+
+These project hooks demonstrate safe agent guardrails for Grafana. They run from the repo root and exchange JSON with Cursor over stdin/stdout.
+
+## Active hooks
+
+- `enforce-fieldsphere-gh.sh`: blocks mutating `gh` commands unless they target `fieldsphere/grafana`.
+- `guard-git-push.sh`: asks for confirmation before `git push` so the agent can summarize branch, commits, and verification.
+- `advise-jest-no-watch.sh`: allows frontend test commands but reminds agents to avoid Jest watch mode.
+- `protect-local-artifacts.sh`: asks before staging or committing likely local-only artifacts such as env files, credentials, or generated manifest JSON files.
+
+## Opt-in demo ideas
+
+Use these as workshop extensions when you want visible automation beyond guardrails:
+
+- Codegen reminder hook: after edits to `pkg/server/wire.go`, `pkg/services/featuremgmt/registry.go`, `kinds/**/*.cue`, or OpenAPI files, add follow-up context that points to `make gen-go`, `make gen-feature-toggles`, `make gen-cue`, or `make swagger-gen`.
+- Split-PR scout hook: after edits that span both `pkg/` and `public/app/`, remind the agent that Grafana prefers separate frontend and backend PRs because they deploy at different cadences.
+
+Keep expensive checks in skills or explicit commands. Hooks should stay fast, deterministic, and easy to reason about.

--- a/.cursor/hooks/advise-jest-no-watch.sh
+++ b/.cursor/hooks/advise-jest-no-watch.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+INPUT_JSON="$(cat)"
+COMMAND="$(python3 -c 'import json,sys; print(json.load(sys.stdin).get("command",""))' <<< "$INPUT_JSON" 2>/dev/null || true)"
+COMMAND_LC="$(printf '%s' "$COMMAND" | tr '[:upper:]' '[:lower:]')"
+
+if [[ ! "$COMMAND_LC" =~ (^|[[:space:]])(yarn|npm|pnpm|npx)([[:space:]]|$) ]] || [[ ! "$COMMAND_LC" =~ (jest|test) ]]; then
+  printf '%s\n' '{"continue":true,"permission":"allow"}'
+  exit 0
+fi
+
+if [[ "$COMMAND_LC" =~ --no-watch ]] || [[ "$COMMAND_LC" =~ --watchall=false ]] || [[ "$COMMAND_LC" =~ --runinband ]]; then
+  printf '%s\n' '{"continue":true,"permission":"allow"}'
+  exit 0
+fi
+
+cat <<'EOF'
+{"continue":true,"permission":"allow","user_message":"Heads up: Grafana frontend tests can enter watch mode. Prefer `yarn jest --no-watch <path>` or add `--watchAll=false` for one-shot agent runs.","agent_message":"If this frontend test hangs in watch mode, rerun it with `yarn jest --no-watch` or `--watchAll=false`."}
+EOF

--- a/.cursor/hooks/guard-git-push.sh
+++ b/.cursor/hooks/guard-git-push.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+INPUT_JSON="$(cat)"
+COMMAND="$(python3 -c 'import json,sys; print(json.load(sys.stdin).get("command",""))' <<< "$INPUT_JSON" 2>/dev/null || true)"
+COMMAND_LC="$(printf '%s' "$COMMAND" | tr '[:upper:]' '[:lower:]')"
+
+if [[ ! "$COMMAND_LC" =~ (^|[[:space:]])git[[:space:]]+push([[:space:]]|$) ]]; then
+  printf '%s\n' '{"continue":true,"permission":"allow"}'
+  exit 0
+fi
+
+cat <<'EOF'
+{"continue":true,"permission":"ask","user_message":"Review gate: this repo asks agents to summarize changes before pushing. Confirm this push should proceed.","agent_message":"Before running git push, summarize the intended branch, commits, and verification results so the user can approve the push."}
+EOF

--- a/.cursor/hooks/protect-local-artifacts.sh
+++ b/.cursor/hooks/protect-local-artifacts.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+INPUT_JSON="$(cat)"
+COMMAND="$(python3 -c 'import json,sys; print(json.load(sys.stdin).get("command",""))' <<< "$INPUT_JSON" 2>/dev/null || true)"
+COMMAND_LC="$(printf '%s' "$COMMAND" | tr '[:upper:]' '[:lower:]')"
+
+if [[ ! "$COMMAND_LC" =~ (^|[[:space:]])git[[:space:]]+(add|commit)([[:space:]]|$) ]]; then
+  printf '%s\n' '{"continue":true,"permission":"allow"}'
+  exit 0
+fi
+
+risky_pattern='(^|/)(\.env|\.env\.|.*secret.*|.*credential.*|manifest.*\.json$|\.aws-config\.json$|awsconfig$|\.npmrc$|\.yarnrc\.yml$)'
+
+files_to_check=""
+if [[ "$COMMAND_LC" =~ (^|[[:space:]])git[[:space:]]+commit([[:space:]]|$) ]]; then
+  files_to_check="$(git diff --cached --name-only 2>/dev/null || true)"
+else
+  files_to_check="$(printf '%s\n' "$COMMAND" | tr ' ' '\n')"
+  if [[ "$COMMAND_LC" =~ (^|[[:space:]])git[[:space:]]+add[[:space:]]+(-a|--all|\.)([[:space:]]|$) ]]; then
+    files_to_check="$files_to_check"$'\n'"$(git status --porcelain 2>/dev/null | sed 's/^...//')"
+  fi
+fi
+
+risky_files="$(printf '%s\n' "$files_to_check" | grep -E "$risky_pattern" || true)"
+
+if [[ -z "$risky_files" ]]; then
+  printf '%s\n' '{"continue":true,"permission":"allow"}'
+  exit 0
+fi
+
+export RISKY_FILES="$risky_files"
+python3 - <<'PY'
+import json
+import os
+
+files = [line for line in os.environ.get("RISKY_FILES", "").splitlines() if line]
+preview = ", ".join(files[:5])
+if len(files) > 5:
+    preview += f", and {len(files) - 5} more"
+
+print(json.dumps({
+    "continue": True,
+    "permission": "ask",
+    "user_message": f"Possible local or sensitive artifact detected before git staging/commit: {preview}. Confirm it belongs in this repo before continuing.",
+    "agent_message": "Review the flagged file list and avoid committing local manifests, credentials, env files, or secrets unless the user explicitly confirms.",
+}))
+PY

--- a/.cursor/rules/backend-services.mdc
+++ b/.cursor/rules/backend-services.mdc
@@ -1,0 +1,14 @@
+---
+description: Grafana backend service conventions
+globs: pkg/**/*.go,apps/**/*.go
+alwaysApply: false
+---
+
+# Backend Services
+
+- Put business logic in `pkg/services/<domain>/`; keep API handlers thin.
+- Enforce authorization and validation server-side, not only in UI checks.
+- Use existing service interfaces, SQL store helpers, and logging patterns.
+- After Wire/provider changes, run `make gen-go`.
+- After feature toggle registry changes, run `make gen-feature-toggles`.
+- Verify with focused package tests such as `go test -run TestName ./pkg/services/domain/`.

--- a/.cursor/rules/docs-authoring.mdc
+++ b/.cursor/rules/docs-authoring.mdc
@@ -1,0 +1,13 @@
+---
+description: Grafana documentation authoring conventions
+globs: docs/**/*.md
+alwaysApply: false
+---
+
+# Docs Authoring
+
+- Read `docs/AGENTS.md` before editing documentation.
+- Preserve Hugo front matter and docs-specific markers.
+- Use clear, user-facing language and sentence case headings.
+- Keep examples accurate for Grafana OSS unless the page is explicitly enterprise-only.
+- For docs-only changes, avoid running unrelated code test suites.

--- a/.cursor/rules/e2e-playwright.mdc
+++ b/.cursor/rules/e2e-playwright.mdc
@@ -1,0 +1,13 @@
+---
+description: Grafana Playwright E2E conventions
+globs: e2e-playwright/**/*.ts
+alwaysApply: false
+---
+
+# E2E Playwright
+
+- Read the nearest `AGENTS.md` before editing an E2E suite.
+- Prefer page objects for repeated interactions and keep selectors stable.
+- Use isolated test data with realistic names and cleanup when the suite expects it.
+- For alerting E2E, run the authentication setup project before targeted specs.
+- Prefer `--grep` or a specific spec path for focused verification.

--- a/.cursor/rules/frontend-react.mdc
+++ b/.cursor/rules/frontend-react.mdc
@@ -1,0 +1,14 @@
+---
+description: Grafana frontend React and TypeScript conventions
+globs: public/app/**/*.{ts,tsx},packages/**/*.{ts,tsx}
+alwaysApply: false
+---
+
+# Frontend React
+
+- Use function components with hooks and existing Grafana UI primitives.
+- Use Emotion styles through `useStyles2`; avoid introducing unrelated styling systems.
+- Prefer Redux Toolkit slices and RTK Query over legacy Redux patterns.
+- Keep feature code in the owning `public/app/features/<domain>/` tree.
+- Run focused frontend tests with `yarn jest --no-watch path/to/file.test.tsx`.
+- For alerting files, read `public/app/features/alerting/unified/AGENTS.md` first.

--- a/.cursor/rules/grafana-basics.mdc
+++ b/.cursor/rules/grafana-basics.mdc
@@ -1,0 +1,13 @@
+---
+description: Core Grafana repo guidance for Cursor agents
+alwaysApply: true
+---
+
+# Grafana Basics
+
+- Read `AGENTS.md` before substantial work; it is the canonical repo guide.
+- Keep changes focused and follow the surrounding code style.
+- Prefer targeted tests over repo-wide commands unless the risk justifies broad verification.
+- Separate unrelated frontend (`public/app/`, `packages/`) and backend (`pkg/`, `apps/`) changes into separate PRs.
+- Do not stage local manifests, credentials, env files, or caches.
+- For GitHub work, target `fieldsphere/grafana` unless the user explicitly requests upstream.

--- a/.cursor/skills/alerting-test-workflow/SKILL.md
+++ b/.cursor/skills/alerting-test-workflow/SKILL.md
@@ -1,0 +1,27 @@
+---
+name: alerting-test-workflow
+description: Add or run Grafana alerting frontend tests using local squad conventions. Use for work under public/app/features/alerting/unified or alerting-related React tests.
+---
+
+# Alerting Test Workflow
+
+## Instructions
+
+1. Read `public/app/features/alerting/unified/AGENTS.md`.
+2. If deeper test guidance is needed, read `public/app/features/alerting/unified/TESTING.md`.
+3. Prefer existing factories, mock APIs, and MSW patterns over ad hoc `jest.fn()` mocks.
+4. Keep RBAC and feature toggle defaults explicit in tests.
+5. Run the narrowest test with Jest in non-watch mode.
+
+## Default command
+
+```sh
+yarn jest --no-watch public/app/features/alerting/unified/path/to/file.test.tsx
+```
+
+## Review checklist
+
+- Uses Testing Library queries that reflect user behavior.
+- Keeps network mocking close to existing `mockApi.ts` patterns.
+- Covers permission-sensitive behavior server-side or via documented RBAC fixtures.
+- Avoids adding frontend dependencies unless the user explicitly requested them.

--- a/.cursor/skills/codegen-change/SKILL.md
+++ b/.cursor/skills/codegen-change/SKILL.md
@@ -1,0 +1,29 @@
+---
+name: codegen-change
+description: Handle Grafana code generation after Wire, feature toggle, CUE schema, OpenAPI, or Go workspace changes. Use when edits touch generated-code inputs or generated files.
+---
+
+# Codegen Change
+
+## Instructions
+
+1. Identify which generator owns the changed inputs.
+2. Run the matching command from the repo root.
+3. Review generated diffs for unrelated churn before continuing.
+4. Run a focused compile or test for the touched package.
+
+## Generator map
+
+| Input changed | Command |
+| --- | --- |
+| `pkg/server/wire.go`, service init, provider sets | `make gen-go` |
+| `pkg/services/featuremgmt/` feature toggle registry | `make gen-feature-toggles` |
+| `kinds/**/*.cue` dashboard or app schemas | `make gen-cue` |
+| OpenAPI or Swagger specs | `make swagger-gen` |
+| Added or removed Go modules | `make update-workspace` |
+
+## Notes
+
+- Do not hand-edit generated files when a generator exists.
+- If the command is expensive, explain why it is needed before running it.
+- For unified storage/search changes under `pkg/storage/unified/`, read `pkg/storage/unified/AGENTS.md` before changing generated contracts.

--- a/.cursor/skills/dashboard-e2e-workflow/SKILL.md
+++ b/.cursor/skills/dashboard-e2e-workflow/SKILL.md
@@ -1,0 +1,30 @@
+---
+name: dashboard-e2e-workflow
+description: Work on Grafana dashboard Playwright E2E specs and page objects. Use when editing e2e-playwright/dashboard-new-layouts or migrating dashboard specs to page-object patterns.
+---
+
+# Dashboard E2E Workflow
+
+## Instructions
+
+1. Read `e2e-playwright/dashboard-new-layouts/AGENTS.md` before editing tests.
+2. Prefer page objects for repeated dashboard interactions.
+3. Do not invent speculative page-object methods; add only what the current spec needs.
+4. Use stable selectors and realistic resource names.
+5. Verify the changed spec with a focused Playwright run.
+
+## Default commands
+
+```sh
+yarn e2e:pw --project dashboard-new-layouts --grep "spec or test title"
+```
+
+For flaky-prone migration work:
+
+```sh
+yarn e2e:pw --project dashboard-new-layouts --repeat-each=3 --grep "spec or test title"
+```
+
+## Demo angle
+
+This skill is a good Cursor 101 example because a parent agent can keep context on the feature request while a subagent migrates one E2E interaction into a reusable page object.

--- a/.cursor/skills/grafana-pr-ready/SKILL.md
+++ b/.cursor/skills/grafana-pr-ready/SKILL.md
@@ -1,0 +1,28 @@
+---
+name: grafana-pr-ready
+description: Prepare a Grafana change for pull request review. Use when the user asks to open a PR, make a branch ready, summarize changes, or verify work before pushing.
+---
+
+# Grafana PR Ready
+
+## Instructions
+
+1. Check `git status --short --branch` and inspect the diff.
+2. Confirm the work is focused; if frontend and backend changes are unrelated, recommend split PRs.
+3. Run the narrowest relevant verification command.
+4. Summarize changed files, tests, and remaining risk before any push.
+5. For GitHub context, target `fieldsphere/grafana` unless the user explicitly says upstream.
+
+## Verification defaults
+
+- Go package change: `go test -run TestName ./pkg/services/domain/`
+- React or TypeScript test: `yarn jest --no-watch path/to/file.test.tsx`
+- Docs-only change: review rendered Markdown/front matter; avoid code test churn.
+- Codegen input change: use the `codegen-change` skill first.
+
+## PR body checklist
+
+- Clear summary of user-visible behavior.
+- Focused test evidence.
+- `Resolves ABC-123` when the task is for a Linear ticket.
+- No local manifests, env files, credentials, or generated cache artifacts.

--- a/.cursor/skills/targeted-tests/SKILL.md
+++ b/.cursor/skills/targeted-tests/SKILL.md
@@ -1,0 +1,43 @@
+---
+name: targeted-tests
+description: Choose and run focused Grafana test commands. Use when the user asks to test a change, reproduce a failure, run unit tests, or verify frontend, backend, or Playwright behavior.
+---
+
+# Targeted Tests
+
+## Instructions
+
+1. Inspect the changed files and pick the narrowest useful test.
+2. Prefer one-shot commands that exit cleanly in agent environments.
+3. If a targeted run fails, diagnose that failure before broadening the test scope.
+
+## Commands
+
+### Backend Go
+
+```sh
+go test -run TestName ./pkg/services/myservice/
+```
+
+Use the package containing the touched code. For large packages such as `pkg/api/`, prefer a specific `-run` pattern.
+
+### Frontend Jest
+
+```sh
+yarn jest --no-watch path/to/file.test.tsx
+```
+
+Do not use `yarn test` without `--watchAll=false`; it can stay in watch mode.
+
+### Playwright E2E
+
+```sh
+yarn e2e:playwright path/to/test.spec.ts
+```
+
+For alerting and dashboard layout specs, read the local `AGENTS.md` first because those suites have additional setup and selector rules.
+
+## Escalation
+
+- If codegen files changed, use the `codegen-change` skill before testing.
+- If integration databases are required, use `make devenv sources=postgres_tests,mysql_tests` only when the test package actually needs them.

--- a/.cursor/subagents/README.md
+++ b/.cursor/subagents/README.md
@@ -1,0 +1,18 @@
+# Cursor Subagent Demo Playbooks
+
+These files are ready-to-copy prompts for Cursor subagents during a Grafana 101 demo. They are not runtime registrations; use them as launch templates when you want parallel agents to explore, test, or review a focused area.
+
+## Suggested demo flow
+
+1. Parent agent scopes the user request and identifies likely files.
+2. Launch one or more subagents with prompts from this directory.
+3. Ask each subagent to return only findings, changed-file suggestions, commands run, and residual risks.
+4. Parent agent integrates the result, makes the final edits, and runs focused verification.
+
+## Playbooks
+
+- `frontend-alerting-fix.md`: alerting React bugfix or test agent.
+- `backend-service-test.md`: backend service unit-test agent.
+- `ci-triage.md`: CI failure investigation against `fieldsphere/grafana`.
+- `security-rbac-review.md`: auth, RBAC, and permission review.
+- `split-pr-scout.md`: creative scout for separating mixed frontend/backend changes.

--- a/.cursor/subagents/backend-service-test.md
+++ b/.cursor/subagents/backend-service-test.md
@@ -1,0 +1,25 @@
+# Backend Service Test Subagent
+
+Use this prompt for backend service changes under `pkg/services/`.
+
+```text
+You are a Grafana backend service subagent.
+
+Scope:
+- Focus on the touched `pkg/services/<domain>/` package.
+- Keep business logic in services and avoid moving behavior into `pkg/api/` handlers.
+- Watch for server-side authorization, validation, and storage boundaries.
+
+Task:
+1. Inspect the service and its existing tests.
+2. Identify the narrowest missing test or failing behavior.
+3. Propose a small implementation or test change that follows local patterns.
+4. Note whether Wire, feature toggle, or SQL migration codegen is relevant.
+
+Return:
+- Files inspected.
+- Suggested test name and location.
+- Exact command: `go test -run TestName ./pkg/services/<domain>/`.
+- Any codegen command required before testing.
+- Remaining risks.
+```

--- a/.cursor/subagents/ci-triage.md
+++ b/.cursor/subagents/ci-triage.md
@@ -1,0 +1,25 @@
+# CI Triage Subagent
+
+Use this prompt when a parent agent needs a focused CI failure summary.
+
+```text
+You are a Grafana CI triage subagent.
+
+Scope:
+- Target GitHub repository `fieldsphere/grafana`.
+- Use read-only GitHub commands and logs.
+- Do not create, edit, merge, or comment on PRs or issues.
+
+Task:
+1. Inspect the failing check, job, or run provided by the parent agent.
+2. Find the first actionable failure, not just the final summary line.
+3. Map the failure to likely files or commands in this repo.
+4. Suggest the narrowest local reproduction command.
+
+Return:
+- Failing check/job name.
+- Root-cause summary.
+- Relevant log excerpt or error text.
+- Suggested local command.
+- Whether the failure looks flaky, environmental, or code-related.
+```

--- a/.cursor/subagents/frontend-alerting-fix.md
+++ b/.cursor/subagents/frontend-alerting-fix.md
@@ -1,0 +1,25 @@
+# Frontend Alerting Fix Subagent
+
+Use this prompt when a parent agent needs focused help under `public/app/features/alerting/unified/`.
+
+```text
+You are a read-mostly Grafana frontend subagent focused on alerting.
+
+Scope:
+- Work only under `public/app/features/alerting/unified/` unless the evidence clearly requires a nearby shared helper.
+- Read `public/app/features/alerting/unified/AGENTS.md` before proposing changes.
+- If tests are involved, also read `public/app/features/alerting/unified/TESTING.md`.
+
+Task:
+1. Identify the smallest code path related to the reported alerting issue.
+2. Propose the minimal fix and the most focused Jest test.
+3. Prefer existing factories, MSW handlers, and RBAC helpers.
+4. Avoid adding dependencies.
+
+Return:
+- Files inspected.
+- Root cause or best-supported hypothesis.
+- Suggested edit locations.
+- Exact test command, using `yarn jest --no-watch`.
+- Risks or open questions.
+```

--- a/.cursor/subagents/security-rbac-review.md
+++ b/.cursor/subagents/security-rbac-review.md
@@ -1,0 +1,24 @@
+# Security RBAC Review Subagent
+
+Use this prompt for auth-sensitive changes, especially alerting, dashboards, folders, and API handlers.
+
+```text
+You are a Grafana security and RBAC review subagent.
+
+Scope:
+- Review only the diff or file list provided by the parent agent.
+- Focus on authorization, tenancy, input validation, XSS, SQL injection, and secret handling.
+- Treat UI-only permission checks as insufficient unless a server-side check also exists.
+
+Task:
+1. Identify trust boundaries and permission checks.
+2. Verify the backend enforces the sensitive operation.
+3. Check whether tests cover denied and allowed paths.
+4. Look for accidental exposure of local files, credentials, or generated manifests.
+
+Return:
+- Findings ordered by severity with file references.
+- Missing tests or evidence gaps.
+- Suggested focused test command.
+- If no issues are found, say so and list residual risk.
+```

--- a/.cursor/subagents/split-pr-scout.md
+++ b/.cursor/subagents/split-pr-scout.md
@@ -1,0 +1,24 @@
+# Split PR Scout Subagent
+
+Use this creative prompt when a change touches multiple Grafana subsystems.
+
+```text
+You are a Grafana split-PR scout.
+
+Scope:
+- Inspect the current diff and changed-file list.
+- Do not modify files.
+- Use Grafana's guidance that frontend and backend changes are often deployed at different cadences.
+
+Task:
+1. Group changed files by subsystem: backend, frontend, docs, E2E, codegen, or tooling.
+2. Identify dependencies between groups.
+3. Decide whether the work should stay in one PR or split into focused PRs.
+4. If split is recommended, propose branch/PR slices in merge-safe order.
+
+Return:
+- File groups.
+- Coupling notes.
+- One-PR vs split-PR recommendation.
+- Suggested verification per slice.
+```

--- a/.gitignore
+++ b/.gitignore
@@ -76,8 +76,14 @@ public/css/*.min.css
 .cursor/
 !.cursor/
 .cursor/*
+!.cursor/hooks/
+!.cursor/hooks/**
+!.cursor/rules/
+!.cursor/rules/**
 !.cursor/skills/
 !.cursor/skills/**
+!.cursor/subagents/
+!.cursor/subagents/**
 .devcontainer/
 .claude/
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
**What is this feature?**

Adds a project-scoped Cursor 101 demo pack for Grafana:
- Advisory hooks for GitHub/push safety, Jest watch-mode reminders, and risky local artifact staging.
- Reusable skills for targeted tests, codegen changes, alerting tests, PR readiness, and dashboard E2E workflows.
- Scoped `.cursor/rules` guidance for core repo behavior, frontend, backend, docs, and Playwright work.
- Subagent prompt playbooks for common and creative parallel-agent demo scenarios.

**Why do we need this feature?**

This gives demo users concrete examples of Cursor primitives that are specific to Grafana workflows while staying safe by default and aligned with existing repo guidance.

**Who is this feature for?**

Developers and demo presenters who want to show how Cursor hooks, skills, rules, and subagents can support Grafana development workflows.

**Which issue(s) does this PR fix?**:

N/A

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle. N/A; this is Cursor config and documentation only.
- [x] The docs are updated, and if this is a notable improvement, it's added to What's New. N/A; this is repo-local Cursor demo material.

Validation performed:
- `python3 -m json.tool .cursor/hooks.json >/dev/null`
- `bash -n .cursor/hooks/enforce-fieldsphere-gh.sh .cursor/hooks/guard-git-push.sh .cursor/hooks/advise-jest-no-watch.sh .cursor/hooks/protect-local-artifacts.sh`
- Sample hook JSON smoke tests for push, Jest watch-mode, and risky file staging.
- `git diff --cached --check`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e31aa959-af84-489b-8410-4e8fbfd27b79"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e31aa959-af84-489b-8410-4e8fbfd27b79"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

