### PR TITLE
ThemeSelector: cache preview theme builds to improve switcher performance

### DIFF
--- a/public/app/core/components/Theme/ThemePreview.tsx
+++ b/public/app/core/components/Theme/ThemePreview.tsx
@@ -1,4 +1,5 @@
 import { css, cx } from '@emotion/css';
+import { memo } from 'react';
 
 import { type GrafanaTheme2, ThemeContext } from '@grafana/data';
 import { Trans } from '@grafana/i18n';
@@ -10,13 +11,13 @@ interface ThemePreviewProps {
   theme: GrafanaTheme2;
 }
 
-export function ThemePreview({ theme }: ThemePreviewProps) {
+export const ThemePreview = memo(function ThemePreview({ theme }: ThemePreviewProps) {
   return (
     <ThemeContext.Provider value={theme}>
       <ThemePreviewWithContext />
     </ThemeContext.Provider>
   );
-}
+});
 
 function ThemePreviewWithContext() {
   const styles = useStyles2(getStyles);

--- a/public/app/core/components/ThemeSelector/ThemeCard.test.tsx
+++ b/public/app/core/components/ThemeSelector/ThemeCard.test.tsx
@@ -31,5 +31,6 @@ describe('ThemeCard', () => {
 
     // Check that onSelect was called only once
     expect(onSelectMock).toHaveBeenCalledTimes(1);
+    expect(onSelectMock).toHaveBeenCalledWith('dark');
   });
 });

--- a/public/app/core/components/ThemeSelector/ThemeCard.tsx
+++ b/public/app/core/components/ThemeSelector/ThemeCard.tsx
@@ -1,4 +1,5 @@
 import { css } from '@emotion/css';
+import { memo } from 'react';
 
 import { FeatureState, type GrafanaTheme2, type ThemeRegistryItem } from '@grafana/data';
 import { t } from '@grafana/i18n';
@@ -6,22 +7,29 @@ import { FeatureBadge, RadioButtonDot, useStyles2 } from '@grafana/ui';
 
 import { ThemePreview } from '../Theme/ThemePreview';
 
+import { getCachedPreviewTheme } from './getCachedPreviewTheme';
+
 interface ThemeCardProps {
   themeOption: ThemeRegistryItem;
   isExperimental?: boolean;
   isSelected?: boolean;
-  onSelect: () => void;
+  onSelect: (themeId: string) => void;
 }
 
-export function ThemeCard({ themeOption, isExperimental, isSelected, onSelect }: ThemeCardProps) {
-  const theme = themeOption.build();
+export const ThemeCard = memo(function ThemeCard({
+  themeOption,
+  isExperimental,
+  isSelected,
+  onSelect,
+}: ThemeCardProps) {
+  const theme = getCachedPreviewTheme(themeOption);
   const label = getTranslatedThemeName(themeOption);
   const styles = useStyles2(getStyles);
 
   return (
     // this is a convenience for mouse users. keyboard/screen reader users will use the radio button
     // eslint-disable-next-line jsx-a11y/no-static-element-interactions,jsx-a11y/click-events-have-key-events
-    <div className={styles.card} onClick={onSelect}>
+    <div className={styles.card} onClick={() => onSelect(themeOption.id)}>
       <div className={styles.header}>
         <RadioButtonDot
           id={`theme-${theme.name}`}
@@ -31,7 +39,7 @@ export function ThemeCard({ themeOption, isExperimental, isSelected, onSelect }:
             // prevent propagation so that onSelect is only called once when clicking the radio button
             event.stopPropagation();
           }}
-          onChange={onSelect}
+          onChange={() => onSelect(themeOption.id)}
           checked={isSelected}
         />
         {isExperimental && <FeatureBadge featureState={FeatureState.experimental} />}
@@ -39,7 +47,7 @@ export function ThemeCard({ themeOption, isExperimental, isSelected, onSelect }:
       <ThemePreview theme={theme} />
     </div>
   );
-}
+});
 
 const getStyles = (theme: GrafanaTheme2) => {
   return {

--- a/public/app/core/components/ThemeSelector/ThemeSelectorDrawer.tsx
+++ b/public/app/core/components/ThemeSelector/ThemeSelectorDrawer.tsx
@@ -1,4 +1,5 @@
 import { css } from '@emotion/css';
+import { useCallback, useMemo } from 'react';
 
 import { type GrafanaTheme2, type ThemeRegistryItem } from '@grafana/data';
 import { Trans, t } from '@grafana/i18n';
@@ -15,16 +16,26 @@ interface Props {
 
 export function ThemeSelectorDrawer({ onClose }: Props) {
   const styles = useStyles2(getStyles);
-  const themes = getSelectableThemes();
+  const themes = useMemo(() => getSelectableThemes(), []);
   const currentTheme = useTheme2();
 
-  const onChange = (theme: ThemeRegistryItem) => {
+  const onChange = useCallback((theme: ThemeRegistryItem) => {
     reportInteraction('grafana_preferences_theme_changed', {
       toTheme: theme.id,
       preferenceType: 'theme_drawer',
     });
     changeTheme(theme.id, false);
-  };
+  }, []);
+
+  const onSelect = useCallback(
+    (themeId: string) => {
+      const theme = themes.find((themeOption) => themeOption.id === themeId);
+      if (theme) {
+        onChange(theme);
+      }
+    },
+    [onChange, themes]
+  );
 
   const subTitle = (
     <Trans i18nKey="shared-preferences.fields.theme-description">
@@ -52,7 +63,7 @@ export function ThemeSelectorDrawer({ onClose }: Props) {
             themeOption={themeOption}
             isExperimental={themeOption.isExtra}
             key={themeOption.id}
-            onSelect={() => onChange(themeOption)}
+            onSelect={onSelect}
             isSelected={currentTheme.name === themeOption.name}
           />
         ))}

--- a/public/app/core/components/ThemeSelector/getCachedPreviewTheme.test.ts
+++ b/public/app/core/components/ThemeSelector/getCachedPreviewTheme.test.ts
@@ -1,0 +1,25 @@
+import { createTheme, type ThemeRegistryItem } from '@grafana/data';
+
+import { getCachedPreviewTheme } from './getCachedPreviewTheme';
+
+describe('getCachedPreviewTheme', () => {
+  const buildMock = jest.fn(() => createTheme({ colors: { mode: 'dark' } }));
+
+  const mockTheme: ThemeRegistryItem = {
+    id: 'cache-test-theme',
+    name: 'Cache test theme',
+    build: buildMock,
+  };
+
+  beforeEach(() => {
+    buildMock.mockClear();
+  });
+
+  it('should build the theme only once for the same theme id', () => {
+    const first = getCachedPreviewTheme(mockTheme);
+    const second = getCachedPreviewTheme(mockTheme);
+
+    expect(buildMock).toHaveBeenCalledTimes(1);
+    expect(second).toBe(first);
+  });
+});

--- a/public/app/core/components/ThemeSelector/getCachedPreviewTheme.ts
+++ b/public/app/core/components/ThemeSelector/getCachedPreviewTheme.ts
@@ -1,0 +1,19 @@
+import { type GrafanaTheme2, type ThemeRegistryItem } from '@grafana/data';
+
+const previewThemeCache = new Map<string, GrafanaTheme2>();
+
+/**
+ * Preview themes are static for a given theme id. Building them via createTheme on
+ * every ThemeCard render is expensive when the drawer shows many themes and the
+ * app re-renders after a theme change.
+ */
+export function getCachedPreviewTheme(themeOption: ThemeRegistryItem): GrafanaTheme2 {
+  const cachedTheme = previewThemeCache.get(themeOption.id);
+  if (cachedTheme) {
+    return cachedTheme;
+  }
+
+  const builtTheme = themeOption.build();
+  previewThemeCache.set(themeOption.id, builtTheme);
+  return builtTheme;
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Investigation found that the theme switcher drawer was rebuilding every preview theme on each render via `themeOption.build()` → `createTheme()`. With 12+ selectable themes, opening the drawer or switching themes (which triggers a full app re-render) caused redundant theme object construction across all cards.

This PR caches preview theme builds by id and reduces avoidable re-render work in the drawer.

## Root cause

1. **`ThemeCard` called `themeOption.build()` on every render** — `createTheme()` is non-trivial (colors, typography, components, v1 theme, etc.) and was executed once per card per render.
2. **Theme selection triggers a full app re-render** via `ThemeChangedEvent` → `ThemeProvider` state update. While the drawer is open, all theme cards re-render along with the rest of Grafana.
3. **Unstable callbacks in `ThemeSelectorDrawer`** — inline `onSelect={() => onChange(themeOption)}` prevented memoization.

## Changes

- Add `getCachedPreviewTheme()` to cache built preview themes by theme id
- Wrap `ThemeCard` and `ThemePreview` in `React.memo`
- Use stable `onSelect` callback in `ThemeSelectorDrawer`
- Memoize selectable themes list with `useMemo`
- Add unit test for preview theme caching

## Remaining performance considerations (not addressed here)

- **Full-app re-render on theme change** is inherent to the current `ThemeContext` architecture (thousands of `useTheme2`/`useStyles2` call sites). A deeper fix would require architectural changes.
- **Light/dark CSS file swap** in `changeTheme()` still causes a stylesheet reload when switching color mode; extra themes within the same mode avoid this.
- **`SharedPreferencesFunctional`** rebuilds `themeOptions` on every render (noted in an existing comment about avoiding memo-break).

## Test plan

- [x] `yarn jest --no-watch public/app/core/components/ThemeSelector/ThemeCard.test.tsx`
- [x] `yarn jest --no-watch public/app/core/components/ThemeSelector/getCachedPreviewTheme.test.ts`
- [ ] Manually open **Profile → Change theme** and switch between themes; drawer should feel more responsive, especially when switching between experimental themes

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-99f301ea-010b-4752-8d8e-26a57395c153"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-99f301ea-010b-4752-8d8e-26a57395c153"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

