### PR TITLE
Navigation: Add Labs page listing enabled feature flags

### DIFF
--- a/pkg/services/navtree/models.go
+++ b/pkg/services/navtree/models.go
@@ -56,6 +56,7 @@ const (
 	NavIDCfgPlugins           = "cfg/plugins"
 	NavIDCfgAccess            = "cfg/access"
 	NavIDBookmarks            = "bookmarks"
+	NavIDLabs                 = "labs"
 )
 
 type NavLink struct {

--- a/pkg/services/navtree/navtreeimpl/navtree.go
+++ b/pkg/services/navtree/navtreeimpl/navtree.go
@@ -162,6 +162,17 @@ func (s *ServiceImpl) GetNavTree(c *contextmodel.ReqContext, prefs *pref.Prefere
 
 	treeRoot.AddSection(s.buildDataConnectionsNavLink(c))
 
+	treeRoot.AddSection(&navtree.NavLink{
+		Text:     "Labs",
+		Id:       navtree.NavIDLabs,
+		SubTitle: "Explore experimental features and enabled feature flags",
+		Icon:     "flask",
+		Url:      s.cfg.AppSubURL + "/labs",
+		// Place between plugin apps and Administration without shifting existing weights.
+		SortWeight: navtree.WeightConfig - 50,
+		IsNew:      true,
+	})
+
 	orgAdminNode, err := s.getAdminNode(c)
 
 	if orgAdminNode != nil && len(orgAdminNode.Children) > 0 {

--- a/public/app/core/utils/navBarItem-translations.ts
+++ b/public/app/core/utils/navBarItem-translations.ts
@@ -185,6 +185,8 @@ export function getNavTitle(navId: string | undefined) {
       return t('nav.search-dashboards.title', 'Search dashboards');
     case 'connections':
       return t('nav.connections.title', 'Connections');
+    case 'labs':
+      return t('nav.labs.title', 'Labs');
     case 'connections-add-new-connection':
       return t('nav.add-new-connections.title', 'Add new connection');
     case 'standalone-plugin-page-/connections/collector':
@@ -312,6 +314,8 @@ export function getNavSubTitle(navId: string | undefined) {
       return t('nav.alerts-and-incidents.subtitle', 'Alerting and incident management apps');
     case 'testing-and-synthetics':
       return t('nav.testing-and-synthetics.subtitle', 'Optimize performance with k6 and Synthetic Monitoring insights');
+    case 'labs':
+      return t('nav.labs.subtitle', 'Explore experimental features and enabled feature flags');
     case 'connections-add-new-connection':
       return t('nav.connections.subtitle', 'Browse and create new connections');
     case 'connections-datasources':

--- a/public/app/features/labs/LabsPage.test.tsx
+++ b/public/app/features/labs/LabsPage.test.tsx
@@ -1,0 +1,59 @@
+import { render, screen } from 'test/test-utils';
+
+import { config } from '@grafana/runtime';
+
+import { LabsPage } from './LabsPage';
+
+const labsNavItem = {
+  id: 'labs',
+  text: 'Labs',
+  url: '/labs',
+  subTitle: 'Explore experimental features and enabled feature flags',
+};
+
+describe('LabsPage', () => {
+  const originalFeatureToggles = config.featureToggles;
+
+  afterEach(() => {
+    config.featureToggles = originalFeatureToggles;
+  });
+
+  it('lists enabled feature flags', async () => {
+    config.featureToggles = {
+      dashboardScene: true,
+      nestedFolders: true,
+      disabledFlag: false,
+    } as typeof config.featureToggles;
+
+    render(<LabsPage />, { preloadedState: { navIndex: { labs: labsNavItem } } });
+
+    expect(await screen.findByRole('heading', { name: 'Labs' })).toBeInTheDocument();
+    expect(screen.getByText('dashboardScene')).toBeInTheDocument();
+    expect(screen.getByText('nestedFolders')).toBeInTheDocument();
+    expect(screen.queryByText('disabledFlag')).not.toBeInTheDocument();
+  });
+
+  it('shows an empty state when no feature flags are enabled', async () => {
+    config.featureToggles = {} as typeof config.featureToggles;
+
+    render(<LabsPage />, { preloadedState: { navIndex: { labs: labsNavItem } } });
+
+    expect(await screen.findByText('No feature flags are currently enabled')).toBeInTheDocument();
+  });
+
+  it('filters feature flags by search query', async () => {
+    config.featureToggles = {
+      dashboardScene: true,
+      nestedFolders: true,
+      alertingSimplifiedRouting: true,
+    } as typeof config.featureToggles;
+
+    const { user } = render(<LabsPage />, { preloadedState: { navIndex: { labs: labsNavItem } } });
+
+    await user.type(screen.getByPlaceholderText('Search feature flags'), 'nested');
+
+    expect(screen.getByText('nestedFolders')).toBeInTheDocument();
+    expect(screen.queryByText('dashboardScene')).not.toBeInTheDocument();
+    expect(screen.queryByText('alertingSimplifiedRouting')).not.toBeInTheDocument();
+  });
+});

--- a/public/app/features/labs/LabsPage.tsx
+++ b/public/app/features/labs/LabsPage.tsx
@@ -1,0 +1,71 @@
+import { useState } from 'react';
+
+import { Trans, t } from '@grafana/i18n';
+import { config } from '@grafana/runtime';
+import { type Column, EmptyState, FilterInput, InteractiveTable, Stack } from '@grafana/ui';
+import { Page } from 'app/core/components/Page/Page';
+
+interface FeatureFlagRow {
+  name: string;
+}
+
+const compareFeatureFlags = new Intl.Collator('en', { sensitivity: 'base', numeric: true }).compare;
+
+function getEnabledFeatureFlags(): FeatureFlagRow[] {
+  return Object.entries(config.featureToggles)
+    .filter(([, enabled]) => Boolean(enabled))
+    .map(([name]) => ({ name }))
+    .sort((a, b) => compareFeatureFlags(a.name, b.name));
+}
+
+export function LabsPage() {
+  const [query, setQuery] = useState('');
+  const enabledFlags = getEnabledFeatureFlags();
+  const filteredFlags = query
+    ? enabledFlags.filter((flag) => flag.name.toLowerCase().includes(query.toLowerCase()))
+    : enabledFlags;
+
+  const columns: Array<Column<FeatureFlagRow>> = [
+    {
+      id: 'name',
+      header: t('labs.feature-flags.columns.name', 'Feature flag'),
+    },
+  ];
+
+  return (
+    <Page navId="labs">
+      <Page.Contents>
+        <Stack direction="column" gap={2}>
+          {enabledFlags.length > 0 && (
+            <FilterInput
+              placeholder={t('labs.feature-flags.filter-placeholder', 'Search feature flags')}
+              value={query}
+              onChange={setQuery}
+              escapeRegex={false}
+            />
+          )}
+
+          {enabledFlags.length === 0 ? (
+            <EmptyState
+              variant="not-found"
+              message={t('labs.feature-flags.empty.message', 'No feature flags are currently enabled')}
+            >
+              <Trans i18nKey="labs.feature-flags.empty.description">
+                Feature flags enabled for this Grafana instance will appear here.
+              </Trans>
+            </EmptyState>
+          ) : filteredFlags.length === 0 ? (
+            <EmptyState
+              variant="not-found"
+              message={t('labs.feature-flags.filter-empty.message', 'No feature flags match your search')}
+            />
+          ) : (
+            <InteractiveTable columns={columns} data={filteredFlags} getRowId={(row) => row.name} />
+          )}
+        </Stack>
+      </Page.Contents>
+    </Page>
+  );
+}
+
+export default LabsPage;

--- a/public/app/routes/routes.tsx
+++ b/public/app/routes/routes.tsx
@@ -580,6 +580,10 @@ export function getAppRoutes(): RouteDescriptor[] {
       ),
     },
     {
+      path: '/labs',
+      component: SafeDynamicImport(() => import(/* webpackChunkName: "LabsPage"*/ 'app/features/labs/LabsPage')),
+    },
+    {
       path: '/theme-playground',
       component: SafeDynamicImport(
         () => import(/* webpackChunkName: "ThemePlayground"*/ 'app/features/theme-playground/ThemePlayground')

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -11001,6 +11001,21 @@
     }
   },
   "label-dropdown-info": "Can't find your label? Enter it manually",
+  "labs": {
+    "feature-flags": {
+      "columns": {
+        "name": "Feature flag"
+      },
+      "empty": {
+        "description": "Feature flags enabled for this Grafana instance will appear here.",
+        "message": "No feature flags are currently enabled"
+      },
+      "filter-empty": {
+        "message": "No feature flags match your search"
+      },
+      "filter-placeholder": "Search feature flags"
+    }
+  },
   "layers": {
     "layer-drag-drop-list": {
       "draggable-aria-label": "Drag and drop to reorder",
@@ -12124,6 +12139,10 @@
     },
     "kubernetes": {
       "title": "Kubernetes"
+    },
+    "labs": {
+      "subtitle": "Explore experimental features and enabled feature flags",
+      "title": "Labs"
     },
     "library-panels": {
       "subtitle": "Reusable panels that can be added to multiple dashboards",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
**What is this feature?**

Adds a top-level **Labs** page in the Grafana sidebar (next to Connections and Administration) with a **New!** badge. The page lists all feature flags currently enabled in the Grafana instance, with search/filter support.

**Why do we need this feature?**

Makes it easy for users and admins to see which experimental/feature-toggle capabilities are active without digging through config or boot data.

**Who is this feature for?**

Operators, admins, and anyone evaluating experimental Grafana features.

**Demo**

Labs nav item with New badge (between Connections and Administration):

![Labs nav item with New badge](https://cursor.com/artifacts/c/art-48aa0eb5-3eed-40d1-8b55-d66f884eb978)

Labs page listing enabled feature flags:

![Labs page feature flags list](https://cursor.com/artifacts/c/art-8bbd2038-a1b2-4bdf-97d2-4c9c66b9c7fe)

<a href="https://cursor.com/agents/bc-71223e57-61c6-447c-ae4f-ccb751599664/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Flabs-page-feature-flags-demo.mp4"><img src="https://cursor.com/artifacts/c/art-95136329-7581-4833-a527-1e006c2ba424" alt="labs-page-feature-flags-demo.mp4" /></a>

**Special notes for your reviewer:**

- Backend adds a `labs` nav section (`IsNew: true`, flask icon) sorted between plugin apps and Administration
- Frontend route: `/labs` → `public/app/features/labs/LabsPage.tsx`
- Enabled flags come from `config.featureToggles` (same set exposed via boot data / frontend settings)
- Unit tests cover listing, empty state, and search filtering

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-71223e57-61c6-447c-ae4f-ccb751599664"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-71223e57-61c6-447c-ae4f-ccb751599664"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

