### PR TITLE
refactor(core): route core services logging through structured monitoring logger

### DIFF
--- a/packages/grafana-runtime/src/services/logging/loggers.ts
+++ b/packages/grafana-runtime/src/services/logging/loggers.ts
@@ -18,6 +18,10 @@ export const Loggers = {
   'features.dashboards.genai': {},
   'features.query-history.local-storage': {},
   'core.crash-detection': {},
+  'core.backend-srv': {},
+  'core.context-srv': {},
+  'core.echo': {},
+  'core.meticulous': {},
   'extensions.auth-config.scim': { context: { module: 'SCIM' } },
 } satisfies Record<string, LoggerDefaults>;
 

--- a/public/app/core/services/backend_srv.ts
+++ b/public/app/core/services/backend_srv.ts
@@ -30,6 +30,7 @@ import {
   type BackendSrv as BackendService,
   type BackendSrvRequest,
   config,
+  createMonitoringLogger,
   type FetchError,
   type FetchResponse,
 } from '@grafana/runtime';
@@ -53,6 +54,8 @@ import { ResponseQueue } from './ResponseQueue';
 import { type ContextSrv, contextSrv } from './context_srv';
 
 const CANCEL_ALL_REQUESTS_REQUEST_ID = 'cancel_all_requests_request_id';
+
+const logger = createMonitoringLogger('core.backendSrv', undefined, process.env.NODE_ENV === 'development');
 
 export interface BackendSrvDependencies {
   fromFetch: (input: string | Request, init?: RequestInit) => Observable<Response>;
@@ -115,7 +118,7 @@ export class BackendSrv implements BackendService {
       const result = await fp.get();
       this.deviceID = result.visitorId;
     } catch (error) {
-      console.error(error);
+      logger.logError(new Error('Failed to initialize Grafana device ID', { cause: error }));
     }
   }
 
@@ -240,7 +243,7 @@ export class BackendSrv implements BackendService {
             observer.complete();
           }) // runs in background
           .catch((e) => {
-            console.log(requestId, 'catch', e);
+            logger.logDebug('Request stream aborted', { requestId });
             observer.error(e);
           }); // from abort
       },

--- a/public/app/core/services/backend_srv.ts
+++ b/public/app/core/services/backend_srv.ts
@@ -30,10 +30,10 @@ import {
   type BackendSrv as BackendService,
   type BackendSrvRequest,
   config,
-  createMonitoringLogger,
   type FetchError,
   type FetchResponse,
 } from '@grafana/runtime';
+import { getLogger } from '@grafana/runtime/unstable';
 import { appEvents } from 'app/core/app_events';
 import { getConfig } from 'app/core/config';
 import { getSessionExpiry, hasSessionExpiry } from 'app/core/utils/auth';
@@ -54,8 +54,6 @@ import { ResponseQueue } from './ResponseQueue';
 import { type ContextSrv, contextSrv } from './context_srv';
 
 const CANCEL_ALL_REQUESTS_REQUEST_ID = 'cancel_all_requests_request_id';
-
-const logger = createMonitoringLogger('core.backendSrv', undefined, process.env.NODE_ENV === 'development');
 
 export interface BackendSrvDependencies {
   fromFetch: (input: string | Request, init?: RequestInit) => Observable<Response>;
@@ -118,7 +116,7 @@ export class BackendSrv implements BackendService {
       const result = await fp.get();
       this.deviceID = result.visitorId;
     } catch (error) {
-      logger.logError(new Error('Failed to initialize Grafana device ID', { cause: error }));
+      getLogger('core.backend-srv').logError(new Error('Failed to initialize Grafana device ID', { cause: error }));
     }
   }
 
@@ -243,7 +241,7 @@ export class BackendSrv implements BackendService {
             observer.complete();
           }) // runs in background
           .catch((e) => {
-            logger.logDebug('Request stream aborted', { requestId });
+            getLogger('core.backend-srv').logDebug('Request stream aborted', { requestId });
             observer.error(e);
           }); // from abort
       },

--- a/public/app/core/services/context_srv.ts
+++ b/public/app/core/services/context_srv.ts
@@ -9,9 +9,11 @@ import {
   userHasPermissionInMetadata,
   userHasAnyPermission,
 } from '@grafana/data';
-import { featureEnabled, getBackendSrv } from '@grafana/runtime';
+import { createMonitoringLogger, featureEnabled, getBackendSrv } from '@grafana/runtime';
 import { getSessionExpiry } from 'app/core/utils/auth';
 import { type UserPermission, AccessControlAction } from 'app/types/accessControl';
+
+const logger = createMonitoringLogger('core.contextSrv', undefined, process.env.NODE_ENV === 'development');
 import { type CurrentUserInternal } from 'app/types/config';
 
 import config from '../../core/config';
@@ -108,7 +110,7 @@ export class ContextSrv {
         reloadcache: true,
       });
     } catch (e) {
-      console.error(e);
+      logger.logError(new Error('Failed to fetch user permissions', { cause: e }));
     }
   }
 
@@ -258,7 +260,7 @@ export class ContextSrv {
         }
       })
       .catch((e) => {
-        console.error(e);
+        logger.logError(new Error('Token rotation request failed', { cause: e }));
       });
   }
 }

--- a/public/app/core/services/context_srv.ts
+++ b/public/app/core/services/context_srv.ts
@@ -9,11 +9,10 @@ import {
   userHasPermissionInMetadata,
   userHasAnyPermission,
 } from '@grafana/data';
-import { createMonitoringLogger, featureEnabled, getBackendSrv } from '@grafana/runtime';
+import { featureEnabled, getBackendSrv } from '@grafana/runtime';
+import { getLogger } from '@grafana/runtime/unstable';
 import { getSessionExpiry } from 'app/core/utils/auth';
 import { type UserPermission, AccessControlAction } from 'app/types/accessControl';
-
-const logger = createMonitoringLogger('core.contextSrv', undefined, process.env.NODE_ENV === 'development');
 import { type CurrentUserInternal } from 'app/types/config';
 
 import config from '../../core/config';
@@ -110,7 +109,7 @@ export class ContextSrv {
         reloadcache: true,
       });
     } catch (e) {
-      logger.logError(new Error('Failed to fetch user permissions', { cause: e }));
+      getLogger('core.context-srv').logError(new Error('Failed to fetch user permissions', { cause: e }));
     }
   }
 
@@ -260,7 +259,7 @@ export class ContextSrv {
         }
       })
       .catch((e) => {
-        logger.logError(new Error('Token rotation request failed', { cause: e }));
+        getLogger('core.context-srv').logError(new Error('Token rotation request failed', { cause: e }));
       });
   }
 }

--- a/public/app/core/services/echo/Echo.test.ts
+++ b/public/app/core/services/echo/Echo.test.ts
@@ -1,4 +1,5 @@
 import { EchoEventType, MAX_PAGE_URL_LENGTH, TRUNCATION_MARKER } from '@grafana/runtime';
+import { clearLoggerRegistry, setLogger } from '@grafana/runtime/unstable';
 
 import { Echo } from './Echo';
 
@@ -143,7 +144,7 @@ describe('Echo onInteraction', () => {
     expect(callback).toHaveBeenCalledWith({});
   });
 
-  it('should not throw when subscriber throws', () => {
+  it('should not throw and reports the error to the structured logger when subscriber throws', () => {
     const errorCallback = jest.fn(() => {
       throw new Error('subscriber error');
     });
@@ -152,7 +153,14 @@ describe('Echo onInteraction', () => {
     echo.onInteraction('test_interaction', errorCallback);
     echo.onInteraction('test_interaction', goodCallback);
 
-    const consoleSpy = jest.spyOn(console, 'error').mockImplementation();
+    const logError = jest.fn();
+    setLogger('core.echo', {
+      logDebug: jest.fn(),
+      logInfo: jest.fn(),
+      logWarning: jest.fn(),
+      logError,
+      logMeasurement: jest.fn(),
+    });
 
     echo.addEvent({
       type: EchoEventType.Interaction,
@@ -161,9 +169,12 @@ describe('Echo onInteraction', () => {
 
     expect(errorCallback).toHaveBeenCalledTimes(1);
     expect(goodCallback).toHaveBeenCalledTimes(1);
-    expect(consoleSpy).toHaveBeenCalled();
+    expect(logError).toHaveBeenCalledTimes(1);
+    const reportedError = logError.mock.calls[0][0];
+    expect(reportedError).toBeInstanceOf(Error);
+    expect(reportedError.message).toContain('test_interaction');
 
-    consoleSpy.mockRestore();
+    clearLoggerRegistry();
   });
 
   it('should still dispatch to backends alongside subscriber dispatch', () => {

--- a/public/app/core/services/echo/Echo.ts
+++ b/public/app/core/services/echo/Echo.ts
@@ -7,11 +7,14 @@ import {
   EchoEventType,
   MAX_PAGE_URL_LENGTH,
   TRUNCATION_MARKER,
+  createMonitoringLogger,
 } from '@grafana/runtime';
 
 import { contextSrv } from '../context_srv';
 
 import { echoLog } from './utils';
+
+const logger = createMonitoringLogger('core.echo', undefined, process.env.NODE_ENV === 'development');
 
 interface EchoConfig {
   // How often should metrics be reported
@@ -76,7 +79,9 @@ export class Echo implements EchoSrv {
             try {
               cb(payload.properties ?? {});
             } catch (err) {
-              console.error(`[Echo] onInteraction subscriber error for "${payload.interactionName}":`, err);
+              logger.logError(
+                new Error(`onInteraction subscriber error for "${payload.interactionName}"`, { cause: err })
+              );
             }
           }
         }

--- a/public/app/core/services/echo/Echo.ts
+++ b/public/app/core/services/echo/Echo.ts
@@ -7,14 +7,12 @@ import {
   EchoEventType,
   MAX_PAGE_URL_LENGTH,
   TRUNCATION_MARKER,
-  createMonitoringLogger,
 } from '@grafana/runtime';
+import { getLogger } from '@grafana/runtime/unstable';
 
 import { contextSrv } from '../context_srv';
 
 import { echoLog } from './utils';
-
-const logger = createMonitoringLogger('core.echo', undefined, process.env.NODE_ENV === 'development');
 
 interface EchoConfig {
   // How often should metrics be reported
@@ -79,7 +77,7 @@ export class Echo implements EchoSrv {
             try {
               cb(payload.properties ?? {});
             } catch (err) {
-              logger.logError(
+              getLogger('core.echo').logError(
                 new Error(`onInteraction subscriber error for "${payload.interactionName}"`, { cause: err })
               );
             }

--- a/public/app/core/services/echo/init.ts
+++ b/public/app/core/services/echo/init.ts
@@ -1,9 +1,11 @@
-import { config, registerEchoBackend, setEchoSrv } from '@grafana/runtime';
+import { config, createMonitoringLogger, registerEchoBackend, setEchoSrv } from '@grafana/runtime';
 import { reportMetricPerformanceMark } from 'app/core/utils/metrics';
 
 import { contextSrv } from '../context_srv';
 
 import { Echo } from './Echo';
+
+const logger = createMonitoringLogger('core.echo.init', undefined, process.env.NODE_ENV === 'development');
 
 // Initialise EchoSrv backends, calls during frontend app startup
 export async function initEchoSrv() {
@@ -28,49 +30,49 @@ export async function initEchoSrv() {
   try {
     await initPerformanceBackend();
   } catch (error) {
-    console.error('Error initializing EchoSrv Performance backend', error);
+    logger.logError(new Error('Error initializing EchoSrv Performance backend', { cause: error }));
   }
 
   try {
     await initFaroBackend();
   } catch (error) {
-    console.error('Error initializing EchoSrv Faro backend', error);
+    logger.logError(new Error('Error initializing EchoSrv Faro backend', { cause: error }));
   }
 
   try {
     await initGoogleAnalyticsBackend();
   } catch (error) {
-    console.error('Error initializing EchoSrv GoogleAnalytics backend', error);
+    logger.logError(new Error('Error initializing EchoSrv GoogleAnalytics backend', { cause: error }));
   }
 
   try {
     await initGoogleAnalaytics4Backend();
   } catch (error) {
-    console.error('Error initializing EchoSrv GoogleAnalaytics4 backend', error);
+    logger.logError(new Error('Error initializing EchoSrv GoogleAnalaytics4 backend', { cause: error }));
   }
 
   try {
     await initRudderstackBackend();
   } catch (error) {
-    console.error('Error initializing EchoSrv Rudderstack backend', error);
+    logger.logError(new Error('Error initializing EchoSrv Rudderstack backend', { cause: error }));
   }
 
   try {
     await initAzureAppInsightsBackend();
   } catch (error) {
-    console.error('Error initializing EchoSrv AzureAppInsights backend', error);
+    logger.logError(new Error('Error initializing EchoSrv AzureAppInsights backend', { cause: error }));
   }
 
   try {
     await initPostHogBackend();
   } catch (error) {
-    console.error('Error initializing EchoSrv PostHog backend', error);
+    logger.logError(new Error('Error initializing EchoSrv PostHog backend', { cause: error }));
   }
 
   try {
     await initConsoleBackend();
   } catch (error) {
-    console.error('Error initializing EchoSrv Console backend', error);
+    logger.logError(new Error('Error initializing EchoSrv Console backend', { cause: error }));
   }
 }
 

--- a/public/app/core/services/echo/init.ts
+++ b/public/app/core/services/echo/init.ts
@@ -1,14 +1,15 @@
-import { config, createMonitoringLogger, registerEchoBackend, setEchoSrv } from '@grafana/runtime';
+import { config, registerEchoBackend, setEchoSrv } from '@grafana/runtime';
+import { getLogger } from '@grafana/runtime/unstable';
 import { reportMetricPerformanceMark } from 'app/core/utils/metrics';
 
 import { contextSrv } from '../context_srv';
 
 import { Echo } from './Echo';
 
-const logger = createMonitoringLogger('core.echo.init', undefined, process.env.NODE_ENV === 'development');
-
 // Initialise EchoSrv backends, calls during frontend app startup
 export async function initEchoSrv() {
+  const logger = getLogger('core.echo');
+
   setEchoSrv(new Echo({ debug: process.env.NODE_ENV === 'development' }));
 
   window.addEventListener('load', (e) => {

--- a/public/app/core/services/meticulous.ts
+++ b/public/app/core/services/meticulous.ts
@@ -1,6 +1,4 @@
-import { createMonitoringLogger } from '@grafana/runtime';
-
-const logger = createMonitoringLogger('core.meticulous', undefined, process.env.NODE_ENV === 'development');
+import { getLogger } from '@grafana/runtime/unstable';
 
 const AUTH_PATH_PREFIXES = ['/login', '/signup', '/invite/', '/verify', '/user/password/', '/profile/password'];
 
@@ -22,6 +20,6 @@ export async function updateMeticulousRecording(pathname: string): Promise<void>
   try {
     window.__meticulous.stopRecording();
   } catch (error) {
-    logger.logError(new Error('Error stopping Meticulous recording', { cause: error }));
+    getLogger('core.meticulous').logError(new Error('Error stopping Meticulous recording', { cause: error }));
   }
 }

--- a/public/app/core/services/meticulous.ts
+++ b/public/app/core/services/meticulous.ts
@@ -1,3 +1,7 @@
+import { createMonitoringLogger } from '@grafana/runtime';
+
+const logger = createMonitoringLogger('core.meticulous', undefined, process.env.NODE_ENV === 'development');
+
 const AUTH_PATH_PREFIXES = ['/login', '/signup', '/invite/', '/verify', '/user/password/', '/profile/password'];
 
 function isAuthPath(pathname: string): boolean {
@@ -18,6 +22,6 @@ export async function updateMeticulousRecording(pathname: string): Promise<void>
   try {
     window.__meticulous.stopRecording();
   } catch (error) {
-    console.error('Error stopping Meticulous recording:', error);
+    logger.logError(new Error('Error stopping Meticulous recording', { cause: error }));
   }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Replaces raw `console.*` calls in the `public/app/core/services/` infrastructure subsystem with Grafana's structured logger, so production diagnostics carry a stable `source` + structured context and are reported to the monitoring backend (Faro).

Grafana already ships this structured-logging approach, and enforces it via the ESLint rule `@grafana/no-direct-create-monitoring-logger`. This PR follows the enforced pattern:

1. Register logger sources in `packages/grafana-runtime/src/services/logging/loggers.ts` (`core.backend-srv`, `core.context-srv`, `core.echo`, `core.meticulous`).
2. Obtain the logger lazily at each call site with `getLogger(source)` from `@grafana/runtime/unstable` (matching the existing `core.crash-detection` usage).

Rather than an unsafe repo-wide rewrite of ~760 `console.*` sites (many intentional, or in packages that cannot import `@grafana/runtime`), this lands a coherent, tested slice plus a documented rollout plan.

### Migrated
- `services/backend_srv.ts` — device-ID init failure -> `logError`; stray abort debug log -> `logDebug`.
- `services/context_srv.ts` — user-permission fetch and token-rotation failures -> `logError`.
- `services/echo/Echo.ts` — `onInteraction` subscriber errors -> `logError`.
- `services/echo/init.ts` — all 8 EchoSrv backend init failures -> `logError`.
- `services/meticulous.ts` — recording-stop failure -> `logError`.
- `services/echo/Echo.test.ts` — updated to assert the structured logger receives the error (via `setLogger`/`clearLoggerRegistry`) instead of `console.error`.

### Intentionally left as `console` (by design)
- `echo/backends/analytics/BrowseConsoleBackend.ts` — a console-analytics backend (already `eslint-disable no-console`).
- `FetchQueue.ts` — dev-only queue inspection gated behind a `debug` flag.
- `services/journey/*` — CUJ instrumentation governed by `public/app/core/journeys/AGENTS.md`; out of scope.

## Testing
- eslint (changed files) — pass
- `tsc --noEmit` — no errors in changed files (one pre-existing, unrelated codegen error in `theme-playground` from a missing generated JSON artifact)
- `jest` for `public/app/core/services/echo/Echo.test.ts` and `public/app/core/specs/backend_srv.test.ts` — pass

No UI or user-facing behavior changes; manual/GUI testing is not applicable.

## Rollout
First tested increment of a broader adoption. The full plan (pattern, mapping table, exclusions, per-area procedure) is documented for the team.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7eb06a0d-0e6d-4eca-b3f0-f1b40396f03c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7eb06a0d-0e6d-4eca-b3f0-f1b40396f03c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

