### PR TITLE
Frontend: Add Labs feature flags UI

### DIFF
--- a/pkg/services/navtree/navtreeimpl/navtree.go
+++ b/pkg/services/navtree/navtreeimpl/navtree.go
@@ -308,6 +308,9 @@ func (s *ServiceImpl) getProfileNode(c *contextmodel.ReqContext) *navtree.NavLin
 	children = append(children, &navtree.NavLink{
 		Text: "Notification history", Id: "profile/notifications", Url: s.cfg.AppSubURL + "/profile/notifications", Icon: "bell",
 	})
+	children = append(children, &navtree.NavLink{
+		Text: "Labs", Id: "profile/labs", Url: s.cfg.AppSubURL + "/profile/labs", Icon: "flask",
+	})
 
 	if s.cfg.AddChangePasswordLink() {
 		children = append(children, &navtree.NavLink{

--- a/public/app/core/utils/navBarItem-translations.ts
+++ b/public/app/core/utils/navBarItem-translations.ts
@@ -175,6 +175,8 @@ export function getNavTitle(navId: string | undefined) {
       return t('nav.profile/settings.title', 'Profile');
     case 'profile/notifications':
       return t('nav.profile/notifications.title', 'Notification history');
+    case 'profile/labs':
+      return t('nav.profile/labs.title', 'Labs');
     case 'profile/password':
       return t('nav.profile/password.title', 'Change password');
     case 'sign-out':

--- a/public/app/features/labs/LabsPage.test.tsx
+++ b/public/app/features/labs/LabsPage.test.tsx
@@ -1,0 +1,65 @@
+import userEvent from '@testing-library/user-event';
+import { render, screen, waitFor } from 'test/test-utils';
+
+import { getLocalStorageProvider } from '@grafana/runtime/internal';
+
+import LabsPage from './LabsPage';
+
+const getStorageKey = (flagName: string) => `grafana.openfeature.${flagName}`;
+
+describe('LabsPage', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+    getLocalStorageProvider().clearFlags();
+  });
+
+  it('renders Labs feature flags from the generated catalog', () => {
+    render(<LabsPage />);
+
+    expect(screen.getByRole('heading', { name: 'Try new Grafana features' })).toBeInTheDocument();
+    expect(screen.getByText('Analytics Framework')).toBeInTheDocument();
+    expect(screen.getByText('Enables new analytics framework')).toBeInTheDocument();
+  });
+
+  it('filters Labs by search query and stage', async () => {
+    const user = userEvent.setup();
+    render(<LabsPage />);
+
+    await user.type(screen.getByRole('textbox', { name: 'Search Labs' }), 'homepage');
+
+    expect(screen.getByText('Grafana Unified Homepage')).toBeInTheDocument();
+    expect(screen.queryByText('Analytics Framework')).not.toBeInTheDocument();
+
+    await user.clear(screen.getByRole('textbox', { name: 'Search Labs' }));
+    await user.click(screen.getByRole('button', { name: 'Preview' }));
+
+    expect(screen.getByText('Query Editor Next')).toBeInTheDocument();
+    expect(screen.queryByText('Analytics Framework')).not.toBeInTheDocument();
+  });
+
+  it('opts into a Labs feature with an OpenFeature local override', async () => {
+    const user = userEvent.setup();
+    render(<LabsPage />);
+
+    await user.click(screen.getByRole('switch', { name: 'Toggle Analytics Framework' }));
+
+    await waitFor(() => {
+      expect(window.localStorage.getItem(getStorageKey('analyticsFramework'))).toBe('true');
+    });
+    expect(screen.getByText('Custom choice')).toBeInTheDocument();
+  });
+
+  it('resets all Labs choices without clearing unrelated feature overrides', async () => {
+    const user = userEvent.setup();
+    getLocalStorageProvider().setFlags({ analyticsFramework: true, unrelatedFlag: true });
+
+    render(<LabsPage />);
+
+    await user.click(screen.getByRole('button', { name: 'Reset all Labs choices' }));
+
+    await waitFor(() => {
+      expect(window.localStorage.getItem(getStorageKey('analyticsFramework'))).toBeNull();
+    });
+    expect(window.localStorage.getItem(getStorageKey('unrelatedFlag'))).toBe('true');
+  });
+});

--- a/public/app/features/labs/LabsPage.tsx
+++ b/public/app/features/labs/LabsPage.tsx
@@ -167,7 +167,9 @@ function LabsFeatureCard({ feature }: { feature: LabsFeatureWithState }) {
           )}
           {feature.defaultEnabled && <Badge color="green" text={t('labs.default-on-badge', 'On by default')} />}
           {feature.hiddenFromDocs && <Badge color="darkgrey" text={t('labs.internal-badge', 'Internal')} />}
-          {feature.requiresRestart && <Badge color="orange" text={t('labs.restart-required-badge', 'Restart required')} />}
+          {feature.requiresRestart && (
+            <Badge color="orange" text={t('labs.restart-required-badge', 'Restart required')} />
+          )}
         </Stack>
 
         <div className={styles.cardFooter}>
@@ -244,12 +246,14 @@ function resetLabsFeatureOverride(key: string) {
 }
 
 function resetAllLabsOverrides() {
-  getLocalStorageProvider().setFlags(
-    Object.fromEntries(labsFeatures.map((feature) => [feature.key, undefined]))
-  );
+  getLocalStorageProvider().setFlags(Object.fromEntries(labsFeatures.map((feature) => [feature.key, undefined])));
 }
 
-function filterFeatures(features: LabsFeatureWithState[], query: string, filter: LabsFeatureFilter): LabsFeatureWithState[] {
+function filterFeatures(
+  features: LabsFeatureWithState[],
+  query: string,
+  filter: LabsFeatureFilter
+): LabsFeatureWithState[] {
   const normalizedQuery = query.trim().toLowerCase();
 
   return features.filter((feature) => {

--- a/public/app/features/labs/LabsPage.tsx
+++ b/public/app/features/labs/LabsPage.tsx
@@ -1,0 +1,406 @@
+import { css } from '@emotion/css';
+import { ClientProviderEvents } from '@openfeature/web-sdk';
+import { useEffect, useMemo, useState } from 'react';
+
+import type { GrafanaTheme2 } from '@grafana/data';
+import { t, Trans } from '@grafana/i18n';
+import { getLocalStorageProvider } from '@grafana/runtime/internal';
+import { Badge, Button, Card, FeatureBadge, FilterInput, Icon, Stack, Switch, Text, useStyles2 } from '@grafana/ui';
+import { Page } from 'app/core/components/Page/Page';
+
+import {
+  getFeatureStageState,
+  labsFeatureFilters,
+  labsFeatures,
+  type LabsFeature,
+  type LabsFeatureFilter,
+} from './labsFlags';
+
+type FlagOverrides = Record<string, unknown>;
+
+type LabsFeatureWithState = LabsFeature & {
+  enabled: boolean;
+  override?: boolean;
+  isOverridden: boolean;
+};
+
+const defaultFilter: LabsFeatureFilter = 'all';
+
+function LabsPage() {
+  const styles = useStyles2(getStyles);
+  const [query, setQuery] = useState('');
+  const [filter, setFilter] = useState<LabsFeatureFilter>(defaultFilter);
+  const overrides = useLocalFlagOverrides();
+
+  const features = useMemo(() => {
+    return labsFeatures.map((feature): LabsFeatureWithState => {
+      const override = getBooleanOverride(overrides, feature.key);
+
+      return {
+        ...feature,
+        enabled: override ?? feature.defaultEnabled,
+        override,
+        isOverridden: override !== undefined,
+      };
+    });
+  }, [overrides]);
+
+  const filteredFeatures = useMemo(() => filterFeatures(features, query, filter), [features, filter, query]);
+  const enabledCount = features.filter((feature) => feature.enabled).length;
+  const overrideCount = features.filter((feature) => feature.isOverridden).length;
+
+  return (
+    <Page navId="profile/labs">
+      <Page.Contents>
+        <Stack direction="column" gap={3}>
+          <section className={styles.hero}>
+            <div className={styles.heroContent}>
+              <Badge icon="flask" color="blue" text={t('labs.hero-badge', 'Labs')} />
+              <Text element="h1">
+                <Trans i18nKey="labs.title">Try new Grafana features</Trans>
+              </Text>
+              <Text variant="body" color="secondary">
+                <Trans i18nKey="labs.description">
+                  Opt into preview and experimental features for this browser. You can turn them off at any time.
+                </Trans>
+              </Text>
+              <Stack direction="row" gap={1} alignItems="center">
+                <Button icon="sync" variant="secondary" onClick={() => window.location.reload()}>
+                  <Trans i18nKey="labs.reload-button">Reload to apply everywhere</Trans>
+                </Button>
+                <Button
+                  icon="times"
+                  variant="secondary"
+                  fill="text"
+                  disabled={overrideCount === 0}
+                  onClick={resetAllLabsOverrides}
+                >
+                  <Trans i18nKey="labs.reset-all-button">Reset all Labs choices</Trans>
+                </Button>
+              </Stack>
+            </div>
+            <div className={styles.heroStats} aria-label={t('labs.summary-label', 'Labs summary')}>
+              <Stat value={labsFeatures.length} label={t('labs.available-features-count', 'Available')} />
+              <Stat value={enabledCount} label={t('labs.enabled-features-count', 'Enabled')} />
+              <Stat value={overrideCount} label={t('labs.customized-features-count', 'Customized')} />
+            </div>
+          </section>
+
+          <Card noMargin className={styles.controlsCard}>
+            <Stack direction="column" gap={2}>
+              <FilterInput
+                value={query}
+                onChange={setQuery}
+                placeholder={t('labs.search-placeholder', 'Search Labs by feature, owner, or flag key')}
+                aria-label={t('labs.search-label', 'Search Labs')}
+              />
+              <div className={styles.filters} aria-label={t('labs.filters-label', 'Labs filters')}>
+                {labsFeatureFilters.map((filterOption) => (
+                  <Button
+                    key={filterOption}
+                    size="sm"
+                    variant={filterOption === filter ? 'primary' : 'secondary'}
+                    fill={filterOption === filter ? 'solid' : 'outline'}
+                    onClick={() => setFilter(filterOption)}
+                  >
+                    {getFilterLabel(filterOption)}
+                  </Button>
+                ))}
+              </div>
+            </Stack>
+          </Card>
+
+          {filteredFeatures.length > 0 ? (
+            <div className={styles.featureGrid}>
+              {filteredFeatures.map((feature) => (
+                <LabsFeatureCard key={feature.key} feature={feature} />
+              ))}
+            </div>
+          ) : (
+            <Card noMargin className={styles.emptyState}>
+              <Icon name="search" size="xxl" />
+              <Text element="h2" variant="h3">
+                <Trans i18nKey="labs.empty-title">No Labs match your search</Trans>
+              </Text>
+              <Text color="secondary">
+                <Trans i18nKey="labs.empty-description">Try another keyword or filter.</Trans>
+              </Text>
+            </Card>
+          )}
+        </Stack>
+      </Page.Contents>
+    </Page>
+  );
+}
+
+function LabsFeatureCard({ feature }: { feature: LabsFeatureWithState }) {
+  const styles = useStyles2(getStyles);
+  const switchId = `labs-feature-${feature.key.replace(/[^a-zA-Z0-9_-]/g, '-')}`;
+
+  return (
+    <Card noMargin className={feature.enabled ? styles.featureCardEnabled : styles.featureCard}>
+      <Stack direction="column" gap={2}>
+        <Stack direction="row" gap={2} justifyContent="space-between" alignItems="flex-start">
+          <Stack direction="column" gap={1}>
+            <Stack direction="row" gap={1} alignItems="center">
+              <Text element="h2" variant="h4">
+                {feature.title}
+              </Text>
+              <FeatureBadge featureState={getFeatureStageState(feature.stage)} />
+            </Stack>
+            <Text color="secondary">{feature.description}</Text>
+          </Stack>
+          <Switch
+            id={switchId}
+            value={feature.enabled}
+            aria-label={t('labs.toggle-feature-label', 'Toggle {{featureTitle}}', { featureTitle: feature.title })}
+            onChange={(event) => setLabsFeatureOverride(feature.key, event.currentTarget.checked)}
+          />
+        </Stack>
+
+        <Stack direction="row" gap={1} alignItems="center">
+          <Text variant="code" color="secondary">
+            {feature.key}
+          </Text>
+          {feature.isOverridden && (
+            <Badge color="purple" text={t('labs.custom-choice-badge', 'Custom choice')} icon="sliders-v-alt" />
+          )}
+          {feature.defaultEnabled && <Badge color="green" text={t('labs.default-on-badge', 'On by default')} />}
+          {feature.hiddenFromDocs && <Badge color="darkgrey" text={t('labs.internal-badge', 'Internal')} />}
+          {feature.requiresRestart && <Badge color="orange" text={t('labs.restart-required-badge', 'Restart required')} />}
+        </Stack>
+
+        <div className={styles.cardFooter}>
+          <Text color="secondary" variant="bodySmall">
+            {feature.codeowner ? (
+              t('labs.owner-label', 'Owned by {{owner}}', { owner: feature.codeowner })
+            ) : (
+              <Trans i18nKey="labs.owner-unknown-label">Owner not listed</Trans>
+            )}
+          </Text>
+          <Button
+            size="sm"
+            variant="secondary"
+            fill="text"
+            disabled={!feature.isOverridden}
+            onClick={() => resetLabsFeatureOverride(feature.key)}
+          >
+            <Trans i18nKey="labs.reset-feature-button">Reset</Trans>
+          </Button>
+        </div>
+      </Stack>
+    </Card>
+  );
+}
+
+function Stat({ value, label }: { value: number; label: string }) {
+  const styles = useStyles2(getStyles);
+
+  return (
+    <div className={styles.stat}>
+      <Text element="span" variant="h2">
+        {value}
+      </Text>
+      <Text color="secondary">{label}</Text>
+    </div>
+  );
+}
+
+function useLocalFlagOverrides(): FlagOverrides {
+  const [overrides, setOverrides] = useState<FlagOverrides>(() => getLocalStorageProvider().getFlags());
+
+  useEffect(() => {
+    const loadOverrides = () => setOverrides({ ...getLocalStorageProvider().getFlags() });
+
+    getLocalStorageProvider().events.addHandler(ClientProviderEvents.ConfigurationChanged, loadOverrides);
+    return () => {
+      getLocalStorageProvider().events.removeHandler(ClientProviderEvents.ConfigurationChanged, loadOverrides);
+    };
+  }, []);
+
+  return overrides;
+}
+
+function getBooleanOverride(overrides: FlagOverrides, key: string): boolean | undefined {
+  const value = overrides[key];
+
+  if (value === true || value === 'true') {
+    return true;
+  }
+
+  if (value === false || value === 'false') {
+    return false;
+  }
+
+  return undefined;
+}
+
+function setLabsFeatureOverride(key: string, enabled: boolean) {
+  getLocalStorageProvider().setFlags({ [key]: enabled });
+}
+
+function resetLabsFeatureOverride(key: string) {
+  getLocalStorageProvider().setFlags({ [key]: undefined });
+}
+
+function resetAllLabsOverrides() {
+  getLocalStorageProvider().setFlags(
+    Object.fromEntries(labsFeatures.map((feature) => [feature.key, undefined]))
+  );
+}
+
+function filterFeatures(features: LabsFeatureWithState[], query: string, filter: LabsFeatureFilter): LabsFeatureWithState[] {
+  const normalizedQuery = query.trim().toLowerCase();
+
+  return features.filter((feature) => {
+    if (filter === 'enabled' && !feature.enabled) {
+      return false;
+    }
+
+    if (filter === 'overridden' && !feature.isOverridden) {
+      return false;
+    }
+
+    if (filter !== 'all' && filter !== 'enabled' && filter !== 'overridden' && feature.stage !== filter) {
+      return false;
+    }
+
+    if (!normalizedQuery) {
+      return true;
+    }
+
+    return [feature.title, feature.description, feature.key, feature.codeowner]
+      .filter(Boolean)
+      .some((value) => value!.toLowerCase().includes(normalizedQuery));
+  });
+}
+
+function getFilterLabel(filter: LabsFeatureFilter): string {
+  switch (filter) {
+    case 'all':
+      return t('labs.filter-all', 'All');
+    case 'enabled':
+      return t('labs.filter-enabled', 'Enabled');
+    case 'overridden':
+      return t('labs.filter-overridden', 'Customized');
+    case 'preview':
+      return t('labs.filter-preview', 'Preview');
+    case 'privatePreview':
+      return t('labs.filter-private-preview', 'Private preview');
+    case 'experimental':
+      return t('labs.filter-experimental', 'Experimental');
+  }
+}
+
+const getStyles = (theme: GrafanaTheme2) => {
+  const cardBorder = `1px solid ${theme.colors.border.weak}`;
+
+  return {
+    hero: css({
+      display: 'grid',
+      gridTemplateColumns: 'minmax(0, 1fr) auto',
+      gap: theme.spacing(3),
+      padding: theme.spacing(4),
+      border: cardBorder,
+      borderRadius: theme.shape.radius.lg,
+      background: `linear-gradient(135deg, ${theme.colors.background.secondary}, ${theme.colors.background.canvas})`,
+      boxShadow: theme.shadows.z1,
+
+      [theme.breakpoints.down('md')]: {
+        gridTemplateColumns: '1fr',
+      },
+    }),
+    heroContent: css({
+      display: 'flex',
+      flexDirection: 'column',
+      gap: theme.spacing(2),
+      maxWidth: theme.spacing(82),
+    }),
+    heroStats: css({
+      display: 'grid',
+      gridTemplateColumns: 'repeat(3, minmax(112px, 1fr))',
+      gap: theme.spacing(1),
+      alignSelf: 'stretch',
+
+      [theme.breakpoints.down('sm')]: {
+        gridTemplateColumns: '1fr',
+      },
+    }),
+    stat: css({
+      display: 'flex',
+      flexDirection: 'column',
+      justifyContent: 'center',
+      minHeight: theme.spacing(12),
+      padding: theme.spacing(2),
+      border: cardBorder,
+      borderRadius: theme.shape.radius.default,
+      background: theme.colors.background.primary,
+    }),
+    controlsCard: css({
+      padding: theme.spacing(2),
+      border: cardBorder,
+      borderRadius: theme.shape.radius.default,
+    }),
+    filters: css({
+      display: 'flex',
+      flexWrap: 'wrap',
+      gap: theme.spacing(1),
+    }),
+    featureGrid: css({
+      display: 'grid',
+      gridTemplateColumns: 'repeat(auto-fit, minmax(360px, 1fr))',
+      gap: theme.spacing(2),
+
+      [theme.breakpoints.down('sm')]: {
+        gridTemplateColumns: '1fr',
+      },
+    }),
+    featureCard: css({
+      minHeight: '100%',
+      padding: theme.spacing(2),
+      border: cardBorder,
+      borderRadius: theme.shape.radius.default,
+      background: theme.colors.background.primary,
+
+      '&:hover': {
+        borderColor: theme.colors.border.medium,
+        boxShadow: theme.shadows.z1,
+        transform: 'translateY(-1px)',
+      },
+    }),
+    featureCardEnabled: css({
+      minHeight: '100%',
+      padding: theme.spacing(2),
+      border: `1px solid ${theme.colors.success.border}`,
+      borderRadius: theme.shape.radius.default,
+      background: theme.colors.background.primary,
+      boxShadow: `inset 4px 0 0 ${theme.colors.success.main}`,
+
+      '&:hover': {
+        borderColor: theme.colors.success.main,
+        boxShadow: `${theme.shadows.z1}, inset 4px 0 0 ${theme.colors.success.main}`,
+        transform: 'translateY(-1px)',
+      },
+    }),
+    cardFooter: css({
+      display: 'flex',
+      justifyContent: 'space-between',
+      alignItems: 'center',
+      gap: theme.spacing(1),
+      paddingTop: theme.spacing(1),
+      borderTop: cardBorder,
+    }),
+    emptyState: css({
+      display: 'flex',
+      flexDirection: 'column',
+      alignItems: 'center',
+      gap: theme.spacing(1),
+      padding: theme.spacing(6),
+      border: cardBorder,
+      borderRadius: theme.shape.radius.default,
+      textAlign: 'center',
+    }),
+  };
+};
+
+export default LabsPage;

--- a/public/app/features/labs/labsFlags.ts
+++ b/public/app/features/labs/labsFlags.ts
@@ -1,0 +1,106 @@
+import { FeatureState } from '@grafana/data';
+import { FlagKeys } from '@grafana/runtime/internal';
+
+import featureList from '../../../../pkg/services/featuremgmt/toggles_gen.json';
+
+const STAGE_ORDER = ['preview', 'privatePreview', 'experimental'] as const;
+const FRONTEND_FLAG_KEYS = new Set<string>(Object.values(FlagKeys));
+const collator = new Intl.Collator('en', { sensitivity: 'base', numeric: true });
+const catalog: FeatureToggleCatalog = featureList;
+
+type FeatureToggleCatalog = {
+  items: FeatureToggleCatalogItem[];
+};
+
+type FeatureToggleCatalogItem = {
+  metadata: {
+    name: string;
+  };
+  spec: {
+    description?: string;
+    stage?: string;
+    codeowner?: string;
+    expression?: string;
+    requiresRestart?: boolean;
+    requiresDevMode?: boolean;
+    hideFromDocs?: boolean;
+  };
+};
+
+export type LabsFeatureStage = (typeof STAGE_ORDER)[number];
+
+export type LabsFeature = {
+  key: string;
+  title: string;
+  description: string;
+  stage: LabsFeatureStage;
+  defaultEnabled: boolean;
+  codeowner?: string;
+  requiresRestart: boolean;
+  hiddenFromDocs: boolean;
+};
+
+export type LabsFeatureFilter = LabsFeatureStage | 'all' | 'enabled' | 'overridden';
+
+export const labsFeatureFilters: LabsFeatureFilter[] = [
+  'all',
+  'enabled',
+  'overridden',
+  'preview',
+  'privatePreview',
+  'experimental',
+];
+
+export const labsFeatures: LabsFeature[] = catalog.items
+  .flatMap((item) => {
+    const stage = item.spec.stage;
+
+    if (!FRONTEND_FLAG_KEYS.has(item.metadata.name) || !isLabsFeatureStage(stage) || item.spec.requiresDevMode) {
+      return [];
+    }
+
+    return [
+      {
+        key: item.metadata.name,
+        title: getFeatureTitle(item.metadata.name),
+        description: item.spec.description || item.metadata.name,
+        stage,
+        defaultEnabled: item.spec.expression === 'true',
+        codeowner: item.spec.codeowner,
+        requiresRestart: item.spec.requiresRestart ?? false,
+        hiddenFromDocs: item.spec.hideFromDocs ?? false,
+      },
+    ];
+  })
+  .sort((a, b) => {
+    const stageSort = STAGE_ORDER.indexOf(a.stage) - STAGE_ORDER.indexOf(b.stage);
+    return stageSort || collator.compare(a.title, b.title);
+  });
+
+export function getFeatureStageState(stage: LabsFeatureStage): FeatureState {
+  switch (stage) {
+    case 'preview':
+      return FeatureState.preview;
+    case 'privatePreview':
+      return FeatureState.privatePreview;
+    case 'experimental':
+      return FeatureState.experimental;
+  }
+}
+
+function getFeatureTitle(key: string): string {
+  const spaced = key
+    .replace(/\./g, ' ')
+    .replace(/([a-z0-9])([A-Z])/g, '$1 $2')
+    .replace(/([A-Z])([A-Z][a-z])/g, '$1 $2')
+    .trim();
+
+  return spaced
+    .split(/\s+/)
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+    .join(' ');
+}
+
+function isLabsFeatureStage(stage: string | undefined): stage is LabsFeatureStage {
+  return stage === 'preview' || stage === 'privatePreview' || stage === 'experimental';
+}

--- a/public/app/features/profile/routes.tsx
+++ b/public/app/features/profile/routes.tsx
@@ -29,6 +29,10 @@ const profileRoutes: RouteDescriptor[] = [
       () => import(/* webpackChunkName: "NotificationsPage"*/ 'app/features/notifications/NotificationsPage')
     ),
   },
+  {
+    path: '/profile/labs',
+    component: SafeDynamicImport(() => import(/* webpackChunkName: "LabsPage"*/ 'app/features/labs/LabsPage')),
+  },
 ];
 
 export function getProfileRoutes(cfg = config): RouteDescriptor[] {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
**What is this feature?**

Adds a new Profile > Labs page that lists frontend-evaluable preview and experimental feature flags from the generated feature catalog, with search, filters, stage badges, default/custom state, local opt-in switches, and reset controls.

<a href="https://cursor.com/agents/bc-70094527-930b-412e-af3a-872bae17a0df/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Flabs_feature_flags_walkthrough.mp4"><img src="https://cursor.com/artifacts/c/art-83db6bdc-350c-49a5-998c-1e3e249f43d8" alt="labs_feature_flags_walkthrough.mp4" /></a>

**Why do we need this feature?**

Users need an approachable GUI to discover and opt into existing in-code Labs features without hand-editing feature flag configuration or using the developer-only Feature Control overlay.

**Who is this feature for?**

Grafana users who want to try preview or experimental frontend features in their current browser session.

**Which issue(s) does this PR fix?**:

N/A

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a notable improvement, it's added to What's New.

Validation performed:
- `yarn prettier --check public/app/features/labs/LabsPage.tsx public/app/features/labs/LabsPage.test.tsx public/app/features/labs/labsFlags.ts public/app/features/profile/routes.tsx public/app/core/utils/navBarItem-translations.ts`
- `yarn eslint public/app/features/labs/LabsPage.tsx public/app/features/labs/LabsPage.test.tsx public/app/features/labs/labsFlags.ts public/app/features/profile/routes.tsx public/app/core/utils/navBarItem-translations.ts`
- `yarn jest --no-watch public/app/features/labs/LabsPage.test.tsx`
- `go test ./pkg/services/navtree/navtreeimpl`
- Manual browser walkthrough of `/profile/labs`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-70094527-930b-412e-af3a-872bae17a0df"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-70094527-930b-412e-af3a-872bae17a0df"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

