### PR TITLE
feat(labs): add server-persistent feature flag dashboard (CUR-55)

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -121,6 +121,8 @@ func (hs *HTTPServer) registerRoutes() {
 	r.Get("/admin/orgs", authorizeInOrg(ac.UseGlobalOrg, ac.OrgsAccessEvaluator), hs.Index)
 	r.Get("/admin/orgs/edit/:id", authorizeInOrg(ac.UseGlobalOrg, ac.OrgsAccessEvaluator), hs.Index)
 	r.Get("/admin/stats", authorize(ac.EvalPermission(ac.ActionServerStatsRead)), hs.Index)
+	r.Get("/labs", authorize(ac.EvalPermission(ac.ActionFeatureManagementRead)), hs.Index)
+	r.Get("/labs/feature-flags", authorize(ac.EvalPermission(ac.ActionFeatureManagementRead)), hs.Index)
 	r.Get("/admin/provisioning", reqOrgAdmin, hs.Index)
 	r.Get("/admin/provisioning/*", middleware.ProvisioningAuth(reqOrgAdmin), hs.Index)
 
@@ -557,6 +559,10 @@ func (hs *HTTPServer) registerRoutes() {
 		adminRoute.Post("/provisioning/plugins/reload", authorize(ac.EvalPermission(ActionProvisioningReload, ScopeProvisionersPlugins)), routing.Wrap(hs.AdminProvisioningReloadPlugins))
 		adminRoute.Post("/provisioning/datasources/reload", authorize(ac.EvalPermission(ActionProvisioningReload, ScopeProvisionersDatasources)), routing.Wrap(hs.AdminProvisioningReloadDatasources))
 		adminRoute.Post("/provisioning/alerting/reload", authorize(ac.EvalPermission(ActionProvisioningReload, ScopeProvisionersAlertRules)), routing.Wrap(hs.AdminProvisioningReloadAlerting))
+
+		adminRoute.Get("/feature-toggles/resolved", authorize(ac.EvalPermission(ac.ActionFeatureManagementRead)), routing.Wrap(hs.AdminGetFeatureTogglesResolved))
+		adminRoute.Post("/feature-toggles", authorize(ac.EvalPermission(ac.ActionFeatureManagementWrite)), routing.Wrap(hs.AdminUpdateFeatureToggle))
+		adminRoute.Delete("/feature-toggles", authorize(ac.EvalPermission(ac.ActionFeatureManagementWrite)), routing.Wrap(hs.AdminResetFeatureToggle))
 	}, reqSignedIn)
 
 	// Administering users

--- a/pkg/api/featuremgmt.go
+++ b/pkg/api/featuremgmt.go
@@ -1,0 +1,90 @@
+package api
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+
+	"github.com/grafana/grafana/pkg/api/response"
+	ac "github.com/grafana/grafana/pkg/services/accesscontrol"
+	contextmodel "github.com/grafana/grafana/pkg/services/contexthandler/model"
+	"github.com/grafana/grafana/pkg/services/featuremgmt"
+	"github.com/grafana/grafana/pkg/services/featuretoggleadmin"
+)
+
+func (hs *HTTPServer) AdminGetFeatureTogglesResolved(c *contextmodel.ReqContext) response.Response {
+	if hs.FeatureToggleAdmin == nil {
+		return response.Error(http.StatusInternalServerError, "Feature toggle admin service not configured", nil)
+	}
+
+	allowEditing := ac.HasAccess(hs.AccessControl, c)(ac.EvalPermission(ac.ActionFeatureManagementWrite))
+	state := hs.FeatureToggleAdmin.GetResolvedStateResponse(allowEditing)
+	return response.JSON(http.StatusOK, state)
+}
+
+func (hs *HTTPServer) AdminUpdateFeatureToggle(c *contextmodel.ReqContext) response.Response {
+	if hs.FeatureToggleAdmin == nil {
+		return response.Error(http.StatusInternalServerError, "Feature toggle admin service not configured", nil)
+	}
+
+	var req featuretoggleadmin.UpdateFlagRequest
+	if err := json.NewDecoder(c.Req.Body).Decode(&req); err != nil {
+		return response.Error(http.StatusBadRequest, "bad request data", err)
+	}
+
+	if req.Name == "" {
+		return response.Error(http.StatusBadRequest, "flag name is required", nil)
+	}
+
+	err := hs.FeatureToggleAdmin.UpdateFlag(
+		c.Req.Context(),
+		req,
+		c.SignedInUser.UserID,
+		c.SignedInUser.Login,
+		c.SignedInUser.OrgID,
+	)
+	if err != nil {
+		if errors.Is(err, featuremgmt.ErrUnknownFeatureFlag) {
+			return response.Error(http.StatusNotFound, "unknown feature flag", err)
+		}
+		if errors.Is(err, featuremgmt.ErrFeatureFlagLocked) {
+			return response.Error(http.StatusForbidden, "feature flag is locked by configuration", err)
+		}
+		if errors.Is(err, featuremgmt.ErrFeatureFlagRestricted) {
+			return response.Error(http.StatusForbidden, "feature flag cannot be changed in this environment", err)
+		}
+		return response.Error(http.StatusInternalServerError, "failed to update feature flag", err)
+	}
+
+	return response.Success("Feature flag updated")
+}
+
+func (hs *HTTPServer) AdminResetFeatureToggle(c *contextmodel.ReqContext) response.Response {
+	if hs.FeatureToggleAdmin == nil {
+		return response.Error(http.StatusInternalServerError, "Feature toggle admin service not configured", nil)
+	}
+
+	name := c.Query("name")
+	if name == "" {
+		return response.Error(http.StatusBadRequest, "flag name is required", nil)
+	}
+
+	err := hs.FeatureToggleAdmin.ResetFlag(
+		c.Req.Context(),
+		name,
+		c.SignedInUser.UserID,
+		c.SignedInUser.Login,
+		c.SignedInUser.OrgID,
+	)
+	if err != nil {
+		if errors.Is(err, featuremgmt.ErrUnknownFeatureFlag) {
+			return response.Error(http.StatusNotFound, "unknown feature flag", err)
+		}
+		if errors.Is(err, featuremgmt.ErrFeatureFlagLocked) {
+			return response.Error(http.StatusForbidden, "feature flag is locked by configuration", err)
+		}
+		return response.Error(http.StatusInternalServerError, "failed to reset feature flag", err)
+	}
+
+	return response.Success("Feature flag reset")
+}

--- a/pkg/api/http_server.go
+++ b/pkg/api/http_server.go
@@ -69,6 +69,7 @@ import (
 	"github.com/grafana/grafana/pkg/services/datasources/guardian"
 	"github.com/grafana/grafana/pkg/services/encryption"
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
+	"github.com/grafana/grafana/pkg/services/featuretoggleadmin"
 	"github.com/grafana/grafana/pkg/services/folder"
 	"github.com/grafana/grafana/pkg/services/hooks"
 	"github.com/grafana/grafana/pkg/services/libraryelements"
@@ -133,6 +134,7 @@ type HTTPServer struct {
 	RenderService                rendering.Service
 	Cfg                          *setting.Cfg
 	Features                     featuremgmt.FeatureToggles
+	FeatureToggleAdmin           *featuretoggleadmin.Service
 	SettingsProvider             setting.Provider
 	HooksService                 *hooks.HooksService
 	navTreeService               navtree.Service
@@ -254,6 +256,7 @@ func ProvideHTTPServer(opts ServerOptions, cfg *setting.Cfg, routeRegister routi
 	accessControl accesscontrol.AccessControl, dataSourceProxy *datasourceproxy.DataSourceProxyService, searchService *search.SearchService,
 	live *live.GrafanaLive, livePushGateway *pushhttp.Gateway, plugCtxProvider *plugincontext.Provider,
 	contextHandler *contexthandler.ContextHandler, loggerMiddleware loggermw.Logger, features featuremgmt.FeatureToggles,
+	featureToggleAdmin *featuretoggleadmin.Service,
 	alertNG *ngalert.AlertNG, libraryPanelService librarypanels.Service, libraryElementService libraryelements.Service,
 	quotaService quota.Service, socialService social.Service, tracer tracing.Tracer,
 	encryptionService encryption.Internal, grafanaUpdateChecker *updatemanager.GrafanaService,
@@ -316,6 +319,7 @@ func ProvideHTTPServer(opts ServerOptions, cfg *setting.Cfg, routeRegister routi
 		QueryHistoryService:          queryHistoryService,
 		CorrelationsService:          correlationsService,
 		Features:                     features, // a read only view of the managers state
+		FeatureToggleAdmin:           featureToggleAdmin,
 		RemoteCacheService:           remoteCache,
 		ProvisioningService:          provisioningService,
 		AccessControl:                accessControl,

--- a/pkg/server/wire.go
+++ b/pkg/server/wire.go
@@ -110,6 +110,8 @@ import (
 	"github.com/grafana/grafana/pkg/services/extsvcauth"
 	extsvcreg "github.com/grafana/grafana/pkg/services/extsvcauth/registry"
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
+	"github.com/grafana/grafana/pkg/services/featuretoggleadmin"
+	"github.com/grafana/grafana/pkg/services/featuretogglestore"
 	"github.com/grafana/grafana/pkg/services/folder"
 	"github.com/grafana/grafana/pkg/services/folder/folderimpl"
 	"github.com/grafana/grafana/pkg/services/grpcserver"
@@ -355,6 +357,10 @@ var wireBasicSet = wire.NewSet(
 	dsquerierclient.NewNullQSDatasourceClientBuilder,
 	expr.ProvideService,
 	featuremgmt.ProvideManagerService,
+	featuretogglestore.ProvideStore,
+	wire.Bind(new(featuretogglestore.OverrideStore), new(*featuretogglestore.Store)),
+	featuremgmt.InitializeFeatureOverrides,
+	featuretoggleadmin.ProvideService,
 	featuremgmt.ProvideToggles,
 	dashboardservice.ProvideDashboardServiceImpl,
 	wire.Bind(new(dashboards.PermissionsRegistrationService), new(*dashboardservice.DashboardServiceImpl)),

--- a/pkg/server/wire_gen.go
+++ b/pkg/server/wire_gen.go
@@ -156,6 +156,8 @@ import (
 	"github.com/grafana/grafana/pkg/services/extsvcauth"
 	registry2 "github.com/grafana/grafana/pkg/services/extsvcauth/registry"
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
+	"github.com/grafana/grafana/pkg/services/featuretoggleadmin"
+	"github.com/grafana/grafana/pkg/services/featuretogglestore"
 	"github.com/grafana/grafana/pkg/services/folder"
 	"github.com/grafana/grafana/pkg/services/folder/folderimpl"
 	"github.com/grafana/grafana/pkg/services/grpcserver"
@@ -331,6 +333,13 @@ func Initialize(ctx context.Context, cfg *setting.Cfg, opts Options, apiOpts api
 	if err != nil {
 		return nil, err
 	}
+	featureToggleStore := featuretogglestore.ProvideStore(sqlStore)
+	featureManager, err = featuremgmt.InitializeFeatureOverrides(featureManager, featureToggleStore)
+	if err != nil {
+		return nil, err
+	}
+	featureToggles = featuremgmt.ProvideToggles(featureManager)
+	featureToggleAdmin := featuretoggleadmin.ProvideService(featureManager, featureToggleStore)
 	kvStore := kvstore.ProvideService(sqlStore)
 	accessControl := acimpl.ProvideAccessControl(featureToggles)
 	bundleregistryService := bundleregistry.ProvideService()
@@ -811,7 +820,7 @@ func Initialize(ctx context.Context, cfg *setting.Cfg, opts Options, apiOpts api
 	}
 	idimplService := idimpl.ProvideService(cfg, localSigner, remoteCache, authnService, registerer, tracer)
 	verifier := userimpl.ProvideVerifier(cfg, userimplService, tempuserService, notificationService, idimplService)
-	httpServer, err := api.ProvideHTTPServer(apiOpts, cfg, routeRegisterImpl, inProcBus, renderingService, ossLicensingService, hooksService, cacheService, sqlStore, ossDataSourceRequestValidator, pluginstoreService, service14, pluginstoreService, middlewareHandler, pluginerrsStore, pluginInstaller, ossImpl, cacheServiceImpl, userAuthTokenService, cleanUpService, shortURLService, queryHistoryService, correlationsService, remoteCache, provisioningServiceImpl, accessControl, dataSourceProxyService, searchService, grafanaLive, gateway, plugincontextProvider, contexthandlerContextHandler, logger, featureToggles, alertNG, libraryPanelService, libraryElementService, quotaService, socialService, tracingService, serviceService, grafanaService, pluginsService, ossService, service13, queryServiceImpl, filestoreService, serviceAccountsProxy, pluginassetsService, authinfoimplService, notificationService, dashboardService, dashboardProvisioningService, folderimplService, ossProvider, serviceImpl, service12, avatarCacheServer, prefService, k8sHandler, migrationProxy, folderPermissionsService, dashboardPermissionsService, dashverService, starService, csrfCSRF, managedpluginsNoop, apikeyService, kvStore, secretsMigrator, secretsService, secretMigrationProviderImpl, secretsKVStore, v6, userimplService, tempuserService, loginattemptimplService, orgService, deletionService, teamimplService, acimplService, navtreeService, repositoryImpl, tagimplService, oauthtokenService, statsService, authnService, pluginscdnService, gatherer, apiAPI, registerer, anonDeviceService, eventualRestConfigProvider, clientGenerator, verifier, preinstallImpl, v4)
+	httpServer, err := api.ProvideHTTPServer(apiOpts, cfg, routeRegisterImpl, inProcBus, renderingService, ossLicensingService, hooksService, cacheService, sqlStore, ossDataSourceRequestValidator, pluginstoreService, service14, pluginstoreService, middlewareHandler, pluginerrsStore, pluginInstaller, ossImpl, cacheServiceImpl, userAuthTokenService, cleanUpService, shortURLService, queryHistoryService, correlationsService, remoteCache, provisioningServiceImpl, accessControl, dataSourceProxyService, searchService, grafanaLive, gateway, plugincontextProvider, contexthandlerContextHandler, logger, featureToggles, featureToggleAdmin, alertNG, libraryPanelService, libraryElementService, quotaService, socialService, tracingService, serviceService, grafanaService, pluginsService, ossService, service13, queryServiceImpl, filestoreService, serviceAccountsProxy, pluginassetsService, authinfoimplService, notificationService, dashboardService, dashboardProvisioningService, folderimplService, ossProvider, serviceImpl, service12, avatarCacheServer, prefService, k8sHandler, migrationProxy, folderPermissionsService, dashboardPermissionsService, dashverService, starService, csrfCSRF, managedpluginsNoop, apikeyService, kvStore, secretsMigrator, secretsService, secretMigrationProviderImpl, secretsKVStore, v6, userimplService, tempuserService, loginattemptimplService, orgService, deletionService, teamimplService, acimplService, navtreeService, repositoryImpl, tagimplService, oauthtokenService, statsService, authnService, pluginscdnService, gatherer, apiAPI, registerer, anonDeviceService, eventualRestConfigProvider, clientGenerator, verifier, preinstallImpl, v4)
 	if err != nil {
 		return nil, err
 	}
@@ -1073,6 +1082,13 @@ func InitializeForTest(ctx context.Context, t sqlutil.ITestDB, testingT interfac
 	if err != nil {
 		return nil, err
 	}
+	featureToggleStore := featuretogglestore.ProvideStore(sqlStore)
+	featureManager, err = featuremgmt.InitializeFeatureOverrides(featureManager, featureToggleStore)
+	if err != nil {
+		return nil, err
+	}
+	featureToggles = featuremgmt.ProvideToggles(featureManager)
+	featureToggleAdmin := featuretoggleadmin.ProvideService(featureManager, featureToggleStore)
 	kvStore := kvstore.ProvideService(sqlStore)
 	accessControl := acimpl.ProvideAccessControl(featureToggles)
 	bundleregistryService := bundleregistry.ProvideService()
@@ -1552,7 +1568,7 @@ func InitializeForTest(ctx context.Context, t sqlutil.ITestDB, testingT interfac
 	}
 	idimplService := idimpl.ProvideService(cfg, localSigner, remoteCache, authnService, registerer, tracer)
 	verifier := userimpl.ProvideVerifier(cfg, userimplService, tempuserService, notificationServiceMock, idimplService)
-	httpServer, err := api.ProvideHTTPServer(apiOpts, cfg, routeRegisterImpl, inProcBus, renderingService, ossLicensingService, hooksService, cacheService, sqlStore, ossDataSourceRequestValidator, pluginstoreService, service14, pluginstoreService, middlewareHandler, pluginerrsStore, pluginInstaller, ossImpl, cacheServiceImpl, userAuthTokenService, cleanUpService, shortURLService, queryHistoryService, correlationsService, remoteCache, provisioningServiceImpl, accessControl, dataSourceProxyService, searchService, grafanaLive, gateway, plugincontextProvider, contexthandlerContextHandler, logger, featureToggles, alertNG, libraryPanelService, libraryElementService, quotaService, socialService, tracingService, serviceService, grafanaService, pluginsService, ossService, service13, queryServiceImpl, filestoreService, serviceAccountsProxy, pluginassetsService, authinfoimplService, notificationServiceMock, dashboardService, dashboardProvisioningService, folderimplService, ossProvider, serviceImpl, service12, avatarCacheServer, prefService, k8sHandler, migrationProxy, folderPermissionsService, dashboardPermissionsService, dashverService, starService, csrfCSRF, managedpluginsNoop, apikeyService, kvStore, secretsMigrator, secretsService, secretMigrationProviderImpl, secretsKVStore, v6, userimplService, tempuserService, loginattemptimplService, orgService, deletionService, teamimplService, acimplService, navtreeService, repositoryImpl, tagimplService, oauthtokentestService, statsService, authnService, pluginscdnService, gatherer, apiAPI, registerer, anonDeviceService, eventualRestConfigProvider, clientGenerator, verifier, preinstallImpl, v4)
+	httpServer, err := api.ProvideHTTPServer(apiOpts, cfg, routeRegisterImpl, inProcBus, renderingService, ossLicensingService, hooksService, cacheService, sqlStore, ossDataSourceRequestValidator, pluginstoreService, service14, pluginstoreService, middlewareHandler, pluginerrsStore, pluginInstaller, ossImpl, cacheServiceImpl, userAuthTokenService, cleanUpService, shortURLService, queryHistoryService, correlationsService, remoteCache, provisioningServiceImpl, accessControl, dataSourceProxyService, searchService, grafanaLive, gateway, plugincontextProvider, contexthandlerContextHandler, logger, featureToggles, featureToggleAdmin, alertNG, libraryPanelService, libraryElementService, quotaService, socialService, tracingService, serviceService, grafanaService, pluginsService, ossService, service13, queryServiceImpl, filestoreService, serviceAccountsProxy, pluginassetsService, authinfoimplService, notificationServiceMock, dashboardService, dashboardProvisioningService, folderimplService, ossProvider, serviceImpl, service12, avatarCacheServer, prefService, k8sHandler, migrationProxy, folderPermissionsService, dashboardPermissionsService, dashverService, starService, csrfCSRF, managedpluginsNoop, apikeyService, kvStore, secretsMigrator, secretsService, secretMigrationProviderImpl, secretsKVStore, v6, userimplService, tempuserService, loginattemptimplService, orgService, deletionService, teamimplService, acimplService, navtreeService, repositoryImpl, tagimplService, oauthtokentestService, statsService, authnService, pluginscdnService, gatherer, apiAPI, registerer, anonDeviceService, eventualRestConfigProvider, clientGenerator, verifier, preinstallImpl, v4)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/server/wireexts_oss.go
+++ b/pkg/server/wireexts_oss.go
@@ -196,6 +196,9 @@ var wireExtsBaseCLISet = wire.NewSet(
 
 	metrics.WireSet,
 	featuremgmt.ProvideManagerService,
+	featuretogglestore.ProvideNoopStore,
+	featuremgmt.InitializeFeatureOverrides,
+	featuretoggleadmin.ProvideService,
 	featuremgmt.ProvideToggles,
 	hooks.ProvideService,
 	setting.ProvideProvider, wire.Bind(new(setting.Provider), new(*setting.OSSImpl)),

--- a/pkg/services/featuremgmt/errors.go
+++ b/pkg/services/featuremgmt/errors.go
@@ -1,0 +1,9 @@
+package featuremgmt
+
+import "errors"
+
+var (
+	ErrUnknownFeatureFlag = errors.New("unknown feature flag")
+	ErrFeatureFlagLocked  = errors.New("feature flag is locked by configuration")
+	ErrFeatureFlagRestricted = errors.New("feature flag cannot be enabled in this environment")
+)

--- a/pkg/services/featuremgmt/initialize_overrides.go
+++ b/pkg/services/featuremgmt/initialize_overrides.go
@@ -1,0 +1,22 @@
+package featuremgmt
+
+import "context"
+
+type overrideLoader interface {
+	List(context.Context) (map[string]bool, error)
+}
+
+func InitializeFeatureOverrides(mgr *FeatureManager, store overrideLoader) (*FeatureManager, error) {
+	if store == nil {
+		return mgr, nil
+	}
+
+	overrides, err := store.List(context.Background())
+	if err != nil {
+		return mgr, err
+	}
+
+	mgr.applyOverrides(overrides)
+	mgr.update()
+	return mgr, nil
+}

--- a/pkg/services/featuremgmt/manager.go
+++ b/pkg/services/featuremgmt/manager.go
@@ -1,9 +1,9 @@
 package featuremgmt
 
 import (
-	"context"
 	"fmt"
 	"reflect"
+	"sync"
 
 	"github.com/grafana/grafana/pkg/infra/log"
 )
@@ -13,13 +13,19 @@ var (
 )
 
 type FeatureManager struct {
+	mu sync.RWMutex
+
 	isDevMod bool
 
-	flags    map[string]*FeatureFlag
-	enabled  map[string]bool   // only the "on" values
-	startup  map[string]bool   // the explicit values registered at startup
-	warnings map[string]string // potential warnings about the flag
-	log      log.Logger
+	flags          map[string]*FeatureFlag
+	enabled        map[string]bool   // only the "on" values
+	startup        map[string]bool   // the explicit values registered at startup
+	configKeys     map[string]bool   // flags pinned by configuration
+	dbOverrides    map[string]bool   // flags overridden via the Labs store
+	pendingRestart map[string]bool   // desired values for restart-required flags
+	restartRequired bool
+	warnings       map[string]string // potential warnings about the flag
+	log            log.Logger
 }
 
 // This will merge the flags with the current configuration
@@ -73,6 +79,12 @@ func (fm *FeatureManager) meetsRequirements(ff *FeatureFlag) (bool, string) {
 
 // Update
 func (fm *FeatureManager) update() {
+	fm.mu.Lock()
+	defer fm.mu.Unlock()
+	fm.updateLocked()
+}
+
+func (fm *FeatureManager) updateLocked() {
 	enabled := make(map[string]bool)
 	for _, flag := range fm.flags {
 		// if grafana cannot run the feature, omit metrics around it
@@ -95,36 +107,6 @@ func (fm *FeatureManager) update() {
 		featureToggleInfo.WithLabelValues(flag.Name).Set(track)
 	}
 	fm.enabled = enabled
-}
-
-// IsEnabled checks if a feature is enabled
-func (fm *FeatureManager) IsEnabled(ctx context.Context, flag string) bool {
-	return fm.enabled[flag]
-}
-
-// IsEnabledGlobally checks if a feature is for all tenants
-func (fm *FeatureManager) IsEnabledGlobally(flag string) bool {
-	return fm.enabled[flag]
-}
-
-// GetEnabled returns a map containing only the features that are enabled
-func (fm *FeatureManager) GetEnabled(ctx context.Context) map[string]bool {
-	enabled := make(map[string]bool, len(fm.enabled))
-	for key, val := range fm.enabled {
-		if val {
-			enabled[key] = true
-		}
-	}
-	return enabled
-}
-
-// GetFlags returns all flag definitions
-func (fm *FeatureManager) GetFlags() []FeatureFlag {
-	v := make([]FeatureFlag, 0, len(fm.flags))
-	for _, value := range fm.flags {
-		v = append(v, *value)
-	}
-	return v
 }
 
 // ############# Test Functions #############

--- a/pkg/services/featuremgmt/manager_test.go
+++ b/pkg/services/featuremgmt/manager_test.go
@@ -1,68 +1,127 @@
 package featuremgmt
 
 import (
-	"context"
 	"testing"
 
 	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/grafana/pkg/setting"
 )
 
-func TestFeatureManager(t *testing.T) {
-	t.Run("check testing stubs", func(t *testing.T) {
-		ft := WithManager("a", "b", "c")
-		require.True(t, ft.IsEnabledGlobally("a"))
-		require.True(t, ft.IsEnabledGlobally("b"))
-		require.True(t, ft.IsEnabledGlobally("c"))
-		require.False(t, ft.IsEnabledGlobally("d"))
+func TestFeatureManagerSetFlag(t *testing.T) {
+	mgr := &FeatureManager{
+		isDevMod:       true,
+		flags:          map[string]*FeatureFlag{},
+		enabled:        map[string]bool{},
+		startup:        map[string]bool{},
+		configKeys:     map[string]bool{},
+		dbOverrides:    map[string]bool{},
+		pendingRestart: map[string]bool{},
+		warnings:       map[string]string{},
+	}
 
-		require.Equal(t, map[string]bool{"a": true, "b": true, "c": true}, ft.GetEnabled(context.Background()))
+	mgr.flags["testFlag"] = &FeatureFlag{
+		Name:        "testFlag",
+		Description: "A test flag",
+		Stage:       FeatureStagePublicPreview,
+		Expression:  "false",
+	}
+	mgr.update()
 
-		// Explicit values
-		ft = WithManager("a", true, "b", false)
-		require.True(t, ft.IsEnabledGlobally("a"))
-		require.False(t, ft.IsEnabledGlobally("b"))
-		require.Equal(t, map[string]bool{"a": true}, ft.GetEnabled(context.Background()))
-	})
+	require.False(t, mgr.IsEnabledGlobally("testFlag"))
 
-	t.Run("check description and stage configs", func(t *testing.T) {
-		ft := FeatureManager{
-			flags: map[string]*FeatureFlag{},
-		}
-		ft.registerFlags(FeatureFlag{
-			Name:        "a",
-			Description: "first",
-		}, FeatureFlag{
-			Name:        "a",
-			Description: "second",
-		}, FeatureFlag{
-			Name:  "a",
-			Stage: FeatureStagePrivatePreview,
-		}, FeatureFlag{
-			Name: "a",
-		})
-		flag := ft.flags["a"]
-		require.Equal(t, "second", flag.Description)
-		require.Equal(t, FeatureStagePrivatePreview, flag.Stage)
-	})
+	err := mgr.SetFlag("testFlag", true)
+	require.NoError(t, err)
+	require.True(t, mgr.IsEnabledGlobally("testFlag"))
+}
 
-	t.Run("check startup false flags", func(t *testing.T) {
-		ft := FeatureManager{
-			flags: map[string]*FeatureFlag{},
-			startup: map[string]bool{
-				"a": true,
-				"b": false, // but default true
-			},
-		}
-		ft.registerFlags(FeatureFlag{
-			Name: "a",
-		}, FeatureFlag{
-			Name:       "b",
-			Expression: "true",
-		}, FeatureFlag{
-			Name: "c",
-		})
-		require.True(t, ft.IsEnabledGlobally("a"))
-		require.False(t, ft.IsEnabledGlobally("b"))
-		require.False(t, ft.IsEnabledGlobally("c"))
-	})
+func TestFeatureManagerSetFlagLocked(t *testing.T) {
+	mgr := &FeatureManager{
+		isDevMod:       true,
+		flags:          map[string]*FeatureFlag{"lockedFlag": {Name: "lockedFlag", Expression: "false"}},
+		enabled:        map[string]bool{},
+		startup:        map[string]bool{"lockedFlag": false},
+		configKeys:     map[string]bool{"lockedFlag": true},
+		dbOverrides:    map[string]bool{},
+		pendingRestart: map[string]bool{},
+		warnings:       map[string]string{},
+	}
+	mgr.update()
+
+	err := mgr.SetFlag("lockedFlag", true)
+	require.ErrorIs(t, err, ErrFeatureFlagLocked)
+}
+
+func TestFeatureManagerRequiresRestartDoesNotApplyImmediately(t *testing.T) {
+	mgr := &FeatureManager{
+		isDevMod:       true,
+		flags:          map[string]*FeatureFlag{},
+		enabled:        map[string]bool{},
+		startup:        map[string]bool{},
+		configKeys:     map[string]bool{},
+		dbOverrides:    map[string]bool{},
+		pendingRestart: map[string]bool{},
+		warnings:       map[string]string{},
+	}
+
+	mgr.flags["restartFlag"] = &FeatureFlag{
+		Name:            "restartFlag",
+		Expression:      "false",
+		RequiresRestart: true,
+	}
+	mgr.update()
+
+	err := mgr.SetFlag("restartFlag", true)
+	require.NoError(t, err)
+	require.False(t, mgr.IsEnabledGlobally("restartFlag"))
+
+	state := mgr.GetResolvedState(true)
+	require.True(t, state.RestartRequired)
+}
+
+func TestFeatureManagerRequiresDevMode(t *testing.T) {
+	mgr := &FeatureManager{
+		isDevMod:       false,
+		flags:          map[string]*FeatureFlag{"devFlag": {Name: "devFlag", RequiresDevMode: true, Expression: "false"}},
+		enabled:        map[string]bool{},
+		startup:        map[string]bool{},
+		configKeys:     map[string]bool{},
+		dbOverrides:    map[string]bool{},
+		pendingRestart: map[string]bool{},
+		warnings:       map[string]string{},
+	}
+	mgr.update()
+
+	err := mgr.SetFlag("devFlag", true)
+	require.ErrorIs(t, err, ErrFeatureFlagRestricted)
+}
+
+func TestFeatureManagerGetResolvedState(t *testing.T) {
+	mgr := &FeatureManager{
+		isDevMod:       true,
+		flags: map[string]*FeatureFlag{
+			"alpha": {Name: "alpha", Description: "Alpha feature", Stage: FeatureStageExperimental, Expression: "true"},
+		},
+		enabled:        map[string]bool{"alpha": true},
+		startup:        map[string]bool{},
+		configKeys:     map[string]bool{},
+		dbOverrides:    map[string]bool{},
+		pendingRestart: map[string]bool{},
+		warnings:       map[string]string{},
+	}
+
+	state := mgr.GetResolvedState(true)
+	require.True(t, state.AllowEditing)
+	require.Len(t, state.Toggles, 1)
+	require.Equal(t, "alpha", state.Toggles[0].Name)
+	require.Equal(t, "experimental", state.Toggles[0].Stage)
+	require.True(t, state.Toggles[0].Enabled)
+	require.True(t, state.Toggles[0].Writeable)
+}
+
+func TestProvideManagerServiceWithNilStore(t *testing.T) {
+	cfg := setting.NewCfg()
+	mgmt, err := ProvideManagerService(cfg)
+	require.NoError(t, err)
+	require.NotNil(t, mgmt)
 }

--- a/pkg/services/featuremgmt/resolved.go
+++ b/pkg/services/featuremgmt/resolved.go
@@ -1,0 +1,228 @@
+package featuremgmt
+
+import (
+	"context"
+	"fmt"
+	"sort"
+
+	common "github.com/grafana/grafana/pkg/apimachinery/apis/common/v0alpha1"
+	featuretoggleapi "github.com/grafana/grafana/pkg/services/featuremgmt/feature_toggle_api"
+)
+
+func sourceRef(name string) *common.ObjectReference {
+	return &common.ObjectReference{Name: name}
+}
+
+func (fm *FeatureManager) GetResolvedState(allowEditing bool) featuretoggleapi.ResolvedToggleState {
+	fm.mu.RLock()
+	defer fm.mu.RUnlock()
+
+	enabled := make(map[string]bool, len(fm.enabled))
+	for key, val := range fm.enabled {
+		if val {
+			enabled[key] = true
+		}
+	}
+
+	toggles := make([]featuretoggleapi.ToggleStatus, 0, len(fm.flags))
+	names := make([]string, 0, len(fm.flags))
+	for name := range fm.flags {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	restartRequired := fm.restartRequired
+
+	for _, name := range names {
+		flag := fm.flags[name]
+		isEnabled := fm.enabled[name]
+		writeable := allowEditing && fm.isWriteableLocked(flag, name)
+
+		status := featuretoggleapi.ToggleStatus{
+			Name:        name,
+			Description: flag.Description,
+			Stage:       flag.Stage.String(),
+			Enabled:     isEnabled,
+			Writeable:   writeable,
+		}
+
+		if warning, ok := fm.warnings[name]; ok {
+			status.Warning = warning
+		}
+
+		if fm.configKeys[name] {
+			status.Source = sourceRef("config")
+			status.Writeable = false
+		} else if _, ok := fm.dbOverrides[name]; ok {
+			status.Source = sourceRef("database")
+		} else if _, ok := fm.startup[name]; ok {
+			status.Source = sourceRef("startup")
+		}
+
+		if flag.RequiresRestart {
+			if pending, ok := fm.pendingRestart[name]; ok && pending != isEnabled {
+				status.Warning = "Change will apply after restart"
+				restartRequired = true
+			}
+		}
+
+		if !writeable && fm.configKeys[name] {
+			if status.Warning == "" {
+				status.Warning = "Locked by configuration"
+			}
+		}
+
+		toggles = append(toggles, status)
+	}
+
+	return featuretoggleapi.ResolvedToggleState{
+		AllowEditing:    allowEditing,
+		RestartRequired: restartRequired,
+		Enabled:         enabled,
+		Toggles:         toggles,
+	}
+}
+
+func (fm *FeatureManager) isWriteableLocked(flag *FeatureFlag, name string) bool {
+	if fm.configKeys[name] {
+		return false
+	}
+	ok, _ := fm.meetsRequirements(flag)
+	return ok
+}
+
+func (fm *FeatureManager) SetFlag(name string, enabled bool) error {
+	fm.mu.Lock()
+	defer fm.mu.Unlock()
+
+	flag, ok := fm.flags[name]
+	if !ok {
+		return ErrUnknownFeatureFlag
+	}
+
+	if fm.configKeys[name] {
+		return ErrFeatureFlagLocked
+	}
+
+	if ok, reason := fm.meetsRequirements(flag); !ok {
+		return fmt.Errorf("%w: %s", ErrFeatureFlagRestricted, reason)
+	}
+
+	fm.dbOverrides[name] = enabled
+
+	if flag.RequiresRestart {
+		fm.pendingRestart[name] = enabled
+		fm.recomputeRestartRequiredLocked()
+		return nil
+	}
+
+	fm.startup[name] = enabled
+	fm.updateLocked()
+	return nil
+}
+
+func (fm *FeatureManager) RemoveOverride(name string) error {
+	fm.mu.Lock()
+	defer fm.mu.Unlock()
+
+	flag, ok := fm.flags[name]
+	if !ok {
+		return ErrUnknownFeatureFlag
+	}
+
+	if fm.configKeys[name] {
+		return ErrFeatureFlagLocked
+	}
+
+	delete(fm.dbOverrides, name)
+	delete(fm.pendingRestart, name)
+
+	if flag.RequiresRestart {
+		fm.recomputeRestartRequiredLocked()
+		return nil
+	}
+
+	delete(fm.startup, name)
+	fm.updateLocked()
+	return nil
+}
+
+func (fm *FeatureManager) IsEnabled(ctx context.Context, flag string) bool {
+	fm.mu.RLock()
+	defer fm.mu.RUnlock()
+	return fm.enabled[flag]
+}
+
+func (fm *FeatureManager) IsEnabledGlobally(flag string) bool {
+	fm.mu.RLock()
+	defer fm.mu.RUnlock()
+	return fm.enabled[flag]
+}
+
+func (fm *FeatureManager) GetEnabled(ctx context.Context) map[string]bool {
+	fm.mu.RLock()
+	defer fm.mu.RUnlock()
+
+	enabled := make(map[string]bool, len(fm.enabled))
+	for key, val := range fm.enabled {
+		if val {
+			enabled[key] = true
+		}
+	}
+	return enabled
+}
+
+func (fm *FeatureManager) GetFlags() []FeatureFlag {
+	fm.mu.RLock()
+	defer fm.mu.RUnlock()
+
+	v := make([]FeatureFlag, 0, len(fm.flags))
+	for _, value := range fm.flags {
+		v = append(v, *value)
+	}
+	return v
+}
+
+func (fm *FeatureManager) EnabledSnapshot(name string) bool {
+	fm.mu.RLock()
+	defer fm.mu.RUnlock()
+	return fm.enabled[name]
+}
+
+func (fm *FeatureManager) CurrentValue(name string) (bool, bool) {
+	fm.mu.RLock()
+	defer fm.mu.RUnlock()
+	val, ok := fm.enabled[name]
+	return val, ok
+}
+
+func (fm *FeatureManager) recomputeRestartRequiredLocked() {
+	fm.restartRequired = false
+	for name, pending := range fm.pendingRestart {
+		if pending != fm.enabled[name] {
+			fm.restartRequired = true
+			return
+		}
+	}
+}
+
+func (fm *FeatureManager) applyOverrides(overrides map[string]bool) {
+	fm.mu.Lock()
+	defer fm.mu.Unlock()
+
+	for name, enabled := range overrides {
+		if fm.configKeys[name] {
+			continue
+		}
+		fm.dbOverrides[name] = enabled
+		flag, ok := fm.flags[name]
+		if !ok {
+			continue
+		}
+		fm.startup[name] = enabled
+		if flag.RequiresRestart {
+			fm.pendingRestart[name] = enabled
+		}
+	}
+	fm.recomputeRestartRequiredLocked()
+}

--- a/pkg/services/featuremgmt/service.go
+++ b/pkg/services/featuremgmt/service.go
@@ -22,12 +22,15 @@ var (
 
 func ProvideManagerService(cfg *setting.Cfg) (*FeatureManager, error) {
 	mgmt := &FeatureManager{
-		isDevMod: cfg.Env != setting.Prod,
-		flags:    make(map[string]*FeatureFlag, 30),
-		enabled:  make(map[string]bool),
-		startup:  make(map[string]bool),
-		warnings: make(map[string]string),
-		log:      log.New("featuremgmt"),
+		isDevMod:       cfg.Env != setting.Prod,
+		flags:          make(map[string]*FeatureFlag, 30),
+		enabled:        make(map[string]bool),
+		startup:        make(map[string]bool),
+		configKeys:     make(map[string]bool),
+		dbOverrides:    make(map[string]bool),
+		pendingRestart: make(map[string]bool),
+		warnings:       make(map[string]string),
+		log:            log.New("featuremgmt"),
 	}
 
 	// Register the standard flags
@@ -48,6 +51,7 @@ func ProvideManagerService(cfg *setting.Cfg) (*FeatureManager, error) {
 			mgmt.warnings[key] = "unknown flag in config"
 		}
 
+		mgmt.configKeys[key] = true
 		mgmt.startup[key] = val.Variants[val.DefaultVariant] == true
 	}
 

--- a/pkg/services/featuretoggleadmin/service.go
+++ b/pkg/services/featuretoggleadmin/service.go
@@ -1,0 +1,118 @@
+package featuretoggleadmin
+
+import (
+	"context"
+
+	"github.com/grafana/grafana/pkg/infra/log"
+	"github.com/grafana/grafana/pkg/services/featuremgmt"
+	featuretoggleapi "github.com/grafana/grafana/pkg/services/featuremgmt/feature_toggle_api"
+	"github.com/grafana/grafana/pkg/services/featuretogglestore"
+)
+
+type Service struct {
+	manager *featuremgmt.FeatureManager
+	store   featuretogglestore.OverrideStore
+	log     log.Logger
+}
+
+func ProvideService(manager *featuremgmt.FeatureManager, store featuretogglestore.OverrideStore) *Service {
+	return &Service{
+		manager: manager,
+		store:   store,
+		log:     log.New("featuretoggleadmin"),
+	}
+}
+
+type UpdateFlagRequest struct {
+	Name    string `json:"name"`
+	Enabled bool   `json:"enabled"`
+}
+
+type ResolvedToggleStateResponse struct {
+	AllowEditing    bool                            `json:"allowEditing,omitempty"`
+	RestartRequired bool                            `json:"restartRequired,omitempty"`
+	Enabled         map[string]bool                 `json:"enabled,omitempty"`
+	Toggles         []featuretoggleapi.ToggleStatus `json:"toggles,omitempty"`
+}
+
+func (s *Service) GetResolvedStateResponse(allowEditing bool) ResolvedToggleStateResponse {
+	state := s.manager.GetResolvedState(allowEditing)
+	return ResolvedToggleStateResponse{
+		AllowEditing:    state.AllowEditing,
+		RestartRequired: state.RestartRequired,
+		Enabled:         state.Enabled,
+		Toggles:         state.Toggles,
+	}
+}
+
+func (s *Service) UpdateFlag(ctx context.Context, req UpdateFlagRequest, userID int64, userLogin string, orgID int64) error {
+	current, _ := s.manager.CurrentValue(req.Name)
+
+	if err := s.manager.SetFlag(req.Name, req.Enabled); err != nil {
+		return err
+	}
+
+	if s.store != nil {
+		if err := s.store.Upsert(ctx, req.Name, req.Enabled, userID); err != nil {
+			return err
+		}
+
+		if err := s.store.LogChange(ctx, featuretogglestore.ChangeLogEntry{
+			FlagName:  req.Name,
+			FromValue: &current,
+			ToValue:   req.Enabled,
+			UserID:    userID,
+			UserLogin: userLogin,
+			OrgID:     orgID,
+		}); err != nil {
+			return err
+		}
+	}
+
+	s.log.Info("feature toggle changed",
+		"flag", req.Name,
+		"from", current,
+		"to", req.Enabled,
+		"userID", userID,
+		"userLogin", userLogin,
+		"orgID", orgID,
+	)
+
+	return nil
+}
+
+func (s *Service) ResetFlag(ctx context.Context, name string, userID int64, userLogin string, orgID int64) error {
+	current, _ := s.manager.CurrentValue(name)
+
+	if err := s.manager.RemoveOverride(name); err != nil {
+		return err
+	}
+
+	if s.store != nil {
+		if err := s.store.Delete(ctx, name); err != nil {
+			return err
+		}
+
+		newValue := s.manager.EnabledSnapshot(name)
+		if err := s.store.LogChange(ctx, featuretogglestore.ChangeLogEntry{
+			FlagName:  name,
+			FromValue: &current,
+			ToValue:   newValue,
+			UserID:    userID,
+			UserLogin: userLogin,
+			OrgID:     orgID,
+		}); err != nil {
+			return err
+		}
+	}
+
+	s.log.Info("feature toggle reset",
+		"flag", name,
+		"from", current,
+		"userID", userID,
+		"userLogin", userLogin,
+		"orgID", orgID,
+	)
+
+	return nil
+}

--- a/pkg/services/featuretogglestore/store.go
+++ b/pkg/services/featuretogglestore/store.go
@@ -1,0 +1,140 @@
+package featuretogglestore
+
+import (
+	"context"
+	"time"
+
+	"github.com/grafana/grafana/pkg/infra/db"
+	"github.com/grafana/grafana/pkg/infra/log"
+)
+
+type FeatureToggleOverride struct {
+	FlagName  string    `xorm:"flag_name pk"`
+	Enabled   bool      `xorm:"enabled"`
+	UpdatedBy int64     `xorm:"updated_by"`
+	Updated   time.Time `xorm:"updated"`
+}
+
+type ChangeLogEntry struct {
+	FlagName  string
+	FromValue *bool
+	ToValue   bool
+	UserID    int64
+	UserLogin string
+	OrgID     int64
+}
+
+type featureToggleChangeLog struct {
+	ID        int64     `xorm:"pk autoincr 'id'"`
+	FlagName  string    `xorm:"flag_name"`
+	FromValue *bool     `xorm:"from_value"`
+	ToValue   bool      `xorm:"to_value"`
+	UserID    int64     `xorm:"user_id"`
+	UserLogin string    `xorm:"user_login"`
+	OrgID     int64     `xorm:"org_id"`
+	Created   time.Time `xorm:"created"`
+}
+
+type Store struct {
+	sqlStore db.DB
+	log      log.Logger
+}
+
+func ProvideStore(sqlStore db.DB) *Store {
+	return &Store{
+		sqlStore: sqlStore,
+		log:      log.New("featuretogglestore"),
+	}
+}
+
+func (s *Store) List(ctx context.Context) (map[string]bool, error) {
+	result := make(map[string]bool)
+
+	err := s.sqlStore.WithDbSession(ctx, func(sess *db.Session) error {
+		rows := make([]FeatureToggleOverride, 0)
+		if err := sess.Find(&rows); err != nil {
+			return err
+		}
+		for _, row := range rows {
+			result[row.FlagName] = row.Enabled
+		}
+		return nil
+	})
+
+	return result, err
+}
+
+func (s *Store) Upsert(ctx context.Context, flagName string, enabled bool, userID int64) error {
+	now := time.Now()
+
+	return s.sqlStore.WithTransactionalDbSession(ctx, func(sess *db.Session) error {
+		existing := FeatureToggleOverride{FlagName: flagName}
+		has, err := sess.Get(&existing)
+		if err != nil {
+			return err
+		}
+
+		row := FeatureToggleOverride{
+			FlagName:  flagName,
+			Enabled:   enabled,
+			UpdatedBy: userID,
+			Updated:   now,
+		}
+
+		if has {
+			_, err = sess.Where("flag_name = ?", flagName).AllCols().Update(&row)
+		} else {
+			_, err = sess.Insert(&row)
+		}
+		return err
+	})
+}
+
+func (s *Store) Delete(ctx context.Context, flagName string) error {
+	return s.sqlStore.WithTransactionalDbSession(ctx, func(sess *db.Session) error {
+		_, err := sess.Where("flag_name = ?", flagName).Delete(&FeatureToggleOverride{})
+		return err
+	})
+}
+
+func (s *Store) LogChange(ctx context.Context, entry ChangeLogEntry) error {
+	row := featureToggleChangeLog{
+		FlagName:  entry.FlagName,
+		FromValue: entry.FromValue,
+		ToValue:   entry.ToValue,
+		UserID:    entry.UserID,
+		UserLogin: entry.UserLogin,
+		OrgID:     entry.OrgID,
+		Created:   time.Now(),
+	}
+
+	return s.sqlStore.WithTransactionalDbSession(ctx, func(sess *db.Session) error {
+		_, err := sess.Insert(&row)
+		return err
+	})
+}
+
+type noopStore struct{}
+
+func ProvideNoopStore() OverrideStore {
+	return noopStore{}
+}
+
+type OverrideStore interface {
+	List(ctx context.Context) (map[string]bool, error)
+	Upsert(ctx context.Context, flagName string, enabled bool, userID int64) error
+	Delete(ctx context.Context, flagName string) error
+	LogChange(ctx context.Context, entry ChangeLogEntry) error
+}
+
+var _ OverrideStore = (*Store)(nil)
+
+func (noopStore) List(context.Context) (map[string]bool, error) {
+	return map[string]bool{}, nil
+}
+
+func (noopStore) Upsert(context.Context, string, bool, int64) error { return nil }
+
+func (noopStore) Delete(context.Context, string) error { return nil }
+
+func (noopStore) LogChange(context.Context, ChangeLogEntry) error { return nil }

--- a/pkg/services/navtree/models.go
+++ b/pkg/services/navtree/models.go
@@ -31,6 +31,7 @@ const (
 	WeightApplication
 	WeightAsserts
 	WeightDataConnections
+	WeightLabs
 	WeightApps
 	WeightPlugin
 	WeightConfig
@@ -56,6 +57,7 @@ const (
 	NavIDCfgPlugins           = "cfg/plugins"
 	NavIDCfgAccess            = "cfg/access"
 	NavIDBookmarks            = "bookmarks"
+	NavIDLabs                 = "labs"
 )
 
 type NavLink struct {

--- a/pkg/services/navtree/navtreeimpl/navtree.go
+++ b/pkg/services/navtree/navtreeimpl/navtree.go
@@ -174,6 +174,10 @@ func (s *ServiceImpl) GetNavTree(c *contextmodel.ReqContext, prefs *pref.Prefere
 
 	treeRoot.AddSection(s.buildDataConnectionsNavLink(c))
 
+	if hasAccess(ac.EvalPermission(ac.ActionFeatureManagementRead)) {
+		treeRoot.AddSection(s.buildLabsNavLink(c))
+	}
+
 	orgAdminNode, err := s.getAdminNode(c)
 
 	if orgAdminNode != nil && len(orgAdminNode.Children) > 0 {
@@ -667,5 +671,29 @@ func (s *ServiceImpl) buildDataConnectionsNavLink(c *contextmodel.ReqContext) *n
 		Url:        baseUrl,
 		Children:   children,
 		SortWeight: navtree.WeightDataConnections,
+	}
+}
+
+func (s *ServiceImpl) buildLabsNavLink(_ *contextmodel.ReqContext) *navtree.NavLink {
+	baseUrl := s.cfg.AppSubURL + "/labs"
+
+	children := []*navtree.NavLink{
+		{
+			Id:       "labs-feature-flags",
+			Text:     "Feature flags",
+			SubTitle: "View and manage feature flags for this instance",
+			Url:      baseUrl + "/feature-flags",
+			Children: []*navtree.NavLink{},
+		},
+	}
+
+	return &navtree.NavLink{
+		Text:       "Labs",
+		Icon:       "flask",
+		Id:         navtree.NavIDLabs,
+		Url:        baseUrl,
+		Children:   children,
+		SortWeight: navtree.WeightLabs,
+		IsNew:      true,
 	}
 }

--- a/pkg/services/navtree/navtreeimpl/navtree_test.go
+++ b/pkg/services/navtree/navtreeimpl/navtree_test.go
@@ -197,3 +197,28 @@ func TestBuildDashboardNavLinks(t *testing.T) {
 		require.False(t, hasPlaylistLink(navLinks), "expected unauthenticated user to not see the Playlists nav link")
 	})
 }
+
+func TestBuildLabsNavLink(t *testing.T) {
+	httpReq, _ := http.NewRequest(http.MethodGet, "", nil)
+	reqCtx := &contextmodel.ReqContext{
+		Context: &web.Context{Req: httpReq},
+	}
+
+	service := ServiceImpl{
+		cfg: setting.NewCfg(),
+	}
+	service.cfg.AppSubURL = ""
+
+	navLink := service.buildLabsNavLink(reqCtx)
+
+	require.Equal(t, "Labs", navLink.Text)
+	require.Equal(t, "flask", navLink.Icon)
+	require.Equal(t, "labs", navLink.Id)
+	require.Equal(t, "/labs", navLink.Url)
+	require.True(t, navLink.IsNew)
+	require.Equal(t, int64(navtree.WeightLabs), navLink.SortWeight)
+	require.Len(t, navLink.Children, 1)
+	require.Equal(t, "labs-feature-flags", navLink.Children[0].Id)
+	require.Equal(t, "Feature flags", navLink.Children[0].Text)
+	require.Equal(t, "/labs/feature-flags", navLink.Children[0].Url)
+}

--- a/pkg/services/sqlstore/migrations/featuretoggle/migrations.go
+++ b/pkg/services/sqlstore/migrations/featuretoggle/migrations.go
@@ -1,0 +1,36 @@
+package featuretoggle
+
+import "github.com/grafana/grafana/pkg/services/sqlstore/migrator"
+
+func AddMigration(mg *migrator.Migrator) {
+	overrideTable := migrator.Table{
+		Name: "feature_toggle_override",
+		Columns: []*migrator.Column{
+			{Name: "flag_name", Type: migrator.DB_NVarchar, Length: 190, IsPrimaryKey: true},
+			{Name: "enabled", Type: migrator.DB_Bool, Nullable: false},
+			{Name: "updated_by", Type: migrator.DB_BigInt, Nullable: false},
+			{Name: "updated", Type: migrator.DB_DateTime, Nullable: false},
+		},
+	}
+
+	changeLogTable := migrator.Table{
+		Name: "feature_toggle_change_log",
+		Columns: []*migrator.Column{
+			{Name: "id", Type: migrator.DB_BigInt, IsPrimaryKey: true, IsAutoIncrement: true},
+			{Name: "flag_name", Type: migrator.DB_NVarchar, Length: 190, Nullable: false},
+			{Name: "from_value", Type: migrator.DB_Bool, Nullable: true},
+			{Name: "to_value", Type: migrator.DB_Bool, Nullable: false},
+			{Name: "user_id", Type: migrator.DB_BigInt, Nullable: false},
+			{Name: "user_login", Type: migrator.DB_NVarchar, Length: 190, Nullable: false},
+			{Name: "org_id", Type: migrator.DB_BigInt, Nullable: false},
+			{Name: "created", Type: migrator.DB_DateTime, Nullable: false},
+		},
+		Indices: []*migrator.Index{
+			{Cols: []string{"flag_name"}, Type: migrator.IndexType},
+			{Cols: []string{"created"}, Type: migrator.IndexType},
+		},
+	}
+
+	mg.AddMigration("create feature_toggle_override table", migrator.NewAddTableMigration(overrideTable))
+	mg.AddMigration("create feature_toggle_change_log table", migrator.NewAddTableMigration(changeLogTable))
+}

--- a/pkg/services/sqlstore/migrations/migrations.go
+++ b/pkg/services/sqlstore/migrations/migrations.go
@@ -5,6 +5,7 @@ import (
 	"github.com/grafana/grafana/pkg/services/sqlstore/migrations/accesscontrol"
 	"github.com/grafana/grafana/pkg/services/sqlstore/migrations/anonservice"
 	"github.com/grafana/grafana/pkg/services/sqlstore/migrations/externalsession"
+	"github.com/grafana/grafana/pkg/services/sqlstore/migrations/featuretoggle"
 	"github.com/grafana/grafana/pkg/services/sqlstore/migrations/signingkeys"
 	"github.com/grafana/grafana/pkg/services/sqlstore/migrations/ssosettings"
 	"github.com/grafana/grafana/pkg/services/sqlstore/migrations/ualert"
@@ -178,6 +179,8 @@ func (oss *OSSMigrations) AddMigration(mg *Migrator) {
 	accesscontrol.AddManagedRoutesPermissions(mg)
 
 	addNatsDiscoveryMigrations(mg)
+
+	featuretoggle.AddMigration(mg)
 
 	ualert.AddAlertRuleStateBigIntMigration(mg)
 }

--- a/public/app/core/utils/navBarItem-translations.ts
+++ b/public/app/core/utils/navBarItem-translations.ts
@@ -181,6 +181,10 @@ export function getNavTitle(navId: string | undefined) {
       return t('nav.sign-out.title', 'Sign out');
     case 'search':
       return t('nav.search-dashboards.title', 'Search dashboards');
+    case 'labs':
+      return t('nav.labs.title', 'Labs');
+    case 'labs-feature-flags':
+      return t('nav.labs-feature-flags.title', 'Feature flags');
     case 'connections':
       return t('nav.connections.title', 'Connections');
     case 'connections-add-new-connection':

--- a/public/app/features/labs/FeatureFlagsPage.test.tsx
+++ b/public/app/features/labs/FeatureFlagsPage.test.tsx
@@ -1,0 +1,111 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import { getBackendSrv } from '@grafana/runtime';
+
+import { TestProvider } from '../../../test/helpers/TestProvider';
+import { contextSrv } from 'app/core/services/context_srv';
+import { AccessControlAction } from 'app/types/accessControl';
+
+import FeatureFlagsPage from './FeatureFlagsPage';
+
+jest.mock('@grafana/runtime', () => ({
+  ...jest.requireActual('@grafana/runtime'),
+  getBackendSrv: jest.fn(),
+}));
+
+const mockGetBackendSrv = jest.mocked(getBackendSrv);
+
+const resolvedState = {
+  allowEditing: true,
+  restartRequired: false,
+  enabled: { alphaFlag: true },
+  toggles: [
+    {
+      name: 'alphaFlag',
+      description: 'Alpha feature',
+      stage: 'experimental',
+      enabled: true,
+      writeable: true,
+      source: { name: 'database' },
+    },
+    {
+      name: 'lockedFlag',
+      description: 'Locked feature',
+      stage: 'preview',
+      enabled: false,
+      writeable: false,
+      source: { name: 'config' },
+      warning: 'Locked by configuration',
+    },
+  ],
+};
+
+const renderPage = () => {
+  render(
+    <TestProvider>
+      <FeatureFlagsPage />
+    </TestProvider>
+  );
+};
+
+describe('FeatureFlagsPage', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    contextSrv.user.permissions = {
+      [AccessControlAction.FeatureManagementRead]: true,
+      [AccessControlAction.FeatureManagementWrite]: true,
+    };
+
+    mockGetBackendSrv.mockReturnValue({
+      get: jest.fn().mockResolvedValue(resolvedState),
+      post: jest.fn().mockResolvedValue({ message: 'Feature flag updated' }),
+      delete: jest.fn().mockResolvedValue({ message: 'Feature flag reset' }),
+    } as unknown as ReturnType<typeof getBackendSrv>);
+  });
+
+  it('renders feature flags from the resolved API', async () => {
+    renderPage();
+
+    expect(await screen.findByText('alphaFlag')).toBeInTheDocument();
+    expect(screen.getByText('lockedFlag')).toBeInTheDocument();
+    expect(screen.getByText('Locked by configuration')).toBeInTheDocument();
+  });
+
+  it('shows confirmation before toggling experimental flags', async () => {
+    const user = userEvent.setup();
+    renderPage();
+
+    const switches = await screen.findAllByRole('switch');
+    await user.click(switches[0]);
+
+    expect(await screen.findByText('Enable experimental feature?')).toBeInTheDocument();
+  });
+
+  it('shows read-only notice without write permission', async () => {
+    contextSrv.user.permissions = {
+      [AccessControlAction.FeatureManagementRead]: true,
+    };
+
+    renderPage();
+
+    expect(await screen.findByText('Read-only access')).toBeInTheDocument();
+  });
+
+  it('posts updates after confirmation', async () => {
+    const user = userEvent.setup();
+    const backend = mockGetBackendSrv();
+    renderPage();
+
+    const switches = await screen.findAllByRole('switch');
+    await user.click(switches[0]);
+    await user.click(await screen.findByRole('button', { name: 'Continue' }));
+
+    await waitFor(() => {
+      expect(backend.post).toHaveBeenCalledWith('/api/admin/feature-toggles', {
+        name: 'alphaFlag',
+        enabled: false,
+      });
+    });
+  });
+});

--- a/public/app/features/labs/FeatureFlagsPage.tsx
+++ b/public/app/features/labs/FeatureFlagsPage.tsx
@@ -1,0 +1,278 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+
+import { FeatureState } from '@grafana/data';
+import { Trans, t } from '@grafana/i18n';
+import { getBackendSrv } from '@grafana/runtime';
+import {
+  Alert,
+  Button,
+  ConfirmModal,
+  type CellProps,
+  type Column,
+  FeatureBadge,
+  InteractiveTable,
+  Stack,
+  Switch,
+  Text,
+} from '@grafana/ui';
+import { Page } from 'app/core/components/Page/Page';
+import { contextSrv } from 'app/core/services/context_srv';
+import { AccessControlAction } from 'app/types/accessControl';
+
+export interface ToggleStatus {
+  name: string;
+  description?: string;
+  stage: string;
+  enabled: boolean;
+  writeable: boolean;
+  source?: { name?: string };
+  warning?: string;
+}
+
+export interface ResolvedToggleState {
+  allowEditing: boolean;
+  restartRequired: boolean;
+  enabled: Record<string, boolean>;
+  toggles: ToggleStatus[];
+}
+
+interface PendingToggle {
+  name: string;
+  enabled: boolean;
+}
+
+function stageToFeatureState(stage: string): FeatureState | undefined {
+  switch (stage) {
+    case 'experimental':
+      return FeatureState.experimental;
+    case 'privatePreview':
+      return FeatureState.privatePreview;
+    case 'preview':
+      return FeatureState.preview;
+    default:
+      return undefined;
+  }
+}
+
+function isExperimentalStage(stage: string) {
+  return stage === 'experimental' || stage === 'privatePreview';
+}
+
+async function fetchResolvedState(): Promise<ResolvedToggleState> {
+  return getBackendSrv().get<ResolvedToggleState>('/api/admin/feature-toggles/resolved');
+}
+
+async function updateFeatureToggle(name: string, enabled: boolean): Promise<void> {
+  await getBackendSrv().post('/api/admin/feature-toggles', { name, enabled });
+}
+
+async function resetFeatureToggle(name: string): Promise<void> {
+  await getBackendSrv().delete(`/api/admin/feature-toggles?name=${encodeURIComponent(name)}`);
+}
+
+function FeatureFlagsPage() {
+  const [state, setState] = useState<ResolvedToggleState | null>(null);
+  const [loadError, setLoadError] = useState<string | null>(null);
+  const [pendingToggle, setPendingToggle] = useState<PendingToggle | null>(null);
+  const [isSaving, setIsSaving] = useState(false);
+  const [reloadSuggested, setReloadSuggested] = useState(false);
+
+  const canWrite = contextSrv.hasPermission(AccessControlAction.FeatureManagementWrite);
+
+  const loadState = useCallback(async () => {
+    try {
+      setLoadError(null);
+      const next = await fetchResolvedState();
+      setState(next);
+    } catch (error) {
+      setLoadError(error instanceof Error ? error.message : 'Failed to load feature flags');
+    }
+  }, []);
+
+  useEffect(() => {
+    loadState();
+  }, [loadState]);
+
+  const applyToggle = useCallback(
+    async (name: string, enabled: boolean) => {
+      setIsSaving(true);
+      try {
+        await updateFeatureToggle(name, enabled);
+        setReloadSuggested(true);
+        await loadState();
+      } finally {
+        setIsSaving(false);
+        setPendingToggle(null);
+      }
+    },
+    [loadState]
+  );
+
+  const handleToggleRequest = useCallback(
+    (toggle: ToggleStatus, enabled: boolean) => {
+      if (!canWrite || !toggle.writeable) {
+        return;
+      }
+
+      if (isExperimentalStage(toggle.stage)) {
+        setPendingToggle({ name: toggle.name, enabled });
+        return;
+      }
+
+      applyToggle(toggle.name, enabled);
+    },
+    [applyToggle, canWrite]
+  );
+
+  const handleReset = useCallback(
+    async (name: string) => {
+      setIsSaving(true);
+      try {
+        await resetFeatureToggle(name);
+        setReloadSuggested(true);
+        await loadState();
+      } finally {
+        setIsSaving(false);
+      }
+    },
+    [loadState]
+  );
+
+  const columns = useMemo<Array<Column<ToggleStatus>>>(
+    () => [
+      {
+        id: 'name',
+        header: t('labs.feature-flags.columns.name', 'Flag'),
+        cell: ({ row: { original } }: CellProps<ToggleStatus, string>) => (
+          <Stack direction="column" gap={0.5}>
+            <Text weight="medium">{original.name}</Text>
+            {original.description && (
+              <Text variant="bodySmall" color="secondary">
+                {original.description}
+              </Text>
+            )}
+          </Stack>
+        ),
+      },
+      {
+        id: 'stage',
+        header: t('labs.feature-flags.columns.stage', 'Stage'),
+        cell: ({ row: { original } }: CellProps<ToggleStatus, string>) => {
+          const featureState = stageToFeatureState(original.stage);
+          return featureState ? <FeatureBadge featureState={featureState} /> : <Text>{original.stage}</Text>;
+        },
+      },
+      {
+        id: 'enabled',
+        header: t('labs.feature-flags.columns.enabled', 'Enabled'),
+        cell: ({ row: { original } }: CellProps<ToggleStatus, boolean>) => (
+          <Switch
+            value={original.enabled}
+            disabled={!canWrite || !original.writeable || isSaving}
+            aria-label={original.name}
+            onChange={(event) => handleToggleRequest(original, event.currentTarget.checked)}
+          />
+        ),
+      },
+      {
+        id: 'status',
+        header: t('labs.feature-flags.columns.status', 'Status'),
+        cell: ({ row: { original } }: CellProps<ToggleStatus, string>) => {
+          if (original.source?.name === 'config') {
+            return <Text color="secondary">{t('labs.feature-flags.locked', 'Locked by configuration')}</Text>;
+          }
+          if (original.warning) {
+            return <Text color="secondary">{original.warning}</Text>;
+          }
+          if (original.source?.name === 'database') {
+            return (
+              <Stack direction="row" gap={1} alignItems="center">
+                <Text color="secondary">{t('labs.feature-flags.overridden', 'Overridden')}</Text>
+                {canWrite && original.writeable && (
+                  <Button size="sm" variant="secondary" fill="outline" onClick={() => handleReset(original.name)}>
+                    {t('labs.feature-flags.reset', 'Reset')}
+                  </Button>
+                )}
+              </Stack>
+            );
+          }
+          return null;
+        },
+      },
+    ],
+    [canWrite, handleReset, handleToggleRequest, isSaving]
+  );
+
+  return (
+    <Page navId="labs">
+      <Page.Contents>
+        <Stack direction="column" gap={2}>
+          <Text variant="h3">
+            <Trans i18nKey="labs.feature-flags.title">Feature flags</Trans>
+          </Text>
+          <Text color="secondary">
+            <Trans i18nKey="labs.feature-flags.description">
+              Discover and manage feature flags for this Grafana instance. Changes are persisted server-side. Some
+              flags require a Grafana restart or browser reload to take full effect.
+            </Trans>
+          </Text>
+
+          {state?.restartRequired && (
+            <Alert severity="warning" title={t('labs.feature-flags.restart-required-title', 'Restart required')}>
+              <Trans i18nKey="labs.feature-flags.restart-required-body">
+                One or more flags have pending changes that require a Grafana restart before they take effect.
+              </Trans>
+            </Alert>
+          )}
+
+          {reloadSuggested && (
+            <Alert severity="info" title={t('labs.feature-flags.reload-title', 'Reload recommended')}>
+              <Stack direction="row" gap={1} alignItems="center">
+                <Trans i18nKey="labs.feature-flags.reload-body">
+                  Reload Grafana in your browser so frontend feature flags pick up the latest values.
+                </Trans>
+                <Button onClick={() => window.location.reload()}>
+                  {t('labs.feature-flags.reload-button', 'Reload Grafana')}
+                </Button>
+              </Stack>
+            </Alert>
+          )}
+
+          {!canWrite && (
+            <Alert severity="info" title={t('labs.feature-flags.read-only-title', 'Read-only access')}>
+              <Trans i18nKey="labs.feature-flags.read-only-body">
+                You can view feature flags but do not have permission to change them.
+              </Trans>
+            </Alert>
+          )}
+
+          {loadError && (
+            <Alert severity="error" title={t('labs.feature-flags.load-error-title', 'Failed to load feature flags')}>
+              {loadError}
+            </Alert>
+          )}
+
+          {state && (
+            <InteractiveTable data={state.toggles} columns={columns} getRowId={(row) => row.name} pageSize={25} />
+          )}
+        </Stack>
+
+        {pendingToggle && (
+          <ConfirmModal
+            isOpen
+            title={t('labs.feature-flags.confirm-title', 'Enable experimental feature?')}
+            body={t(
+              'labs.feature-flags.confirm-body',
+              'This feature is still early — behavior may change or break. Are you sure you want to continue?'
+            )}
+            confirmText={t('labs.feature-flags.confirm-continue', 'Continue')}
+            onConfirm={() => applyToggle(pendingToggle.name, pendingToggle.enabled)}
+            onDismiss={() => setPendingToggle(null)}
+          />
+        )}
+      </Page.Contents>
+    </Page>
+  );
+}
+
+export default FeatureFlagsPage;

--- a/public/app/routes/routes.tsx
+++ b/public/app/routes/routes.tsx
@@ -221,6 +221,18 @@ export function getAppRoutes(): RouteDescriptor[] {
       component: () => <NavLandingPage navId="frontend" />,
     },
     {
+      path: '/labs',
+      roles: () => contextSrv.evaluatePermission([AccessControlAction.FeatureManagementRead]),
+      component: () => <NavLandingPage navId="labs" />,
+    },
+    {
+      path: '/labs/feature-flags',
+      roles: () => contextSrv.evaluatePermission([AccessControlAction.FeatureManagementRead]),
+      component: SafeDynamicImport(
+        () => import(/* webpackChunkName: "LabsFeatureFlags" */ 'app/features/labs/FeatureFlagsPage')
+      ),
+    },
+    {
       path: '/admin/general',
       component: () => <NavLandingPage navId="cfg/general" />,
     },

--- a/public/app/types/accessControl.ts
+++ b/public/app/types/accessControl.ts
@@ -197,6 +197,10 @@ export enum AccessControlAction {
   QueriesRead = 'queries:read',
   QueriesWrite = 'queries:write',
 
+  // Feature management (Labs)
+  FeatureManagementRead = 'featuremgmt.read',
+  FeatureManagementWrite = 'featuremgmt.write',
+
   // Provisioning
   ProvisioningRepositoriesRead = 'provisioning.repositories:read',
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements CUR-55 with a full RFC-scope **Labs → Feature flags** admin experience: server-persistent toggles, RBAC view/write split, audit logging, and correct handling of locked and restart-required flags.

### Backend
- **Runtime-safe `FeatureManager`**: mutex-protected `SetFlag` / `RemoveOverride`, `GetResolvedState`, config-locked flags, and restart-required flags that persist without applying until restart
- **Persistence**: `feature_toggle_override` + `feature_toggle_change_log` tables (`pkg/services/featuretogglestore`)
- **Admin API** (RBAC `featuremgmt.read` / `featuremgmt.write`):
  - `GET /api/admin/feature-toggles/resolved`
  - `POST /api/admin/feature-toggles`
  - `DELETE /api/admin/feature-toggles?name=...`
- **Nav**: new top-level **Labs** section (flask icon, `IsNew` badge) gated by `featuremgmt.read`
- **Audit**: structured logs + DB change log rows on every toggle/reset

### Frontend
- Routes: `/labs`, `/labs/feature-flags`
- `FeatureFlagsPage`: table with stage badges, permission-gated switches, experimental confirmation modal, locked/restart messaging, reload prompt

## Validation

```bash
go test -v -short ./pkg/services/featuremgmt/... ./pkg/services/navtree/navtreeimpl/...
yarn jest --no-watch --runTestsByPath public/app/features/labs/FeatureFlagsPage.test.tsx
```

## Notes

- Overrides load after SQL store init via `InitializeFeatureOverrides` to avoid circular DI with migrations.
- `make gen-go` still fails on pre-existing wire issues in this branch; `wire_gen.go` was updated manually for the new providers.
- Target repo: **fieldsphere/grafana**
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9e85c0ac-b4af-4173-823f-94106e572bf4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9e85c0ac-b4af-4173-823f-94106e572bf4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

