### PR TITLE
Labs: add /labs page for runtime feature toggle control

### DIFF
--- a/public/app/core/utils/navBarItem-translations.ts
+++ b/public/app/core/utils/navBarItem-translations.ts
@@ -185,6 +185,8 @@ export function getNavTitle(navId: string | undefined) {
       return t('nav.sign-out.title', 'Sign out');
     case 'search':
       return t('nav.search-dashboards.title', 'Search dashboards');
+    case 'labs':
+      return t('nav.labs.title', 'Labs');
     case 'connections':
       return t('nav.connections.title', 'Connections');
     case 'connections-add-new-connection':
@@ -327,6 +329,8 @@ export function getNavSubTitle(navId: string | undefined) {
       );
     case 'plugin-page-grafana-ml-app':
       return t('nav.machine-learning.subtitle', 'Explore AI and machine learning features');
+    case 'labs':
+      return t('nav.labs.subtitle', 'Experiment with feature toggles');
     default:
       return undefined;
   }

--- a/public/app/features/labs/LabsPage.test.tsx
+++ b/public/app/features/labs/LabsPage.test.tsx
@@ -1,0 +1,100 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { TestProvider } from 'test/helpers/TestProvider';
+
+import { config, setBackendSrv, type BackendSrv } from '@grafana/runtime';
+import { contextSrv } from 'app/core/services/context_srv';
+
+import LabsPage from './LabsPage';
+
+const features = [
+  {
+    name: 'featureA',
+    description: 'Feature A description',
+    stage: 'experimental',
+    enabled: false,
+    requiresRestart: false,
+    requiresDevMode: false,
+  },
+  {
+    name: 'featureB',
+    description: 'Feature B description',
+    stage: 'GA',
+    enabled: true,
+    requiresRestart: true,
+    requiresDevMode: false,
+  },
+];
+
+const getMock = jest.fn();
+const patchMock = jest.fn();
+
+function setup() {
+  config.bootData.navTree = [
+    {
+      text: 'Labs',
+      id: 'labs',
+      url: '/labs',
+      subTitle: 'Experiment with feature toggles',
+    },
+  ];
+
+  return render(
+    <TestProvider>
+      <LabsPage />
+    </TestProvider>
+  );
+}
+
+describe('LabsPage', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.spyOn(contextSrv, 'hasPermission').mockReturnValue(true);
+    getMock.mockResolvedValue({ features });
+    patchMock.mockResolvedValue({ updated: ['featureA'] });
+    setBackendSrv({ get: getMock, patch: patchMock } as unknown as BackendSrv);
+  });
+
+  it('lists the feature toggles returned by the API', async () => {
+    setup();
+
+    expect(await screen.findByText('featureA')).toBeInTheDocument();
+    expect(screen.getByText('featureB')).toBeInTheDocument();
+    expect(getMock).toHaveBeenCalledWith('/api/labs/features');
+  });
+
+  it('shows the runtime-only alert', async () => {
+    setup();
+    await screen.findByText('featureA');
+    expect(screen.getByText(/applied at runtime/i)).toBeInTheDocument();
+  });
+
+  it('sends a PATCH request and prompts for reload when a toggle is flipped', async () => {
+    setup();
+    await screen.findByText('featureA');
+
+    const toggle = screen.getByLabelText('featureA');
+    await userEvent.click(toggle);
+
+    await waitFor(() => {
+      expect(patchMock).toHaveBeenCalledWith('/api/labs/features', { featureA: true });
+    });
+    expect(await screen.findByText(/Reload page/i)).toBeInTheDocument();
+  });
+
+  it('reflects the enabled state of each flag in its switch', async () => {
+    setup();
+    await screen.findByText('featureA');
+
+    expect(screen.getByLabelText('featureA')).not.toBeChecked();
+    expect(screen.getByLabelText('featureB')).toBeChecked();
+  });
+
+  it('marks restart-required flags with a warning indicator', async () => {
+    setup();
+    await screen.findByText('featureB');
+
+    expect(screen.getByTestId('labs-restart-warning-featureB')).toBeInTheDocument();
+    expect(screen.queryByTestId('labs-restart-warning-featureA')).not.toBeInTheDocument();
+  });
+});

--- a/public/app/features/labs/LabsPage.tsx
+++ b/public/app/features/labs/LabsPage.tsx
@@ -201,7 +201,7 @@ export default function LabsPage() {
                 onChange={setQuery}
                 escapeRegex={false}
               />
-              <InteractiveTable columns={columns} data={filtered} getRowId={(feature) => feature.name} />
+              <InteractiveTable columns={columns} data={filtered} getRowId={(feature) => feature.name} pageSize={25} />
             </>
           )}
         </Stack>

--- a/public/app/features/labs/LabsPage.tsx
+++ b/public/app/features/labs/LabsPage.tsx
@@ -1,0 +1,221 @@
+import { css } from '@emotion/css';
+import { useCallback, useEffect, useMemo, useState } from 'react';
+
+import { type GrafanaTheme2 } from '@grafana/data';
+import { Trans, t } from '@grafana/i18n';
+import { config, getBackendSrv, isFetchError } from '@grafana/runtime';
+import {
+  Alert,
+  Badge,
+  type BadgeColor,
+  Button,
+  type CellProps,
+  type Column,
+  FilterInput,
+  Icon,
+  InteractiveTable,
+  LoadingPlaceholder,
+  Stack,
+  Switch,
+  Tooltip,
+  useStyles2,
+} from '@grafana/ui';
+import { Page } from 'app/core/components/Page/Page';
+import { contextSrv } from 'app/core/services/context_srv';
+import { AccessControlAction } from 'app/types/accessControl';
+
+interface LabsFeature {
+  name: string;
+  description: string;
+  stage: string;
+  enabled: boolean;
+  requiresRestart: boolean;
+  requiresDevMode: boolean;
+}
+
+const stageBadgeColor: Record<string, BadgeColor> = {
+  experimental: 'orange',
+  privatePreview: 'purple',
+  preview: 'blue',
+  GA: 'green',
+  deprecated: 'red',
+};
+
+// The backend runs in dev mode whenever the environment is not "production"
+// (see FeatureManager.isDevMod). Dev-only flags cannot be enabled otherwise.
+const isDevMode = config.buildInfo.env !== 'production';
+
+export default function LabsPage() {
+  const styles = useStyles2(getStyles);
+  const canWrite = contextSrv.hasPermission(AccessControlAction.FeatureManagementWrite);
+
+  const [features, setFeatures] = useState<LabsFeature[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [loadError, setLoadError] = useState<string | undefined>();
+  const [query, setQuery] = useState('');
+  const [updating, setUpdating] = useState<string | undefined>();
+  const [needsReload, setNeedsReload] = useState(false);
+
+  useEffect(() => {
+    let mounted = true;
+    getBackendSrv()
+      .get<{ features: LabsFeature[] }>('/api/labs/features')
+      .then((res) => {
+        if (mounted) {
+          setFeatures(res.features ?? []);
+          setIsLoading(false);
+        }
+      })
+      .catch((err) => {
+        if (mounted) {
+          setLoadError(isFetchError(err) ? (err.data?.message ?? err.statusText) : String(err));
+          setIsLoading(false);
+        }
+      });
+    return () => {
+      mounted = false;
+    };
+  }, []);
+
+  const handleToggle = useCallback(async (feature: LabsFeature, enabled: boolean) => {
+    setUpdating(feature.name);
+    try {
+      await getBackendSrv().patch('/api/labs/features', { [feature.name]: enabled });
+      setFeatures((prev) => prev.map((f) => (f.name === feature.name ? { ...f, enabled } : f)));
+      setNeedsReload(true);
+    } finally {
+      setUpdating(undefined);
+    }
+  }, []);
+
+  const filtered = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    if (!q) {
+      return features;
+    }
+    return features.filter((f) => f.name.toLowerCase().includes(q) || f.description.toLowerCase().includes(q));
+  }, [features, query]);
+
+  const columns: Array<Column<LabsFeature>> = useMemo(
+    () => [
+      {
+        id: 'name',
+        header: t('labs.column.name', 'Name'),
+        sortType: 'string',
+        cell: ({ row: { original } }: CellProps<LabsFeature>) => <span className={styles.name}>{original.name}</span>,
+      },
+      {
+        id: 'description',
+        header: t('labs.column.description', 'Description'),
+        cell: ({ row: { original } }: CellProps<LabsFeature>) => <span>{original.description}</span>,
+      },
+      {
+        id: 'stage',
+        header: t('labs.column.stage', 'Stage'),
+        sortType: 'string',
+        cell: ({ row: { original } }: CellProps<LabsFeature>) => (
+          <Badge text={original.stage} color={stageBadgeColor[original.stage] ?? 'darkgrey'} />
+        ),
+      },
+      {
+        id: 'enabled',
+        header: t('labs.column.state', 'State'),
+        cell: ({ row: { original } }: CellProps<LabsFeature>) => {
+          const devDisabled = original.requiresDevMode && !isDevMode;
+          return (
+            <Stack alignItems="center" gap={1}>
+              <Switch
+                value={original.enabled}
+                disabled={!canWrite || devDisabled || updating === original.name}
+                aria-label={original.name}
+                onChange={(e) => handleToggle(original, e.currentTarget.checked)}
+              />
+              {original.requiresRestart && (
+                <Tooltip
+                  content={t(
+                    'labs.requires-restart-tooltip',
+                    'This flag is read at startup. Changing it at runtime may not fully take effect until Grafana is restarted.'
+                  )}
+                >
+                  <span data-testid={`labs-restart-warning-${original.name}`}>
+                    <Icon name="exclamation-triangle" className={styles.warnIcon} />
+                  </span>
+                </Tooltip>
+              )}
+              {devDisabled && (
+                <Tooltip
+                  content={t(
+                    'labs.requires-dev-mode-tooltip',
+                    'This flag can only be enabled when Grafana runs in development mode.'
+                  )}
+                >
+                  <Icon name="lock" />
+                </Tooltip>
+              )}
+            </Stack>
+          );
+        },
+      },
+    ],
+    [canWrite, handleToggle, styles.name, styles.warnIcon, updating]
+  );
+
+  return (
+    <Page navId="labs">
+      <Page.Contents>
+        <Stack direction="column" gap={2}>
+          <Alert
+            severity="info"
+            title={t('labs.runtime-only-alert-title', 'Feature toggle changes are applied at runtime')}
+          >
+            <Trans i18nKey="labs.runtime-only-alert-body">
+              Changes are kept in memory only and reset when Grafana restarts. Frontend features are read when the page
+              loads, so reload the page after toggling for them to take effect.
+            </Trans>
+          </Alert>
+
+          {needsReload && (
+            <Alert severity="success" title={t('labs.reload-alert-title', 'Feature toggle updated')}>
+              <Stack direction="row" alignItems="center" gap={2}>
+                <Trans i18nKey="labs.reload-alert-body">Reload the page for the change to fully take effect.</Trans>
+                <Button size="sm" onClick={() => window.location.reload()}>
+                  <Trans i18nKey="labs.reload-button">Reload page</Trans>
+                </Button>
+              </Stack>
+            </Alert>
+          )}
+
+          {loadError && (
+            <Alert severity="error" title={t('labs.load-error-title', 'Failed to load feature toggles')}>
+              {loadError}
+            </Alert>
+          )}
+
+          {isLoading ? (
+            <LoadingPlaceholder text={t('labs.loading', 'Loading feature toggles...')} />
+          ) : (
+            <>
+              <FilterInput
+                placeholder={t('labs.search-placeholder', 'Search feature toggles')}
+                value={query}
+                onChange={setQuery}
+                escapeRegex={false}
+              />
+              <InteractiveTable columns={columns} data={filtered} getRowId={(feature) => feature.name} />
+            </>
+          )}
+        </Stack>
+      </Page.Contents>
+    </Page>
+  );
+}
+
+const getStyles = (theme: GrafanaTheme2) => ({
+  name: css({
+    fontWeight: theme.typography.fontWeightMedium,
+    wordBreak: 'break-word',
+  }),
+  warnIcon: css({
+    color: theme.colors.warning.text,
+  }),
+});

--- a/public/app/routes/routes.tsx
+++ b/public/app/routes/routes.tsx
@@ -354,6 +354,12 @@ export function getAppRoutes(): RouteDescriptor[] {
         contextSrv.evaluatePermission([AccessControlAction.ActionTeamsRead, AccessControlAction.ActionTeamsCreate]),
       component: SafeDynamicImport(() => import(/* webpackChunkName: "TeamPages" */ 'app/features/teams/TeamPages')),
     },
+    // LABS
+    {
+      path: '/labs',
+      roles: () => contextSrv.evaluatePermission([AccessControlAction.FeatureManagementRead]),
+      component: SafeDynamicImport(() => import(/* webpackChunkName: "LabsPage" */ 'app/features/labs/LabsPage')),
+    },
     // ADMIN
     {
       path: '/admin',

--- a/public/app/types/accessControl.ts
+++ b/public/app/types/accessControl.ts
@@ -57,6 +57,9 @@ export enum AccessControlAction {
 
   ActionServerStatsRead = 'server.stats:read',
 
+  FeatureManagementRead = 'featuremgmt.read',
+  FeatureManagementWrite = 'featuremgmt.write',
+
   ActionTeamsCreate = 'teams:create',
   ActionTeamsDelete = 'teams:delete',
   ActionTeamsRead = 'teams:read',

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -11087,6 +11087,24 @@
     }
   },
   "label-dropdown-info": "Can't find your label? Enter it manually",
+  "labs": {
+    "column": {
+      "description": "Description",
+      "name": "Name",
+      "stage": "Stage",
+      "state": "State"
+    },
+    "load-error-title": "Failed to load feature toggles",
+    "loading": "Loading feature toggles...",
+    "reload-alert-body": "Reload the page for the change to fully take effect.",
+    "reload-alert-title": "Feature toggle updated",
+    "reload-button": "Reload page",
+    "requires-dev-mode-tooltip": "This flag can only be enabled when Grafana runs in development mode.",
+    "requires-restart-tooltip": "This flag is read at startup. Changing it at runtime may not fully take effect until Grafana is restarted.",
+    "runtime-only-alert-body": "Changes are kept in memory only and reset when Grafana restarts. Frontend features are read when the page loads, so reload the page after toggling for them to take effect.",
+    "runtime-only-alert-title": "Feature toggle changes are applied at runtime",
+    "search-placeholder": "Search feature toggles"
+  },
   "layers": {
     "layer-drag-drop-list": {
       "draggable-aria-label": "Drag and drop to reorder",
@@ -12210,6 +12228,10 @@
     },
     "kubernetes": {
       "title": "Kubernetes"
+    },
+    "labs": {
+      "subtitle": "Experiment with feature toggles",
+      "title": "Labs"
     },
     "library-panels": {
       "subtitle": "Reusable panels that can be added to multiple dashboards",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
**What is this feature?**

Adds the frontend `LabsPage` (`/labs`) for the new Labs section. It lists every feature toggle in a searchable, paginated `InteractiveTable` and lets admins flip them at runtime.

- **Route** (`public/app/routes/routes.tsx`): `/labs` → dynamically imported `LabsPage`, gated by `AccessControlAction.FeatureManagementRead`.
- **Page** (`public/app/features/labs/LabsPage.tsx`): `<Page navId="labs">` with:
  - `InteractiveTable` of toggles: name, description, stage (`Badge`), and a `Switch` per row, paginated (25/page) to stay responsive with the full flag list.
  - `FilterInput` search over name/description.
  - An info `Alert` explaining changes are runtime-only (reset on restart) and that a reload is needed for frontend-gated features.
  - A green success `Alert` with a "Reload page" button after a successful toggle.
  - Switches disabled for dev-mode-only flags when not in dev mode, and a warning indicator for restart-required flags.
  - Fetches via `GET /api/labs/features` and applies changes via `PATCH /api/labs/features` using `getBackendSrv()`.
- **Access control** (`public/app/types/accessControl.ts`): `FeatureManagementRead` / `FeatureManagementWrite` actions.
- **i18n**: `labs` nav title/subtitle cases in `navBarItem-translations.ts`, page strings wrapped in `t()`/`<Trans>`, extracted into `en-US/grafana.json`.

**Why do we need this feature?**

Gives admins a UI to inspect and toggle features at runtime after the old Feature Toggles page was removed.

**Who is this feature for?**

Grafana admins (RBAC `featuremgmt.read`/`featuremgmt.write`).

**Which issue(s) does this PR fix?**:

Fixes #

**Special notes for your reviewer:**

- Stacked on the backend PR (`cursor/labs-feature-flags-backend-b041`, #357) and targets that branch; it depends on the `/api/labs/features` endpoints and the `labs` nav node. Re-point the base to `main` once the backend merges.
- Tests: RTL suite for `LabsPage` (renders flags, runtime alert, toggle → PATCH + reload prompt, enabled-state reflection, restart-required indicator).

### Verification

Mega menu showing the new **Labs** section with flask icon and **New!** badge between Connections and Administration:

![Labs nav item with New! badge](https://cursor.com/artifacts/c/art-895c94da-0d4a-4e9e-90a6-aae59d2a2a8a)

The `/labs` page: runtime-only info alert, search box, and the toggle table with stage badges and a restart-required warning icon:

![Labs page with feature toggle table](https://cursor.com/artifacts/c/art-60f63b2e-a2a9-4d1a-9027-ab9f2531e79b)

After flipping a toggle: the green "Feature toggle updated" success alert with the reload prompt:

![Toggle flipped with success/reload prompt](https://cursor.com/artifacts/c/art-a19930bd-c2d5-4df2-b379-daad0e4dc87d)

End-to-end demo (open menu → open Labs → flip a toggle → success/reload prompt):

<a href="https://cursor.com/agents/bc-5db882a5-7bb1-4d81-8971-1f376709b041/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Flabs_feature_toggle_demo_clean.mp4"><img src="https://cursor.com/artifacts/c/art-acf16108-f9e4-4882-8981-ccf507431d1f" alt="labs_feature_toggle_demo_clean.mp4" /></a>

Please check that:
- [x] It works as expected from a user's perspective.
- [x] Pre-GA feature considerations (page is RBAC-gated and nav item marked new).
- [ ] The docs are updated.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5db882a5-7bb1-4d81-8971-1f376709b041?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5db882a5-7bb1-4d81-8971-1f376709b041&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

