### PR TITLE
test(dashboard): harden Angular panel v2 migration contract tests

### DIFF
--- a/.cursor/docs/angular-migration-scope-gate.md
+++ b/.cursor/docs/angular-migration-scope-gate.md
@@ -1,0 +1,37 @@
+# Angular Panel Migration Scope Gate
+
+This document confirms scope for the legacy Angular panel JSON to dashboard schema v2 migration work tracked in CUR-related efforts and `.cursor/docs/angular-v2-react-migration-status.md`.
+
+## In scope
+
+- Legacy Angular panel types stored in dashboard JSON (v0/v1 schema versions).
+- Panel type conversion and `__angularMigration` metadata during v1 to v2 conversion.
+- Frontend scene loading that extracts `__angularMigration`, runs React panel migration handlers, and strips migration metadata from runtime options.
+- Go and TypeScript parity for migration target selection and `originalOptions` extraction.
+- Panel-family fixtures and tests under:
+  - `apps/dashboard/pkg/migration/`
+  - `public/app/features/dashboard/api/ResponseTransformers.ts`
+  - `public/app/features/dashboard-scene/serialization/`
+  - `public/app/plugins/panel/*/migrations*.test.ts`
+
+## Out of scope
+
+- Unified-storage `/api` to `/apis` resource migration (folders, playlists, provisioning, search routing). That track is documented separately in `.cursor/docs/api-to-api-migration-status.md` when present.
+- Backend API changes unrelated to dashboard schema conversion.
+- New panel plugins or datasource query functions.
+- Running dev servers unless explicitly requested for demo artifacts.
+
+## Two-track separation
+
+| Track | Purpose | Primary code |
+| --- | --- | --- |
+| Angular panel to React/v2 | Convert deprecated panel types and preserve Angular options for handler migration | `apps/dashboard/pkg/migration/conversion/`, `public/app/features/dashboard-scene/serialization/angularMigration.ts` |
+| `/api` to `/apis` unified storage | Move Grafana resources to app-platform APIs | `pkg/storage/unified/`, registry APIs |
+
+Changes in this effort must not conflate the two tracks in status docs or PR descriptions.
+
+## Acceptance for scope gate
+
+- [x] Work targets legacy Angular panel JSON and dashboard schema v2 conversion only.
+- [x] No unified-storage routing or resource handler changes unless a dashboard conversion bug requires it.
+- [x] Status and handoff live in `.cursor/docs/angular-v2-react-migration-status.md`.

--- a/.cursor/docs/angular-v2-react-migration-status.md
+++ b/.cursor/docs/angular-v2-react-migration-status.md
@@ -1,0 +1,76 @@
+# Angular V2 to React Migration Status
+
+Status matrix for legacy Angular panel JSON to dashboard schema v2 conversion. Updated during the api-migrator implementation pass.
+
+## Worker lane rules
+
+Each lane owns backend conversion, frontend handler behavior, fixtures, and tests end to end. Do not split by layer only.
+
+## Migration matrix
+
+| Source ID | Target plugin | Go mapping | TS mapping | Backend fixture | Frontend handler tests | Status |
+| --- | --- | --- | --- | --- | --- | --- |
+| `graph` (default) | `timeseries` | `GetGraphMigrationTarget` | `getPanelPluginToMigrateTo` | `v1beta1.angular-migrations.json` | `timeseries/migrations.test.ts` | Verified |
+| `graphite` (default) | `timeseries` | same as graph | same as graph | same fixture | `timeseries/migrations.test.ts` | Verified |
+| `graph` xaxis `series` | `barchart` | `GetGraphMigrationTarget` | `getPanelPluginToMigrateTo` | fixture | `barchart/migrations.test.ts` | Verified |
+| `graph` xaxis `series` + legend values | `bargauge` | `GetGraphMigrationTarget` | `getPanelPluginToMigrateTo` | partial | `BarGaugeMigrations.test.ts` (6.x only) | Partial — graph-series bargauge path needs dedicated fixture |
+| `graph` xaxis `histogram` | `histogram` | `GetGraphMigrationTarget` | `getPanelPluginToMigrateTo` | fixture | `histogram/migrations.test.ts` | Verified |
+| `table-old` | `table` | `AngularPanelMigrations` | `autoMigrateAngular` | fixture | `table/migrations.test.ts` | Verified |
+| `table` with Angular `styles` | `table` | v24 schema migration | v24 `DashboardMigrator` | `v2beta1.v24.table-angular.json` | `table/migrations.test.ts` | Verified |
+| `singlestat` | `stat` | `AngularPanelMigrations` | `autoMigrateAngular` | fixture | `StatMigrations.test.ts` | Verified |
+| `grafana-singlestat-panel` | `stat` | `AngularPanelMigrations` | `autoMigrateAngular` | fixture | `StatMigrations.test.ts` | Verified |
+| `grafana-piechart-panel` | `piechart` | `AngularPanelMigrations` | `autoMigrateAngular` | fixture | `piechart/migrations.test.ts` | Verified |
+| `grafana-worldmap-panel` | `geomap` | `AngularPanelMigrations` | `autoMigrateAngular` | fixture | `geomap/migrations.test.ts` | Verified |
+| `natel-discrete-panel` | `state-timeline` | `AngularPanelMigrations` | `autoMigrateAngular` | fixture | `state-timeline/migrations.test.ts` | Verified |
+| `text` (Angular root props) | `text` | `autoMigrateFrom=text` via root options | same via `buildPanelKind` | fixture | `text/textPanelMigrationHandler.test.ts` | Verified |
+
+## Shared contract
+
+| Contract point | Go location | TS location | Test coverage |
+| --- | --- | --- | --- |
+| Migration target selection | `schemaversion.GetAngularPanelMigration` | `getPanelPluginToMigrateTo` | `migration_utils_test.go`, `getPanelPluginToMigrateTo.test.ts` |
+| Angular option extraction | `extractAngularOptions` in `v1_to_v2alpha1.go` | `extractAngularOptions` in `ResponseTransformers.ts` | `ResponseTransformers.angularMigration.test.ts` |
+| `__angularMigration` payload | `buildVizConfigKind` conversion | `buildPanelKind` | same TS test file + conversion golden fixtures |
+| Scene load strips metadata | n/a | `buildVizPanel` in `layoutSerializers/utils.ts` | `utils.test.ts` |
+| Handler invocation | n/a | `getV2AngularMigrationHandler` | `angularMigration.test.ts` |
+
+## Known gaps
+
+- **Bargauge from graph series**: target mapping exists in Go/TS, but no dedicated graph-to-bargauge handler fixture; `BarGaugeMigrations.test.ts` covers 6.x panel option shape only.
+- **Library panel references**: may not run through the same `buildPanelKind` path as inline panels; mark out of scope until a failing fixture exists.
+- **Nested panels in collapsed rows**: covered indirectly by layout serializers; no dedicated Angular migration fixture.
+
+## Tests run (implementation pass)
+
+All targeted tests passed on 2026-06-23:
+
+| Command | Result |
+| --- | --- |
+| `go test -v -short ./apps/dashboard/pkg/migration/schemaversion/... -run 'TestGetAngularPanelMigration\|TestGetGraphMigrationTarget\|TestIsAngularPanelType\|TestAngularPanelMigrationsParity'` | PASS (4 tests) |
+| `go test -v -short ./apps/dashboard/pkg/migration/conversion/... -run 'TestDashboardConversionToAllVersions\|TestMigratedDashboardsConversion'` | PASS |
+| Frontend contract tests (4 files, 62 tests) | PASS |
+| Panel-family migration handler tests (10 files, 68 tests) | PASS |
+
+## Lane completion summary
+
+| Lane | Status | Notes |
+| --- | --- | --- |
+| A — Graph family | Complete | timeseries, barchart, histogram handlers verified; bargauge mapping verified, graph-series handler fixture still partial |
+| B — Table | Complete | table-old and Angular styles covered |
+| C — Singlestat/stat | Complete | singlestat and grafana-singlestat-panel covered |
+| D — Pie/worldmap | Complete | piechart and geomap handlers verified |
+| E — Discrete + same-type | Complete | state-timeline and text root-option spreading verified |
+
+## Files added in this pass
+
+- `.cursor/docs/angular-migration-scope-gate.md`
+- `.cursor/docs/api-to-api-migration-status.md`
+- `.cursor/docs/angular-v2-react-migration-status.md`
+- `apps/dashboard/pkg/migration/schemaversion/migration_utils_test.go`
+- `public/app/features/dashboard/state/getPanelPluginToMigrateTo.test.ts`
+- `public/app/features/dashboard/api/ResponseTransformers.angularMigration.test.ts`
+- `public/app/features/dashboard-scene/serialization/layoutSerializers/utils.test.ts` (extended)
+
+## Intentional differences
+
+None identified between Go and TypeScript migration target selection after parity tests were added.

--- a/.cursor/docs/api-to-api-migration-status.md
+++ b/.cursor/docs/api-to-api-migration-status.md
@@ -1,0 +1,16 @@
+# API to APIS Migration Status
+
+This document tracks the unified-storage `/api` to `/apis` resource migration track.
+
+## Relationship to Angular panel migration
+
+The Angular panel JSON to dashboard schema v2 migration is a **separate track**. See:
+
+- [Angular migration scope gate](angular-migration-scope-gate.md)
+- [Angular v2 React migration status](angular-v2-react-migration-status.md)
+
+Do not update this file when completing Angular panel migration work unless `/api` to `/apis` behavior actually changed.
+
+## Status
+
+No `/api` to `/apis` migration changes were made as part of the Angular panel migration implementation pass.

--- a/apps/dashboard/pkg/migration/schemaversion/migration_utils_test.go
+++ b/apps/dashboard/pkg/migration/schemaversion/migration_utils_test.go
@@ -1,0 +1,147 @@
+package schemaversion_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/grafana/apps/dashboard/pkg/migration/schemaversion"
+)
+
+func TestGetAngularPanelMigration(t *testing.T) {
+	tests := []struct {
+		name      string
+		panelType string
+		panel     map[string]interface{}
+		expected  string
+	}{
+		{
+			name:      "graph defaults to timeseries",
+			panelType: "graph",
+			panel:     map[string]interface{}{},
+			expected:  "timeseries",
+		},
+		{
+			name:      "graphite defaults to timeseries",
+			panelType: "graphite",
+			panel:     map[string]interface{}{},
+			expected:  "timeseries",
+		},
+		{
+			name:      "graph series mode without legend values becomes barchart",
+			panelType: "graph",
+			panel: map[string]interface{}{
+				"xaxis": map[string]interface{}{"mode": "series"},
+			},
+			expected: "barchart",
+		},
+		{
+			name:      "graph series mode with legend values becomes bargauge",
+			panelType: "graph",
+			panel: map[string]interface{}{
+				"xaxis":  map[string]interface{}{"mode": "series"},
+				"legend": map[string]interface{}{"values": true},
+			},
+			expected: "bargauge",
+		},
+		{
+			name:      "graph histogram mode becomes histogram",
+			panelType: "graph",
+			panel: map[string]interface{}{
+				"xaxis": map[string]interface{}{"mode": "histogram"},
+			},
+			expected: "histogram",
+		},
+		{
+			name:      "table-old becomes table",
+			panelType: "table-old",
+			panel:     map[string]interface{}{},
+			expected:  "table",
+		},
+		{
+			name:      "singlestat becomes stat",
+			panelType: "singlestat",
+			panel:     map[string]interface{}{},
+			expected:  "stat",
+		},
+		{
+			name:      "grafana-singlestat-panel becomes stat",
+			panelType: "grafana-singlestat-panel",
+			panel:     map[string]interface{}{},
+			expected:  "stat",
+		},
+		{
+			name:      "grafana-piechart-panel becomes piechart",
+			panelType: "grafana-piechart-panel",
+			panel:     map[string]interface{}{},
+			expected:  "piechart",
+		},
+		{
+			name:      "grafana-worldmap-panel becomes geomap",
+			panelType: "grafana-worldmap-panel",
+			panel:     map[string]interface{}{},
+			expected:  "geomap",
+		},
+		{
+			name:      "natel-discrete-panel becomes state-timeline",
+			panelType: "natel-discrete-panel",
+			panel:     map[string]interface{}{},
+			expected:  "state-timeline",
+		},
+		{
+			name:      "modern panel type returns empty",
+			panelType: "timeseries",
+			panel:     map[string]interface{}{},
+			expected:  "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := schemaversion.GetAngularPanelMigration(tt.panelType, tt.panel)
+			require.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestGetGraphMigrationTarget(t *testing.T) {
+	tests := []struct {
+		name     string
+		panel    map[string]interface{}
+		expected string
+	}{
+		{
+			name:     "empty panel defaults to timeseries",
+			panel:    map[string]interface{}{},
+			expected: "timeseries",
+		},
+		{
+			name: "series mode with explicit legend values false becomes barchart",
+			panel: map[string]interface{}{
+				"xaxis":  map[string]interface{}{"mode": "series"},
+				"legend": map[string]interface{}{"values": false},
+			},
+			expected: "barchart",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := schemaversion.GetGraphMigrationTarget(tt.panel)
+			require.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestIsAngularPanelType(t *testing.T) {
+	require.True(t, schemaversion.IsAngularPanelType("graph"))
+	require.True(t, schemaversion.IsAngularPanelType("table-old"))
+	require.False(t, schemaversion.IsAngularPanelType("timeseries"))
+}
+
+func TestAngularPanelMigrationsParity(t *testing.T) {
+	for source, target := range schemaversion.AngularPanelMigrations {
+		result := schemaversion.GetAngularPanelMigration(source, map[string]interface{}{})
+		require.Equal(t, target, result, "mapping for %s", source)
+	}
+}

--- a/public/app/features/dashboard-scene/serialization/layoutSerializers/utils.test.ts
+++ b/public/app/features/dashboard-scene/serialization/layoutSerializers/utils.test.ts
@@ -492,4 +492,38 @@ describe('buildVizPanel', () => {
       expect(viz.state.hoverHeader).toBe(false);
     });
   });
+
+  it('strips __angularMigration from runtime options and attaches migration handler', () => {
+    const panel: PanelKind = {
+      kind: 'Panel',
+      spec: {
+        ...defaultPanelSpec(),
+        title: 'Stat panel',
+        vizConfig: {
+          kind: 'VizConfig',
+          group: 'stat',
+          version: '11.0.0',
+          spec: {
+            fieldConfig: { defaults: {}, overrides: [] },
+            options: {
+              reduceOptions: { calcs: ['lastNotNull'] },
+              __angularMigration: {
+                autoMigrateFrom: 'singlestat',
+                originalOptions: {
+                  format: 'short',
+                  valueName: 'avg',
+                },
+              },
+            },
+          },
+        },
+      },
+    };
+
+    const viz = buildVizPanel(panel);
+
+    expect(viz.state.options).toEqual({ reduceOptions: { calcs: ['lastNotNull'] } });
+    expect(viz.state.options).not.toHaveProperty('__angularMigration');
+    expect(viz.state._UNSAFE_customMigrationHandler).toBeDefined();
+  });
 });

--- a/public/app/features/dashboard/api/ResponseTransformers.angularMigration.test.ts
+++ b/public/app/features/dashboard/api/ResponseTransformers.angularMigration.test.ts
@@ -1,0 +1,103 @@
+import { type Panel } from '@grafana/schema';
+
+import { buildPanelKind } from './ResponseTransformers';
+
+describe('ResponseTransformers angular migration contract', () => {
+  it('buildPanelKind composes __angularMigration when autoMigrateFrom is set', () => {
+    const panel = {
+      id: 1,
+      type: 'stat',
+      title: 'CPU',
+      autoMigrateFrom: 'singlestat',
+      format: 'short',
+      valueName: 'avg',
+      options: { reduceOptions: { calcs: ['lastNotNull'] } },
+      fieldConfig: { defaults: {}, overrides: [] },
+      targets: [{ refId: 'A', expr: 'up' }],
+    } as unknown as Panel;
+
+    const panelKind = buildPanelKind(panel);
+    const options = panelKind.spec.vizConfig.spec.options as Record<string, unknown>;
+    const migration = options.__angularMigration as {
+      autoMigrateFrom: string;
+      originalOptions: Record<string, unknown>;
+    };
+
+    expect(migration.autoMigrateFrom).toBe('singlestat');
+    expect(migration.originalOptions).toEqual({
+      format: 'short',
+      valueName: 'avg',
+    });
+    expect(options.reduceOptions).toEqual({ calcs: ['lastNotNull'] });
+  });
+
+  it('buildPanelKind sets autoMigrateFrom to panel type when Angular root options exist', () => {
+    const panel = {
+      id: 2,
+      type: 'text',
+      title: 'Notes',
+      content: 'Hello',
+      mode: 'markdown',
+      options: {},
+      fieldConfig: { defaults: {}, overrides: [] },
+      targets: [],
+    } as unknown as Panel;
+
+    const panelKind = buildPanelKind(panel);
+    const options = panelKind.spec.vizConfig.spec.options as Record<string, unknown>;
+    const migration = options.__angularMigration as {
+      autoMigrateFrom: string;
+      originalOptions: Record<string, unknown>;
+    };
+
+    expect(migration.autoMigrateFrom).toBe('text');
+    expect(migration.originalOptions).toEqual({
+      content: 'Hello',
+      mode: 'markdown',
+    });
+  });
+
+  it('buildPanelKind filters known Panel schema properties from originalOptions', () => {
+    const panel = {
+      id: 3,
+      type: 'stat',
+      title: 'Memory',
+      autoMigrateFrom: 'singlestat',
+      gridPos: { x: 0, y: 0, w: 6, h: 4 },
+      targets: [{ refId: 'A' }],
+      transformations: [],
+      fieldConfig: { defaults: {}, overrides: [] },
+      format: 'bytes',
+      options: {},
+    } as unknown as Panel;
+
+    const panelKind = buildPanelKind(panel);
+    const options = panelKind.spec.vizConfig.spec.options as Record<string, unknown>;
+    const migration = options.__angularMigration as {
+      originalOptions: Record<string, unknown>;
+    };
+
+    expect(migration.originalOptions).toEqual({ format: 'bytes' });
+    expect(migration.originalOptions).not.toHaveProperty('gridPos');
+    expect(migration.originalOptions).not.toHaveProperty('targets');
+    expect(migration.originalOptions).not.toHaveProperty('transformations');
+    expect(migration.originalOptions).not.toHaveProperty('fieldConfig');
+  });
+
+  it('buildPanelKind does not compose __angularMigration for modern panels without legacy options', () => {
+    const panel = {
+      id: 4,
+      type: 'timeseries',
+      title: 'Requests',
+      options: { legend: { showLegend: true } },
+      fieldConfig: { defaults: {}, overrides: [] },
+      targets: [{ refId: 'A' }],
+    } as unknown as Panel;
+
+    const panelKind = buildPanelKind(panel);
+    const options = panelKind.spec.vizConfig.spec.options as Record<string, unknown>;
+
+    expect(options.__angularMigration).toBeUndefined();
+    expect(options.legend).toEqual({ showLegend: true });
+  });
+});

--- a/public/app/features/dashboard/state/getPanelPluginToMigrateTo.test.ts
+++ b/public/app/features/dashboard/state/getPanelPluginToMigrateTo.test.ts
@@ -1,0 +1,31 @@
+import { getPanelPluginToMigrateTo } from './getPanelPluginToMigrateTo';
+
+describe('getPanelPluginToMigrateTo', () => {
+  it.each([
+    ['graph default', { type: 'graph' }, 'timeseries'],
+    ['graphite default', { type: 'graphite' }, 'timeseries'],
+    [
+      'graph series mode without legend values',
+      { type: 'graph', xaxis: { mode: 'series' } },
+      'barchart',
+    ],
+    [
+      'graph series mode with legend values',
+      { type: 'graph', xaxis: { mode: 'series' }, legend: { values: true } },
+      'bargauge',
+    ],
+    ['graph histogram mode', { type: 'graph', xaxis: { mode: 'histogram' } }, 'histogram'],
+    ['table-old', { type: 'table-old' }, 'table'],
+    ['singlestat', { type: 'singlestat' }, 'stat'],
+    ['grafana-singlestat-panel', { type: 'grafana-singlestat-panel' }, 'stat'],
+    ['grafana-piechart-panel', { type: 'grafana-piechart-panel' }, 'piechart'],
+    ['grafana-worldmap-panel', { type: 'grafana-worldmap-panel' }, 'geomap'],
+    ['natel-discrete-panel', { type: 'natel-discrete-panel' }, 'state-timeline'],
+  ] as const)('%s', (_name, panel, expected) => {
+    expect(getPanelPluginToMigrateTo(panel)).toBe(expected);
+  });
+
+  it('returns undefined for modern panel types', () => {
+    expect(getPanelPluginToMigrateTo({ type: 'timeseries' })).toBeUndefined();
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements the Angular panel JSON to dashboard schema v2 migration plan: scope documentation, migration status matrix, and hardened shared contract tests across Go conversion and frontend scene loading.

## Changes

- **Scope gate**: `.cursor/docs/angular-migration-scope-gate.md` confirms this track is separate from unified-storage `/api` to `/apis` migration.
- **Status matrix**: `.cursor/docs/angular-v2-react-migration-status.md` documents all panel-family lanes, test coverage, and known gaps.
- **Go parity tests**: `migration_utils_test.go` covers `GetAngularPanelMigration`, `GetGraphMigrationTarget`, and simple mapping parity.
- **Frontend parity tests**: `getPanelPluginToMigrateTo.test.ts` mirrors Go target selection.
- **Contract tests**: `ResponseTransformers.angularMigration.test.ts` validates `buildPanelKind` `__angularMigration` composition and option filtering.
- **Scene loader test**: extended `utils.test.ts` to verify `__angularMigration` is stripped from runtime options and migration handler is attached.

## Tests run

- Go schemaversion parity tests (4 tests) — PASS
- Go conversion golden fixtures — PASS
- Frontend contract tests (62 tests across 4 files) — PASS
- Panel-family migration handler tests (68 tests across 10 files) — PASS

## Known gaps (documented, not fixed)

- Graph-to-bargauge handler lacks a dedicated fixture (mapping verified, handler partial).
- Library panel references and nested collapsed-row panels remain out of scope until failing fixtures exist.

## Out of scope

No changes to unified-storage `/api` to `/apis` routing or persisted conversion behavior. No integration tests added (unit coverage sufficient for this pass).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-23d6e0a8-abae-4460-975f-0f170030dd35"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-23d6e0a8-abae-4460-975f-0f170030dd35"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

