### PR TITLE
feat(labs): add browser-local feature flag dashboard (CUR-55)

### DIFF
--- a/pkg/services/navtree/models.go
+++ b/pkg/services/navtree/models.go
@@ -31,6 +31,7 @@ const (
 	WeightApplication
 	WeightAsserts
 	WeightDataConnections
+	WeightLabs
 	WeightApps
 	WeightPlugin
 	WeightConfig
@@ -56,6 +57,7 @@ const (
 	NavIDCfgPlugins           = "cfg/plugins"
 	NavIDCfgAccess            = "cfg/access"
 	NavIDBookmarks            = "bookmarks"
+	NavIDLabs                 = "labs"
 )
 
 type NavLink struct {

--- a/pkg/services/navtree/navtreeimpl/navtree.go
+++ b/pkg/services/navtree/navtreeimpl/navtree.go
@@ -163,6 +163,10 @@ func (s *ServiceImpl) GetNavTree(c *contextmodel.ReqContext, prefs *pref.Prefere
 
 	treeRoot.AddSection(s.buildDataConnectionsNavLink(c))
 
+	if c.IsSignedIn {
+		treeRoot.AddSection(s.buildLabsNavLink(c))
+	}
+
 	orgAdminNode, err := s.getAdminNode(c)
 
 	if orgAdminNode != nil && len(orgAdminNode.Children) > 0 {
@@ -652,5 +656,29 @@ func (s *ServiceImpl) buildDataConnectionsNavLink(c *contextmodel.ReqContext) *n
 		Url:        baseUrl,
 		Children:   children,
 		SortWeight: navtree.WeightDataConnections,
+	}
+}
+
+func (s *ServiceImpl) buildLabsNavLink(_ *contextmodel.ReqContext) *navtree.NavLink {
+	baseUrl := s.cfg.AppSubURL + "/labs"
+
+	children := []*navtree.NavLink{
+		{
+			Id:       "labs-feature-flags",
+			Text:     "Feature flags",
+			SubTitle: "View and manage browser-local feature flag overrides",
+			Url:      baseUrl + "/feature-flags",
+			Children: []*navtree.NavLink{},
+		},
+	}
+
+	return &navtree.NavLink{
+		Text:       "Labs",
+		Icon:       "flask",
+		Id:         navtree.NavIDLabs,
+		Url:        baseUrl,
+		Children:   children,
+		SortWeight: navtree.WeightLabs,
+		IsNew:      true,
 	}
 }

--- a/pkg/services/navtree/navtreeimpl/navtree_test.go
+++ b/pkg/services/navtree/navtreeimpl/navtree_test.go
@@ -10,9 +10,11 @@ import (
 
 	contextmodel "github.com/grafana/grafana/pkg/services/contexthandler/model"
 	"github.com/grafana/grafana/pkg/services/dashboards"
+	"github.com/grafana/grafana/pkg/services/navtree"
 	"github.com/grafana/grafana/pkg/services/search/model"
 	starapi "github.com/grafana/grafana/pkg/services/star/api"
 	"github.com/grafana/grafana/pkg/services/user"
+	"github.com/grafana/grafana/pkg/setting"
 	"github.com/grafana/grafana/pkg/web"
 )
 
@@ -138,4 +140,29 @@ func TestBuildStarredItemsNavLinks(t *testing.T) {
 		require.Equal(t, "B Dashboard", navLinks[1].Text)
 		require.Equal(t, "C Dashboard", navLinks[2].Text)
 	})
+}
+
+func TestBuildLabsNavLink(t *testing.T) {
+	httpReq, _ := http.NewRequest(http.MethodGet, "", nil)
+	reqCtx := &contextmodel.ReqContext{
+		Context: &web.Context{Req: httpReq},
+	}
+
+	service := ServiceImpl{
+		cfg: setting.NewCfg(),
+	}
+	service.cfg.AppSubURL = ""
+
+	navLink := service.buildLabsNavLink(reqCtx)
+
+	require.Equal(t, "Labs", navLink.Text)
+	require.Equal(t, "flask", navLink.Icon)
+	require.Equal(t, "labs", navLink.Id)
+	require.Equal(t, "/labs", navLink.Url)
+	require.True(t, navLink.IsNew)
+	require.Equal(t, int64(navtree.WeightLabs), navLink.SortWeight)
+	require.Len(t, navLink.Children, 1)
+	require.Equal(t, "labs-feature-flags", navLink.Children[0].Id)
+	require.Equal(t, "Feature flags", navLink.Children[0].Text)
+	require.Equal(t, "/labs/feature-flags", navLink.Children[0].Url)
 }

--- a/public/app/features/labs/FeatureFlagsPage.test.tsx
+++ b/public/app/features/labs/FeatureFlagsPage.test.tsx
@@ -1,0 +1,71 @@
+import { render, screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import config from 'app/core/config';
+
+import { TestProvider } from '../../../test/helpers/TestProvider';
+
+import FeatureFlagsPage from './FeatureFlagsPage';
+import { FEATURE_TOGGLES_LOCAL_STORAGE_KEY } from './featureFlagOverrides';
+
+const renderPage = () => {
+  render(
+    <TestProvider>
+      <FeatureFlagsPage />
+    </TestProvider>
+  );
+};
+
+describe('FeatureFlagsPage', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+    config.featureToggles = {
+      alphaFlag: true,
+      betaFlag: false,
+    } as typeof config.featureToggles;
+  });
+
+  it('renders enabled flags from config.featureToggles', async () => {
+    renderPage();
+
+    expect(await screen.findByText('alphaFlag')).toBeInTheDocument();
+    expect(screen.getByText('betaFlag')).toBeInTheDocument();
+    expect(screen.getByText('Browser-local feature flag overrides')).toBeInTheDocument();
+  });
+
+  it('writes grafana.featureToggles when a flag is toggled', async () => {
+    const user = userEvent.setup();
+    renderPage();
+
+    const switches = await screen.findAllByRole('switch');
+    await user.click(switches[1]);
+
+    expect(window.localStorage.getItem(FEATURE_TOGGLES_LOCAL_STORAGE_KEY)).toBe('betaFlag=1');
+    expect(screen.getByText('Reload required')).toBeInTheDocument();
+  });
+
+  it('removes a flag override when reset is clicked', async () => {
+    window.localStorage.setItem(FEATURE_TOGGLES_LOCAL_STORAGE_KEY, 'betaFlag=1');
+    const user = userEvent.setup();
+    renderPage();
+
+    const betaFlagRow = (await screen.findByText('betaFlag')).closest('tr');
+    expect(betaFlagRow).not.toBeNull();
+
+    await user.click(within(betaFlagRow!).getByRole('button', { name: 'Reset' }));
+
+    expect(window.localStorage.getItem(FEATURE_TOGGLES_LOCAL_STORAGE_KEY)).toBeNull();
+    expect(screen.getByText('Reload required')).toBeInTheDocument();
+  });
+
+  it('shows a reload prompt after changing overrides', async () => {
+    const user = userEvent.setup();
+    renderPage();
+
+    const switches = await screen.findAllByRole('switch');
+    await user.click(switches[0]);
+
+    expect(screen.getByText('Reload required')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Reload Grafana' })).toBeInTheDocument();
+  });
+});

--- a/public/app/features/labs/FeatureFlagsPage.tsx
+++ b/public/app/features/labs/FeatureFlagsPage.tsx
@@ -1,0 +1,133 @@
+import { useCallback, useMemo, useState } from 'react';
+
+import { Trans, t } from '@grafana/i18n';
+import { Alert, Button, type CellProps, type Column, InteractiveTable, Stack, Switch, Text } from '@grafana/ui';
+import { Page } from 'app/core/components/Page/Page';
+import config from 'app/core/config';
+
+import {
+  type FeatureFlagEntry,
+  getFeatureFlagEntries,
+  readFeatureToggleOverridesFromLocalStorage,
+  removeFeatureToggleOverride,
+  setFeatureToggleOverride,
+  writeFeatureToggleOverridesToLocalStorage,
+} from './featureFlagOverrides';
+
+function FeatureFlagsPage() {
+  const [overrides, setOverrides] = useState(() => readFeatureToggleOverridesFromLocalStorage());
+  const [pendingReload, setPendingReload] = useState(false);
+
+  const entries = useMemo(
+    () => getFeatureFlagEntries(config.featureToggles as Record<string, boolean>, overrides),
+    [overrides]
+  );
+
+  const persistOverrides = useCallback((nextOverrides: Record<string, boolean>) => {
+    writeFeatureToggleOverridesToLocalStorage(nextOverrides);
+    setOverrides(nextOverrides);
+    setPendingReload(true);
+  }, []);
+
+  const handleToggle = useCallback(
+    (name: string, value: boolean) => {
+      persistOverrides(setFeatureToggleOverride(overrides, name, value));
+    },
+    [overrides, persistOverrides]
+  );
+
+  const handleReset = useCallback(
+    (name: string) => {
+      persistOverrides(removeFeatureToggleOverride(overrides, name));
+    },
+    [overrides, persistOverrides]
+  );
+
+  const columns = useMemo<Array<Column<FeatureFlagEntry>>>(
+    () => [
+      {
+        id: 'name',
+        header: t('labs.feature-flags.columns.name', 'Flag'),
+      },
+      {
+        id: 'bootValue',
+        header: t('labs.feature-flags.columns.boot-value', 'Boot value'),
+        cell: ({ cell: { value } }: CellProps<FeatureFlagEntry, boolean>) => (
+          <Text>{value ? t('labs.feature-flags.enabled', 'Enabled') : t('labs.feature-flags.disabled', 'Disabled')}</Text>
+        ),
+      },
+      {
+        id: 'hasOverride',
+        header: t('labs.feature-flags.columns.override', 'Override'),
+        cell: ({ row: { original } }: CellProps<FeatureFlagEntry, boolean>) => (
+          <Text>
+            {original.hasOverride
+              ? original.effectiveValue
+                ? t('labs.feature-flags.enabled', 'Enabled')
+                : t('labs.feature-flags.disabled', 'Disabled')
+              : t('labs.feature-flags.default', 'Default')}
+          </Text>
+        ),
+      },
+      {
+        id: 'effectiveValue',
+        header: t('labs.feature-flags.columns.toggle', 'Toggle'),
+        cell: ({ row: { original } }: CellProps<FeatureFlagEntry, boolean>) => (
+          <Switch
+            value={original.effectiveValue}
+            onChange={({ currentTarget }) => handleToggle(original.name, currentTarget.checked)}
+          />
+        ),
+      },
+      {
+        id: 'actions',
+        header: t('labs.feature-flags.columns.actions', 'Actions'),
+        cell: ({ row: { original } }: CellProps<FeatureFlagEntry, string>) => (
+          <Button
+            size="sm"
+            variant="secondary"
+            disabled={!original.hasOverride}
+            onClick={() => handleReset(original.name)}
+          >
+            <Trans i18nKey="labs.feature-flags.reset">Reset</Trans>
+          </Button>
+        ),
+      },
+    ],
+    [handleReset, handleToggle]
+  );
+
+  return (
+    <Page navId="labs-feature-flags">
+      <Page.Contents>
+        <Stack direction="column" gap={2}>
+          <Alert severity="info" title={t('labs.feature-flags.info-title', 'Browser-local feature flag overrides')}>
+            <Trans i18nKey="labs.feature-flags.info-description">
+              These overrides are stored in your browser and are not saved to the Grafana server. Reload Grafana after
+              changing flags so they take effect.
+            </Trans>
+          </Alert>
+
+          {pendingReload && (
+            <Alert severity="warning" title={t('labs.feature-flags.reload-title', 'Reload required')}>
+              <Stack direction="column" gap={1}>
+                <Text>
+                  <Trans i18nKey="labs.feature-flags.reload-description">
+                    Your browser-local overrides were saved. Reload Grafana to apply them.
+                  </Trans>
+                </Text>
+                <Button icon="repeat" onClick={() => window.location.reload()}>
+                  <Trans i18nKey="labs.feature-flags.reload-button">Reload Grafana</Trans>
+                </Button>
+              </Stack>
+            </Alert>
+          )}
+
+          <InteractiveTable columns={columns} data={entries} getRowId={(entry) => entry.name} />
+        </Stack>
+      </Page.Contents>
+    </Page>
+  );
+}
+
+export default FeatureFlagsPage;

--- a/public/app/features/labs/featureFlagOverrides.test.ts
+++ b/public/app/features/labs/featureFlagOverrides.test.ts
@@ -1,0 +1,80 @@
+import {
+  FEATURE_TOGGLES_LOCAL_STORAGE_KEY,
+  getFeatureFlagEntries,
+  parseFeatureToggleOverrides,
+  removeFeatureToggleOverride,
+  serializeFeatureToggleOverrides,
+  setFeatureToggleOverride,
+} from './featureFlagOverrides';
+
+describe('featureFlagOverrides', () => {
+  it('parses localStorage override values', () => {
+    expect(parseFeatureToggleOverrides('panelEditor=1,panelInspector=true,disabledFlag=0')).toEqual({
+      panelEditor: true,
+      panelInspector: true,
+      disabledFlag: false,
+    });
+  });
+
+  it('serializes overrides using the existing localStorage format', () => {
+    expect(
+      serializeFeatureToggleOverrides({
+        panelEditor: true,
+        panelInspector: false,
+      })
+    ).toBe('panelEditor=1,panelInspector=0');
+  });
+
+  it('builds entries from boot flags and overrides', () => {
+    expect(
+      getFeatureFlagEntries(
+        {
+          alphaFlag: true,
+          betaFlag: false,
+        },
+        {
+          betaFlag: true,
+          localOnlyFlag: true,
+        }
+      )
+    ).toEqual([
+      {
+        name: 'alphaFlag',
+        bootValue: true,
+        effectiveValue: true,
+        hasOverride: false,
+      },
+      {
+        name: 'betaFlag',
+        bootValue: false,
+        effectiveValue: true,
+        hasOverride: true,
+      },
+      {
+        name: 'localOnlyFlag',
+        bootValue: false,
+        effectiveValue: true,
+        hasOverride: true,
+      },
+    ]);
+  });
+
+  it('sets and removes overrides immutably', () => {
+    const initialOverrides = { alphaFlag: true };
+
+    expect(setFeatureToggleOverride(initialOverrides, 'betaFlag', false)).toEqual({
+      alphaFlag: true,
+      betaFlag: false,
+    });
+    expect(removeFeatureToggleOverride(initialOverrides, 'alphaFlag')).toEqual({});
+  });
+
+  it('returns an empty object for blank localStorage values', () => {
+    expect(parseFeatureToggleOverrides(null)).toEqual({});
+    expect(parseFeatureToggleOverrides('')).toEqual({});
+  });
+
+  it('uses the expected localStorage key', () => {
+    expect(FEATURE_TOGGLES_LOCAL_STORAGE_KEY).toBe('grafana.featureToggles');
+  });
+});

--- a/public/app/features/labs/featureFlagOverrides.ts
+++ b/public/app/features/labs/featureFlagOverrides.ts
@@ -1,0 +1,94 @@
+export const FEATURE_TOGGLES_LOCAL_STORAGE_KEY = 'grafana.featureToggles';
+
+export interface FeatureFlagEntry {
+  name: string;
+  bootValue: boolean;
+  effectiveValue: boolean;
+  hasOverride: boolean;
+}
+
+export function parseFeatureToggleOverrides(value: string | null): Record<string, boolean> {
+  if (!value) {
+    return {};
+  }
+
+  const overrides: Record<string, boolean> = {};
+
+  for (const feature of value.split(',')) {
+    const [featureName, featureValue] = feature.split('=');
+    if (!featureName) {
+      continue;
+    }
+
+    overrides[featureName] = featureValue === 'true' || featureValue === '1';
+  }
+
+  return overrides;
+}
+
+export function serializeFeatureToggleOverrides(overrides: Record<string, boolean>): string {
+  return Object.entries(overrides)
+    .map(([name, value]) => `${name}=${value ? '1' : '0'}`)
+    .join(',');
+}
+
+export function readFeatureToggleOverridesFromLocalStorage(
+  storage: Pick<Storage, 'getItem'> = window.localStorage
+): Record<string, boolean> {
+  return parseFeatureToggleOverrides(storage.getItem(FEATURE_TOGGLES_LOCAL_STORAGE_KEY));
+}
+
+export function writeFeatureToggleOverridesToLocalStorage(
+  overrides: Record<string, boolean>,
+  storage: Pick<Storage, 'setItem' | 'removeItem'> = window.localStorage
+): void {
+  const serialized = serializeFeatureToggleOverrides(overrides);
+
+  if (serialized) {
+    storage.setItem(FEATURE_TOGGLES_LOCAL_STORAGE_KEY, serialized);
+    return;
+  }
+
+  storage.removeItem(FEATURE_TOGGLES_LOCAL_STORAGE_KEY);
+}
+
+export function getFeatureFlagEntries(
+  featureToggles: Record<string, boolean>,
+  overrides: Record<string, boolean>
+): FeatureFlagEntry[] {
+  const names = new Set([...Object.keys(featureToggles), ...Object.keys(overrides)]);
+
+  return Array.from(names)
+    .sort((a, b) => a.localeCompare(b))
+    .map((name) => {
+      const hasOverride = Object.hasOwn(overrides, name);
+      const bootValue = featureToggles[name] ?? false;
+
+      return {
+        name,
+        bootValue,
+        effectiveValue: hasOverride ? overrides[name] : bootValue,
+        hasOverride,
+      };
+    });
+}
+
+export function setFeatureToggleOverride(
+  overrides: Record<string, boolean>,
+  name: string,
+  value: boolean
+): Record<string, boolean> {
+  return {
+    ...overrides,
+    [name]: value,
+  };
+}
+
+export function removeFeatureToggleOverride(
+  overrides: Record<string, boolean>,
+  name: string
+): Record<string, boolean> {
+  const nextOverrides = { ...overrides };
+  delete nextOverrides[name];
+  return nextOverrides;
+}

--- a/public/app/routes/routes.tsx
+++ b/public/app/routes/routes.tsx
@@ -221,6 +221,16 @@ export function getAppRoutes(): RouteDescriptor[] {
       component: () => <NavLandingPage navId="frontend" />,
     },
     {
+      path: '/labs',
+      component: () => <NavLandingPage navId="labs" />,
+    },
+    {
+      path: '/labs/feature-flags',
+      component: SafeDynamicImport(
+        () => import(/* webpackChunkName: "FeatureFlagsPage" */ 'app/features/labs/FeatureFlagsPage')
+      ),
+    },
+    {
       path: '/admin/general',
       component: () => <NavLandingPage navId="cfg/general" />,
     },


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Implements CUR-55 by adding a new Labs navigation section and a browser-local feature flag dashboard.

- Adds a signed-in-only `Labs` nav section with a `New` badge and a `Feature flags` child page
- Adds `/labs` landing page and `/labs/feature-flags` dashboard
- Lists frontend-visible enabled flags plus locally overridden flags
- Saves overrides to the existing `grafana.featureToggles` localStorage key
- Prompts users to reload Grafana after changes so overrides apply through the existing boot-time path

## Stack summary
1. `feat(navtree): add Labs navigation section for feature flags` - backend nav wiring and Labs section metadata
2. `feat(labs): add browser-local feature flags dashboard` - routes, override helpers, and dashboard UI
3. `test(labs): cover feature flag override dashboard behavior` - unit and page tests

## Validation
- `go test -v -short ./pkg/services/navtree/...`
- `yarn jest --no-watch --runTestsByPath public/app/features/labs/featureFlagOverrides.test.ts public/app/features/labs/FeatureFlagsPage.test.tsx`

## Notes
This is intentionally browser-local only. It does not add server-persistent feature flag editing.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f28bd80f-48f2-47ac-b017-c361698c426c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f28bd80f-48f2-47ac-b017-c361698c426c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

