### PR TITLE
Navigation: Add Labs page for open feature flags

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -123,6 +123,7 @@ func (hs *HTTPServer) registerRoutes() {
 	r.Get("/admin/stats", authorize(ac.EvalPermission(ac.ActionServerStatsRead)), hs.Index)
 	r.Get("/admin/provisioning", reqOrgAdmin, hs.Index)
 	r.Get("/admin/provisioning/*", middleware.ProvisioningAuth(reqOrgAdmin), hs.Index)
+	r.Get("/labs", reqSignedIn, hs.Index)
 
 	if hs.Cfg.CloudMigration.Enabled {
 		r.Get("/admin/migrate-to-cloud", authorize(cloudmigration.MigrationAssistantAccess), hs.Index)
@@ -539,6 +540,8 @@ func (hs *HTTPServer) registerRoutes() {
 			// Some channels may have info
 			liveRoute.Get("/info/*", routing.Wrap(hs.Live.HandleInfoHTTP))
 		}, requestmeta.SetSLOGroup(requestmeta.SLOGroupNone))
+
+		apiRoute.Get("/labs/feature-toggles", routing.Wrap(hs.GetLabsFeatureToggles))
 	}, reqSignedIn)
 
 	// admin api

--- a/pkg/api/labs.go
+++ b/pkg/api/labs.go
@@ -1,0 +1,71 @@
+package api
+
+import (
+	"net/http"
+	"sort"
+
+	"github.com/grafana/grafana/pkg/api/response"
+	contextmodel "github.com/grafana/grafana/pkg/services/contexthandler/model"
+	"github.com/grafana/grafana/pkg/services/featuremgmt"
+)
+
+// LabsFeatureToggleDTO describes an open (non-GA) feature flag for the Labs page.
+type LabsFeatureToggleDTO struct {
+	Name        string `json:"name"`
+	Description string `json:"description"`
+	Stage       string `json:"stage"`
+	Enabled     bool   `json:"enabled"`
+}
+
+func isOpenFeatureStage(stage string) bool {
+	switch stage {
+	case "experimental", "preview", "privatePreview":
+		return true
+	default:
+		return false
+	}
+}
+
+// swagger:route GET /labs/feature-toggles signed_in getLabsFeatureToggles
+//
+// Get open feature toggles.
+//
+// Returns feature toggles that are in an experimental or preview stage.
+//
+// Responses:
+// 200: getLabsFeatureTogglesResponse
+// 401: unauthorisedError
+func (hs *HTTPServer) GetLabsFeatureToggles(c *contextmodel.ReqContext) response.Response {
+	featureList, err := featuremgmt.GetEmbeddedFeatureList()
+	if err != nil {
+		return response.Error(http.StatusInternalServerError, "Failed to load feature toggles", err)
+	}
+
+	enabled := hs.Features.GetEnabled(c.Req.Context())
+	toggles := make([]LabsFeatureToggleDTO, 0)
+
+	for _, item := range featureList.Items {
+		if !isOpenFeatureStage(item.Spec.Stage) {
+			continue
+		}
+
+		toggles = append(toggles, LabsFeatureToggleDTO{
+			Name:        item.Name,
+			Description: item.Spec.Description,
+			Stage:       item.Spec.Stage,
+			Enabled:     enabled[item.Name],
+		})
+	}
+
+	sort.Slice(toggles, func(i, j int) bool {
+		return toggles[i].Name < toggles[j].Name
+	})
+
+	return response.JSON(http.StatusOK, toggles)
+}
+
+// swagger:response getLabsFeatureTogglesResponse
+type GetLabsFeatureTogglesResponse struct {
+	// in:body
+	Body []LabsFeatureToggleDTO `json:"body"`
+}

--- a/pkg/api/labs_test.go
+++ b/pkg/api/labs_test.go
@@ -1,0 +1,83 @@
+package api
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/grafana/pkg/services/featuremgmt"
+	"github.com/grafana/grafana/pkg/web/webtest"
+)
+
+func TestAPI_GetLabsFeatureToggles(t *testing.T) {
+	server := SetupAPITestServer(t, func(hs *HTTPServer) {
+		hs.Features = featuremgmt.WithFeatures("adHocFilterDefaultValues", true)
+	})
+
+	res, err := server.Send(webtest.RequestWithSignedInUser(server.NewGetRequest("/api/labs/feature-toggles"), userWithPermissions(1, nil)))
+	require.NoError(t, err)
+	defer res.Body.Close()
+
+	assert.Equal(t, http.StatusOK, res.StatusCode)
+
+	body, err := io.ReadAll(res.Body)
+	require.NoError(t, err)
+
+	var toggles []LabsFeatureToggleDTO
+	require.NoError(t, json.Unmarshal(body, &toggles))
+
+	assert.NotEmpty(t, toggles)
+
+	for _, toggle := range toggles {
+		assert.True(t, isOpenFeatureStage(toggle.Stage), "expected open stage, got %q for %q", toggle.Stage, toggle.Name)
+	}
+
+	names := make([]string, len(toggles))
+	for i, toggle := range toggles {
+		names[i] = toggle.Name
+	}
+	for i := 1; i < len(names); i++ {
+		assert.LessOrEqual(t, names[i-1], names[i])
+	}
+
+	enabledByName := make(map[string]bool, len(toggles))
+	for _, toggle := range toggles {
+		enabledByName[toggle.Name] = toggle.Enabled
+	}
+
+	assert.True(t, enabledByName["adHocFilterDefaultValues"])
+}
+
+func TestAPI_GetLabsFeatureToggles_Unauthorized(t *testing.T) {
+	server := SetupAPITestServer(t, func(hs *HTTPServer) {})
+
+	res, err := server.Send(server.NewGetRequest("/api/labs/feature-toggles"))
+	require.NoError(t, err)
+	defer res.Body.Close()
+
+	assert.Equal(t, http.StatusUnauthorized, res.StatusCode)
+}
+
+func TestIsOpenFeatureStage(t *testing.T) {
+	tests := []struct {
+		stage string
+		open  bool
+	}{
+		{stage: "experimental", open: true},
+		{stage: "preview", open: true},
+		{stage: "privatePreview", open: true},
+		{stage: "GA", open: false},
+		{stage: "deprecated", open: false},
+		{stage: "unknown", open: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.stage, func(t *testing.T) {
+			assert.Equal(t, tt.open, isOpenFeatureStage(tt.stage))
+		})
+	}
+}

--- a/pkg/services/navtree/models.go
+++ b/pkg/services/navtree/models.go
@@ -33,6 +33,7 @@ const (
 	WeightDataConnections
 	WeightApps
 	WeightPlugin
+	WeightLabs
 	WeightConfig
 	WeightProfile
 	WeightHelp
@@ -56,6 +57,7 @@ const (
 	NavIDCfgPlugins           = "cfg/plugins"
 	NavIDCfgAccess            = "cfg/access"
 	NavIDBookmarks            = "bookmarks"
+	NavIDLabs                 = "labs"
 )
 
 type NavLink struct {

--- a/pkg/services/navtree/navtreeimpl/navtree.go
+++ b/pkg/services/navtree/navtreeimpl/navtree.go
@@ -174,6 +174,17 @@ func (s *ServiceImpl) GetNavTree(c *contextmodel.ReqContext, prefs *pref.Prefere
 
 	treeRoot.AddSection(s.buildDataConnectionsNavLink(c))
 
+	if c.IsSignedIn {
+		treeRoot.AddSection(&navtree.NavLink{
+			Text:       "Labs",
+			Id:         navtree.NavIDLabs,
+			SubTitle:   "Preview and experimental feature flags",
+			Icon:       "flask",
+			SortWeight: navtree.WeightLabs,
+			Url:        s.cfg.AppSubURL + "/labs",
+		})
+	}
+
 	orgAdminNode, err := s.getAdminNode(c)
 
 	if orgAdminNode != nil && len(orgAdminNode.Children) > 0 {

--- a/public/app/core/utils/navBarItem-translations.ts
+++ b/public/app/core/utils/navBarItem-translations.ts
@@ -93,6 +93,8 @@ export function getNavTitle(navId: string | undefined) {
       return t('nav.alerts-recently-deleted.title', 'Recently deleted');
     case 'cfg':
       return t('nav.config.title', 'Administration');
+    case 'labs':
+      return t('nav.labs.title', 'Labs');
     case 'cfg/general':
       return t('nav.config-general.title', 'General');
     case 'cfg/plugins':
@@ -290,6 +292,8 @@ export function getNavSubTitle(navId: string | undefined) {
         'nav.admin.subtitle',
         'Manage server-wide settings and access to resources such as organizations, users, and licenses'
       );
+    case 'labs':
+      return t('nav.labs.subtitle', 'Preview and experimental feature flags');
     case 'cfg/general':
       return t('nav.config-general.subtitle', 'Manage default preferences and settings across Grafana');
     case 'cfg/plugins':

--- a/public/app/features/labs/LabsFeatureFlagsTable.test.tsx
+++ b/public/app/features/labs/LabsFeatureFlagsTable.test.tsx
@@ -1,0 +1,32 @@
+import { render, screen } from '@testing-library/react';
+
+import { LabsFeatureFlagsTable } from './LabsFeatureFlagsTable';
+import { type LabsFeatureToggle } from './types';
+
+const featureToggles: LabsFeatureToggle[] = [
+  {
+    name: 'adHocFilterDefaultValues',
+    description: 'Enables configuring default origin filters for ad-hoc filter variables',
+    stage: 'experimental',
+    enabled: true,
+  },
+  {
+    name: 'panelTitleSearch',
+    description: 'Search for dashboards using panel title',
+    stage: 'preview',
+    enabled: false,
+  },
+];
+
+describe('LabsFeatureFlagsTable', () => {
+  it('renders open feature flags', () => {
+    render(<LabsFeatureFlagsTable featureToggles={featureToggles} />);
+
+    expect(screen.getByText('adHocFilterDefaultValues')).toBeInTheDocument();
+    expect(screen.getByText('panelTitleSearch')).toBeInTheDocument();
+    expect(screen.getByText('Experimental')).toBeInTheDocument();
+    expect(screen.getByText('Public preview')).toBeInTheDocument();
+    expect(screen.getByText('Enabled')).toBeInTheDocument();
+    expect(screen.getByText('Disabled')).toBeInTheDocument();
+  });
+});

--- a/public/app/features/labs/LabsFeatureFlagsTable.tsx
+++ b/public/app/features/labs/LabsFeatureFlagsTable.tsx
@@ -1,0 +1,91 @@
+import { css } from '@emotion/css';
+
+import { type GrafanaTheme2 } from '@grafana/data';
+import { Trans, t } from '@grafana/i18n';
+import { Badge, type CellProps, type Column, InteractiveTable, Text, useStyles2 } from '@grafana/ui';
+
+import { type LabsFeatureToggle } from './types';
+
+const stageLabel = (stage: string) => {
+  switch (stage) {
+    case 'experimental':
+      return t('labs.feature-flags.stage.experimental', 'Experimental');
+    case 'preview':
+      return t('labs.feature-flags.stage.preview', 'Public preview');
+    case 'privatePreview':
+      return t('labs.feature-flags.stage.private-preview', 'Private preview');
+    default:
+      return stage;
+  }
+};
+
+const stageColor = (stage: string): 'orange' | 'blue' | 'purple' | 'darkgrey' => {
+  switch (stage) {
+    case 'experimental':
+      return 'orange';
+    case 'preview':
+      return 'blue';
+    case 'privatePreview':
+      return 'purple';
+    default:
+      return 'darkgrey';
+  }
+};
+
+interface Props {
+  featureToggles: LabsFeatureToggle[];
+}
+
+export function LabsFeatureFlagsTable({ featureToggles }: Props) {
+  const styles = useStyles2(getStyles);
+
+  const columns: Array<Column<LabsFeatureToggle>> = [
+    {
+      id: 'name',
+      header: t('labs.feature-flags.table.name', 'Name'),
+      cell: ({ cell: { value } }: CellProps<LabsFeatureToggle, string>) => (
+        <Text variant="code" truncate>
+          {value}
+        </Text>
+      ),
+    },
+    {
+      id: 'description',
+      header: t('labs.feature-flags.table.description', 'Description'),
+      cell: ({ cell: { value } }: CellProps<LabsFeatureToggle, string>) => <Text>{value}</Text>,
+    },
+    {
+      id: 'stage',
+      header: t('labs.feature-flags.table.stage', 'Stage'),
+      cell: ({ cell: { value } }: CellProps<LabsFeatureToggle, string>) => (
+        <Badge color={stageColor(value)} text={stageLabel(value)} />
+      ),
+    },
+    {
+      id: 'enabled',
+      header: t('labs.feature-flags.table.status', 'Status'),
+      cell: ({ cell: { value } }: CellProps<LabsFeatureToggle, boolean>) => (
+        <Badge
+          color={value ? 'green' : 'red'}
+          text={
+            value
+              ? t('labs.feature-flags.status.enabled', 'Enabled')
+              : t('labs.feature-flags.status.disabled', 'Disabled')
+          }
+        />
+      ),
+    },
+  ];
+
+  return (
+    <div className={styles.table}>
+      <InteractiveTable columns={columns} data={featureToggles} getRowId={(toggle) => toggle.name} />
+    </div>
+  );
+}
+
+const getStyles = (theme: GrafanaTheme2) => ({
+  table: css({
+    marginTop: theme.spacing(2),
+  }),
+});

--- a/public/app/features/labs/LabsPage.tsx
+++ b/public/app/features/labs/LabsPage.tsx
@@ -1,0 +1,43 @@
+import { useAsync } from 'react-use';
+
+import { Trans, t } from '@grafana/i18n';
+import { getBackendSrv } from '@grafana/runtime';
+import { Alert, EmptyState } from '@grafana/ui';
+import { Page } from 'app/core/components/Page/Page';
+
+import { LabsFeatureFlagsTable } from './LabsFeatureFlagsTable';
+import { type LabsFeatureToggle } from './types';
+
+function LabsPage() {
+  const { loading, error, value: featureToggles } = useAsync(
+    () => getBackendSrv().get<LabsFeatureToggle[]>('/api/labs/feature-toggles'),
+    []
+  );
+
+  return (
+    <Page navId="labs">
+      <Page.Contents isLoading={loading}>
+        <Alert severity="info" title="">
+          <Trans i18nKey="labs.feature-flags.info">
+            These feature flags are in an experimental or preview stage. Enable them in your Grafana configuration to try
+            new functionality before it becomes generally available.
+          </Trans>
+        </Alert>
+
+        {error && (
+          <Alert severity="error" title={t('labs.feature-flags.error-title', 'Failed to load feature flags')}>
+            <Trans i18nKey="labs.feature-flags.error-body">Unable to load open feature flags. Please try again.</Trans>
+          </Alert>
+        )}
+
+        {!loading && !error && featureToggles?.length === 0 && (
+          <EmptyState variant="not-found" message={t('labs.feature-flags.empty', 'No open feature flags found')} />
+        )}
+
+        {featureToggles && featureToggles.length > 0 && <LabsFeatureFlagsTable featureToggles={featureToggles} />}
+      </Page.Contents>
+    </Page>
+  );
+}
+
+export default LabsPage;

--- a/public/app/features/labs/types.ts
+++ b/public/app/features/labs/types.ts
@@ -1,0 +1,6 @@
+export interface LabsFeatureToggle {
+  name: string;
+  description: string;
+  stage: string;
+  enabled: boolean;
+}

--- a/public/app/routes/routes.tsx
+++ b/public/app/routes/routes.tsx
@@ -537,6 +537,10 @@ export function getAppRoutes(): RouteDescriptor[] {
       ),
     },
     {
+      path: '/labs',
+      component: SafeDynamicImport(() => import(/* webpackChunkName: "LabsPage" */ 'app/features/labs/LabsPage')),
+    },
+    {
       path: '/theme-playground',
       component: SafeDynamicImport(
         () => import(/* webpackChunkName: "ThemePlayground"*/ 'app/features/theme-playground/ThemePlayground')


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What is this feature?

Adds a new **Labs** page accessible from the main navigation (with a flask icon, positioned next to Administration). The page lists all open feature flags — experimental, public preview, and private preview stages — along with their descriptions and enabled/disabled status.

## Why do we need this feature?

Provides a discoverable place for users to browse in-development and preview feature toggles without digging through configuration files or internal docs.

## Who is this feature for?

Signed-in Grafana users who want to see which experimental and preview features exist and whether they are currently enabled.

## Changes

- **Backend**: New `GET /api/labs/feature-toggles` endpoint returning open-stage feature flags with metadata and enabled status
- **Navigation**: New top-level Labs nav item (`flask` icon) with sort weight immediately before Administration
- **Frontend**: New `/labs` route with `LabsPage` and `LabsFeatureFlagsTable` components
- **i18n**: Nav title/subtitle translations for the Labs item

## Testing

API validation (317 open feature flags returned):

[labs_api_test_output.txt](https://cursor.com/artifacts/c/art-dd578abd-521e-4498-91b2-fe26a4107ac6)

- ✅ `go test -run 'TestAPI_GetLabsFeatureToggles|TestIsOpenFeatureStage' ./pkg/api/`
- ✅ `yarn jest public/app/features/labs/LabsFeatureFlagsTable.test.tsx --no-watch`
- ✅ Manual API test via authenticated curl against running backend

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a notable improvement, it's added to What's New doc.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f18c3-a1fa-7f1e-92d4-0e365e82ea05"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f18c3-a1fa-7f1e-92d4-0e365e82ea05"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

