### PR TITLE
Labs: add nav section and runtime feature toggle API

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -218,6 +218,8 @@ func (hs *HTTPServer) registerRoutes() {
 	r.Get("/explore", authorize(ac.EvalPermission(ac.ActionDatasourcesExplore)), hs.Index)
 	r.Get("/drilldown", authorize(ac.EvalPermission(ac.ActionDatasourcesExplore)), hs.Index)
 
+	r.Get("/labs", authorize(ac.EvalPermission(ac.ActionFeatureManagementRead)), hs.Index)
+
 	r.Get("/playlists/", reqSignedIn, hs.Index)
 	r.Get("/playlists/*", reqSignedIn, hs.Index)
 	r.Get("/alerting/", reqSignedIn, hs.Index)
@@ -569,6 +571,12 @@ func (hs *HTTPServer) registerRoutes() {
 		adminRoute.Post("/provisioning/plugins/reload", authorize(ac.EvalPermission(ActionProvisioningReload, ScopeProvisionersPlugins)), routing.Wrap(hs.AdminProvisioningReloadPlugins))
 		adminRoute.Post("/provisioning/datasources/reload", authorize(ac.EvalPermission(ActionProvisioningReload, ScopeProvisionersDatasources)), routing.Wrap(hs.AdminProvisioningReloadDatasources))
 		adminRoute.Post("/provisioning/alerting/reload", authorize(ac.EvalPermission(ActionProvisioningReload, ScopeProvisionersAlertRules)), routing.Wrap(hs.AdminProvisioningReloadAlerting))
+	}, reqSignedIn)
+
+	// Labs: runtime feature toggle management
+	r.Group("/api/labs", func(labsRoute routing.RouteRegister) {
+		labsRoute.Get("/features", authorize(ac.EvalPermission(ac.ActionFeatureManagementRead)), routing.Wrap(hs.GetLabsFeatures))
+		labsRoute.Patch("/features", authorize(ac.EvalPermission(ac.ActionFeatureManagementWrite)), routing.Wrap(hs.UpdateLabsFeatures))
 	}, reqSignedIn)
 
 	// Administering users

--- a/pkg/api/labs.go
+++ b/pkg/api/labs.go
@@ -1,0 +1,116 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"sort"
+
+	"github.com/grafana/grafana/pkg/api/response"
+	contextmodel "github.com/grafana/grafana/pkg/services/contexthandler/model"
+	"github.com/grafana/grafana/pkg/services/featuremgmt"
+)
+
+// labsFeatureDTO describes a single feature toggle for the Labs page.
+type labsFeatureDTO struct {
+	Name            string `json:"name"`
+	Description     string `json:"description"`
+	Stage           string `json:"stage"`
+	Enabled         bool   `json:"enabled"`
+	RequiresRestart bool   `json:"requiresRestart"`
+	RequiresDevMode bool   `json:"requiresDevMode"`
+}
+
+type labsFeaturesResponse struct {
+	Features []labsFeatureDTO `json:"features"`
+}
+
+type labsUpdateResponse struct {
+	Updated []string `json:"updated"`
+	// RestartRequired lists flags that changed but require a restart to fully
+	// take effect, so the runtime change may not be reflected everywhere.
+	RestartRequired []string `json:"restartRequired,omitempty"`
+}
+
+// featureManager returns the concrete FeatureManager backing hs.Features. The
+// read-only FeatureToggles interface does not expose flag definitions or
+// runtime mutation, both of which the Labs API needs.
+func (hs *HTTPServer) featureManager() (*featuremgmt.FeatureManager, bool) {
+	mgr, ok := hs.Features.(*featuremgmt.FeatureManager)
+	return mgr, ok
+}
+
+// GetLabsFeatures returns all feature toggles with their current state.
+//
+// GET /api/labs/features
+func (hs *HTTPServer) GetLabsFeatures(c *contextmodel.ReqContext) response.Response {
+	mgr, ok := hs.featureManager()
+	if !ok {
+		return response.Error(http.StatusNotImplemented, "Feature toggle management is not available", nil)
+	}
+
+	flags := mgr.GetFlags()
+	enabled := mgr.GetEnabled(c.Req.Context())
+
+	features := make([]labsFeatureDTO, 0, len(flags))
+	for _, flag := range flags {
+		features = append(features, labsFeatureDTO{
+			Name:            flag.Name,
+			Description:     flag.Description,
+			Stage:           flag.Stage.String(),
+			Enabled:         enabled[flag.Name],
+			RequiresRestart: flag.RequiresRestart,
+			RequiresDevMode: flag.RequiresDevMode,
+		})
+	}
+
+	sort.Slice(features, func(i, j int) bool {
+		return features[i].Name < features[j].Name
+	})
+
+	return response.JSON(http.StatusOK, labsFeaturesResponse{Features: features})
+}
+
+// UpdateLabsFeatures flips one or more feature toggles at runtime.
+//
+// PATCH /api/labs/features
+func (hs *HTTPServer) UpdateLabsFeatures(c *contextmodel.ReqContext) response.Response {
+	mgr, ok := hs.featureManager()
+	if !ok {
+		return response.Error(http.StatusNotImplemented, "Feature toggle management is not available", nil)
+	}
+
+	changes := map[string]bool{}
+	if err := json.NewDecoder(c.Req.Body).Decode(&changes); err != nil {
+		return response.Error(http.StatusBadRequest, "Invalid request body", err)
+	}
+
+	if len(changes) == 0 {
+		return response.Error(http.StatusBadRequest, "No feature toggles provided", nil)
+	}
+
+	// Index flag definitions so we can report which changes require a restart.
+	flagsByName := make(map[string]featuremgmt.FeatureFlag)
+	for _, flag := range mgr.GetFlags() {
+		flagsByName[flag.Name] = flag
+	}
+
+	updated := make([]string, 0, len(changes))
+	restartRequired := []string{}
+	for name, enabled := range changes {
+		if err := mgr.SetEnabled(name, enabled); err != nil {
+			return response.Error(http.StatusBadRequest, err.Error(), err)
+		}
+		updated = append(updated, name)
+		if flag, ok := flagsByName[name]; ok && flag.RequiresRestart {
+			restartRequired = append(restartRequired, name)
+		}
+	}
+
+	sort.Strings(updated)
+	sort.Strings(restartRequired)
+
+	return response.JSON(http.StatusOK, labsUpdateResponse{
+		Updated:         updated,
+		RestartRequired: restartRequired,
+	})
+}

--- a/pkg/api/labs_test.go
+++ b/pkg/api/labs_test.go
@@ -1,0 +1,117 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/grafana/pkg/services/accesscontrol"
+	"github.com/grafana/grafana/pkg/services/featuremgmt"
+	"github.com/grafana/grafana/pkg/web/webtest"
+)
+
+func setupLabsTestServer(t *testing.T, features featuremgmt.FeatureToggles) *webtest.Server {
+	t.Helper()
+	return SetupAPITestServer(t, func(hs *HTTPServer) {
+		hs.Features = features
+	})
+}
+
+func TestGetLabsFeatures(t *testing.T) {
+	features := featuremgmt.WithManager("flagA", true, "flagB", false)
+
+	t.Run("returns all flags with their state for a user with read permission", func(t *testing.T) {
+		server := setupLabsTestServer(t, features)
+
+		req := webtest.RequestWithSignedInUser(
+			server.NewRequest(http.MethodGet, "/api/labs/features", nil),
+			userWithPermissions(1, []accesscontrol.Permission{{Action: accesscontrol.ActionFeatureManagementRead}}),
+		)
+		res, err := server.Send(req)
+		require.NoError(t, err)
+		defer func() { require.NoError(t, res.Body.Close()) }()
+
+		require.Equal(t, http.StatusOK, res.StatusCode)
+
+		var body labsFeaturesResponse
+		require.NoError(t, json.NewDecoder(res.Body).Decode(&body))
+
+		enabled := map[string]bool{}
+		for _, f := range body.Features {
+			enabled[f.Name] = f.Enabled
+		}
+		require.True(t, enabled["flagA"])
+		require.False(t, enabled["flagB"])
+	})
+
+	t.Run("is forbidden without read permission", func(t *testing.T) {
+		server := setupLabsTestServer(t, features)
+
+		req := webtest.RequestWithSignedInUser(
+			server.NewRequest(http.MethodGet, "/api/labs/features", nil),
+			userWithPermissions(1, nil),
+		)
+		res, err := server.Send(req)
+		require.NoError(t, err)
+		defer func() { require.NoError(t, res.Body.Close()) }()
+
+		assert.Equal(t, http.StatusForbidden, res.StatusCode)
+	})
+}
+
+func TestUpdateLabsFeatures(t *testing.T) {
+	t.Run("flips a flag for a user with write permission", func(t *testing.T) {
+		features := featuremgmt.WithManager("flagA", false)
+		server := setupLabsTestServer(t, features)
+
+		req := webtest.RequestWithSignedInUser(
+			server.NewRequest(http.MethodPatch, "/api/labs/features", mockRequestBody(map[string]bool{"flagA": true})),
+			userWithPermissions(1, []accesscontrol.Permission{{Action: accesscontrol.ActionFeatureManagementWrite}}),
+		)
+		res, err := server.Send(req)
+		require.NoError(t, err)
+		defer func() { require.NoError(t, res.Body.Close()) }()
+
+		require.Equal(t, http.StatusOK, res.StatusCode)
+
+		var body labsUpdateResponse
+		require.NoError(t, json.NewDecoder(res.Body).Decode(&body))
+		require.Equal(t, []string{"flagA"}, body.Updated)
+
+		require.True(t, features.IsEnabledGlobally("flagA"))
+	})
+
+	t.Run("returns a bad request for an unknown flag", func(t *testing.T) {
+		features := featuremgmt.WithManager("flagA", false)
+		server := setupLabsTestServer(t, features)
+
+		req := webtest.RequestWithSignedInUser(
+			server.NewRequest(http.MethodPatch, "/api/labs/features", mockRequestBody(map[string]bool{"unknown": true})),
+			userWithPermissions(1, []accesscontrol.Permission{{Action: accesscontrol.ActionFeatureManagementWrite}}),
+		)
+		res, err := server.Send(req)
+		require.NoError(t, err)
+		defer func() { require.NoError(t, res.Body.Close()) }()
+
+		assert.Equal(t, http.StatusBadRequest, res.StatusCode)
+	})
+
+	t.Run("is forbidden with only read permission", func(t *testing.T) {
+		features := featuremgmt.WithManager("flagA", false)
+		server := setupLabsTestServer(t, features)
+
+		req := webtest.RequestWithSignedInUser(
+			server.NewRequest(http.MethodPatch, "/api/labs/features", mockRequestBody(map[string]bool{"flagA": true})),
+			userWithPermissions(1, []accesscontrol.Permission{{Action: accesscontrol.ActionFeatureManagementRead}}),
+		)
+		res, err := server.Send(req)
+		require.NoError(t, err)
+		defer func() { require.NoError(t, res.Body.Close()) }()
+
+		assert.Equal(t, http.StatusForbidden, res.StatusCode)
+		require.False(t, features.IsEnabledGlobally("flagA"))
+	})
+}

--- a/pkg/services/featuremgmt/manager.go
+++ b/pkg/services/featuremgmt/manager.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"reflect"
+	"sync"
 
 	"github.com/grafana/grafana/pkg/infra/log"
 )
@@ -15,6 +16,10 @@ var (
 type FeatureManager struct {
 	isDevMod bool
 
+	// mu guards flags, enabled, startup and warnings. Runtime mutations (e.g. the
+	// Labs HTTP handlers calling SetEnabled) can race with the many concurrent
+	// readers throughout Grafana, so all access must go through the lock.
+	mu       sync.RWMutex
 	flags    map[string]*FeatureFlag
 	enabled  map[string]bool   // only the "on" values
 	startup  map[string]bool   // the explicit values registered at startup
@@ -24,6 +29,9 @@ type FeatureManager struct {
 
 // This will merge the flags with the current configuration
 func (fm *FeatureManager) registerFlags(flags ...FeatureFlag) {
+	fm.mu.Lock()
+	defer fm.mu.Unlock()
+
 	for _, add := range flags {
 		if add.Name == "" {
 			continue // skip it with warning?
@@ -71,7 +79,32 @@ func (fm *FeatureManager) meetsRequirements(ff *FeatureFlag) (bool, string) {
 	return true, ""
 }
 
-// Update
+// SetEnabled toggles a feature flag at runtime. The change is kept in memory
+// only (stored in startup) and is reset when Grafana restarts. It returns an
+// error when the flag is unknown or cannot be enabled in the current
+// environment (e.g. a dev-mode flag on a production server).
+func (fm *FeatureManager) SetEnabled(name string, enabled bool) error {
+	fm.mu.Lock()
+	defer fm.mu.Unlock()
+
+	flag, ok := fm.flags[name]
+	if !ok {
+		return fmt.Errorf("unknown feature flag: %s", name)
+	}
+
+	if enabled {
+		if ok, reason := fm.meetsRequirements(flag); !ok {
+			return fmt.Errorf("cannot enable feature flag %q: %s", name, reason)
+		}
+	}
+
+	fm.startup[name] = enabled
+	fm.update()
+	return nil
+}
+
+// Update recomputes the enabled map from the flag definitions and startup
+// values. Callers must hold fm.mu (write lock).
 func (fm *FeatureManager) update() {
 	enabled := make(map[string]bool)
 	for _, flag := range fm.flags {
@@ -99,16 +132,22 @@ func (fm *FeatureManager) update() {
 
 // IsEnabled checks if a feature is enabled
 func (fm *FeatureManager) IsEnabled(ctx context.Context, flag string) bool {
+	fm.mu.RLock()
+	defer fm.mu.RUnlock()
 	return fm.enabled[flag]
 }
 
 // IsEnabledGlobally checks if a feature is for all tenants
 func (fm *FeatureManager) IsEnabledGlobally(flag string) bool {
+	fm.mu.RLock()
+	defer fm.mu.RUnlock()
 	return fm.enabled[flag]
 }
 
 // GetEnabled returns a map containing only the features that are enabled
 func (fm *FeatureManager) GetEnabled(ctx context.Context) map[string]bool {
+	fm.mu.RLock()
+	defer fm.mu.RUnlock()
 	enabled := make(map[string]bool, len(fm.enabled))
 	for key, val := range fm.enabled {
 		if val {
@@ -120,6 +159,8 @@ func (fm *FeatureManager) GetEnabled(ctx context.Context) map[string]bool {
 
 // GetFlags returns all flag definitions
 func (fm *FeatureManager) GetFlags() []FeatureFlag {
+	fm.mu.RLock()
+	defer fm.mu.RUnlock()
 	v := make([]FeatureFlag, 0, len(fm.flags))
 	for _, value := range fm.flags {
 		v = append(v, *value)

--- a/pkg/services/featuremgmt/manager_test.go
+++ b/pkg/services/featuremgmt/manager_test.go
@@ -2,6 +2,7 @@ package featuremgmt
 
 import (
 	"context"
+	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -64,5 +65,87 @@ func TestFeatureManager(t *testing.T) {
 		require.True(t, ft.IsEnabledGlobally("a"))
 		require.False(t, ft.IsEnabledGlobally("b"))
 		require.False(t, ft.IsEnabledGlobally("c"))
+	})
+}
+
+func TestFeatureManagerSetEnabled(t *testing.T) {
+	newManager := func(devMode bool) *FeatureManager {
+		fm := &FeatureManager{
+			isDevMod: devMode,
+			flags:    map[string]*FeatureFlag{},
+			enabled:  map[string]bool{},
+			startup:  map[string]bool{},
+			warnings: map[string]string{},
+		}
+		fm.registerFlags(
+			FeatureFlag{Name: "stable"},
+			FeatureFlag{Name: "onByDefault", Expression: "true"},
+			FeatureFlag{Name: "devOnly", RequiresDevMode: true, Stage: FeatureStageExperimental},
+		)
+		return fm
+	}
+
+	t.Run("returns an error for an unknown flag", func(t *testing.T) {
+		fm := newManager(true)
+		err := fm.SetEnabled("does-not-exist", true)
+		require.Error(t, err)
+		require.False(t, fm.IsEnabledGlobally("does-not-exist"))
+	})
+
+	t.Run("enables and disables a known flag at runtime", func(t *testing.T) {
+		fm := newManager(true)
+		require.False(t, fm.IsEnabledGlobally("stable"))
+
+		require.NoError(t, fm.SetEnabled("stable", true))
+		require.True(t, fm.IsEnabledGlobally("stable"))
+
+		require.NoError(t, fm.SetEnabled("stable", false))
+		require.False(t, fm.IsEnabledGlobally("stable"))
+	})
+
+	t.Run("can disable a flag that is on by default", func(t *testing.T) {
+		fm := newManager(true)
+		require.True(t, fm.IsEnabledGlobally("onByDefault"))
+
+		require.NoError(t, fm.SetEnabled("onByDefault", false))
+		require.False(t, fm.IsEnabledGlobally("onByDefault"))
+	})
+
+	t.Run("cannot enable a dev-mode flag when not in dev mode", func(t *testing.T) {
+		fm := newManager(false)
+		err := fm.SetEnabled("devOnly", true)
+		require.Error(t, err)
+		require.False(t, fm.IsEnabledGlobally("devOnly"))
+
+		// Disabling a dev-mode flag is always allowed.
+		require.NoError(t, fm.SetEnabled("devOnly", false))
+	})
+
+	t.Run("enables a dev-mode flag when in dev mode", func(t *testing.T) {
+		fm := newManager(true)
+		require.NoError(t, fm.SetEnabled("devOnly", true))
+		require.True(t, fm.IsEnabledGlobally("devOnly"))
+	})
+
+	t.Run("is safe for concurrent reads and writes", func(t *testing.T) {
+		fm := newManager(true)
+
+		var wg sync.WaitGroup
+		for i := 0; i < 50; i++ {
+			wg.Add(3)
+			go func() {
+				defer wg.Done()
+				_ = fm.SetEnabled("stable", true)
+			}()
+			go func() {
+				defer wg.Done()
+				_ = fm.IsEnabledGlobally("stable")
+			}()
+			go func() {
+				defer wg.Done()
+				_ = fm.GetEnabled(context.Background())
+			}()
+		}
+		wg.Wait()
 	})
 }

--- a/pkg/services/navtree/models.go
+++ b/pkg/services/navtree/models.go
@@ -33,6 +33,7 @@ const (
 	WeightDataConnections
 	WeightApps
 	WeightPlugin
+	WeightLabs
 	WeightConfig
 	WeightProfile
 	WeightHelp
@@ -56,6 +57,7 @@ const (
 	NavIDCfgPlugins           = "cfg/plugins"
 	NavIDCfgAccess            = "cfg/access"
 	NavIDBookmarks            = "bookmarks"
+	NavIDLabs                 = "labs"
 )
 
 type NavLink struct {

--- a/pkg/services/navtree/navtreeimpl/navtree.go
+++ b/pkg/services/navtree/navtreeimpl/navtree.go
@@ -162,6 +162,10 @@ func (s *ServiceImpl) GetNavTree(c *contextmodel.ReqContext, prefs *pref.Prefere
 
 	treeRoot.AddSection(s.buildDataConnectionsNavLink(c))
 
+	if labsNode := s.buildLabsNavLink(c); labsNode != nil {
+		treeRoot.AddSection(labsNode)
+	}
+
 	orgAdminNode, err := s.getAdminNode(c)
 
 	if orgAdminNode != nil && len(orgAdminNode.Children) > 0 {
@@ -563,6 +567,27 @@ func (s *ServiceImpl) buildAlertNavLinks(c *contextmodel.ReqContext) *navtree.Na
 	}
 
 	return nil
+}
+
+// buildLabsNavLink adds the experimental "Labs" section where admins can flip
+// feature toggles at runtime. It is gated behind the feature management read
+// permission, which is granted to admins by the fixed:featuremgmt:reader role.
+func (s *ServiceImpl) buildLabsNavLink(c *contextmodel.ReqContext) *navtree.NavLink {
+	hasAccess := ac.HasAccess(s.accessControl, c)
+
+	if !hasAccess(ac.EvalPermission(ac.ActionFeatureManagementRead)) {
+		return nil
+	}
+
+	return &navtree.NavLink{
+		Text:       "Labs",
+		SubTitle:   "Experiment with feature toggles",
+		Id:         navtree.NavIDLabs,
+		Icon:       "flask",
+		Url:        s.cfg.AppSubURL + "/labs",
+		SortWeight: navtree.WeightLabs,
+		IsNew:      true,
+	}
 }
 
 func (s *ServiceImpl) buildDataConnectionsNavLink(c *contextmodel.ReqContext) *navtree.NavLink {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
**What is this feature?**

Adds the backend for a new top-level **Labs** section where admins can view and flip feature toggles at runtime.

- **Nav section** (`pkg/services/navtree`): new `WeightLabs` (placed between Connections/Apps and Administration) and `NavIDLabs` constants, plus `buildLabsNavLink` in `GetNavTree`. The section uses the `flask` icon, an `IsNew` "New!" badge, and is gated behind `featuremgmt.read`.
- **Runtime mutation** (`pkg/services/featuremgmt/manager.go`): new thread-safe `FeatureManager.SetEnabled(name, enabled)` that validates the flag exists and meets requirements (dev-mode check) and updates the in-memory state. A `sync.RWMutex` now guards `flags/enabled/startup/warnings` since the HTTP handlers write concurrently with the many existing readers.
- **HTTP API** (`pkg/api/labs.go`):
  - `GET /api/labs/features` — returns every flag with name, description, stage, enabled, `requiresRestart`, `requiresDevMode` (gated by `featuremgmt.read`).
  - `PATCH /api/labs/features` — body `{ "featureName": bool, ... }`, applied via `SetEnabled`, response lists flags that `requiresRestart` (gated by `featuremgmt.write`).
  - Registers the routes plus the `/labs` SPA index route in `pkg/api/api.go`.

**Why do we need this feature?**

The old Feature Toggles admin page and its k8s-style API were removed in Sept 2025. This restores runtime toggle control for operators, kept intentionally simple: changes are **in-memory only** and reset on restart.

**Who is this feature for?**

Grafana admins (the `featuremgmt.read`/`featuremgmt.write` fixed roles are granted to Admin).

**Which issue(s) does this PR fix?**:

Fixes #

**Special notes for your reviewer:**

- Runtime-only, in-memory: toggle changes are not persisted and reset on restart.
- The API resolves the concrete `*featuremgmt.FeatureManager` from the read-only `hs.Features` interface (which is that manager at runtime) so the read-only `FeatureToggles` interface stays unchanged and no Wire regeneration is required.
- Tests: `FeatureManager.SetEnabled` unit tests (unknown flag, dev-mode gating, on-by-default disable, race-tested concurrent read/write) and API handler tests for both endpoints incl. RBAC denial.
- The frontend `/labs` page lands in #358 (backend and frontend deploy at different cadences).

### Verification

End-to-end with the frontend stacked on top (open menu → open Labs → `GET /api/labs/features` renders the table → flip a toggle → `PATCH /api/labs/features` → reload prompt):

<a href="https://cursor.com/agents/bc-5db882a5-7bb1-4d81-8971-1f376709b041/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Flabs_feature_toggle_demo_clean.mp4"><img src="https://cursor.com/artifacts/c/art-acf16108-f9e4-4882-8981-ccf507431d1f" alt="labs_feature_toggle_demo_clean.mp4" /></a>

The `/api/labs/features` response rendered as the Labs table:

![Labs page backed by the labs API](https://cursor.com/artifacts/c/art-60f63b2e-a2a9-4d1a-9027-ab9f2531e79b)

Please check that:
- [x] It works as expected from a user's perspective.
- [x] Pre-GA feature considerations (the section is gated by RBAC and marked as new/experimental).
- [ ] The docs are updated.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5db882a5-7bb1-4d81-8971-1f376709b041?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5db882a5-7bb1-4d81-8971-1f376709b041&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

