### PR TITLE
feat(canvas): Add double line stroke style (DEMO-13)

### DIFF
--- a/public/app/plugins/panel/canvas/components/connections/ConnectionSVG.tsx
+++ b/public/app/plugins/panel/canvas/components/connections/ConnectionSVG.tsx
@@ -18,8 +18,8 @@ import {
   getParentBoundingClientRect,
 } from '../../utils';
 
-import { CONNECTION_VERTEX_ADD_ID, CONNECTION_VERTEX_ID } from './Connections';
 import { ConnectionLineStroke, ConnectionPathStroke } from './ConnectionStroke';
+import { CONNECTION_VERTEX_ADD_ID, CONNECTION_VERTEX_ID } from './Connections';
 
 type Props = {
   setSVGRef: (anchorElement: SVGSVGElement) => void;

--- a/public/app/plugins/panel/canvas/components/connections/ConnectionSVG.tsx
+++ b/public/app/plugins/panel/canvas/components/connections/ConnectionSVG.tsx
@@ -19,6 +19,7 @@ import {
 } from '../../utils';
 
 import { CONNECTION_VERTEX_ADD_ID, CONNECTION_VERTEX_ID } from './Connections';
+import { ConnectionLineStroke, ConnectionPathStroke } from './ConnectionStroke';
 
 type Props = {
   setSVGRef: (anchorElement: SVGSVGElement) => void;
@@ -164,7 +165,7 @@ export const ConnectionSVG = ({
           const xDist = xEnd - xStart;
           const yDist = yEnd - yStart;
 
-          const { strokeColor, strokeWidth, strokeRadius, arrowDirection, lineStyle, shouldAnimate } =
+          const { strokeColor, strokeWidth, strokeRadius, arrowDirection, lineStyle, lineStyleType, shouldAnimate } =
             getConnectionStyles(
               info,
               scene,
@@ -420,27 +421,17 @@ export const ConnectionSVG = ({
                       fill={'none'}
                       style={isSelected ? selectedStyles : {}}
                     />
-                    <path
-                      d={pathString}
+                    <ConnectionPathStroke
+                      pathD={pathString}
                       stroke={strokeColor}
                       strokeWidth={strokeWidth}
+                      lineStyleType={lineStyleType}
                       strokeDasharray={lineStyle}
-                      strokeDashoffset={1}
-                      fill={'none'}
+                      shouldAnimate={shouldAnimate}
+                      getAnimationDirection={getAnimationDirection}
                       markerEnd={markerEnd}
                       markerStart={markerStart}
-                    >
-                      {shouldAnimate && (
-                        <animate
-                          attributeName="stroke-dashoffset"
-                          values={getAnimationDirection()}
-                          dur="5s"
-                          calcMode="linear"
-                          repeatCount="indefinite"
-                          fill={'freeze'}
-                        />
-                      )}
-                    </path>
+                    />
                     {isSelected && (
                       <g>
                         {vertices.map((value, index) => {
@@ -493,32 +484,23 @@ export const ConnectionSVG = ({
                       x2={x2}
                       y2={y2}
                     />
-                    <line
+                    <ConnectionLineStroke
                       id={CONNECTION_LINE_ID}
                       stroke={strokeColor}
                       pointerEvents="auto"
                       strokeWidth={strokeWidth}
                       markerEnd={markerEnd}
                       markerStart={markerStart}
+                      lineStyleType={lineStyleType}
                       strokeDasharray={lineStyle}
-                      strokeDashoffset={1}
+                      shouldAnimate={shouldAnimate}
+                      getAnimationDirection={getAnimationDirection}
                       x1={x1}
                       y1={y1}
                       x2={x2}
                       y2={y2}
                       cursor={connectionCursorStyle}
-                    >
-                      {shouldAnimate && (
-                        <animate
-                          attributeName="stroke-dashoffset"
-                          values={getAnimationDirection()}
-                          dur="5s"
-                          calcMode="linear"
-                          repeatCount="indefinite"
-                          fill={'freeze'}
-                        />
-                      )}
-                    </line>
+                    />
                     {isSelected && (
                       <circle
                         id={CONNECTION_VERTEX_ADD_ID}

--- a/public/app/plugins/panel/canvas/components/connections/ConnectionSVG2.tsx
+++ b/public/app/plugins/panel/canvas/components/connections/ConnectionSVG2.tsx
@@ -18,6 +18,7 @@ import {
 } from '../../utils';
 
 import { CONNECTION_VERTEX_ADD_ID, CONNECTION_VERTEX_ID } from './Connections';
+import { ConnectionLineStroke, ConnectionPathStroke } from './ConnectionStroke';
 
 type Props = {
   setLineRef: (anchorElement: SVGLineElement) => void;
@@ -154,7 +155,7 @@ export const ConnectionSVG = ({ setLineRef, setVertexPathRef, setVertexRef, setC
           const xDist = xEnd - xStart;
           const yDist = yEnd - yStart;
 
-          const { strokeColor, strokeWidth, strokeRadius, arrowDirection, lineStyle, shouldAnimate } =
+          const { strokeColor, strokeWidth, strokeRadius, arrowDirection, lineStyle, lineStyleType, shouldAnimate } =
             getConnectionStyles(
               info,
               scene,
@@ -411,27 +412,17 @@ export const ConnectionSVG = ({ setLineRef, setVertexPathRef, setVertexRef, setC
                     style={isSelected ? selectedStyles : {}}
                   />
                   {/* real line */}
-                  <path
-                    d={pathString}
+                  <ConnectionPathStroke
+                    pathD={pathString}
                     stroke={strokeColor}
                     strokeWidth={strokeWidth}
+                    lineStyleType={lineStyleType}
                     strokeDasharray={lineStyle}
-                    strokeDashoffset={1}
-                    fill={'none'}
+                    shouldAnimate={shouldAnimate}
+                    getAnimationDirection={getAnimationDirection}
                     markerEnd={markerEnd}
                     markerStart={markerStart}
-                  >
-                    {shouldAnimate && (
-                      <animate
-                        attributeName="stroke-dashoffset"
-                        values={getAnimationDirection()}
-                        dur="5s"
-                        calcMode="linear"
-                        repeatCount="indefinite"
-                        fill={'freeze'}
-                      />
-                    )}
-                  </path>
+                  />
                   {isSelected && (
                     <g>
                       {/* vertices */}
@@ -489,32 +480,23 @@ export const ConnectionSVG = ({ setLineRef, setVertexPathRef, setVertexRef, setC
                     y2={y2}
                   />
                   {/* real line */}
-                  <line
+                  <ConnectionLineStroke
                     id={CONNECTION_LINE_ID}
                     stroke={strokeColor}
                     pointerEvents="auto"
                     strokeWidth={strokeWidth}
                     markerEnd={markerEnd}
                     markerStart={markerStart}
+                    lineStyleType={lineStyleType}
                     strokeDasharray={lineStyle}
-                    strokeDashoffset={1}
+                    shouldAnimate={shouldAnimate}
+                    getAnimationDirection={getAnimationDirection}
                     x1={x1}
                     y1={y1}
                     x2={x2}
                     y2={y2}
                     cursor={connectionCursorStyle}
-                  >
-                    {shouldAnimate && (
-                      <animate
-                        attributeName="stroke-dashoffset"
-                        values={getAnimationDirection()}
-                        dur="5s"
-                        calcMode="linear"
-                        repeatCount="indefinite"
-                        fill={'freeze'}
-                      />
-                    )}
-                  </line>
+                  />
                   {/* initial midpoint */}
                   {isSelected && (
                     <circle

--- a/public/app/plugins/panel/canvas/components/connections/ConnectionSVG2.tsx
+++ b/public/app/plugins/panel/canvas/components/connections/ConnectionSVG2.tsx
@@ -17,8 +17,8 @@ import {
   getConnectionStyles,
 } from '../../utils';
 
-import { CONNECTION_VERTEX_ADD_ID, CONNECTION_VERTEX_ID } from './Connections';
 import { ConnectionLineStroke, ConnectionPathStroke } from './ConnectionStroke';
+import { CONNECTION_VERTEX_ADD_ID, CONNECTION_VERTEX_ID } from './Connections';
 
 type Props = {
   setLineRef: (anchorElement: SVGLineElement) => void;

--- a/public/app/plugins/panel/canvas/components/connections/ConnectionStroke.tsx
+++ b/public/app/plugins/panel/canvas/components/connections/ConnectionStroke.tsx
@@ -1,0 +1,188 @@
+import { type CSSProperties, type ReactNode } from 'react';
+
+import { LineStyle } from '../../types';
+
+import { getDoubleLineSeparation, getParallelLineCoords, offsetPathBySampling } from './doubleLineUtils';
+
+interface SharedStrokeProps {
+  stroke: string;
+  strokeWidth: number;
+  lineStyleType: LineStyle;
+  strokeDasharray?: string;
+  shouldAnimate?: boolean;
+  getAnimationDirection?: () => string;
+  markerEnd?: string;
+  markerStart?: string;
+  id?: string;
+  cursor?: string;
+  pointerEvents?: string;
+  style?: CSSProperties;
+}
+
+interface ConnectionLineStrokeProps extends SharedStrokeProps {
+  x1: number;
+  y1: number;
+  x2: number;
+  y2: number;
+}
+
+interface ConnectionPathStrokeProps extends SharedStrokeProps {
+  pathD: string;
+}
+
+const renderAnimation = (shouldAnimate?: boolean, getAnimationDirection?: () => string): ReactNode => {
+  if (!shouldAnimate || !getAnimationDirection) {
+    return null;
+  }
+
+  return (
+    <animate
+      attributeName="stroke-dashoffset"
+      values={getAnimationDirection()}
+      dur="5s"
+      calcMode="linear"
+      repeatCount="indefinite"
+      fill="freeze"
+    />
+  );
+};
+
+export const ConnectionLineStroke = ({
+  x1,
+  y1,
+  x2,
+  y2,
+  stroke,
+  strokeWidth,
+  lineStyleType,
+  strokeDasharray,
+  shouldAnimate,
+  getAnimationDirection,
+  markerEnd,
+  markerStart,
+  id,
+  cursor,
+  pointerEvents,
+  style,
+}: ConnectionLineStrokeProps) => {
+  if (lineStyleType !== LineStyle.Double) {
+    return (
+      <line
+        id={id}
+        stroke={stroke}
+        pointerEvents={pointerEvents}
+        strokeWidth={strokeWidth}
+        markerEnd={markerEnd}
+        markerStart={markerStart}
+        strokeDasharray={strokeDasharray}
+        strokeDashoffset={1}
+        x1={x1}
+        y1={y1}
+        x2={x2}
+        y2={y2}
+        cursor={cursor}
+        style={style}
+      >
+        {renderAnimation(shouldAnimate, getAnimationDirection)}
+      </line>
+    );
+  }
+
+  const halfWidth = strokeWidth / 2;
+  const separation = getDoubleLineSeparation(strokeWidth);
+  const { line1, line2 } = getParallelLineCoords(x1, y1, x2, y2, separation);
+
+  return (
+    <>
+      <line
+        id={id}
+        stroke={stroke}
+        pointerEvents={pointerEvents}
+        strokeWidth={halfWidth}
+        markerEnd={markerEnd}
+        markerStart={markerStart}
+        x1={line1.x1}
+        y1={line1.y1}
+        x2={line1.x2}
+        y2={line1.y2}
+        cursor={cursor}
+        style={style}
+      />
+      <line
+        stroke={stroke}
+        pointerEvents={pointerEvents}
+        strokeWidth={halfWidth}
+        x1={line2.x1}
+        y1={line2.y1}
+        x2={line2.x2}
+        y2={line2.y2}
+        cursor={cursor}
+        style={style}
+      />
+    </>
+  );
+};
+
+export const ConnectionPathStroke = ({
+  pathD,
+  stroke,
+  strokeWidth,
+  lineStyleType,
+  strokeDasharray,
+  shouldAnimate,
+  getAnimationDirection,
+  markerEnd,
+  markerStart,
+  cursor,
+  pointerEvents,
+  style,
+}: ConnectionPathStrokeProps) => {
+  if (lineStyleType !== LineStyle.Double) {
+    return (
+      <path
+        d={pathD}
+        stroke={stroke}
+        strokeWidth={strokeWidth}
+        strokeDasharray={strokeDasharray}
+        strokeDashoffset={1}
+        fill="none"
+        markerEnd={markerEnd}
+        markerStart={markerStart}
+        cursor={cursor}
+        pointerEvents={pointerEvents}
+        style={style}
+      >
+        {renderAnimation(shouldAnimate, getAnimationDirection)}
+      </path>
+    );
+  }
+
+  const halfWidth = strokeWidth / 2;
+  const separation = getDoubleLineSeparation(strokeWidth);
+  const { positive, negative } = offsetPathBySampling(pathD, separation);
+
+  return (
+    <>
+      <path
+        d={positive}
+        stroke={stroke}
+        strokeWidth={halfWidth}
+        fill="none"
+        markerEnd={markerEnd}
+        markerStart={markerStart}
+        cursor={cursor}
+        pointerEvents={pointerEvents}
+        style={style}
+      />
+      <path
+        d={negative}
+        stroke={stroke}
+        strokeWidth={halfWidth}
+        fill="none"
+        cursor={cursor}
+        pointerEvents={pointerEvents}
+        style={style}
+      />
+    </>
+  );
+};

--- a/public/app/plugins/panel/canvas/components/connections/ConnectionStroke.tsx
+++ b/public/app/plugins/panel/canvas/components/connections/ConnectionStroke.tsx
@@ -109,6 +109,7 @@ export const ConnectionLineStroke = ({
         style={style}
       />
       <line
+        id={id}
         stroke={stroke}
         pointerEvents={pointerEvents}
         strokeWidth={halfWidth}

--- a/public/app/plugins/panel/canvas/components/connections/doubleLineUtils.ts
+++ b/public/app/plugins/panel/canvas/components/connections/doubleLineUtils.ts
@@ -1,0 +1,70 @@
+export function getPerpendicularUnitVector(x1: number, y1: number, x2: number, y2: number) {
+  const dx = x2 - x1;
+  const dy = y2 - y1;
+  const len = Math.hypot(dx, dy) || 1;
+
+  return { nx: -dy / len, ny: dx / len };
+}
+
+export function getDoubleLineSeparation(strokeWidth: number): number {
+  return Math.max(strokeWidth * 1.25, 3);
+}
+
+export function getParallelLineCoords(x1: number, y1: number, x2: number, y2: number, separation: number) {
+  const { nx, ny } = getPerpendicularUnitVector(x1, y1, x2, y2);
+  const half = separation / 2;
+
+  return {
+    line1: {
+      x1: x1 + nx * half,
+      y1: y1 + ny * half,
+      x2: x2 + nx * half,
+      y2: y2 + ny * half,
+    },
+    line2: {
+      x1: x1 - nx * half,
+      y1: y1 - ny * half,
+      x2: x2 - nx * half,
+      y2: y2 - ny * half,
+    },
+  };
+}
+
+export function offsetPathBySampling(pathD: string, offset: number, sampleCount = 50) {
+  if (typeof document === 'undefined') {
+    return { positive: pathD, negative: pathD };
+  }
+
+  const path = document.createElementNS('http://www.w3.org/2000/svg', 'path');
+  path.setAttribute('d', pathD);
+
+  const length = path.getTotalLength();
+  if (length === 0) {
+    return { positive: pathD, negative: pathD };
+  }
+
+  const points1: string[] = [];
+  const points2: string[] = [];
+  const half = offset / 2;
+
+  for (let i = 0; i <= sampleCount; i++) {
+    const distance = (i / sampleCount) * length;
+    const point = path.getPointAtLength(distance);
+    const pointBefore = path.getPointAtLength(Math.max(0, distance - 0.5));
+    const pointAfter = path.getPointAtLength(Math.min(length, distance + 0.5));
+    const dx = pointAfter.x - pointBefore.x;
+    const dy = pointAfter.y - pointBefore.y;
+    const segmentLength = Math.hypot(dx, dy) || 1;
+    const nx = -dy / segmentLength;
+    const ny = dx / segmentLength;
+    const command = i === 0 ? 'M' : 'L';
+
+    points1.push(`${command}${point.x + nx * half} ${point.y + ny * half}`);
+    points2.push(`${command}${point.x - nx * half} ${point.y - ny * half}`);
+  }
+
+  return {
+    positive: points1.join(' '),
+    negative: points2.join(' '),
+  };
+}

--- a/public/app/plugins/panel/canvas/doubleLine.test.ts
+++ b/public/app/plugins/panel/canvas/doubleLine.test.ts
@@ -1,0 +1,60 @@
+import { getStrokeDasharray } from './utils';
+import { LineStyle, StrokeDasharray } from './types';
+import {
+  getDoubleLineSeparation,
+  getParallelLineCoords,
+  getPerpendicularUnitVector,
+} from './components/connections/doubleLineUtils';
+
+describe('canvas utils', () => {
+  describe('getStrokeDasharray', () => {
+    it('returns dashed pattern for dashed style', () => {
+      expect(getStrokeDasharray(LineStyle.Dashed)).toBe(StrokeDasharray.Dashed);
+    });
+
+    it('returns dotted pattern for dotted style', () => {
+      expect(getStrokeDasharray(LineStyle.Dotted)).toBe(StrokeDasharray.Dotted);
+    });
+
+    it('returns solid pattern for solid style', () => {
+      expect(getStrokeDasharray(LineStyle.Solid)).toBe(StrokeDasharray.Solid);
+    });
+
+    it('returns solid pattern for double style', () => {
+      expect(getStrokeDasharray(LineStyle.Double)).toBe(StrokeDasharray.Solid);
+    });
+  });
+});
+
+describe('double line utils', () => {
+  describe('getPerpendicularUnitVector', () => {
+    it('returns perpendicular vector for horizontal line', () => {
+      const { nx, ny } = getPerpendicularUnitVector(0, 0, 10, 0);
+      expect(nx).toBeCloseTo(0);
+      expect(ny).toBe(1);
+    });
+
+    it('returns perpendicular vector for vertical line', () => {
+      expect(getPerpendicularUnitVector(0, 0, 0, 10)).toEqual({ nx: -1, ny: 0 });
+    });
+  });
+
+  describe('getDoubleLineSeparation', () => {
+    it('uses a minimum separation for thin strokes', () => {
+      expect(getDoubleLineSeparation(1)).toBe(3);
+    });
+
+    it('scales separation with stroke width', () => {
+      expect(getDoubleLineSeparation(8)).toBe(10);
+    });
+  });
+
+  describe('getParallelLineCoords', () => {
+    it('offsets lines equally on both sides of the center line', () => {
+      const { line1, line2 } = getParallelLineCoords(0, 0, 10, 0, 4);
+
+      expect(line1).toEqual({ x1: 0, y1: 2, x2: 10, y2: 2 });
+      expect(line2).toEqual({ x1: 0, y1: -2, x2: 10, y2: -2 });
+    });
+  });
+});

--- a/public/app/plugins/panel/canvas/doubleLine.test.ts
+++ b/public/app/plugins/panel/canvas/doubleLine.test.ts
@@ -1,10 +1,10 @@
-import { getStrokeDasharray } from './utils';
-import { LineStyle, StrokeDasharray } from './types';
 import {
   getDoubleLineSeparation,
   getParallelLineCoords,
   getPerpendicularUnitVector,
 } from './components/connections/doubleLineUtils';
+import { LineStyle, StrokeDasharray } from './types';
+import { getStrokeDasharray } from './utils';
 
 describe('canvas utils', () => {
   describe('getStrokeDasharray', () => {

--- a/public/app/plugins/panel/canvas/editor/LineStyleEditor.tsx
+++ b/public/app/plugins/panel/canvas/editor/LineStyleEditor.tsx
@@ -7,9 +7,10 @@ import { Field, RadioButtonGroup, Switch } from '@grafana/ui';
 import { LineStyle } from '../types';
 
 const options: Array<SelectableValue<LineStyle>> = [
-  { value: LineStyle.Solid, label: 'Solid' },
-  { value: LineStyle.Dashed, label: 'Dashed' },
-  { value: LineStyle.Dotted, label: 'Dotted' },
+  { value: LineStyle.Solid, label: t('canvas.line-style-options.label-solid', 'Solid') },
+  { value: LineStyle.Dashed, label: t('canvas.line-style-options.label-dashed', 'Dashed') },
+  { value: LineStyle.Dotted, label: t('canvas.line-style-options.label-dotted', 'Dotted') },
+  { value: LineStyle.Double, label: t('canvas.line-style-options.label-double', 'Double') },
 ];
 
 export interface LineStyleConfig {
@@ -51,7 +52,7 @@ export const LineStyleEditor = ({ value, onChange }: Props) => {
   return (
     <>
       <RadioButtonGroup value={value.style} options={options} onChange={onLineStyleChange} fullWidth />
-      {value.style !== LineStyle.Solid && (
+      {value.style !== LineStyle.Solid && value.style !== LineStyle.Double && (
         <>
           <br />
           <Field label={t('canvas.line-style-editor.label-animate', 'Animate')}>

--- a/public/app/plugins/panel/canvas/editor/LineStyleEditor.tsx
+++ b/public/app/plugins/panel/canvas/editor/LineStyleEditor.tsx
@@ -1,17 +1,10 @@
-import { useCallback } from 'react';
+import { useCallback, useMemo } from 'react';
 
 import { type SelectableValue, type StandardEditorProps } from '@grafana/data';
 import { t } from '@grafana/i18n';
 import { Field, RadioButtonGroup, Switch } from '@grafana/ui';
 
 import { LineStyle } from '../types';
-
-const options: Array<SelectableValue<LineStyle>> = [
-  { value: LineStyle.Solid, label: t('canvas.line-style-options.label-solid', 'Solid') },
-  { value: LineStyle.Dashed, label: t('canvas.line-style-options.label-dashed', 'Dashed') },
-  { value: LineStyle.Dotted, label: t('canvas.line-style-options.label-dotted', 'Dotted') },
-  { value: LineStyle.Double, label: t('canvas.line-style-options.label-double', 'Double') },
-];
 
 export interface LineStyleConfig {
   style: LineStyle;
@@ -34,6 +27,16 @@ export const LineStyleEditor = ({ value, onChange }: Props) => {
       animate: false,
     };
   }
+
+  const options = useMemo<Array<SelectableValue<LineStyle>>>(
+    () => [
+      { value: LineStyle.Solid, label: t('canvas.line-style-options.label-solid', 'Solid') },
+      { value: LineStyle.Dashed, label: t('canvas.line-style-options.label-dashed', 'Dashed') },
+      { value: LineStyle.Dotted, label: t('canvas.line-style-options.label-dotted', 'Dotted') },
+      { value: LineStyle.Double, label: t('canvas.line-style-options.label-double', 'Double') },
+    ],
+    []
+  );
 
   const onLineStyleChange = useCallback(
     (lineStyle: LineStyle) => {

--- a/public/app/plugins/panel/canvas/types.ts
+++ b/public/app/plugins/panel/canvas/types.ts
@@ -49,6 +49,7 @@ export enum LineStyle {
   Solid = 'solid',
   Dashed = 'dashed',
   Dotted = 'dotted',
+  Double = 'double',
 }
 
 export enum StrokeDasharray {

--- a/public/app/plugins/panel/canvas/utils.ts
+++ b/public/app/plugins/panel/canvas/utils.ts
@@ -359,13 +359,14 @@ export const getConnectionStyles = (
   const arrowDirection = info.direction
     ? scene.context.getDirection(info.direction).get(lastRowIndex)
     : defaultArrowDirection;
-  const lineStyle = getLineStyle(info.lineStyle?.style);
+  const lineStyleType = info.lineStyle?.style ?? LineStyle.Solid;
+  const lineStyle = getStrokeDasharray(lineStyleType);
   const shouldAnimate = info.lineStyle?.animate;
 
-  return { strokeColor, strokeWidth, strokeRadius, arrowDirection, lineStyle, shouldAnimate };
+  return { strokeColor, strokeWidth, strokeRadius, arrowDirection, lineStyle, lineStyleType, shouldAnimate };
 };
 
-const getLineStyle = (lineStyle?: LineStyle) => {
+export const getStrokeDasharray = (lineStyle?: LineStyle) => {
   switch (lineStyle) {
     case LineStyle.Dashed:
       return StrokeDasharray.Dashed;

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -4695,6 +4695,9 @@
       "label-animate": "Animate"
     },
     "line-style-options": {
+      "label-dashed": "Dashed",
+      "label-dotted": "Dotted",
+      "label-double": "Double",
       "label-solid": "Solid"
     },
     "metric-value-item": {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a **Double** stroke style option to the Grafana Canvas panel connection line style selector, alongside the existing Solid, Dashed, and Dotted options.

Resolves DEMO-13.

## Changes

- Added `LineStyle.Double` enum value
- Added double-line rendering utilities (`doubleLineUtils.ts`) that offset strokes perpendicular to the connection path
- Added shared `ConnectionStroke` components for line and path rendering
- Updated `ConnectionSVG` and `ConnectionSVG2` to render two parallel strokes when Double is selected
- Updated `LineStyleEditor` with the new option and i18n labels
- Added unit tests for stroke dasharray mapping and double-line geometry helpers

## Behavior

When **Double** is selected in the line style selector, connection lines render as two parallel strokes with spacing proportional to stroke width. Works for both straight connections and paths with vertices/arcs.

## Testing

- `yarn jest --no-watch public/app/plugins/panel/canvas/doubleLine.test.ts` — all 9 tests pass
- `yarn eslint` on changed files — passes
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [DEMO-13](https://linear.app/dawsons-personal-workspace/issue/DEMO-13/add-a-double-line-stroke-style)

<div><a href="https://cursor.com/agents/bc-827de433-bf8a-4dd3-acd2-e80db5413b2d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-827de433-bf8a-4dd3-acd2-e80db5413b2d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

