### PR TITLE
feat: add Labs page showing enabled feature flags

### DIFF
--- a/pkg/services/navtree/models.go
+++ b/pkg/services/navtree/models.go
@@ -31,6 +31,7 @@ const (
 	WeightApplication
 	WeightAsserts
 	WeightDataConnections
+	WeightLabs
 	WeightApps
 	WeightPlugin
 	WeightConfig
@@ -56,6 +57,7 @@ const (
 	NavIDCfgPlugins           = "cfg/plugins"
 	NavIDCfgAccess            = "cfg/access"
 	NavIDBookmarks            = "bookmarks"
+	NavIDLabs                 = "labs"
 )
 
 type NavLink struct {

--- a/pkg/services/navtree/navtreeimpl/navtree.go
+++ b/pkg/services/navtree/navtreeimpl/navtree.go
@@ -162,6 +162,18 @@ func (s *ServiceImpl) GetNavTree(c *contextmodel.ReqContext, prefs *pref.Prefere
 
 	treeRoot.AddSection(s.buildDataConnectionsNavLink(c))
 
+	if c.IsSignedIn {
+		treeRoot.AddSection(&navtree.NavLink{
+			Text:       "Labs",
+			SubTitle:   "Explore experimental features and enabled feature flags",
+			Id:         navtree.NavIDLabs,
+			Icon:       "flask",
+			Url:        s.cfg.AppSubURL + "/labs",
+			SortWeight: navtree.WeightLabs,
+			IsNew:      true,
+		})
+	}
+
 	orgAdminNode, err := s.getAdminNode(c)
 
 	if orgAdminNode != nil && len(orgAdminNode.Children) > 0 {

--- a/public/app/core/utils/navBarItem-translations.ts
+++ b/public/app/core/utils/navBarItem-translations.ts
@@ -185,6 +185,8 @@ export function getNavTitle(navId: string | undefined) {
       return t('nav.search-dashboards.title', 'Search dashboards');
     case 'connections':
       return t('nav.connections.title', 'Connections');
+    case 'labs':
+      return t('nav.labs.title', 'Labs');
     case 'connections-add-new-connection':
       return t('nav.add-new-connections.title', 'Add new connection');
     case 'standalone-plugin-page-/connections/collector':
@@ -312,6 +314,8 @@ export function getNavSubTitle(navId: string | undefined) {
       return t('nav.alerts-and-incidents.subtitle', 'Alerting and incident management apps');
     case 'testing-and-synthetics':
       return t('nav.testing-and-synthetics.subtitle', 'Optimize performance with k6 and Synthetic Monitoring insights');
+    case 'labs':
+      return t('nav.labs.subtitle', 'Explore experimental features and enabled feature flags');
     case 'connections-add-new-connection':
       return t('nav.connections.subtitle', 'Browse and create new connections');
     case 'connections-datasources':

--- a/public/app/features/labs/LabsPage.test.tsx
+++ b/public/app/features/labs/LabsPage.test.tsx
@@ -1,0 +1,76 @@
+import { screen } from '@testing-library/react';
+import { render } from 'test/test-utils';
+
+import config from 'app/core/config';
+
+import LabsPage, { getEnabledFeatureFlags } from './LabsPage';
+
+describe('LabsPage', () => {
+  const originalFeatureToggles = { ...config.featureToggles };
+
+  afterEach(() => {
+    config.featureToggles = { ...originalFeatureToggles };
+  });
+
+  it('lists only enabled feature flags sorted alphabetically', () => {
+    const flags = getEnabledFeatureFlags({
+      zebraFlag: true,
+      alphaFlag: true,
+      disabledFlag: false,
+      unsetFlag: undefined,
+    });
+
+    expect(flags.map((flag) => flag.name)).toEqual(['alphaFlag', 'zebraFlag']);
+  });
+
+  it('renders enabled feature flags on the page', async () => {
+    config.featureToggles = {
+      publicDashboards: true,
+      nestedFolders: true,
+      someDisabledFlag: false,
+    };
+
+    render(<LabsPage />, {
+      preloadedState: {
+        navIndex: {
+          labs: {
+            id: 'labs',
+            text: 'Labs',
+            subTitle: 'Explore experimental features and enabled feature flags',
+            url: '/labs',
+          },
+        },
+      },
+    });
+
+    expect(await screen.findByText('Feature flags')).toBeInTheDocument();
+    expect(screen.getByText('nestedFolders')).toBeInTheDocument();
+    expect(screen.getByText('publicDashboards')).toBeInTheDocument();
+    expect(screen.queryByText('someDisabledFlag')).not.toBeInTheDocument();
+  });
+
+  it('filters feature flags by search query', async () => {
+    config.featureToggles = {
+      publicDashboards: true,
+      nestedFolders: true,
+    };
+
+    const { user } = render(<LabsPage />, {
+      preloadedState: {
+        navIndex: {
+          labs: {
+            id: 'labs',
+            text: 'Labs',
+            subTitle: 'Explore experimental features and enabled feature flags',
+            url: '/labs',
+          },
+        },
+      },
+    });
+
+    await user.type(await screen.findByPlaceholderText(/search feature flags/i), 'nested');
+
+    expect(screen.getByText('nestedFolders')).toBeInTheDocument();
+    expect(screen.queryByText('publicDashboards')).not.toBeInTheDocument();
+  });
+});

--- a/public/app/features/labs/LabsPage.test.tsx
+++ b/public/app/features/labs/LabsPage.test.tsx
@@ -1,6 +1,7 @@
 import { screen } from '@testing-library/react';
 import { render } from 'test/test-utils';
 
+import { type FeatureToggles } from '@grafana/data';
 import config from 'app/core/config';
 
 import LabsPage, { getEnabledFeatureFlags } from './LabsPage';
@@ -14,21 +15,20 @@ describe('LabsPage', () => {
 
   it('lists only enabled feature flags sorted alphabetically', () => {
     const flags = getEnabledFeatureFlags({
-      zebraFlag: true,
-      alphaFlag: true,
-      disabledFlag: false,
-      unsetFlag: undefined,
+      dashboardNewLayouts: true,
+      alertingListViewV2: true,
+      featureHighlights: false,
     });
 
-    expect(flags.map((flag) => flag.name)).toEqual(['alphaFlag', 'zebraFlag']);
+    expect(flags.map((flag) => flag.name)).toEqual(['alertingListViewV2', 'dashboardNewLayouts']);
   });
 
   it('renders enabled feature flags on the page', async () => {
     config.featureToggles = {
-      publicDashboards: true,
-      nestedFolders: true,
-      someDisabledFlag: false,
-    };
+      dashboardNewLayouts: true,
+      alertingListViewV2: true,
+      featureHighlights: false,
+    } satisfies FeatureToggles;
 
     render(<LabsPage />, {
       preloadedState: {
@@ -44,16 +44,16 @@ describe('LabsPage', () => {
     });
 
     expect(await screen.findByText('Feature flags')).toBeInTheDocument();
-    expect(screen.getByText('nestedFolders')).toBeInTheDocument();
-    expect(screen.getByText('publicDashboards')).toBeInTheDocument();
-    expect(screen.queryByText('someDisabledFlag')).not.toBeInTheDocument();
+    expect(screen.getByText('alertingListViewV2')).toBeInTheDocument();
+    expect(screen.getByText('dashboardNewLayouts')).toBeInTheDocument();
+    expect(screen.queryByText('featureHighlights')).not.toBeInTheDocument();
   });
 
   it('filters feature flags by search query', async () => {
     config.featureToggles = {
-      publicDashboards: true,
-      nestedFolders: true,
-    };
+      dashboardNewLayouts: true,
+      alertingListViewV2: true,
+    } satisfies FeatureToggles;
 
     const { user } = render(<LabsPage />, {
       preloadedState: {
@@ -68,9 +68,9 @@ describe('LabsPage', () => {
       },
     });
 
-    await user.type(await screen.findByPlaceholderText(/search feature flags/i), 'nested');
+    await user.type(await screen.findByPlaceholderText(/search feature flags/i), 'dashboard');
 
-    expect(screen.getByText('nestedFolders')).toBeInTheDocument();
-    expect(screen.queryByText('publicDashboards')).not.toBeInTheDocument();
+    expect(screen.getByText('dashboardNewLayouts')).toBeInTheDocument();
+    expect(screen.queryByText('alertingListViewV2')).not.toBeInTheDocument();
   });
 });

--- a/public/app/features/labs/LabsPage.tsx
+++ b/public/app/features/labs/LabsPage.tsx
@@ -56,8 +56,8 @@ export default function LabsPage() {
         <Stack direction="column" gap={2}>
           <Alert severity="info" title={t('labs.feature-flags.info-title', 'Feature flags')}>
             <Trans i18nKey="labs.feature-flags.info-description">
-              These are the feature flags currently enabled in this Grafana instance. Flags are configured in grafana.ini
-              or via environment variables.
+              These are the feature flags currently enabled in this Grafana instance. Flags are configured in
+              grafana.ini or via environment variables.
             </Trans>
           </Alert>
 

--- a/public/app/features/labs/LabsPage.tsx
+++ b/public/app/features/labs/LabsPage.tsx
@@ -1,5 +1,6 @@
 import { useMemo, useState } from 'react';
 
+import { type FeatureToggles } from '@grafana/data';
 import { t, Trans } from '@grafana/i18n';
 import { config } from '@grafana/runtime';
 import { Alert, type Column, FilterInput, InteractiveTable, Stack, Text } from '@grafana/ui';
@@ -10,13 +11,13 @@ interface FeatureFlagRow {
   enabled: boolean;
 }
 
-export function getEnabledFeatureFlags(
-  featureToggles: Record<string, boolean | undefined> = config.featureToggles
-): FeatureFlagRow[] {
+const featureFlagNameCollator = new Intl.Collator('en', { sensitivity: 'base', numeric: true });
+
+export function getEnabledFeatureFlags(featureToggles: FeatureToggles = config.featureToggles): FeatureFlagRow[] {
   return Object.entries(featureToggles)
     .filter(([, enabled]) => Boolean(enabled))
     .map(([name]) => ({ name, enabled: true }))
-    .sort((a, b) => a.name.localeCompare(b.name));
+    .sort((a, b) => featureFlagNameCollator.compare(a.name, b.name));
 }
 
 export default function LabsPage() {

--- a/public/app/features/labs/LabsPage.tsx
+++ b/public/app/features/labs/LabsPage.tsx
@@ -1,0 +1,83 @@
+import { useMemo, useState } from 'react';
+
+import { t, Trans } from '@grafana/i18n';
+import { config } from '@grafana/runtime';
+import { Alert, type Column, FilterInput, InteractiveTable, Stack, Text } from '@grafana/ui';
+import { Page } from 'app/core/components/Page/Page';
+
+interface FeatureFlagRow {
+  name: string;
+  enabled: boolean;
+}
+
+export function getEnabledFeatureFlags(
+  featureToggles: Record<string, boolean | undefined> = config.featureToggles
+): FeatureFlagRow[] {
+  return Object.entries(featureToggles)
+    .filter(([, enabled]) => Boolean(enabled))
+    .map(([name]) => ({ name, enabled: true }))
+    .sort((a, b) => a.name.localeCompare(b.name));
+}
+
+export default function LabsPage() {
+  const [query, setQuery] = useState('');
+  const enabledFlags = useMemo(() => getEnabledFeatureFlags(), []);
+
+  const filteredFlags = useMemo(() => {
+    const normalizedQuery = query.trim().toLowerCase();
+    if (!normalizedQuery) {
+      return enabledFlags;
+    }
+
+    return enabledFlags.filter((flag) => flag.name.toLowerCase().includes(normalizedQuery));
+  }, [enabledFlags, query]);
+
+  const columns = useMemo<Array<Column<FeatureFlagRow>>>(
+    () => [
+      {
+        id: 'name',
+        header: t('labs.feature-flags.column-name', 'Feature flag'),
+        cell: ({ row: { original } }) => <Text variant="body">{original.name}</Text>,
+      },
+      {
+        id: 'enabled',
+        header: t('labs.feature-flags.column-status', 'Status'),
+        disableGrow: true,
+        cell: () => t('labs.feature-flags.status-enabled', 'Enabled'),
+      },
+    ],
+    []
+  );
+
+  return (
+    <Page navId="labs">
+      <Page.Contents>
+        <Stack direction="column" gap={2}>
+          <Alert severity="info" title={t('labs.feature-flags.info-title', 'Feature flags')}>
+            <Trans i18nKey="labs.feature-flags.info-description">
+              These are the feature flags currently enabled in this Grafana instance. Flags are configured in grafana.ini
+              or via environment variables.
+            </Trans>
+          </Alert>
+
+          <FilterInput
+            placeholder={t('labs.feature-flags.search-placeholder', 'Search feature flags')}
+            value={query}
+            onChange={setQuery}
+            escapeRegex={false}
+          />
+
+          {filteredFlags.length === 0 ? (
+            <Text color="secondary">
+              {enabledFlags.length === 0
+                ? t('labs.feature-flags.empty', 'No feature flags are currently enabled.')
+                : t('labs.feature-flags.no-matches', 'No feature flags match your search.')}
+            </Text>
+          ) : (
+            <InteractiveTable columns={columns} data={filteredFlags} getRowId={(row) => row.name} />
+          )}
+        </Stack>
+      </Page.Contents>
+    </Page>
+  );
+}

--- a/public/app/routes/routes.tsx
+++ b/public/app/routes/routes.tsx
@@ -580,6 +580,10 @@ export function getAppRoutes(): RouteDescriptor[] {
       ),
     },
     {
+      path: '/labs',
+      component: SafeDynamicImport(() => import(/* webpackChunkName: "LabsPage"*/ 'app/features/labs/LabsPage')),
+    },
+    {
       path: '/theme-playground',
       component: SafeDynamicImport(
         () => import(/* webpackChunkName: "ThemePlayground"*/ 'app/features/theme-playground/ThemePlayground')


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a top-level **Labs** page in the Grafana sidebar (next to Connections and Administration) with a **New!** badge. The page lists all feature flags currently enabled in the Grafana instance.

### Changes
- **Backend nav**: Registers a Labs nav item (`/labs`) with `IsNew: true` and sort weight between Connections and Apps
- **Frontend route + page**: Lazy-loaded Labs page that reads `config.featureToggles` and displays enabled flags in a searchable table
- **i18n**: Nav title/subtitle translations for `labs`
- **Tests**: Unit tests covering enabled-flag filtering/sorting, rendering, and search

### Demo

Sidebar with Labs + New! badge:

![Labs sidebar New badge](https://cursor.com/artifacts/c/art-e6c5bf1a-4348-4df8-9a57-7581b537981c)

Labs page listing enabled feature flags:

![Labs page feature flags](https://cursor.com/artifacts/c/art-40329462-62d9-4a96-a8ee-2eac3067a8cd)

Search filtering:

![Labs page search filter](https://cursor.com/artifacts/c/art-805b774f-0bd9-456a-a6fa-860d553a3f42)

<a href="https://cursor.com/agents/bc-ca07c614-e5ab-466d-b0ba-ba0b9d6c0d9a/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Flabs-page-demo.mp4"><img src="https://cursor.com/artifacts/c/art-9e6c7a3c-ecec-4876-990c-94a4c3cdcf04" alt="labs-page-demo.mp4" /></a>

## Test plan

- [x] Log in to Grafana and confirm **Labs** appears in the mega menu near Connections/Administration with a **New!** badge
- [x] Open Labs and verify enabled feature flags are listed
- [x] Search for a flag name and confirm the table filters correctly
- [x] Run `yarn jest --no-watch public/app/features/labs/LabsPage.test.tsx`
- [x] Run `go test ./pkg/services/navtree/...`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ca07c614-e5ab-466d-b0ba-ba0b9d6c0d9a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ca07c614-e5ab-466d-b0ba-ba0b9d6c0d9a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

