### PR TITLE
Themes: Add Cursor experimental theme

### DIFF
--- a/.cursor/skills/grafana-feature-map/SKILL.md
+++ b/.cursor/skills/grafana-feature-map/SKILL.md
@@ -1,0 +1,62 @@
+---
+name: grafana-feature-map
+description: Navigate Grafana's major product areas and trace user-visible changes to routes, frontend code, backend services, permissions, tests, and proof paths. Use when scoping, implementing, reviewing, or verifying work in Explore, Dashboards, Alerting, Connections, Administration, or Plugins, or when asked for Grafana's feature map or control glass.
+---
+
+# Grafana feature map
+
+Use this skill as the control glass for Grafana's major product areas. It points to structural sources of truth. It does not replace reading the current code.
+
+## Start here
+
+1. Read [`features/README.md`](features/README.md).
+2. Open every area touched by the request.
+3. Resolve routes, navigation, permissions, feature flags, selectors, and tests from the cited source anchors. Treat literals in the map as orientation, not authority.
+4. Trace the user action through the frontend boundary and into the backend when the change crosses it.
+5. State the affected areas, cross-area handoffs, and proof path before editing.
+6. Follow any directory-scoped `AGENTS.md` files under the paths you touch.
+
+## Choose the area
+
+- [Explore](features/explore.md) covers ad hoc datasource queries, split panes, query history, live tail, correlations, and Explore-to-dashboard handoff.
+- [Dashboards](features/dashboards.md) covers browse, view, edit, panels, variables, sharing, storage, and public dashboards.
+- [Alerting](features/alerting.md) covers rules, alert instances, notification routing, silences, history, and Alertmanager settings.
+- [Connections](features/connections.md) covers connection discovery and datasource creation, configuration, health, and dashboards.
+- [Administration](features/administration.md) covers server and organization settings, users, access, authentication, provisioning, and stats.
+- [Plugins](features/plugins.md) covers the plugin catalog, installation, settings, runtime loading, app routes, and extension points.
+
+Read more than one file when a flow crosses an area boundary. Common handoffs include Explore to Dashboards, Connections to Plugins, Connections to Alerting, and Administration to Plugins.
+
+## Scope a change
+
+For each affected area, report:
+
+- The user capability and entry point.
+- The route and navigation source.
+- The frontend owner and state or API boundary.
+- The backend service when persistence, permissions, or query execution changes.
+- The permission, configuration, edition, or feature-toggle gate.
+- The nearest automated test and the user-visible proof path.
+- Cross-area effects and compatibility constraints.
+
+Do not turn the map into an exhaustive file list. Follow imports and registrations from the anchors for the requested behavior.
+
+## Verify behavior
+
+Use the repository's existing test and selector anchors first. Resolve selector values from `@grafana/e2e-selectors`; do not copy generated CSS classes or DOM positions into new tests.
+
+For a UI change, prove the real user path and its resulting state. For a mutation, add a read-only cross-check of the saved value. For permission and feature-gated behavior, exercise both the allowed path and the unavailable or denied state.
+
+Use the local development skills for launch instructions. This skill owns feature location and proof scope, not process startup.
+
+## Keep the map alive
+
+Update an area file when a structural source moves, an area gains or loses a major capability, or its boundary changes. Do not update it for a component rename that leaves the starting anchors and runtime flow intact.
+
+Run:
+
+```bash
+python3 .cursor/skills/grafana-feature-map/scripts/validate_feature_map.py
+```
+
+The validator checks the six-area index, required sections, links, and source-anchor paths. A passing validator proves the map is structurally coherent. It does not prove that its architectural claims are current, so inspect the cited code in every maintenance pass.

--- a/.cursor/skills/grafana-feature-map/features/README.md
+++ b/.cursor/skills/grafana-feature-map/features/README.md
@@ -1,0 +1,53 @@
+# Grafana feature map
+
+This index maps Grafana's major user areas to stable code entry points. Read the relevant area before changing or verifying behavior.
+
+## Map contract
+
+Each area records:
+
+1. User capabilities and entry points.
+2. Structural source anchors that an agent can follow from the current checkout.
+3. Frontend, state, API, backend, permission, and storage boundaries.
+4. Existing tests and selectors that can prove behavior.
+5. Cross-area handoffs and traps.
+
+The source anchors are maintained. Detailed component trees, route inventories, display labels, toggle defaults, and selector strings are runtime discoveries because they change too often to freeze here.
+
+## Areas
+
+- [Explore](explore.md)
+- [Dashboards](dashboards.md)
+- [Alerting](alerting.md)
+- [Connections](connections.md)
+- [Administration](administration.md)
+- [Plugins](plugins.md)
+
+## Cross-area handoffs
+
+- Explore sends queries and visualizations into Dashboards through the Add to dashboard extension and its critical user journey.
+- Dashboards and Explore share the datasource query pipeline.
+- Connections owns datasource setup, while datasource plugins and the plugin catalog belong to Plugins.
+- Alerting consumes datasources for external rules and links alert rules back to dashboard panels.
+- Administration supplies server-wide access and settings for Connections, Alerting, and Plugins.
+- App plugins can add navigation under Connections and Administration or register standalone pages.
+
+## Reading rules
+
+- Start with route and navigation registrations, then follow imports into the feature.
+- Treat a top-level directory as an orientation point, not proof of ownership.
+- Read directory-scoped `AGENTS.md` files before editing.
+- Resolve permissions from route guards and backend registration, not from whether a control happens to render.
+- Resolve feature toggles from the registry and current code. Do not assume defaults.
+- Resolve test selectors from `packages/grafana-e2e-selectors`.
+- When frontend and backend deploy independently, preserve compatibility across the boundary.
+
+## Maintenance
+
+Run the validator after every map edit:
+
+```bash
+python3 .cursor/skills/grafana-feature-map/scripts/validate_feature_map.py
+```
+
+For each changed area, open every source anchor and check one representative flow from route to visible result. Remove dead anchors instead of adding aliases for old paths.

--- a/.cursor/skills/grafana-feature-map/features/administration.md
+++ b/.cursor/skills/grafana-feature-map/features/administration.md
@@ -1,0 +1,67 @@
+# Administration
+
+Administration groups server and organization settings, users and access, authentication, provisioning, statistics, and other instance-wide controls.
+
+## User capabilities
+
+- View and change server settings and organization defaults.
+- Create and manage users, organizations, teams, and service accounts.
+- Configure authentication providers and inspect LDAP state.
+- Manage provisioning repositories and reload provisioned resources.
+- Inspect server statistics, upgrade information, and migration tools.
+- Reach plugin, extension, and data administration through nested sections.
+
+## Entry points
+
+- Administration navigation and `/admin`.
+- General, Plugins and data, and Users and access landing pages.
+- Settings, users, organizations, authentication, stats, provisioning, and migration routes.
+- Organization routes for teams, service accounts, and preferences.
+- Plugin-injected administration pages.
+
+## Source anchors
+
+- `public/app/routes/routes.tsx`
+- `public/app/core/components/NavLandingPage/NavLandingPage.tsx`
+- `public/app/features/admin`
+- `public/app/features/auth-config`
+- `public/app/features/org`
+- `public/app/features/teams`
+- `public/app/features/serviceaccounts`
+- `public/app/features/provisioning/utils/routes.tsx`
+- `public/app/types/accessControl.ts`
+- `packages/grafana-e2e-selectors/src/selectors/pages.ts`
+- `e2e-playwright/smoke-tests-suite/accessibility.spec.ts`
+- `pkg/services/navtree/navtreeimpl/admin.go`
+- `pkg/services/navtree/models.go`
+- `pkg/api/admin.go`
+- `pkg/api/admin_users.go`
+- `pkg/api/admin_provisioning.go`
+- `pkg/services/ldap/api`
+
+## Boundaries and change paths
+
+- Administration is a navigation grouping, not one frontend module. Follow the selected card or route into its owning feature.
+- The server builds the administration navigation tree and removes sections the current user cannot access.
+- SPA route guards and backend HTML or API authorization both matter. Check both for permission changes.
+- `NavLandingPage` renders the current navigation children, including plugin extensions.
+- User, organization, authentication, service-account, and provisioning state live in separate feature reducers and APIs.
+- Plugin and connection administration cross into their own areas. Read those map files when changing nested cards or routes.
+
+## Verification anchors
+
+- Use `e2e-playwright/smoke-tests-suite/accessibility.spec.ts` for route reachability across administration pages.
+- Use admin page selector groups from `packages/grafana-e2e-selectors/src/selectors/pages.ts`.
+- Use colocated tests under `public/app/features/admin` for users, tables, and server stats.
+- For permission work, verify that navigation, direct route access, and API access agree.
+- For user or organization mutations, prove the updated list or detail and cross-check the read API.
+- For server settings pages, distinguish read-only display from settings that are editable elsewhere.
+
+## Gotchas
+
+- Teams, service accounts, authentication, and provisioning do not live under `features/admin`.
+- `/admin/users` combines global and organization user views in tabs.
+- Datasource administration moved to Connections even though old administration links may redirect.
+- A route visible to an organization admin can still require a different backend action.
+- Empty administration sections disappear after permission filtering.
+- Plugin extensions can change landing-page content after core navigation loads.

--- a/.cursor/skills/grafana-feature-map/features/alerting.md
+++ b/.cursor/skills/grafana-feature-map/features/alerting.md
@@ -1,0 +1,66 @@
+# Alerting
+
+Alerting lets users define rules, inspect alert activity, and route notifications through contact points, policies, templates, mute timings, and silences.
+
+## User capabilities
+
+- List, create, edit, view, export, migrate, restore, and delete alert rules.
+- Inspect firing and pending alerts, groups, state history, and notification history.
+- Configure contact points, notification policies, templates, and time intervals.
+- Create and manage silences.
+- Select Grafana-managed or datasource-managed rules and Alertmanagers.
+- Configure Alertmanager behavior and alerting administration.
+
+## Entry points
+
+- Alerting navigation and `/alerting`.
+- Rule routes under `/alerting/list`, `/alerting/new`, and rule view or edit paths.
+- Notification configuration under `/alerting/notifications` and `/alerting/routes`.
+- Alert activity, groups, history, silences, and recently deleted routes.
+- Folder and dashboard panel links that open alerting in resource context.
+
+## Source anchors
+
+- `public/app/features/alerting/routes.tsx`
+- `public/app/features/alerting/unified/AGENTS.md`
+- `public/app/features/alerting/unified/TESTING.md`
+- `public/app/features/alerting/unified/RuleList.tsx`
+- `public/app/features/alerting/unified/rule-editor`
+- `public/app/features/alerting/unified/api/alertingApi.ts`
+- `public/app/features/alerting/unified/navigation`
+- `public/app/features/alerting/unified/featureToggles.ts`
+- `public/app/features/alerting/unified/utils/navigation.ts`
+- `packages/grafana-alerting`
+- `packages/grafana-e2e-selectors/src/selectors/pages.ts`
+- `e2e-playwright/alerting-suite`
+- `pkg/services/ngalert`
+- `pkg/services/navtree/navtreeimpl/navtree.go`
+
+## Boundaries and change paths
+
+- `routes.tsx` is the frontend route table and applies the global unified-alerting availability gate.
+- Most current frontend work lives under `unified`. Read its `AGENTS.md` before editing.
+- New server data access should start with generated `@grafana/api-clients` clients and RTK Query. Legacy Redux remains for existing flows.
+- Grafana-managed and datasource-managed rules use different API and ownership paths. Resolve the rule source before changing behavior.
+- Notification configuration crosses Alertmanager APIs and can target Grafana or external Alertmanagers.
+- The Go service and HTTP registrations live under `pkg/services/ngalert`. Generated base API files are outputs, not editing targets.
+- Navigation has server and client layers, and the active structure can change behind alerting navigation toggles.
+
+## Verification anchors
+
+- Follow `public/app/features/alerting/unified/TESTING.md` for MSW, permissions, datasource setup, and factories.
+- Use the alerting selector groups from `packages/grafana-e2e-selectors/src/selectors/pages.ts` and `selectors/components.ts`.
+- Use page objects and specs under `e2e-playwright/alerting-suite`.
+- Test route access with the exact read or write permission required by the route and control.
+- For rule mutations, prove save and reload against the correct rule source.
+- For notification changes, prove the visible configuration and a read-only API result from the selected Alertmanager.
+
+## Gotchas
+
+- Alerting can be globally disabled even when the SPA route exists.
+- Navigation v1 and v2 use different nav IDs and groupings.
+- Rule list v1 and v2 can also vary by user preview preference.
+- Grafana-managed and external rules are not interchangeable test fixtures.
+- Static routes must remain ahead of dynamic rule identifier routes.
+- Use `createRelativeUrl` for native anchors, but not with router-aware navigation helpers.
+- Do not hand-edit generated API registration files.

--- a/.cursor/skills/grafana-feature-map/features/connections.md
+++ b/.cursor/skills/grafana-feature-map/features/connections.md
@@ -1,0 +1,64 @@
+# Connections
+
+Connections is Grafana's hub for finding integrations and creating, configuring, testing, and managing datasources.
+
+## User capabilities
+
+- Browse available connections and datasource plugins.
+- Add a datasource and configure authentication, endpoints, and plugin-specific settings.
+- List, edit, test, delete, and manage permissions for existing datasources.
+- Open datasource-provided dashboards and health or advisor results.
+- Reach integration, collector, and private-connection pages supplied by plugins.
+
+## Entry points
+
+- Connections navigation and `/connections`.
+- Add new connection under `/connections/add-new-connection`.
+- Datasource list and create routes under `/connections/datasources`.
+- Datasource edit, detail, and bundled-dashboard routes.
+- Legacy `/datasources` routes that redirect into Connections.
+- Plugin navigation entries registered under Connections.
+
+## Source anchors
+
+- `public/app/features/connections/routes.tsx`
+- `public/app/features/connections/constants.ts`
+- `public/app/features/connections/Connections.tsx`
+- `public/app/features/connections/pages`
+- `public/app/features/connections/tabs/ConnectData`
+- `public/app/features/datasources/api.ts`
+- `public/app/features/datasources/state`
+- `public/app/features/datasources/components/DataSourceTabPage.tsx`
+- `public/app/features/plugins/admin`
+- `packages/grafana-e2e-selectors/src/selectors/pages.ts`
+- `e2e-playwright/smoke-tests-suite/accessibility.spec.ts`
+- `pkg/api/datasources.go`
+- `pkg/services/datasources`
+- `pkg/services/navtree/navtreeimpl/applinks.go`
+
+## Boundaries and change paths
+
+- Connections owns routing, discovery, and page composition. Datasource CRUD and configuration usually live under `public/app/features/datasources`.
+- The add-connection catalog consumes plugin-admin state. Plugin installation and runtime belong to Plugins.
+- Datasource persistence uses datasource APIs and services. There is no separate Connections backend service.
+- Datasource plugins own their query editors and most plugin-specific configuration fields.
+- The server navigation tree and app-plugin links can add or replace pages under Connections.
+- Legacy datasource routes and selector URLs still exist. Check redirects and current canonical routes before changing navigation.
+
+## Verification anchors
+
+- Use datasource selector groups from `packages/grafana-e2e-selectors/src/selectors/pages.ts`, but confirm whether each URL is legacy or canonical.
+- Use Connections and datasource component tests for routing and configuration forms.
+- Use the Connections routes in `e2e-playwright/smoke-tests-suite/accessibility.spec.ts` for basic reachability.
+- For datasource creation, prove catalog selection, configuration save, health check, list presence, and API persistence.
+- For edit changes, use a disposable datasource and restore or delete it after proof.
+- Verify plugin-supplied pages with the plugin enabled and the expected navigation registration present.
+
+## Gotchas
+
+- Connections and datasources are separate frontend areas. Thin Connections pages often delegate to datasource components.
+- Plugin routes register before core nested routes and can override the add-connection page.
+- Connections home cards come from the navigation index, not a fixed frontend list.
+- Existing e2e selector URLs may still use `/datasources`.
+- Datasource route contexts can override default paths.
+- Permissions, caching, insights, and advisor tabs vary by edition, license, and access.

--- a/.cursor/skills/grafana-feature-map/features/dashboards.md
+++ b/.cursor/skills/grafana-feature-map/features/dashboards.md
@@ -1,0 +1,64 @@
+# Dashboards
+
+Dashboards let users organize, query, visualize, edit, share, and revisit operational views.
+
+## User capabilities
+
+- Browse folders and dashboards, search, star, move, and delete resources.
+- Create and edit dashboards, panels, queries, variables, links, annotations, and layout.
+- View dashboards with time controls, refresh, interactions, and live updates.
+- Import, export, share, snapshot, embed, or publish dashboards.
+- Manage library panels, playlists, recently deleted dashboards, and folder-scoped content.
+
+## Entry points
+
+- Dashboards navigation and `/dashboards` for browse.
+- `/d/:uid/:slug?` for normal dashboard view and edit.
+- `/dashboard/new` and import actions for creation.
+- Folder routes under `/dashboards/f/:uid`.
+- Public, snapshot, embedded, and solo routes for specialized viewing.
+
+## Source anchors
+
+- `public/app/routes/routes.tsx`
+- `public/app/features/dashboard/routes.ts`
+- `public/app/features/browse-dashboards/BrowseDashboardsPage.tsx`
+- `public/app/features/browse-dashboards/api/browseDashboardsAPI.ts`
+- `public/app/features/dashboard/containers/DashboardPageProxy.tsx`
+- `public/app/features/dashboard-scene/pages/DashboardScenePage.tsx`
+- `public/app/features/dashboard-scene/pages/DashboardScenePageStateManager.ts`
+- `public/app/features/dashboard-scene/scene/DashboardScene.tsx`
+- `public/app/features/dashboard/api/dashboard_api.ts`
+- `public/app/features/dashboard-scene/serialization`
+- `public/app/core/journeys/dashboardEdit.ts`
+- `e2e-playwright/dashboards-suite`
+- `packages/grafana-e2e-selectors/src/selectors/pages.ts`
+- `pkg/services/dashboards`
+- `pkg/api/dashboard.go`
+
+## Boundaries and change paths
+
+- Browse and folder management live under `browse-dashboards`. Dashboard view and edit run through `dashboard-scene`.
+- `DashboardPageProxy` routes normal dashboards into the Scenes implementation. Scene objects and `DashboardScenePageStateManager` own active runtime state.
+- Legacy dashboard and panel models still participate in compatibility, import, and serialization. Do not remove them based only on the render path.
+- `getDashboardAPI()` chooses the storage client. Follow its version resolver before changing save, load, or schema behavior.
+- Panel queries use the shared datasource query pipeline. Query changes can affect Explore and datasource plugins.
+- Dashboard API or unified-storage changes cross independently deployed components. Read `pkg/storage/unified/AGENTS.md` and preserve compatibility in both directions.
+
+## Verification anchors
+
+- Use dashboard and browse selector groups from `packages/grafana-e2e-selectors/src/selectors/pages.ts` and panel selectors from `selectors/components.ts`.
+- Start with `e2e-playwright/dashboards-suite/general-dashboards.spec.ts` and `dashboard-browse.spec.ts`.
+- Use tests under `e2e-playwright/dashboard-new-layouts` when the new layout or v2 schema is involved.
+- For edit changes, prove enter edit, mutate, save, reload, and read the persisted value.
+- For browse changes, prove search or navigation from the dashboard list into the expected resource.
+- Cover both schema paths when behavior differs between dashboard v1 and v2.
+
+## Gotchas
+
+- Browse and dashboard view are separate applications with different state and API paths.
+- Scenes owns the render path, but legacy models remain part of saved-model compatibility.
+- Dashboard v1 and v2 can differ in layout, serialization, and API selection.
+- The home route may resolve preferences before loading or redirecting to a dashboard.
+- Public, snapshot, and solo routes have different authentication and chrome assumptions.
+- Some panel menus become actionable only after hover in browser tests.

--- a/.cursor/skills/grafana-feature-map/features/explore.md
+++ b/.cursor/skills/grafana-feature-map/features/explore.md
@@ -25,6 +25,7 @@ Explore lets users run ad hoc queries against datasources and inspect metrics, l
 - `public/app/features/explore/state/main.ts`
 - `public/app/features/explore/state/query.ts`
 - `public/app/features/explore/hooks/useStateSync`
+- `public/app/features/explore/extensions/AddToDashboard`
 - `public/app/features/query/state/runRequest.ts`
 - `public/app/core/journeys/exploreToDashboard.ts`
 - `packages/grafana-e2e-selectors/src/selectors/pages.ts`
@@ -38,6 +39,7 @@ Explore lets users run ad hoc queries against datasources and inspect metrics, l
 - Query execution leaves Explore through the shared query runner and reaches the generic datasource query API. Explore has no dedicated query backend.
 - Datasource plugins own query editors and result behavior after the plugin boundary.
 - The Add to dashboard extension crosses into Dashboards. Treat that flow as a two-area change.
+- The current handoff opens dashboard editing. Persisting the dashboard is a separate dashboard action, so requirements must distinguish handoff from save.
 - Access depends on Explore configuration, datasource exploration permission, and datasource-level query permission.
 
 ## Verification anchors

--- a/.cursor/skills/grafana-feature-map/features/explore.md
+++ b/.cursor/skills/grafana-feature-map/features/explore.md
@@ -1,0 +1,58 @@
+# Explore
+
+Explore lets users run ad hoc queries against datasources and inspect metrics, logs, traces, profiles, and tables without first creating a dashboard.
+
+## User capabilities
+
+- Select a datasource, author queries, run them, and inspect results.
+- Change time range, use live tail where supported, and inspect query details.
+- Open a second pane and compare queries or time ranges.
+- Revisit query history and follow correlations or data links.
+- Move a useful query into a dashboard.
+
+## Entry points
+
+- Main navigation and `/explore`.
+- Datasource and panel actions that open a query in Explore.
+- Explore-to-dashboard actions that hand a query to Dashboards.
+- URL state that restores panes, datasources, queries, and time ranges.
+
+## Source anchors
+
+- `public/app/routes/routes.tsx`
+- `public/app/features/explore/ExplorePage.tsx`
+- `public/app/features/explore/Explore.tsx`
+- `public/app/features/explore/state/main.ts`
+- `public/app/features/explore/state/query.ts`
+- `public/app/features/explore/hooks/useStateSync`
+- `public/app/features/query/state/runRequest.ts`
+- `public/app/core/journeys/exploreToDashboard.ts`
+- `packages/grafana-e2e-selectors/src/selectors/pages.ts`
+- `e2e-playwright/various-suite/explore.spec.ts`
+- `pkg/api/api.go`
+
+## Boundaries and change paths
+
+- `ExplorePage` owns the page shell and pane layout. Per-pane behavior continues through `Explore`, connected pane containers, and the reducers under `state/`.
+- URL synchronization under `hooks/useStateSync` is part of the public behavior. Update its schema migrators and tests when serialized Explore state changes.
+- Query execution leaves Explore through the shared query runner and reaches the generic datasource query API. Explore has no dedicated query backend.
+- Datasource plugins own query editors and result behavior after the plugin boundary.
+- The Add to dashboard extension crosses into Dashboards. Treat that flow as a two-area change.
+- Access depends on Explore configuration, datasource exploration permission, and datasource-level query permission.
+
+## Verification anchors
+
+- Use the `Pages.Explore` selector group from `packages/grafana-e2e-selectors/src/selectors/pages.ts`.
+- Use `public/app/features/explore/spec/helper/setup.tsx` for feature-level integration tests.
+- Keep URL synchronization covered by tests under `hooks/useStateSync`.
+- For query changes, prove datasource selection, query execution, visible results, loading, and error behavior.
+- For pane or URL changes, reload the copied URL and verify the same state returns.
+- For Add to dashboard, run the `exploreToDashboard` critical user journey and verify the query appears in the dashboard editor.
+
+## Gotchas
+
+- URL state and Redux state are synchronized. Changing only one side creates reload and history bugs.
+- Explore supports at most two panes. Closing and reopening panes can expose stale connected children.
+- `Explore.tsx` still mixes a connected class component with newer hooks-based children.
+- Metrics sidebar behavior can use OpenFeature in addition to Grafana feature toggles.
+- Generic datasource query permissions still apply after the Explore route guard passes.

--- a/.cursor/skills/grafana-feature-map/features/plugins.md
+++ b/.cursor/skills/grafana-feature-map/features/plugins.md
@@ -1,0 +1,67 @@
+# Plugins
+
+Plugins covers catalog administration and the runtime that loads datasource, panel, app, and renderer extensions into Grafana.
+
+## User capabilities
+
+- Browse installed and available plugins and inspect plugin details.
+- Install, update, uninstall, enable, disable, and configure plugins when allowed.
+- Open app-plugin pages and custom navigation.
+- Use datasource and panel plugins inside Connections, Explore, and Dashboards.
+- Register and consume plugin links, components, and extension points.
+- Inspect signatures, compatibility, loading failures, and extension logs.
+
+## Entry points
+
+- Plugin catalog under `/plugins` and `/plugins/browse`.
+- Plugin detail pages under `/plugins/:pluginId`.
+- App-plugin runtime routes under `/a/:pluginId`.
+- Connections for datasource discovery and setup.
+- Dashboard panel and Explore datasource pickers for runtime plugin use.
+- Administration's Plugins and data section and extension log.
+
+## Source anchors
+
+- `public/app/features/plugins/admin/routes.tsx`
+- `public/app/features/plugins/admin`
+- `public/app/features/plugins/routes.tsx`
+- `public/app/features/plugins/components/AppRootPage.tsx`
+- `public/app/features/plugins/importer`
+- `public/app/features/plugins/loader`
+- `public/app/features/plugins/extensions`
+- `public/app/plugins`
+- `packages/grafana-e2e-selectors/src/selectors/pages.ts`
+- `e2e-playwright/plugin-catalog-suite`
+- `pkg/api/plugins.go`
+- `pkg/services/pluginsintegration`
+- `pkg/services/pluginsintegration/pluginaccesscontrol/accesscontrol.go`
+- `pkg/services/navtree/navtreeimpl/applinks.go`
+- `pkg/setting/setting_plugins.go`
+
+## Boundaries and change paths
+
+- Catalog and install behavior live under `features/plugins/admin`. Runtime loading, app routes, sandboxing, and extensions live beside it.
+- Built-in plugin implementations live under `public/app/plugins` and may be separate Yarn workspaces.
+- App-plugin routes are derived from the navigation index before the fallback `/a/:pluginId` route.
+- Datasource plugin discovery appears in Connections. Query and visualization runtime appears in Explore and Dashboards.
+- Plugin installation can cross legacy REST and Kubernetes-backed plugin metadata paths. Trace both paths before changing install behavior.
+- Backend plugin discovery, settings, loading, and access control live under `pkg/services/pluginsintegration`.
+
+## Verification anchors
+
+- Use `PluginsList`, `PluginPage`, and plugin URL selector groups from `packages/grafana-e2e-selectors/src/selectors/pages.ts`.
+- Use `e2e-playwright/plugin-catalog-suite` for install and uninstall round trips.
+- Use colocated tests under `public/app/features/plugins/admin` for catalog, detail, and API behavior.
+- For install changes, prove install, visible installed state, runtime availability, uninstall, and clean final state.
+- For app routes, verify direct navigation and a navigation-index entry.
+- For extensions, verify the host extension point and the plugin contribution together.
+
+## Gotchas
+
+- The plugin catalog is only the `admin` subtree. It is not the whole plugin runtime.
+- Catalog lookup can fall back to local plugins when the remote catalog times out.
+- Plugin administration can be disabled or externally managed.
+- Provisioned and built-in plugins do not support every install control.
+- App routes can override core routes and may require a reload after navigation registration changes.
+- The Redux `plugins` state is unrelated to the built-in plugin source directory name.
+- Plugin list links can perform full-page navigation instead of client-side routing.

--- a/.cursor/skills/grafana-feature-map/scripts/validate_feature_map.py
+++ b/.cursor/skills/grafana-feature-map/scripts/validate_feature_map.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+
+import re
+import sys
+from pathlib import Path
+
+
+AREAS = {
+    "explore.md": "Explore",
+    "dashboards.md": "Dashboards",
+    "alerting.md": "Alerting",
+    "connections.md": "Connections",
+    "administration.md": "Administration",
+    "plugins.md": "Plugins",
+}
+
+REQUIRED_SECTIONS = [
+    "User capabilities",
+    "Entry points",
+    "Source anchors",
+    "Boundaries and change paths",
+    "Verification anchors",
+    "Gotchas",
+]
+
+
+def repository_root(start: Path) -> Path:
+    for candidate in [start, *start.parents]:
+        if (candidate / ".git").exists():
+            return candidate
+    raise RuntimeError("could not locate repository root")
+
+
+def section(text: str, heading: str) -> str:
+    match = re.search(rf"^## {re.escape(heading)}\n(.*?)(?=^## |\Z)", text, re.MULTILINE | re.DOTALL)
+    return match.group(1) if match else ""
+
+
+def validate() -> list[str]:
+    script = Path(__file__).resolve()
+    skill_root = script.parents[1]
+    feature_root = skill_root / "features"
+    repo_root = repository_root(skill_root)
+    errors: list[str] = []
+
+    skill_text = (skill_root / "SKILL.md").read_text()
+    frontmatter = re.match(r"^---\n(.*?)\n---\n", skill_text, re.DOTALL)
+    if not frontmatter:
+        errors.append("SKILL.md: missing YAML frontmatter")
+    else:
+        for key in ("name:", "description:"):
+            if not re.search(rf"^{re.escape(key)}\s+\S", frontmatter.group(1), re.MULTILINE):
+                errors.append(f"SKILL.md: missing {key[:-1]}")
+
+    index_text = (feature_root / "README.md").read_text()
+    actual_files = {path.name for path in feature_root.glob("*.md") if path.name != "README.md"}
+    expected_files = set(AREAS)
+    for missing in sorted(expected_files - actual_files):
+        errors.append(f"features: missing {missing}")
+    for extra in sorted(actual_files - expected_files):
+        errors.append(f"features: unindexed file {extra}")
+
+    for filename, title in AREAS.items():
+        path = feature_root / filename
+        if not path.exists():
+            continue
+
+        expected_link = f"[{title}]({filename})"
+        if expected_link not in index_text:
+            errors.append(f"features/README.md: missing {expected_link}")
+
+        text = path.read_text()
+        if not text.startswith(f"# {title}\n"):
+            errors.append(f"features/{filename}: expected title '# {title}'")
+
+        headings = re.findall(r"^## (.+)$", text, re.MULTILINE)
+        if headings != REQUIRED_SECTIONS:
+            errors.append(
+                f"features/{filename}: sections must be {', '.join(REQUIRED_SECTIONS)} in order"
+            )
+
+        anchors = re.findall(r"^- `([^`]+)`", section(text, "Source anchors"), re.MULTILINE)
+        if not anchors:
+            errors.append(f"features/{filename}: no source anchors")
+        for anchor in anchors:
+            if not (repo_root / anchor).exists():
+                errors.append(f"features/{filename}: missing source anchor {anchor}")
+
+    return errors
+
+
+def main() -> int:
+    errors = validate()
+    if errors:
+        for error in errors:
+            print(f"ERROR {error}")
+        return 1
+
+    print(f"grafana-feature-map valid: {len(AREAS)} areas, all source anchors present")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/packages/grafana-data/src/themes/registry.ts
+++ b/packages/grafana-data/src/themes/registry.ts
@@ -2,6 +2,7 @@ import { Registry, type RegistryItem } from '../utils/Registry';
 
 import { createTheme, NewThemeOptionsSchema } from './createTheme';
 import aubergine from './themeDefinitions/aubergine.json';
+import cursor from './themeDefinitions/cursor.json';
 import debug from './themeDefinitions/debug.json';
 import desertbloom from './themeDefinitions/desertbloom.json';
 import deut_prot_dark from './themeDefinitions/deut_prot_dark.json';
@@ -30,6 +31,7 @@ const compareThemeNames = new Intl.Collator().compare;
 
 const extraThemes: { [key: string]: unknown } = {
   aubergine,
+  cursor,
   debug,
   desertbloom,
   deut_prot_dark,

--- a/packages/grafana-data/src/themes/themeDefinitions/cursor.json
+++ b/packages/grafana-data/src/themes/themeDefinitions/cursor.json
@@ -1,0 +1,42 @@
+{
+  "name": "Cursor",
+  "id": "cursor",
+  "colors": {
+    "mode": "dark",
+    "background": {
+      "canvas": "#14120b",
+      "page": "#14120b",
+      "primary": "#1b1913",
+      "secondary": "#201e18",
+      "elevated": "#26241e"
+    },
+    "text": {
+      "primary": "#edecec",
+      "secondary": "rgba(237, 236, 236, 0.6)",
+      "disabled": "rgba(237, 236, 236, 0.4)",
+      "link": "#f54e00",
+      "maxContrast": "#edecec"
+    },
+    "border": {
+      "weak": "rgba(237, 236, 236, 0.12)",
+      "medium": "rgba(237, 236, 236, 0.2)",
+      "strong": "rgba(237, 236, 236, 0.3)"
+    },
+    "primary": {
+      "main": "#f54e00"
+    },
+    "secondary": {
+      "text": "#edecec"
+    },
+    "accent": {
+      "main": "#f54e00"
+    },
+    "gradients": {
+      "brandVertical": "linear-gradient(0deg, #f54e00 0%, #ff7a33 100%)",
+      "brandHorizontal": "linear-gradient(90deg, #f54e00 0%, #ff7a33 100%)"
+    },
+    "action": {
+      "selectedBorder": "#f54e00"
+    }
+  }
+}

--- a/pkg/services/preference/themes_generated.go
+++ b/pkg/services/preference/themes_generated.go
@@ -7,6 +7,7 @@ var themes = []ThemeDTO{
 	{ID: "dark", Type: "dark"},
 	{ID: "system", Type: "dark"},
 	{ID: "aubergine", Type: "dark", IsExtra: true},
+	{ID: "cursor", Type: "dark", IsExtra: true},
 	{ID: "debug", Type: "dark", IsExtra: true},
 	{ID: "desertbloom", Type: "light", IsExtra: true},
 	{ID: "deut_prot_dark", Type: "dark", IsExtra: true},

--- a/public/app/core/components/SharedPreferences/SharedPreferencesFunctional.test.tsx
+++ b/public/app/core/components/SharedPreferences/SharedPreferencesFunctional.test.tsx
@@ -3,7 +3,7 @@ import { getSelectParent, selectOptionInTest } from 'test/helpers/selectOptionIn
 import { act, render, screen, userEvent, waitFor, within } from 'test/test-utils';
 
 import { setBackendSrv } from '@grafana/runtime';
-import { mockComboboxRect } from '@grafana/test-utils';
+import { mockBoundingClientRect } from '@grafana/test-utils';
 import { preferencesHandlers } from '@grafana/test-utils/handlers';
 import server, { setupMockServer } from '@grafana/test-utils/server';
 import { getFolderFixtures, setTestFlags } from '@grafana/test-utils/unstable';
@@ -62,7 +62,8 @@ afterEach(async () => {
 
 beforeAll(() => {
   jest.spyOn(window, 'location', 'get').mockReturnValue({ ...originalLocation, reload: mockReload });
-  mockComboboxRect();
+  // Tall enough for all theme options, including newly exposed experimental themes.
+  mockBoundingClientRect({ width: 400, height: 2000 });
 });
 
 afterAll(() => {
@@ -156,7 +157,7 @@ describe('SharedPreferencesFunctional', () => {
     const capture = captureRequests();
     const { user } = await setup();
 
-    await selectComboboxOptionInTest(await screen.findByRole('combobox', { name: /Interface theme/ }), 'Gilded grove');
+    await selectComboboxOptionInTest(await screen.findByRole('combobox', { name: /Interface theme/ }), 'Cursor');
 
     await user.click(screen.getByText('Save preferences'));
 
@@ -164,7 +165,7 @@ describe('SharedPreferencesFunctional', () => {
     const newPreferences = await getPrefsUpdateRequest(requests);
 
     expect(newPreferences).toMatchObject({
-      spec: { theme: 'gildedgrove' },
+      spec: { theme: 'cursor' },
     });
   });
 

--- a/public/app/core/components/ThemeSelector/getSelectableThemes.test.ts
+++ b/public/app/core/components/ThemeSelector/getSelectableThemes.test.ts
@@ -1,0 +1,12 @@
+import { getSelectableThemes } from './getSelectableThemes';
+
+describe('getSelectableThemes', () => {
+  it('includes Cursor as a selectable extra theme', () => {
+    const themes = getSelectableThemes();
+    const cursor = themes.find((theme) => theme.id === 'cursor');
+
+    expect(cursor).toBeDefined();
+    expect(cursor?.name).toBe('Cursor');
+    expect(cursor?.isExtra).toBe(true);
+  });
+});

--- a/public/app/core/components/ThemeSelector/getSelectableThemes.ts
+++ b/public/app/core/components/ThemeSelector/getSelectableThemes.ts
@@ -11,6 +11,7 @@ export function getSelectableThemes() {
     'sapphiredusk',
     'tron',
     'gloom',
+    'cursor',
   ];
 
   return getBuiltInThemes(allowedExtraThemes);


### PR DESCRIPTION
**What is this feature?**

Adds a dark experimental **Cursor** theme (Cursor brand colors: `#14120b` backgrounds, `#f54e00` accent) that users can select from the theme drawer and Preferences UI. Preference persistence accepts the new `cursor` theme id via regenerated backend theme validation.

**Why do we need this feature?**

Issue #14 requested an additional selectable UI theme. This implements that as a Cursor-branded theme instead of exposing the existing green Matrix theme.

**Who is this feature for?**

Users who want an additional experimental interface theme in Grafana.

**Which issue(s) does this PR fix?**:

Fixes https://github.com/Jstein77/grafana/issues/14

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.

Manual check: Profile → Change theme / Preferences → select **Cursor** under Experimental; accent and dark canvas apply and survive reload.

Made with [Cursor](https://cursor.com)