### PR TITLE
Navigation: Use blue link color for nav link hover states

### DIFF
--- a/public/app/core/components/AppChrome/MegaMenu/MegaMenuItemText.tsx
+++ b/public/app/core/components/AppChrome/MegaMenu/MegaMenuItemText.tsx
@@ -107,8 +107,8 @@ const getStyles = (theme: GrafanaTheme2, isActive: Props['isActive']) => ({
     position: 'relative',
     width: '100%',
 
-    '&:hover span, &:focus-visible span': {
-      color: theme.colors.text.primary,
+    '&:hover, &:focus-visible': {
+      color: theme.colors.text.link,
       textDecoration: 'underline',
     },
 

--- a/public/app/core/components/AppChrome/TopBar/SignInLink.tsx
+++ b/public/app/core/components/AppChrome/TopBar/SignInLink.tsx
@@ -39,6 +39,7 @@ const getStyles = (theme: GrafanaTheme2) => {
       paddingRight: theme.spacing(1),
       whiteSpace: 'nowrap',
       '&:hover': {
+        color: theme.colors.text.link,
         textDecoration: 'underline',
       },
     }),

--- a/public/app/features/scopes/dashboards/ScopesNavigationTreeLink.tsx
+++ b/public/app/features/scopes/dashboards/ScopesNavigationTreeLink.tsx
@@ -128,6 +128,7 @@ const getStyles = (theme: GrafanaTheme2) => {
       wordBreak: 'break-word',
 
       '&:hover, &:focus': css({
+        color: theme.colors.text.link,
         textDecoration: 'underline',
       }),
     }),


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
**What is this feature?**

Updates navigation link hover styles to use Grafana's standard link blue (`theme.colors.text.link`) instead of primary text color.

**Why do we need this feature?**

Navigation links previously used primary text color (and underline) on hover, which did not match Grafana's standard link hover treatment. This aligns sidebar, scopes nav tree, and top bar sign-in links with the `TextLink` pattern.

**Who is this feature for?**

All Grafana users interacting with sidebar/mega menu navigation, scopes navigation tree, and the top bar sign-in link.

**Which issue(s) does this PR fix?**:

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.

## Changes

| File | Before | After |
|------|--------|-------|
| `MegaMenuItemText.tsx` | Hover/focus: `text.primary` + underline (span-only selector) | Hover/focus: `text.link` + underline on link container |
| `ScopesNavigationTreeLink.tsx` | Hover/focus: underline only | Hover/focus: `text.link` + underline |
| `SignInLink.tsx` | Hover: underline only | Hover: `text.link` + underline |

## Tests

```
PASS public/app/features/scopes/dashboards/ScopesNavigationTreeLink.test.tsx
PASS public/app/core/components/AppChrome/TopBar/SignInLink.test.tsx
PASS public/app/core/components/AppChrome/MegaMenu/MegaMenu.test.tsx

Test Suites: 3 passed, 3 total
Tests:       25 passed, 25 total
```
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d4a9b76d-853f-4c8e-8d81-ae1b02c1125f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d4a9b76d-853f-4c8e-8d81-ae1b02c1125f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

