### PR TITLE
Frontend: Add dark/light theme toggle to app chrome

### DIFF
--- a/e2e-playwright/various-suite/theme-toggle.spec.ts
+++ b/e2e-playwright/various-suite/theme-toggle.spec.ts
@@ -1,0 +1,43 @@
+import { test, expect } from '@grafana/plugin-e2e';
+
+test.describe('Theme toggle', { tag: ['@various'] }, () => {
+  test('is visible on the login page', async ({ selectors, page }) => {
+    await page.goto(selectors.pages.Login.url);
+
+    await expect(page.getByTestId(selectors.components.NavToolbar.themeToggleFloating)).toBeVisible();
+    await expect(page.getByTestId(selectors.components.NavToolbar.themeToggle)).toBeVisible();
+  });
+
+  test('is visible in the top bar after login', async ({ selectors, page, grafanaAPICredentials }) => {
+    await page.goto(selectors.pages.Login.url);
+
+    await page.getByTestId(selectors.pages.Login.username).fill(grafanaAPICredentials.user);
+    await page.getByTestId(selectors.pages.Login.password).fill(grafanaAPICredentials.password);
+    await page.getByTestId(selectors.pages.Login.submit).click();
+
+    if (grafanaAPICredentials.password === 'admin') {
+      await page.getByTestId(selectors.pages.Login.skip).click();
+    }
+
+    await expect(page.getByTestId(selectors.components.NavToolbar.themeToggle)).toBeVisible();
+  });
+
+  test('switches theme when clicked', async ({ selectors, page, grafanaAPICredentials }) => {
+    await page.goto(selectors.pages.Login.url);
+
+    await page.getByTestId(selectors.pages.Login.username).fill(grafanaAPICredentials.user);
+    await page.getByTestId(selectors.pages.Login.password).fill(grafanaAPICredentials.password);
+    await page.getByTestId(selectors.pages.Login.submit).click();
+
+    if (grafanaAPICredentials.password === 'admin') {
+      await page.getByTestId(selectors.pages.Login.skip).click();
+    }
+
+    const themeToggle = page.getByTestId(selectors.components.NavToolbar.themeToggle);
+    const initialLabel = await themeToggle.getAttribute('aria-label');
+
+    await themeToggle.click();
+
+    await expect(themeToggle).not.toHaveAttribute('aria-label', initialLabel ?? '');
+  });
+});

--- a/packages/grafana-e2e-selectors/src/selectors/components.ts
+++ b/packages/grafana-e2e-selectors/src/selectors/components.ts
@@ -1103,6 +1103,12 @@ export const versionedComponents = {
     commandPaletteTrigger: {
       '11.5.0': 'data-testid Command palette trigger',
     },
+    themeToggle: {
+      '13.2.0': 'data-testid theme-toggle',
+    },
+    themeToggleFloating: {
+      '13.2.0': 'data-testid theme-toggle-floating',
+    },
     shareDashboard: {
       '11.1.0': 'data-testid Share dashboard',
     },

--- a/public/app/core/components/AppChrome/TopBar/SingleTopBar.tsx
+++ b/public/app/core/components/AppChrome/TopBar/SingleTopBar.tsx
@@ -18,7 +18,7 @@ import { useSelector } from 'app/types/store';
 import { HomeLink } from '../../Branding/Branding';
 import { Breadcrumbs } from '../../Breadcrumbs/Breadcrumbs';
 import { buildBreadcrumbs } from '../../Breadcrumbs/utils';
-import { ThemeToggleButton } from '../../ThemeToggle';
+import { ThemeToggleButton } from '../../ThemeToggle/ThemeToggleButton';
 import { ExtensionToolbarItem } from '../ExtensionSidebar/ExtensionToolbarItem';
 import { FeatureControlButton } from '../FeatureControl/FeatureControlButton';
 import { NavToolbarSeparator } from '../NavToolbar/NavToolbarSeparator';

--- a/public/app/core/components/AppChrome/TopBar/SingleTopBar.tsx
+++ b/public/app/core/components/AppChrome/TopBar/SingleTopBar.tsx
@@ -18,6 +18,7 @@ import { useSelector } from 'app/types/store';
 import { HomeLink } from '../../Branding/Branding';
 import { Breadcrumbs } from '../../Breadcrumbs/Breadcrumbs';
 import { buildBreadcrumbs } from '../../Breadcrumbs/utils';
+import { ThemeToggleButton } from '../../ThemeToggle';
 import { ExtensionToolbarItem } from '../ExtensionSidebar/ExtensionToolbarItem';
 import { FeatureControlButton } from '../FeatureControl/FeatureControlButton';
 import { NavToolbarSeparator } from '../NavToolbar/NavToolbarSeparator';
@@ -100,6 +101,7 @@ export const SingleTopBar = memo(function SingleTopBar({
           {!isSmallScreen && <QuickAdd />}
           <FeatureControlButton />
           <HelpTopBarButton isSmallScreen={isSmallScreen} />
+          <ThemeToggleButton />
           <NavToolbarSeparator />
           {!isSmallScreen && <ExtensionToolbarItem compact={isSmallScreen} />}
           {!showToolbarLevel && actions}

--- a/public/app/core/components/Login/LoginLayout.tsx
+++ b/public/app/core/components/Login/LoginLayout.tsx
@@ -9,7 +9,7 @@ import { useStyles2 } from '@grafana/ui';
 import { Branding } from '../Branding/Branding';
 import { type BrandingSettings } from '../Branding/types';
 import { Footer } from '../Footer/Footer';
-import { ThemeToggleFloatingButton } from '../ThemeToggle';
+import { ThemeToggleFloatingButton } from '../ThemeToggle/ThemeToggleFloatingButton';
 
 interface InnerBoxProps {
   enterAnimation?: boolean;

--- a/public/app/core/components/Login/LoginLayout.tsx
+++ b/public/app/core/components/Login/LoginLayout.tsx
@@ -9,6 +9,7 @@ import { useStyles2 } from '@grafana/ui';
 import { Branding } from '../Branding/Branding';
 import { type BrandingSettings } from '../Branding/types';
 import { Footer } from '../Footer/Footer';
+import { ThemeToggleFloatingButton } from '../ThemeToggle';
 
 interface InnerBoxProps {
   enterAnimation?: boolean;
@@ -39,6 +40,7 @@ export const LoginLayout = ({ children, branding, isChangingPassword }: React.Pr
     <Branding.LoginBackground
       className={cx(loginStyles.container, startAnim && loginStyles.loginAnim, branding?.loginBackground)}
     >
+      <ThemeToggleFloatingButton />
       <div className={loginStyles.loginMain}>
         <div className={cx(loginStyles.loginContent, loginBoxBackground, 'login-content-box')}>
           <div className={loginStyles.loginLogoWrapper}>

--- a/public/app/core/components/ThemeToggle/ThemeToggleButton.test.tsx
+++ b/public/app/core/components/ThemeToggle/ThemeToggleButton.test.tsx
@@ -3,7 +3,6 @@ import userEvent from '@testing-library/user-event';
 import { render } from 'test/test-utils';
 
 import { reportInteraction } from '@grafana/runtime';
-
 import { toggleTheme } from 'app/core/services/theme';
 
 import { ThemeToggleButton } from './ThemeToggleButton';

--- a/public/app/core/components/ThemeToggle/ThemeToggleButton.test.tsx
+++ b/public/app/core/components/ThemeToggle/ThemeToggleButton.test.tsx
@@ -1,0 +1,45 @@
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { render } from 'test/test-utils';
+
+import { reportInteraction } from '@grafana/runtime';
+
+import { toggleTheme } from 'app/core/services/theme';
+
+import { ThemeToggleButton } from './ThemeToggleButton';
+
+jest.mock('app/core/services/theme', () => ({
+  toggleTheme: jest.fn().mockResolvedValue(undefined),
+}));
+
+jest.mock('@grafana/runtime', () => ({
+  ...jest.requireActual('@grafana/runtime'),
+  reportInteraction: jest.fn(),
+}));
+
+describe('ThemeToggleButton', () => {
+  const user = userEvent.setup();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders an accessible theme toggle button', () => {
+    render(<ThemeToggleButton />);
+
+    expect(screen.getByTestId('theme-toggle')).toBeInTheDocument();
+    expect(screen.getByRole('button')).toHaveAccessibleName(/theme/i);
+  });
+
+  it('toggles theme and reports interaction on click', async () => {
+    render(<ThemeToggleButton />);
+
+    await user.click(screen.getByRole('button'));
+
+    expect(reportInteraction).toHaveBeenCalledWith('grafana_preferences_theme_changed', {
+      toTheme: expect.stringMatching(/^(dark|light)$/),
+      preferenceType: 'toolbar_toggle',
+    });
+    expect(toggleTheme).toHaveBeenCalledWith(false);
+  });
+});

--- a/public/app/core/components/ThemeToggle/ThemeToggleButton.tsx
+++ b/public/app/core/components/ThemeToggle/ThemeToggleButton.tsx
@@ -1,5 +1,6 @@
 import { memo } from 'react';
 
+import { Components } from '@grafana/e2e-selectors';
 import { ToolbarButton } from '@grafana/ui';
 
 import { useThemeToggle } from './useThemeToggle';
@@ -12,16 +13,17 @@ import { useThemeToggle } from './useThemeToggle';
  * `HelpTopBarButton` and `TopSearchBarCommandPaletteTrigger`.
  */
 export const ThemeToggleButton = memo(function ThemeToggleButton() {
-  const { icon, ariaLabel, tooltip, toggle } = useThemeToggle();
+  const { isDark, icon, ariaLabel, tooltip, toggle } = useThemeToggle();
 
   return (
     <ToolbarButton
       iconOnly
       icon={icon}
       aria-label={ariaLabel}
+      aria-pressed={isDark}
       tooltip={tooltip}
       onClick={toggle}
-      data-testid="theme-toggle"
+      data-testid={Components.NavToolbar.themeToggle}
     />
   );
 });

--- a/public/app/core/components/ThemeToggle/ThemeToggleButton.tsx
+++ b/public/app/core/components/ThemeToggle/ThemeToggleButton.tsx
@@ -1,0 +1,27 @@
+import { memo } from 'react';
+
+import { ToolbarButton } from '@grafana/ui';
+
+import { useThemeToggle } from './useThemeToggle';
+
+/**
+ * Top-bar dark/light toggle for standard (non-chromeless) pages.
+ *
+ * Placement: `SingleTopBar` right-side toolbar, after Help and before the profile
+ * separator — consistent with other icon-only `ToolbarButton` controls such as
+ * `HelpTopBarButton` and `TopSearchBarCommandPaletteTrigger`.
+ */
+export const ThemeToggleButton = memo(function ThemeToggleButton() {
+  const { icon, ariaLabel, tooltip, toggle } = useThemeToggle();
+
+  return (
+    <ToolbarButton
+      iconOnly
+      icon={icon}
+      aria-label={ariaLabel}
+      tooltip={tooltip}
+      onClick={toggle}
+      data-testid="theme-toggle"
+    />
+  );
+});

--- a/public/app/core/components/ThemeToggle/ThemeToggleFloatingButton.test.tsx
+++ b/public/app/core/components/ThemeToggle/ThemeToggleFloatingButton.test.tsx
@@ -6,7 +6,7 @@ import { Components } from '@grafana/e2e-selectors';
 import { reportInteraction } from '@grafana/runtime';
 import { toggleTheme } from 'app/core/services/theme';
 
-import { ThemeToggleButton } from './ThemeToggleButton';
+import { ThemeToggleFloatingButton } from './ThemeToggleFloatingButton';
 
 jest.mock('app/core/services/theme', () => ({
   toggleTheme: jest.fn().mockResolvedValue(undefined),
@@ -17,22 +17,22 @@ jest.mock('@grafana/runtime', () => ({
   reportInteraction: jest.fn(),
 }));
 
-describe('ThemeToggleButton', () => {
+describe('ThemeToggleFloatingButton', () => {
   const user = userEvent.setup();
 
   beforeEach(() => {
     jest.clearAllMocks();
   });
 
-  it('renders an accessible theme toggle button', () => {
-    render(<ThemeToggleButton />);
+  it('renders a fixed-position wrapper with the theme toggle button', () => {
+    render(<ThemeToggleFloatingButton />);
 
+    expect(screen.getByTestId(Components.NavToolbar.themeToggleFloating)).toBeInTheDocument();
     expect(screen.getByTestId(Components.NavToolbar.themeToggle)).toBeInTheDocument();
-    expect(screen.getByRole('button')).toHaveAccessibleName(/theme/i);
   });
 
   it('toggles theme and reports interaction on click', async () => {
-    render(<ThemeToggleButton />);
+    render(<ThemeToggleFloatingButton />);
 
     await user.click(screen.getByRole('button'));
 

--- a/public/app/core/components/ThemeToggle/ThemeToggleFloatingButton.tsx
+++ b/public/app/core/components/ThemeToggle/ThemeToggleFloatingButton.tsx
@@ -1,0 +1,42 @@
+import { css } from '@emotion/css';
+import { memo } from 'react';
+
+import { type GrafanaTheme2 } from '@grafana/data';
+import { ToolbarButton, useStyles2 } from '@grafana/ui';
+
+import { useThemeToggle } from './useThemeToggle';
+
+interface Props {
+  className?: string;
+}
+
+/**
+ * Fixed-position dark/light toggle for chromeless surfaces (login, signup, etc.)
+ * where `SingleTopBar` is not rendered.
+ */
+export const ThemeToggleFloatingButton = memo(function ThemeToggleFloatingButton({ className }: Props) {
+  const styles = useStyles2(getStyles);
+  const { icon, ariaLabel, tooltip, toggle } = useThemeToggle();
+
+  return (
+    <div className={css(styles.wrapper, className)} data-testid="theme-toggle-floating">
+      <ToolbarButton
+        iconOnly
+        icon={icon}
+        aria-label={ariaLabel}
+        tooltip={tooltip}
+        onClick={toggle}
+        data-testid="theme-toggle"
+      />
+    </div>
+  );
+});
+
+const getStyles = (theme: GrafanaTheme2) => ({
+  wrapper: css({
+    position: 'fixed',
+    top: theme.spacing(2),
+    right: theme.spacing(2),
+    zIndex: theme.zIndex.dropdown,
+  }),
+});

--- a/public/app/core/components/ThemeToggle/ThemeToggleFloatingButton.tsx
+++ b/public/app/core/components/ThemeToggle/ThemeToggleFloatingButton.tsx
@@ -20,10 +20,7 @@ export const ThemeToggleFloatingButton = memo(function ThemeToggleFloatingButton
   const { isDark, icon, ariaLabel, tooltip, toggle } = useThemeToggle();
 
   return (
-    <div
-      className={css(styles.wrapper, className)}
-      data-testid={Components.NavToolbar.themeToggleFloating}
-    >
+    <div className={css(styles.wrapper, className)} data-testid={Components.NavToolbar.themeToggleFloating}>
       <ToolbarButton
         iconOnly
         icon={icon}

--- a/public/app/core/components/ThemeToggle/ThemeToggleFloatingButton.tsx
+++ b/public/app/core/components/ThemeToggle/ThemeToggleFloatingButton.tsx
@@ -2,6 +2,7 @@ import { css } from '@emotion/css';
 import { memo } from 'react';
 
 import { type GrafanaTheme2 } from '@grafana/data';
+import { Components } from '@grafana/e2e-selectors';
 import { ToolbarButton, useStyles2 } from '@grafana/ui';
 
 import { useThemeToggle } from './useThemeToggle';
@@ -16,17 +17,21 @@ interface Props {
  */
 export const ThemeToggleFloatingButton = memo(function ThemeToggleFloatingButton({ className }: Props) {
   const styles = useStyles2(getStyles);
-  const { icon, ariaLabel, tooltip, toggle } = useThemeToggle();
+  const { isDark, icon, ariaLabel, tooltip, toggle } = useThemeToggle();
 
   return (
-    <div className={css(styles.wrapper, className)} data-testid="theme-toggle-floating">
+    <div
+      className={css(styles.wrapper, className)}
+      data-testid={Components.NavToolbar.themeToggleFloating}
+    >
       <ToolbarButton
         iconOnly
         icon={icon}
         aria-label={ariaLabel}
+        aria-pressed={isDark}
         tooltip={tooltip}
         onClick={toggle}
-        data-testid="theme-toggle"
+        data-testid={Components.NavToolbar.themeToggle}
       />
     </div>
   );

--- a/public/app/core/components/ThemeToggle/index.ts
+++ b/public/app/core/components/ThemeToggle/index.ts
@@ -1,0 +1,9 @@
+export { ThemeToggleButton } from './ThemeToggleButton';
+export { ThemeToggleFloatingButton } from './ThemeToggleFloatingButton';
+export { useThemeToggle } from './useThemeToggle';
+export {
+  getTargetThemeId,
+  getThemeToggleAriaLabel,
+  getThemeToggleIcon,
+  getThemeToggleTooltip,
+} from './themeToggleUtils';

--- a/public/app/core/components/ThemeToggle/index.ts
+++ b/public/app/core/components/ThemeToggle/index.ts
@@ -1,9 +1,0 @@
-export { ThemeToggleButton } from './ThemeToggleButton';
-export { ThemeToggleFloatingButton } from './ThemeToggleFloatingButton';
-export { useThemeToggle } from './useThemeToggle';
-export {
-  getTargetThemeId,
-  getThemeToggleAriaLabel,
-  getThemeToggleIcon,
-  getThemeToggleTooltip,
-} from './themeToggleUtils';

--- a/public/app/core/components/ThemeToggle/themeToggleUtils.test.ts
+++ b/public/app/core/components/ThemeToggle/themeToggleUtils.test.ts
@@ -1,0 +1,50 @@
+import {
+  getTargetThemeId,
+  getThemeToggleAriaLabel,
+  getThemeToggleIcon,
+  getThemeToggleTooltip,
+} from './themeToggleUtils';
+
+describe('themeToggleUtils', () => {
+  describe('getThemeToggleIcon', () => {
+    it('returns lightbulb-alt when switching from dark to light', () => {
+      expect(getThemeToggleIcon(true)).toBe('lightbulb-alt');
+    });
+
+    it('returns adjust-circle when switching from light to dark', () => {
+      expect(getThemeToggleIcon(false)).toBe('adjust-circle');
+    });
+  });
+
+  describe('getTargetThemeId', () => {
+    it('returns light when current theme is dark', () => {
+      expect(getTargetThemeId(true)).toBe('light');
+    });
+
+    it('returns dark when current theme is light', () => {
+      expect(getTargetThemeId(false)).toBe('dark');
+    });
+  });
+
+  describe('getThemeToggleAriaLabel', () => {
+    it('describes switching to light when dark', () => {
+      expect(getThemeToggleAriaLabel(true)).toBe('Switch to light theme');
+    });
+
+    it('describes switching to dark when light', () => {
+      expect(getThemeToggleAriaLabel(false)).toBe('Switch to dark theme');
+    });
+  });
+
+  describe('getThemeToggleTooltip', () => {
+    it('mentions light theme and keyboard shortcut when dark', () => {
+      expect(getThemeToggleTooltip(true)).toContain('Light');
+      expect(getThemeToggleTooltip(true)).toContain('c t');
+    });
+
+    it('mentions dark theme and keyboard shortcut when light', () => {
+      expect(getThemeToggleTooltip(false)).toContain('Dark');
+      expect(getThemeToggleTooltip(false)).toContain('c t');
+    });
+  });
+});

--- a/public/app/core/components/ThemeToggle/themeToggleUtils.ts
+++ b/public/app/core/components/ThemeToggle/themeToggleUtils.ts
@@ -1,0 +1,31 @@
+import { type IconName } from '@grafana/data';
+import { t } from '@grafana/i18n';
+
+/**
+ * Icons represent the target mode after toggling (not the current mode).
+ *
+ * Grafana's icon set does not include dedicated sun/moon glyphs yet; these pair
+ * lightbulb-alt (switch to light) with adjust-circle (switch to dark) as the
+ * closest semantic match in @grafana/data IconName.
+ */
+export function getThemeToggleIcon(isDark: boolean): IconName {
+  return isDark ? 'lightbulb-alt' : 'adjust-circle';
+}
+
+export function getThemeToggleAriaLabel(isDark: boolean): string {
+  return isDark
+    ? t('navigation.theme.toggle-to-light-aria-label', 'Switch to light theme')
+    : t('navigation.theme.toggle-to-dark-aria-label', 'Switch to dark theme');
+}
+
+export function getThemeToggleTooltip(isDark: boolean): string {
+  const targetTheme = isDark
+    ? t('command-palette.action.light-theme', 'Light')
+    : t('command-palette.action.dark-theme', 'Dark');
+
+  return t('navigation.theme.toggle-tooltip', 'Switch to {{targetTheme}} theme (c t)', { targetTheme });
+}
+
+export function getTargetThemeId(isDark: boolean): 'dark' | 'light' {
+  return isDark ? 'light' : 'dark';
+}

--- a/public/app/core/components/ThemeToggle/useThemeToggle.ts
+++ b/public/app/core/components/ThemeToggle/useThemeToggle.ts
@@ -1,0 +1,44 @@
+import { useCallback } from 'react';
+
+import { reportInteraction } from '@grafana/runtime';
+import { useTheme2 } from '@grafana/ui';
+import { toggleTheme } from 'app/core/services/theme';
+
+import {
+  getTargetThemeId,
+  getThemeToggleAriaLabel,
+  getThemeToggleIcon,
+  getThemeToggleTooltip,
+} from './themeToggleUtils';
+
+export interface ThemeToggleState {
+  isDark: boolean;
+  icon: ReturnType<typeof getThemeToggleIcon>;
+  ariaLabel: string;
+  tooltip: string;
+  toggle: () => Promise<void>;
+}
+
+export function useThemeToggle(): ThemeToggleState {
+  const theme = useTheme2();
+  const isDark = theme.isDark;
+
+  const toggle = useCallback(async () => {
+    const toTheme = getTargetThemeId(isDark);
+
+    reportInteraction('grafana_preferences_theme_changed', {
+      toTheme,
+      preferenceType: 'toolbar_toggle',
+    });
+
+    await toggleTheme(false);
+  }, [isDark]);
+
+  return {
+    isDark,
+    icon: getThemeToggleIcon(isDark),
+    ariaLabel: getThemeToggleAriaLabel(isDark),
+    tooltip: getThemeToggleTooltip(isDark),
+    toggle,
+  };
+}

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -12143,7 +12143,12 @@
       "aria-label": "New",
       "new-template-dashboard-button": "Use template"
     },
-    "rss-button": "Latest from the blog"
+    "rss-button": "Latest from the blog",
+    "theme": {
+      "toggle-to-dark-aria-label": "Switch to dark theme",
+      "toggle-to-light-aria-label": "Switch to light theme",
+      "toggle-tooltip": "Switch to {{targetTheme}} theme (c t)"
+    }
   },
   "news": {
     "category-news": "News",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What is this feature?

Adds a global dark/light theme toggle visible on every standard page and auth (chromeless) pages.

- **`ThemeToggleButton`** — icon-only control in `SingleTopBar` (after Help, before profile separator)
- **`ThemeToggleFloatingButton`** — fixed-position control in `LoginLayout` for login/signup/password flows

## Why do we need this feature?

Theme switching already exists via keyboard (`c t`), command palette, and preferences, but lacked a persistent, discoverable UI control in the page chrome.

## Implementation

- Reuses `ToolbarButton`, `toggleTheme(false)`, and `reportInteraction('grafana_preferences_theme_changed')`
- Not gated on `grafanaconThemes` (binary dark/light is core UX; experimental theme drawer stays in profile menu)
- Icons show **target** mode: `lightbulb-alt` → light, `adjust-circle` → dark
- `aria-pressed` reflects current dark mode state
- E2E selectors: `NavToolbar.themeToggle`, `NavToolbar.themeToggleFloating`

## Files

```
public/app/core/components/ThemeToggle/
├── themeToggleUtils.ts (+ test)
├── useThemeToggle.ts
├── ThemeToggleButton.tsx (+ test)
└── ThemeToggleFloatingButton.tsx (+ test)

e2e-playwright/various-suite/theme-toggle.spec.ts
packages/grafana-e2e-selectors/src/selectors/components.ts
```

## Tests

- `yarn jest public/app/core/components/ThemeToggle --no-watch` — 12 tests passing
- `e2e-playwright/various-suite/theme-toggle.spec.ts` — login visibility, top-bar visibility, click switches aria-label

## Out of scope (per planning)

- Solo panel / public dashboard / kiosk pages
- User docs update
- Dedicated sun/moon icons

**Target repo:** fieldsphere/grafana
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a05264a3-553a-4bf9-a1b9-43887c674019"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a05264a3-553a-4bf9-a1b9-43887c674019"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

