### PR TITLE
feat(library-app): add items API endpoint

### DIFF
--- a/library-app/.gitignore
+++ b/library-app/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+*.pyc
+.pytest_cache/

--- a/library-app/main.py
+++ b/library-app/main.py
@@ -1,0 +1,43 @@
+from fastapi import FastAPI
+from fastapi.staticfiles import StaticFiles
+from pydantic import BaseModel
+
+app = FastAPI()
+
+
+class BookResponse(BaseModel):
+    title: str
+    author: str
+    year: int
+    genre: str
+
+
+class ItemResponse(BaseModel):
+    id: str
+    name: str
+
+
+BOOKS: list[BookResponse] = [
+    BookResponse(title="The Pragmatic Programmer", author="Hunt & Thomas", year=1999, genre="Technology"),
+    BookResponse(title="Dune", author="Frank Herbert", year=1965, genre="Science Fiction"),
+    BookResponse(title="Pride and Prejudice", author="Jane Austen", year=1813, genre="Classic"),
+]
+
+ITEMS: list[ItemResponse] = [
+    ItemResponse(id="1", name="Reading Lamp"),
+    ItemResponse(id="2", name="Bookmark Set"),
+    ItemResponse(id="3", name="Library Card Holder"),
+]
+
+
+@app.get("/api/books", response_model=list[BookResponse])
+def get_books():
+    return BOOKS
+
+
+@app.get("/api/items", response_model=list[ItemResponse])
+def get_items():
+    return ITEMS
+
+
+app.mount("/", StaticFiles(directory="static", html=True), name="static")

--- a/library-app/requirements.txt
+++ b/library-app/requirements.txt
@@ -1,0 +1,4 @@
+fastapi==0.115.6
+uvicorn==0.34.0
+pytest==8.3.4
+httpx==0.28.1

--- a/library-app/static/index.html
+++ b/library-app/static/index.html
@@ -1,0 +1,140 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Library App</title>
+  <style>
+    :root {
+      --bg: #f7f7f4;
+      --fg: #26251e;
+      --accent: #f54e00;
+      --card: #f2f1ed;
+      --muted: rgba(38, 37, 30, 0.6);
+    }
+
+    * {
+      box-sizing: border-box;
+    }
+
+    body {
+      margin: 0;
+      font-family: system-ui, sans-serif;
+      background: var(--bg);
+      color: var(--fg);
+    }
+
+    main {
+      max-width: 960px;
+      margin: 0 auto;
+      padding: 2rem 1.5rem;
+    }
+
+    h1 {
+      margin: 0 0 0.5rem;
+    }
+
+    .subtitle {
+      color: var(--muted);
+      margin: 0 0 2rem;
+    }
+
+    section {
+      margin-bottom: 2.5rem;
+    }
+
+    h2 {
+      margin: 0 0 1rem;
+      border-bottom: 2px solid var(--accent);
+      display: inline-block;
+      padding-bottom: 0.25rem;
+    }
+
+    .grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+      gap: 1rem;
+    }
+
+    .card {
+      background: var(--card);
+      border-radius: 8px;
+      padding: 1rem;
+    }
+
+    .card h3 {
+      margin: 0 0 0.5rem;
+      font-size: 1rem;
+    }
+
+    .card p {
+      margin: 0.25rem 0;
+      color: var(--muted);
+      font-size: 0.9rem;
+    }
+
+    .error {
+      color: var(--accent);
+    }
+  </style>
+</head>
+<body>
+  <main>
+    <h1>Library App</h1>
+    <p class="subtitle">Browse books and library items from the FastAPI backend.</p>
+
+    <section>
+      <h2>Books</h2>
+      <div id="books" class="grid"></div>
+    </section>
+
+    <section>
+      <h2>Items</h2>
+      <div id="items" class="grid"></div>
+    </section>
+  </main>
+
+  <script>
+    function renderCards(containerId, items, renderFn) {
+      const container = document.getElementById(containerId);
+      container.innerHTML = items.map(renderFn).join("");
+    }
+
+    function showError(containerId, message) {
+      document.getElementById(containerId).innerHTML =
+        `<p class="error">${message}</p>`;
+    }
+
+    fetch("/api/books")
+      .then((res) => {
+        if (!res.ok) throw new Error("Failed to load books");
+        return res.json();
+      })
+      .then((books) => {
+        renderCards("books", books, (book) => `
+          <article class="card">
+            <h3>${book.title}</h3>
+            <p>${book.author}</p>
+            <p>${book.year} · ${book.genre}</p>
+          </article>
+        `);
+      })
+      .catch(() => showError("books", "Could not load books."));
+
+    fetch("/api/items")
+      .then((res) => {
+        if (!res.ok) throw new Error("Failed to load items");
+        return res.json();
+      })
+      .then((items) => {
+        renderCards("items", items, (item) => `
+          <article class="card">
+            <h3>${item.name}</h3>
+            <p>ID: ${item.id}</p>
+          </article>
+        `);
+      })
+      .catch(() => showError("items", "Could not load items."));
+  </script>
+</body>
+</html>

--- a/library-app/tests/test_main.py
+++ b/library-app/tests/test_main.py
@@ -1,0 +1,23 @@
+from starlette.testclient import TestClient
+
+from main import app
+
+client = TestClient(app)
+
+
+def test_get_books():
+    response = client.get("/api/books")
+    assert response.status_code == 200
+    books = response.json()
+    assert isinstance(books, list)
+    assert len(books) > 0
+    assert set(books[0].keys()) == {"title", "author", "year", "genre"}
+
+
+def test_get_items():
+    response = client.get("/api/items")
+    assert response.status_code == 200
+    items = response.json()
+    assert isinstance(items, list)
+    assert len(items) > 0
+    assert set(items[0].keys()) == {"id", "name"}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Scaffolds a `library-app` FastAPI project and adds a new `/api/items` endpoint following the `add-api-endpoint` skill and `fastapi-conventions.mdc` rules.

## Changes

- **Pydantic models**: `BookResponse` and `ItemResponse` with explicit `response_model` on routes
- **New endpoint**: `GET /api/items` returns library items (`id`, `name`)
- **Frontend**: `static/index.html` fetches and renders books and items using the existing card pattern
- **Tests**: `test_get_books` and `test_get_items` using FastAPI `TestClient`

## Conventions followed

- Pydantic `BaseModel` for response schemas
- Static files mounted after API routes
- Cursor brand palette in frontend
- pytest happy-path tests for each endpoint

## Test plan

- [x] `python3 -m pytest tests/ -v` — 2 passed
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8495ab17-1d03-470f-9664-4495c7c0566b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8495ab17-1d03-470f-9664-4495c7c0566b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

