### PR TITLE
Structured logging migration for issue #12

### DIFF
--- a/contribute/backend/instrumentation.md
+++ b/contribute/backend/instrumentation.md
@@ -20,7 +20,7 @@ import (
 logger := log.New("my-logger")
 logger.Debug("Debug msg")
 logger.Info("Info msg")
-logger.Warning("Warning msg")
+logger.Warn("Warning msg")
 logger.Error("Error msg", "error", fmt.Errorf("BOOM"))
 ```
 
@@ -34,7 +34,22 @@ Start the log message with a capital letter, for example, `logger.Info("Hello wo
 
 To be consistent with Go identifiers, prefer using camelCase style when naming log keys; for example, `remoteAddr`.
 
-Use the key `Error` when logging Go errors; for example, `logger.Error("Something failed", "error", fmt.Errorf("BOOM"))`.
+Use the key `error` when logging Go errors; for example, `logger.Error("Something failed", "error", fmt.Errorf("BOOM"))`.
+
+### Structured logging
+
+Use static log messages and put operational data in key/value fields. Do not embed values in the message with `fmt.Sprintf`, string concatenation, or printf-style formatting.
+
+```go
+// Good
+logger.Error("Failed to list events", "error", err, "userId", userID)
+
+// Avoid
+logger.Error(fmt.Sprintf("failed to list event: %s", err))
+logger.Error("failed to list event: %s", err)
+```
+
+Prefer `logger.FromContext(ctx)` in request-scoped code so contextual fields such as `traceID` are included automatically.
 
 ### Validate and sanitize input coming from user input
 
@@ -73,7 +88,7 @@ func doSomething(ctx context.Context) {
   ctxLogger := logger.FromContext(ctx)
   ctxLogger.Debug("Debug msg")
   ctxLogger.Info("Info msg")
-  ctxLogger.Warning("Warning msg")
+  ctxLogger.Warn("Warning msg")
   ctxLogger.Error("Error msg", "error", fmt.Errorf("BOOM"))
 }
 ```

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -694,6 +694,19 @@ module.exports = [
     },
   },
 
+  {
+    name: 'grafana/structured-logging',
+    files: [
+      'public/app/features/scopes/**/*.{ts,tsx}',
+      'public/app/features/variables/**/*.{ts,tsx}',
+      'public/app/features/dashboard-scene/**/*.{ts,tsx}',
+    ],
+    ignores: ['**/*.test.{ts,tsx}', '**/*.story.{ts,tsx}', '**/logging.ts'],
+    rules: {
+      'no-console': 'error',
+    },
+  },
+
   // {
   //   name: 'grafana/plugin-external-import-paths',
   //   files: [

--- a/packages/grafana-runtime/src/services/logging/README.md
+++ b/packages/grafana-runtime/src/services/logging/README.md
@@ -9,6 +9,23 @@ A centralized logger registry built on top of [Grafana Faro Web SDK](https://git
 - **Logger registry** — singleton record that stores one `MonitoringLogger` per source. Initialized once at app boot via `initializeLoggersRegistry()`, which iterates over `Loggers` automatically.
 - **`MonitoringLogger`** — object with five methods: `logDebug`, `logInfo`, `logWarning`, `logError`, `logMeasurement`.
 
+## Structured logging conventions
+
+- Register a logger source in `loggers.ts` before calling `getLogger(...)`.
+- Use a static message string and pass operational data in the context object.
+- Do not add new raw `console.*` calls in product code. Use `logToConsole: true` on the registry entry when local console output is needed during development.
+- Prefer feature-local wrappers (for example, alerting's `Analytics.ts`) when a feature logs frequently.
+
+```ts
+// Good
+logger.logError(new Error('Failed to fetch scope'), { scopeName: name });
+
+// Avoid
+console.error('Failed to fetch scope:', name, err);
+```
+
+Legacy logger source names remain supported, but new loggers should use `grafana.<area>.<feature>`.
+
 ## How to add a new logger
 
 1. **Add an entry to the `Loggers` object** in `loggers.ts`. Follow the naming convention `grafana.<area>.<feature>`:

--- a/packages/grafana-runtime/src/services/logging/loggers.ts
+++ b/packages/grafana-runtime/src/services/logging/loggers.ts
@@ -7,6 +7,10 @@ export const Loggers = {
   'grafana/runtime.plugins.meta': { logToConsole: true },
   'grafana/runtime.plugins.settings': { logToConsole: true },
   'grafana/runtime.utils.getCachedPromise': {},
+  'grafana.features.scopes': { logToConsole: true },
+  'grafana.features.variables': { logToConsole: true },
+  'grafana.dashboard.scenes': { logToConsole: true },
+  'grafana.plugins.sql': { logToConsole: true },
 
   /* existing loggers that keep their existing source name */
   sandbox: {},

--- a/packages/grafana-sql/src/utils/logging.ts
+++ b/packages/grafana-sql/src/utils/logging.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line @grafana/no-direct-create-monitoring-logger
-import { createMonitoringLogger, type MonitoringLogger } from '@grafana/runtime';
+import { getLogger } from '@grafana/runtime/unstable';
 
-export const sqlPluginLogger: MonitoringLogger = createMonitoringLogger('features.plugins.sql');
+export const sqlPluginLogger = getLogger('grafana.plugins.sql');

--- a/pkg/api/frontend_logging.go
+++ b/pkg/api/frontend_logging.go
@@ -70,8 +70,8 @@ func GrafanaJavascriptAgentLogMessageHandler(store *frontendlogging.SourceMapSto
 					var ctx = frontendlogging.CtxVector{}
 					ctx = event.AddMetaToContext(ctx)
 					ctx = append(ctx, measurementName, measurementValue)
-					ctx = append(ctx, "kind", "measurement", "original_timestamp", measurementEntry.Timestamp)
-					frontendLogger.Info("Measurement: "+measurementEntry.Type, ctx...)
+					ctx = append(ctx, "kind", "measurement", "measurementType", measurementEntry.Type, "original_timestamp", measurementEntry.Timestamp)
+					frontendLogger.Info("Frontend measurement", ctx...)
 				}
 			}
 		}

--- a/pkg/services/cloudmigration/cloudmigrationimpl/snapshot_mgmt.go
+++ b/pkg/services/cloudmigration/cloudmigrationimpl/snapshot_mgmt.go
@@ -550,7 +550,7 @@ func (s *Service) buildSnapshot(
 
 	start := time.Now()
 	defer func() {
-		s.log.Debug(fmt.Sprintf("buildSnapshot: method completed in %d ms", time.Since(start).Milliseconds()))
+		s.log.Debug("buildSnapshot completed", "durationMs", time.Since(start).Milliseconds())
 	}()
 
 	encrypter := crypto.NewNacl()
@@ -563,7 +563,7 @@ func (s *Service) buildSnapshot(
 		return fmt.Errorf("nacl: generating public and private key: %w", err)
 	}
 
-	s.log.Debug(fmt.Sprintf("buildSnapshot: generated keys in %d ms", time.Since(start).Milliseconds()))
+	s.log.Debug("buildSnapshot generated keys", "durationMs", time.Since(start).Milliseconds())
 
 	// Use GMS public key + the grafana generated private key to encrypt snapshot files.
 	snapshotWriter, err := snapshot.NewSnapshotWriter(contracts.AssymetricKeys{
@@ -577,14 +577,14 @@ func (s *Service) buildSnapshot(
 		return fmt.Errorf("instantiating snapshot writer: %w", err)
 	}
 
-	s.log.Debug(fmt.Sprintf("buildSnapshot: created snapshot writing in %d ms", time.Since(start).Milliseconds()))
+	s.log.Debug("buildSnapshot created snapshot writer", "durationMs", time.Since(start).Milliseconds())
 
 	migrationData, err := s.getMigrationDataJSON(ctx, signedInUser, resourceTypes)
 	if err != nil {
 		return fmt.Errorf("fetching migration data: %w", err)
 	}
 
-	s.log.Debug(fmt.Sprintf("buildSnapshot: got migration data json in %d ms", time.Since(start).Milliseconds()))
+	s.log.Debug("buildSnapshot got migration data json", "durationMs", time.Since(start).Milliseconds())
 
 	localSnapshotResource := make([]cloudmigration.CloudMigrationResource, len(migrationData.Items))
 	resourcesGroupedByType := make(map[cloudmigration.MigrateDataType][]snapshot.MigrateDataRequestItemDTO, 0)
@@ -615,13 +615,13 @@ func (s *Service) buildSnapshot(
 		if err := s.buildSnapshotWithDBStorage(ctx, snapshotMeta.UID, snapshotWriter, resourcesGroupedByType, maxItemsPerPartition); err != nil {
 			return fmt.Errorf("building snapshot with database storage: %w", err)
 		}
-		s.log.Debug(fmt.Sprintf("buildSnapshot: wrote data partitions with database storage in %d ms", time.Since(start).Milliseconds()))
+		s.log.Debug("buildSnapshot wrote data partitions with database storage", "durationMs", time.Since(start).Milliseconds())
 
 	case cloudmigration.ResourceStorageTypeFs:
 		if err := s.buildSnapshotWithFSStorage(keys.Public, metadata, snapshotWriter, resourcesGroupedByType, maxItemsPerPartition); err != nil {
 			return fmt.Errorf("building snapshot with file system storage: %w", err)
 		}
-		s.log.Debug(fmt.Sprintf("buildSnapshot: wrote data partitions with file system storage in %d ms", time.Since(start).Milliseconds()))
+		s.log.Debug("buildSnapshot wrote data partitions with file system storage", "durationMs", time.Since(start).Milliseconds())
 
 	default:
 		return fmt.Errorf("unknown resource storage type, check your configuration and try again: %q", s.cfg.CloudMigration.ResourceStorageType)
@@ -692,7 +692,7 @@ func (s *Service) uploadSnapshot(ctx context.Context, session *cloudmigration.Cl
 
 	start := time.Now()
 	defer func() {
-		s.log.Debug(fmt.Sprintf("uploadSnapshot: method completed in %d ms", time.Since(start).Milliseconds()))
+		s.log.Debug("uploadSnapshot completed", "durationMs", time.Since(start).Milliseconds())
 	}()
 
 	switch s.cfg.CloudMigration.ResourceStorageType {
@@ -814,12 +814,12 @@ func (s *Service) uploadSnapshotWithFSStorage(ctx context.Context, session *clou
 
 				return fmt.Errorf("uploading snapshot file using presigned url: %w", err)
 			}
-			s.log.Debug(fmt.Sprintf("uploadSnapshot: uploaded %s in %d ms", fileName, time.Since(start).Milliseconds()))
+			s.log.Debug("uploadSnapshot uploaded file", "fileName", fileName, "durationMs", time.Since(start).Milliseconds())
 		}
 	}
 	uploadSpan.End()
 
-	s.log.Debug(fmt.Sprintf("uploadSnapshot: uploaded all data files in %d ms", time.Since(start).Milliseconds()))
+	s.log.Debug("uploadSnapshot uploaded all data files", "durationMs", time.Since(start).Milliseconds())
 
 	uploadCtx, uploadSpan = s.tracer.Start(ctx, "CloudMigrationService.uploadSnapshot.uploadIndex")
 
@@ -843,7 +843,7 @@ func (s *Service) uploadSnapshotWithFSStorage(ctx context.Context, session *clou
 
 	uploadSpan.End()
 
-	s.log.Debug(fmt.Sprintf("uploadSnapshot: uploaded index file in %d ms", time.Since(start).Milliseconds()))
+	s.log.Debug("uploadSnapshot uploaded index file", "durationMs", time.Since(start).Milliseconds())
 
 	return nil
 }

--- a/pkg/services/ngalert/backtesting/engine.go
+++ b/pkg/services/ngalert/backtesting/engine.go
@@ -103,7 +103,7 @@ func (e *Engine) Test(ctx context.Context, user identity.Requester, rule *models
 	effectiveStrategy := e.jitterStrategy
 	if e.jitterStrategy == schedule.JitterByGroup && (rule.RuleGroup == "" || rule.NamespaceUID == "") ||
 		e.jitterStrategy == schedule.JitterByRule && rule.UID == "" {
-		logger.Warn(fmt.Sprintf("Jitter strategy is set to %s, but rule group or namespace is not set. Ignore jitter", e.jitterStrategy))
+		logger.Warn("Jitter strategy ignored", "jitterStrategy", e.jitterStrategy, "reason", "rule group or namespace is not set")
 		warns = append(warns, fmt.Sprintf("Jitter strategy is set to %s, but rule group or namespace is not set. Ignore jitter. The results of testing will be different than real evaluations", e.jitterStrategy))
 		effectiveStrategy = schedule.JitterNever
 	}

--- a/pkg/services/notifications/notifications.go
+++ b/pkg/services/notifications/notifications.go
@@ -126,14 +126,10 @@ func (ns *NotificationService) Run(ctx context.Context) error {
 		case msg := <-ns.mailQueue:
 			num, err := ns.Send(ctx, msg)
 			tos := strings.Join(msg.To, "; ")
-			info := ""
 			if err != nil {
-				if len(msg.Info) > 0 {
-					info = ", info: " + msg.Info
-				}
-				ns.log.Error(fmt.Sprintf("Async sent email %d succeed, not send emails: %s%s err: %s", num, tos, info, err))
+				ns.log.Error("Async email send failed", "num", num, "recipients", tos, "info", msg.Info, "error", err)
 			} else {
-				ns.log.Debug(fmt.Sprintf("Async sent email %d succeed, sent emails: %s%s", num, tos, info))
+				ns.log.Debug("Async email send succeeded", "num", num, "recipients", tos, "info", msg.Info)
 			}
 		case <-ctx.Done():
 			return ctx.Err()

--- a/pkg/services/secrets/migrator/reencrypt.go
+++ b/pkg/services/secrets/migrator/reencrypt.go
@@ -68,9 +68,9 @@ func (s simpleSecret) ReEncrypt(ctx context.Context, secretsSrv *manager.Secrets
 	}
 
 	if anyFailure {
-		logger.Warn(fmt.Sprintf("Column %s from %s has been re-encrypted with errors", s.columnName, s.tableName))
+		logger.Warn("Column re-encryption completed with errors", "columnName", s.columnName, "tableName", s.tableName)
 	} else {
-		logger.Info(fmt.Sprintf("Column %s from %s has been re-encrypted successfully", s.columnName, s.tableName))
+		logger.Info("Column re-encryption completed successfully", "columnName", s.columnName, "tableName", s.tableName)
 	}
 
 	return !anyFailure
@@ -139,9 +139,9 @@ func (s b64Secret) ReEncrypt(ctx context.Context, secretsSrv *manager.SecretsSer
 	}
 
 	if anyFailure {
-		logger.Warn(fmt.Sprintf("Column %s from %s has been re-encrypted with errors", s.columnName, s.tableName))
+		logger.Warn("Column re-encryption completed with errors", "columnName", s.columnName, "tableName", s.tableName)
 	} else {
-		logger.Info(fmt.Sprintf("Column %s from %s has been re-encrypted successfully", s.columnName, s.tableName))
+		logger.Info("Column re-encryption completed successfully", "columnName", s.columnName, "tableName", s.tableName)
 	}
 
 	return !anyFailure
@@ -202,9 +202,9 @@ func (s jsonSecret) ReEncrypt(ctx context.Context, secretsSrv *manager.SecretsSe
 	}
 
 	if anyFailure {
-		logger.Warn(fmt.Sprintf("Secure json data secrets from %s have been re-encrypted with errors", s.tableName))
+		logger.Warn("Secure json data secrets re-encryption completed with errors", "tableName", s.tableName)
 	} else {
-		logger.Info(fmt.Sprintf("Secure json data secrets from %s have been re-encrypted successfully", s.tableName))
+		logger.Info("Secure json data secrets re-encryption completed successfully", "tableName", s.tableName)
 	}
 
 	return !anyFailure

--- a/pkg/services/secrets/migrator/rollback.go
+++ b/pkg/services/secrets/migrator/rollback.go
@@ -67,9 +67,9 @@ func (s simpleSecret) Rollback(
 	}
 
 	if anyFailure {
-		logger.Warn(fmt.Sprintf("Column %s from %s has been rolled back with errors", s.columnName, s.tableName))
+		logger.Warn("Column rollback completed with errors", "columnName", s.columnName, "tableName", s.tableName)
 	} else {
-		logger.Info(fmt.Sprintf("Column %s from %s has been rolled back successfully", s.columnName, s.tableName))
+		logger.Info("Column rollback completed successfully", "columnName", s.columnName, "tableName", s.tableName)
 	}
 
 	return !anyFailure
@@ -142,9 +142,9 @@ func (s b64Secret) Rollback(
 	}
 
 	if anyFailure {
-		logger.Warn(fmt.Sprintf("Column %s from %s has been rolled back with errors", s.columnName, s.tableName))
+		logger.Warn("Column rollback completed with errors", "columnName", s.columnName, "tableName", s.tableName)
 	} else {
-		logger.Info(fmt.Sprintf("Column %s from %s has been rolled back successfully", s.columnName, s.tableName))
+		logger.Info("Column rollback completed successfully", "columnName", s.columnName, "tableName", s.tableName)
 	}
 
 	return !anyFailure
@@ -207,9 +207,9 @@ func (s jsonSecret) Rollback(
 	}
 
 	if anyFailure {
-		logger.Warn(fmt.Sprintf("Secure json data secrets from %s have been rolled back with errors", s.tableName))
+		logger.Warn("Secure json data secrets rollback completed with errors", "tableName", s.tableName)
 	} else {
-		logger.Info(fmt.Sprintf("Secure json data secrets from %s have been rolled back successfully", s.tableName))
+		logger.Info("Secure json data secrets rollback completed successfully", "tableName", s.tableName)
 	}
 
 	return !anyFailure

--- a/pkg/services/sqlstore/logger.go
+++ b/pkg/services/sqlstore/logger.go
@@ -25,56 +25,56 @@ func NewXormLogger(level glog.Lvl, grafanaLog glog.Logger) *XormLogger {
 // Error implement core.ILogger
 func (s *XormLogger) Error(v ...any) {
 	if s.level <= glog.LvlError {
-		s.grafanaLog.Error(fmt.Sprint(v...))
+		s.grafanaLog.Error("xorm error", "message", fmt.Sprint(v...))
 	}
 }
 
 // Errorf implement core.ILogger
 func (s *XormLogger) Errorf(format string, v ...any) {
 	if s.level <= glog.LvlError {
-		s.grafanaLog.Error(fmt.Sprintf(format, v...))
+		s.grafanaLog.Error("xorm error", "format", format, "args", fmt.Sprint(v...))
 	}
 }
 
 // Debug implement core.ILogger
 func (s *XormLogger) Debug(v ...any) {
 	if s.level <= glog.LvlDebug {
-		s.grafanaLog.Debug(fmt.Sprint(v...))
+		s.grafanaLog.Debug("xorm debug", "message", fmt.Sprint(v...))
 	}
 }
 
 // Debugf implement core.ILogger
 func (s *XormLogger) Debugf(format string, v ...any) {
 	if s.level <= glog.LvlDebug {
-		s.grafanaLog.Debug(fmt.Sprintf(format, v...))
+		s.grafanaLog.Debug("xorm debug", "format", format, "args", fmt.Sprint(v...))
 	}
 }
 
 // Info implement core.ILogger
 func (s *XormLogger) Info(v ...any) {
 	if s.level <= glog.LvlInfo {
-		s.grafanaLog.Info(fmt.Sprint(v...))
+		s.grafanaLog.Info("xorm info", "message", fmt.Sprint(v...))
 	}
 }
 
 // Infof implement core.ILogger
 func (s *XormLogger) Infof(format string, v ...any) {
 	if s.level <= glog.LvlInfo {
-		s.grafanaLog.Info(fmt.Sprintf(format, v...))
+		s.grafanaLog.Info("xorm info", "format", format, "args", fmt.Sprint(v...))
 	}
 }
 
 // Warn implement core.ILogger
 func (s *XormLogger) Warn(v ...any) {
 	if s.level <= glog.LvlWarn {
-		s.grafanaLog.Warn(fmt.Sprint(v...))
+		s.grafanaLog.Warn("xorm warning", "message", fmt.Sprint(v...))
 	}
 }
 
 // Warnf implement core.ILogger
 func (s *XormLogger) Warnf(format string, v ...any) {
 	if s.level <= glog.LvlWarn {
-		s.grafanaLog.Warn(fmt.Sprintf(format, v...))
+		s.grafanaLog.Warn("xorm warning", "format", format, "args", fmt.Sprint(v...))
 	}
 }
 

--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -1905,7 +1905,7 @@ func (cfg *Cfg) LogConfigSources() {
 	cfg.Logger.Info("Path Logs", "path", cfg.LogsPath)
 	cfg.Logger.Info("Path Plugins", "path", cfg.PluginsPaths)
 	cfg.Logger.Info("Path Provisioning", "path", cfg.ProvisioningPath)
-	cfg.Logger.Info("App mode " + cfg.Env)
+	cfg.Logger.Info("App mode", "mode", cfg.Env)
 }
 
 type DynamicSection struct {

--- a/pkg/tsdb/influxdb/fsql/fsql.go
+++ b/pkg/tsdb/influxdb/fsql/fsql.go
@@ -50,7 +50,7 @@ func Query(ctx context.Context, dsInfo *models.DatasourceInfo, req backend.Query
 			continue
 		}
 
-		logger.Info(fmt.Sprintf("InfluxDB executing SQL: %s", qm.RawSQL))
+		logger.Info("InfluxDB executing SQL", "sql", qm.RawSQL)
 		info, err := r.client.Execute(ctx, qm.RawSQL)
 		if err != nil {
 			errStr := fmt.Sprintf("flightsql: %s", err)
@@ -88,7 +88,7 @@ func Query(ctx context.Context, dsInfo *models.DatasourceInfo, req backend.Query
 
 		headers, err := reader.Header()
 		if err != nil {
-			logger.Error(fmt.Sprintf("Failed to extract headers: %s", err))
+			logger.Error("Failed to extract headers", "error", err)
 		}
 
 		tRes.Responses[q.RefID] = newQueryDataResponse(reader, *qm.Query, headers)

--- a/pkg/tsdb/influxdb/influxdb.go
+++ b/pkg/tsdb/influxdb/influxdb.go
@@ -107,7 +107,7 @@ func (s *Service) QueryData(ctx context.Context, req *backend.QueryDataRequest) 
 		return nil, err
 	}
 
-	logger.Debug(fmt.Sprintf("Making a %s type query", dsInfo.Version))
+	logger.Debug("Making query", "version", dsInfo.Version)
 
 	switch dsInfo.Version {
 	case influxVersionFlux:

--- a/pkg/tsdb/influxdb/influxql/influxql.go
+++ b/pkg/tsdb/influxdb/influxql/influxql.go
@@ -3,7 +3,6 @@ package influxql
 import (
 	"context"
 	"errors"
-	"fmt"
 	"net/http"
 	"net/url"
 	"path"
@@ -44,7 +43,7 @@ func Query(ctx context.Context, tracer trace.Tracer, dsInfo *models.DatasourceIn
 	if config.FeatureToggles().IsEnabled("influxdbRunQueriesInParallel") {
 		concurrentQueryCount, err := req.PluginContext.GrafanaConfig.ConcurrentQueryCount()
 		if err != nil {
-			logger.Debug(fmt.Sprintf("Concurrent Query Count read/parse error: %v", err), "influxdbRunQueriesInParallel")
+			logger.Debug("Concurrent query count read/parse error", "error", err, "influxdbRunQueriesInParallel", true)
 			concurrentQueryCount = 10
 		}
 

--- a/pkg/tsdb/influxdb/models/model_parser.go
+++ b/pkg/tsdb/influxdb/models/model_parser.go
@@ -70,7 +70,7 @@ func QueryParse(query backend.DataQuery, logger log.Logger) (*Query, error) {
 	if useRawQuery {
 		statement, err = influxql.ParseStatement(rawQuery)
 		if err != nil {
-			logger.Debug(fmt.Sprintf("Couldn't parse raw query: %v", err), "rawQuery", rawQuery)
+			logger.Debug("Couldn't parse raw query", "error", err, "rawQuery", rawQuery)
 		}
 	}
 

--- a/pkg/tsdb/mssql/kerberos/kerberos.go
+++ b/pkg/tsdb/mssql/kerberos/kerberos.go
@@ -104,16 +104,16 @@ func Krb5ParseAuthCredentials(host string, port string, db string, user string, 
 }
 
 func getCredentialCacheFromLookup(lookupFile string, host string, port string, dbName string, user string, logger log.Logger) string {
-	logger.Info(fmt.Sprintf("reading credential cache lookup: %s", lookupFile))
+	logger.Info("Reading credential cache lookup", "lookupFile", lookupFile)
 	content, err := os.ReadFile(filepath.Clean(lookupFile))
 	if err != nil {
-		logger.Error(fmt.Sprintf("error reading: %s, %v", lookupFile, err))
+		logger.Error("Error reading credential cache lookup file", "lookupFile", lookupFile, "error", err)
 		return ""
 	}
 	var lookups []KerberosLookup
 	err = json.Unmarshal(content, &lookups)
 	if err != nil {
-		logger.Error(fmt.Sprintf("error parsing: %s, %v", lookupFile, err))
+		logger.Error("Error parsing credential cache lookup file", "lookupFile", lookupFile, "error", err)
 		return ""
 	}
 	// find cache file
@@ -122,10 +122,10 @@ func getCredentialCacheFromLookup(lookupFile string, host string, port string, d
 			item.Address = host + ":0"
 		}
 		if item.Address == host+":"+port && item.DBName == dbName && item.User == user {
-			logger.Info(fmt.Sprintf("matched: %+v", item))
+			logger.Info("Matched credential cache lookup entry", "address", item.Address, "database", item.DBName, "user", item.User)
 			return item.CredentialCacheFilename
 		}
 	}
-	logger.Error(fmt.Sprintf("no match found for %s", host+":"+port))
+	logger.Error("No credential cache lookup match found", "address", host+":"+port)
 	return ""
 }

--- a/public/app/features/dashboard-scene/logging.ts
+++ b/public/app/features/dashboard-scene/logging.ts
@@ -1,0 +1,8 @@
+import { type LogContext } from '@grafana/faro-web-sdk';
+import { getLogger } from '@grafana/runtime/unstable';
+
+const logger = () => getLogger('grafana.dashboard.scenes');
+
+export const logWarning = (message: string, contexts?: LogContext) => logger().logWarning(message, contexts);
+
+export const logError = (error: Error, contexts?: LogContext) => logger().logError(error, contexts);

--- a/public/app/features/dashboard-scene/scene/DashboardLayoutOrchestrator.tsx
+++ b/public/app/features/dashboard-scene/scene/DashboardLayoutOrchestrator.tsx
@@ -3,7 +3,6 @@ import { type PointerEvent as ReactPointerEvent } from 'react';
 import { createPortal } from 'react-dom';
 
 import { type GrafanaTheme2 } from '@grafana/data';
-import { logWarning } from '@grafana/runtime';
 import {
   sceneGraph,
   type SceneComponentProps,
@@ -17,6 +16,7 @@ import { useStyles2 } from '@grafana/ui';
 import { getLayoutType } from 'app/features/dashboard/utils/tracking';
 
 import { dashboardEditActions, DashboardStateChangedEvent, ObjectsReorderedOnCanvasEvent } from '../edit-pane/shared';
+import { logWarning } from '../logging';
 import { DashboardInteractions } from '../utils/interactions';
 import { getDefaultVizPanel, getLayoutForObject } from '../utils/utils';
 
@@ -240,9 +240,7 @@ export class DashboardLayoutOrchestrator extends SceneObjectBase<DashboardLayout
               sourceDropTarget.state.layout.endExternalDrag();
             }
           } else {
-            const warningMessage = 'No grid item to drag';
-            console.warn(warningMessage);
-            logWarning(warningMessage);
+            logWarning('No grid item to drag');
           }
         });
       } else {

--- a/public/app/features/scopes/ScopesApiClient.ts
+++ b/public/app/features/scopes/ScopesApiClient.ts
@@ -5,8 +5,13 @@ import { getMessageFromError } from 'app/core/utils/errors';
 import { dispatch } from 'app/store/store';
 
 import { type ScopeNavigation } from './dashboards/types';
+import { logError, logWarning } from './logging';
 
 export class ScopesApiClient {
+  private logFetchError(message: string, error: unknown, context: Record<string, unknown> = {}) {
+    const errorMessage = getMessageFromError(error);
+    logError(new Error(message), { ...context, errorMessage });
+  }
   /**
    * Checks if the data is a Kubernetes Status error response.
    * @param data The data to check
@@ -33,16 +38,14 @@ export class ScopesApiClient {
     if ('data' in result && result.data) {
       // Check if the data is actually an error response (Kubernetes Status object)
       if (this.isStatusError(result.data)) {
-        const errorMessage = getMessageFromError(result.data);
-        console.error(`Failed to fetch %s:`, context, errorMessage);
+        this.logFetchError('Failed to fetch resource', result.data, { context });
         return undefined;
       }
       return result.data;
     }
 
     if ('error' in result) {
-      const errorMessage = getMessageFromError(result.error);
-      console.error(`Failed to fetch %s:`, context, errorMessage);
+      this.logFetchError('Failed to fetch resource', result.error, { context });
     }
 
     return undefined;
@@ -53,8 +56,7 @@ export class ScopesApiClient {
       const result = await subscription;
       return this.extractDataOrHandleError(result, `scope: ${name}`);
     } catch (err) {
-      const errorMessage = getMessageFromError(err);
-      console.error('Failed to fetch scope:', name, errorMessage);
+      this.logFetchError('Failed to fetch scope', err, { scopeName: name });
       return undefined;
     } finally {
       // Unsubscribe for extra safety, even though with subscribe: false and awaiting,
@@ -74,20 +76,16 @@ export class ScopesApiClient {
 
       if (successfulScopes.length < scopesIds.length) {
         const failedCount = scopesIds.length - successfulScopes.length;
-        console.warn(
-          'Failed to fetch',
+        logWarning('Failed to fetch some scopes', {
           failedCount,
-          'of',
-          scopesIds.length,
-          'scope(s). Requested IDs:',
-          scopesIds.join(', ')
-        );
+          requestedCount: scopesIds.length,
+          scopeIds: scopesIds.join(', '),
+        });
       }
 
       return successfulScopes;
     } catch (err) {
-      const errorMessage = getMessageFromError(err);
-      console.error('Failed to fetch multiple scopes:', scopesIds, errorMessage);
+      this.logFetchError('Failed to fetch multiple scopes', err, { scopeIds: scopesIds.join(', ') });
       return [];
     }
   }
@@ -109,14 +107,12 @@ export class ScopesApiClient {
       }
 
       if ('error' in result) {
-        const errorMessage = getMessageFromError(result.error);
-        console.error('Failed to fetch multiple scope nodes:', names, errorMessage);
+        this.logFetchError('Failed to fetch multiple scope nodes', result.error, { names: names.join(', ') });
       }
 
       return [];
     } catch (err) {
-      const errorMessage = getMessageFromError(err);
-      console.error('Failed to fetch multiple scope nodes:', names, errorMessage);
+      this.logFetchError('Failed to fetch multiple scope nodes', err, { names: names.join(', ') });
       return [];
     } finally {
       // Unsubscribe for extra safety, even though with subscribe: false and awaiting,
@@ -160,7 +156,6 @@ export class ScopesApiClient {
       }
 
       if ('error' in result) {
-        const errorMessage = getMessageFromError(result.error);
         const contextParts: string[] = [];
         if (options.parent) {
           contextParts.push('parent="' + options.parent + '"');
@@ -169,13 +164,11 @@ export class ScopesApiClient {
           contextParts.push('query="' + options.query + '"');
         }
         contextParts.push('limit=' + limit);
-        const context = contextParts.join(', ');
-        console.error('Failed to fetch scope nodes:', context, errorMessage);
+        this.logFetchError('Failed to fetch scope nodes', result.error, { context: contextParts.join(', ') });
       }
 
       return [];
     } catch (err) {
-      const errorMessage = getMessageFromError(err);
       const contextParts: string[] = [];
       if (options.parent) {
         contextParts.push('parent="' + options.parent + '"');
@@ -184,8 +177,7 @@ export class ScopesApiClient {
         contextParts.push('query="' + options.query + '"');
       }
       contextParts.push('limit=' + limit);
-      const context = contextParts.join(', ');
-      console.error('Failed to fetch scope nodes:', context, errorMessage);
+      this.logFetchError('Failed to fetch scope nodes', err, { context: contextParts.join(', ') });
       return [];
     } finally {
       // Unsubscribe for extra safety, even though with subscribe: false and awaiting,
@@ -212,14 +204,14 @@ export class ScopesApiClient {
       }
 
       if ('error' in result) {
-        const errorMessage = getMessageFromError(result.error);
-        console.error('Failed to fetch dashboards for scopes:', scopeNames, errorMessage);
+        this.logFetchError('Failed to fetch dashboards for scopes', result.error, {
+          scopeNames: scopeNames.join(', '),
+        });
       }
 
       return [];
     } catch (err) {
-      const errorMessage = getMessageFromError(err);
-      console.error('Failed to fetch dashboards for scopes:', scopeNames, errorMessage);
+      this.logFetchError('Failed to fetch dashboards for scopes', err, { scopeNames: scopeNames.join(', ') });
       return [];
     } finally {
       // Unsubscribe for extra safety, even though with subscribe: false and awaiting,
@@ -251,14 +243,14 @@ export class ScopesApiClient {
       }
 
       if ('error' in result) {
-        const errorMessage = getMessageFromError(result.error);
-        console.error('Failed to fetch scope navigations for scopes:', scopeNames, errorMessage);
+        this.logFetchError('Failed to fetch scope navigations for scopes', result.error, {
+          scopeNames: scopeNames.join(', '),
+        });
       }
 
       return [];
     } catch (err) {
-      const errorMessage = getMessageFromError(err);
-      console.error('Failed to fetch scope navigations for scopes:', scopeNames, errorMessage);
+      this.logFetchError('Failed to fetch scope navigations for scopes', err, { scopeNames: scopeNames.join(', ') });
       return [];
     } finally {
       // Unsubscribe for extra safety, even though with subscribe: false and awaiting,
@@ -279,8 +271,7 @@ export class ScopesApiClient {
       const result = await subscription;
       return this.extractDataOrHandleError(result, `scope node: ${scopeNodeId}`);
     } catch (err) {
-      const errorMessage = getMessageFromError(err);
-      console.error('Failed to fetch scope node:', scopeNodeId, errorMessage);
+      this.logFetchError('Failed to fetch scope node', err, { scopeNodeId });
       return undefined;
     } finally {
       // Unsubscribe for extra safety, even though with subscribe: false and awaiting,

--- a/public/app/features/scopes/logging.ts
+++ b/public/app/features/scopes/logging.ts
@@ -1,0 +1,10 @@
+import { type LogContext } from '@grafana/faro-web-sdk';
+import { getLogger } from '@grafana/runtime/unstable';
+
+const logger = () => getLogger('grafana.features.scopes');
+
+export const logInfo = (message: string, contexts?: LogContext) => logger().logInfo(message, contexts);
+
+export const logWarning = (message: string, contexts?: LogContext) => logger().logWarning(message, contexts);
+
+export const logError = (error: Error, contexts?: LogContext) => logger().logError(error, contexts);

--- a/public/app/features/variables/logging.ts
+++ b/public/app/features/variables/logging.ts
@@ -1,0 +1,8 @@
+import { type LogContext } from '@grafana/faro-web-sdk';
+import { getLogger } from '@grafana/runtime/unstable';
+
+const logger = () => getLogger('grafana.features.variables');
+
+export const logWarning = (message: string, contexts?: LogContext) => logger().logWarning(message, contexts);
+
+export const logError = (error: Error, contexts?: LogContext) => logger().logError(error, contexts);

--- a/public/app/features/variables/state/actions.ts
+++ b/public/app/features/variables/state/actions.ts
@@ -41,6 +41,7 @@ import { cleanEditorState } from '../editor/reducer';
 import { ensureStringValues } from '../ensureStringValues';
 import { hasCurrent, hasLegacyVariableSupport, hasOptions, hasStandardVariableSupport, isMulti } from '../guard';
 import { getAllAffectedPanelIdsForVariableChange, getPanelVars } from '../inspect/utils';
+import { logError as logVariableError } from '../logging';
 import { cleanPickerState } from '../pickers/OptionsPicker/reducer';
 import { alignCurrentWithMulti } from '../shared/multiOptions';
 import { toStateKey } from '../toStateKey';
@@ -81,6 +82,10 @@ import {
 } from './transactionReducer';
 import { type KeyedVariableIdentifier } from './types';
 import { cleanVariables } from './variablesReducer';
+
+function logVariablesError(error: unknown) {
+  logVariableError(error instanceof Error ? error : new Error(String(error)));
+}
 
 export const initDashboardTemplating = (key: string, dashboard: DashboardModel): ThunkResult<void> => {
   return (dispatch, getState) => {
@@ -778,7 +783,7 @@ export const onTimeRangeUpdated =
       await Promise.all(promises);
       dependencies.events.publish(new VariablesTimeRangeProcessDone({ variableIds }));
     } catch (error) {
-      console.error(error);
+      logVariablesError(error);
       dispatch(notifyApp(createVariableErrorNotification('Template variable service failed', error)));
     }
   };
@@ -932,7 +937,7 @@ export const initVariablesTransaction =
       dispatch(toKeyedAction(uid, variablesCompleteTransaction({ uid })));
     } catch (err) {
       dispatch(notifyApp(createVariableErrorNotification('Templating init failed', err)));
-      console.error(err);
+      logVariablesError(err);
     }
   };
 
@@ -1003,7 +1008,7 @@ export const updateOptions =
       dispatch(toKeyedAction(rootStateKey, variableStateFailed(toVariablePayload(identifier, { error }))));
 
       if (!rethrow) {
-        console.error(error);
+        logVariablesError(error);
         dispatch(notifyApp(createVariableErrorNotification('Error updating options:', error, identifier)));
       }
 
@@ -1083,7 +1088,7 @@ export function upgradeLegacyQueries(
       );
     } catch (err) {
       dispatch(notifyApp(createVariableErrorNotification('Failed to upgrade legacy queries', err)));
-      console.error(err);
+      logVariablesError(err);
     }
   };
 }

--- a/scripts/check-structured-logging.sh
+++ b/scripts/check-structured-logging.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+PATTERN='logger\.(Debug|Info|Warn|Error)\(fmt\.Sprintf'
+
+if matches=$(rg -n "$PATTERN" pkg --glob '*.go' || true); then
+  if [ -n "$matches" ]; then
+    echo "Found unstructured logging calls using fmt.Sprintf inside logger methods:"
+    echo "$matches"
+    exit 1
+  fi
+fi
+
+echo "Structured logging check passed."

--- a/scripts/demo-structured-logging.sh
+++ b/scripts/demo-structured-logging.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# Demo script for structured logging migration (issue #12)
+
+echo "=== Structured logging migration demo ==="
+echo
+echo "BEFORE (unstructured - hard to query):"
+echo '  logger.Error(fmt.Sprintf("failed to list event: %s", err))'
+echo '  logger.Debug(fmt.Sprintf("buildSnapshot: method completed in %d ms", duration))'
+echo '  console.error("Failed to fetch scope:", name, errorMessage)'
+echo
+echo "AFTER (structured - queryable fields):"
+echo '  logger.Error("Failed to list events", "error", err, "userId", userID)'
+echo '  logger.Debug("buildSnapshot completed", "durationMs", duration)'
+echo '  logError(new Error("Failed to fetch scope"), { scopeName: name, errorMessage })'
+echo
+echo "=== Running structured logging check ==="
+./scripts/check-structured-logging.sh
+echo
+echo "=== Sample backend log fields (from migrated code) ==="
+grep -n 'durationMs\|"error"' pkg/services/cloudmigration/cloudmigrationimpl/snapshot_mgmt.go | head -5
+echo
+echo "=== Frontend logger registry entries ==="
+grep "grafana.features\|grafana.dashboard\|grafana.plugins" packages/grafana-runtime/src/services/logging/loggers.ts


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Migrates Grafana toward consistent structured logging across backend and frontend, addressing [fieldsphere/grafana#12](https://github.com/fieldsphere/grafana/issues/12).

**Target repo: fieldsphere/grafana**

### Backend
- Document structured logging standards and fix `Warn` vs `Warning` guidance in instrumentation docs
- Harden the xorm logger adapter to emit structured fields instead of formatted strings
- Migrate high-traffic call sites in notifications, cloud migration, ngalert backtesting, influxdb, kerberos, secrets migrator, frontend log ingestion, and settings bootstrap
- Add `scripts/check-structured-logging.sh` to catch new `fmt.Sprintf` usage inside logger calls

### Frontend
- Register new logger sources for scopes, variables, dashboard scenes, and SQL plugins
- Add feature-local logging wrappers and migrate scopes, variables, and dashboard scene call sites off raw `console.*`
- Enforce scoped `no-console` ESLint rules for migrated feature directories

## Demo

<a href="https://cursor.com/agents/bc-de81c7e1-417c-4b27-8c25-8449f56c7149/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fstructured-logging-migration-demo.mp4"><img src="https://cursor.com/artifacts/c/art-883f003d-377c-4ff3-84ac-b0dac0412da8" alt="structured-logging-migration-demo.mp4" /></a>

Run locally: `./scripts/demo-structured-logging.sh`

## Test plan
- [x] `./scripts/check-structured-logging.sh`
- [x] `go test ./pkg/services/sqlstore/... ./pkg/services/notifications/... ./pkg/services/cloudmigration/cloudmigrationimpl/... ./pkg/services/ngalert/backtesting/... ./pkg/tsdb/influxdb/... ./pkg/tsdb/mssql/kerberos/...`
- [x] ESLint on migrated frontend files
- [x] Video artifact demonstrating structured logging improvements
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-de81c7e1-417c-4b27-8c25-8449f56c7149"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-de81c7e1-417c-4b27-8c25-8449f56c7149"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

