### PR TITLE
TimeSeries: add moving average / linear regression overlay

### DIFF
--- a/packages/grafana-schema/src/raw/composable/timeseries/panelcfg/x/types.gen.ts
+++ b/packages/grafana-schema/src/raw/composable/timeseries/panelcfg/x/types.gen.ts
@@ -24,10 +24,28 @@ export const defaultTimeSeriesLegendOptions: Partial<TimeSeriesLegendOptions> = 
   facetedFilterPinned: false,
 };
 
+export enum OverlayType {
+  LinearRegression = 'linearRegression',
+  MovingAverage = 'movingAverage',
+}
+
+export interface TimeSeriesOverlayOptions {
+  enabled?: boolean;
+  type?: (OverlayType | 'movingAverage');
+  windowSize?: number;
+}
+
+export const defaultTimeSeriesOverlayOptions: Partial<TimeSeriesOverlayOptions> = {
+  enabled: false,
+  type: 'movingAverage',
+  windowSize: 10,
+};
+
 export interface Options extends common.OptionsWithTimezones, common.OptionsWithAnnotations {
   disableKeyboardEvents?: boolean;
   legend: TimeSeriesLegendOptions;
   orientation?: common.VizOrientation;
+  overlay?: TimeSeriesOverlayOptions;
   timeCompare?: common.TimeCompareOptions;
   tooltip: common.VizTooltipOptions;
 }

--- a/public/app/plugins/panel/timeseries/TimeSeriesPanel.tsx
+++ b/public/app/plugins/panel/timeseries/TimeSeriesPanel.tsx
@@ -30,7 +30,7 @@ import { ExemplarsPlugin, getVisibleLabels } from './plugins/ExemplarsPlugin';
 import { OutsideRangePlugin } from './plugins/OutsideRangePlugin';
 import { getXAnnotationFrames } from './plugins/utils';
 import { getPrepareTimeseriesSuggestion } from './suggestions';
-import { getTimezones, prepareGraphableFields } from './utils';
+import { applyOverlays, getTimezones, prepareGraphableFields } from './utils';
 
 interface TimeSeriesPanelProps extends PanelProps<Options> {}
 
@@ -66,6 +66,10 @@ export const TimeSeriesPanel = ({
   const { frames, compareDiffMs } = useMemo(() => {
     let frames = prepareGraphableFields(data.series, config.theme2, timeRange);
     if (frames != null) {
+      // Inject overlay series before compareDiffMs is built so the per-series diff array below stays
+      // index-aligned with the augmented field list (overlays inherit their frame's diff).
+      frames = applyOverlays(frames, options.overlay, config.theme2);
+
       let compareDiffMs: number[] = [0];
       // Held separately from `frames` below: TS won't retain the null-check narrowing of `frames`
       // inside the .map callback once `frames` itself gets reassigned in this scope.
@@ -97,7 +101,7 @@ export const TimeSeriesPanel = ({
     }
 
     return { frames };
-  }, [data.series, timeRange]);
+  }, [data.series, timeRange, options.overlay]);
 
   const timezones = useMemo(() => getTimezones(options.timezone, timeZone), [options.timezone, timeZone]);
   const suggestions = useMemo(() => {

--- a/public/app/plugins/panel/timeseries/module.tsx
+++ b/public/app/plugins/panel/timeseries/module.tsx
@@ -8,7 +8,7 @@ import { TimeSeriesPanel } from './TimeSeriesPanel';
 import { TimezonesEditor } from './TimezonesEditor';
 import { defaultGraphConfig, getGraphFieldConfig } from './config';
 import { graphPanelChangedHandler } from './migrations';
-import { type FieldConfig, type Options } from './panelcfg.gen';
+import { type FieldConfig, type Options, OverlayType } from './panelcfg.gen';
 import { timeseriesPresetsSupplier } from './presets';
 import { timeseriesSuggestionsSupplier } from './suggestions';
 
@@ -40,6 +40,51 @@ export const plugin = new PanelPlugin<Options, FieldConfig>(TimeSeriesPanel)
       editor: TimezonesEditor,
       defaultValue: undefined,
     });
+
+    const overlayCategory = [t('timeseries.overlay.category', 'Overlay')];
+
+    builder
+      .addBooleanSwitch({
+        path: 'overlay.enabled',
+        name: t('timeseries.overlay.name-enabled', 'Show overlay'),
+        description: t(
+          'timeseries.overlay.description-enabled',
+          'Render an extra derived line per numeric series, computed from the visible data'
+        ),
+        category: overlayCategory,
+        defaultValue: false,
+      })
+      .addRadio({
+        path: 'overlay.type',
+        name: t('timeseries.overlay.name-type', 'Overlay type'),
+        category: overlayCategory,
+        defaultValue: OverlayType.MovingAverage,
+        settings: {
+          options: [
+            {
+              value: OverlayType.MovingAverage,
+              label: t('timeseries.overlay.type-options.label-moving-average', 'Moving average'),
+            },
+            {
+              value: OverlayType.LinearRegression,
+              label: t('timeseries.overlay.type-options.label-linear-regression', 'Linear regression'),
+            },
+          ],
+        },
+        showIf: (opts) => opts.overlay?.enabled === true,
+      })
+      .addNumberInput({
+        path: 'overlay.windowSize',
+        name: t('timeseries.overlay.name-window-size', 'Window size'),
+        description: t('timeseries.overlay.description-window-size', 'Number of trailing points averaged (minimum 2)'),
+        category: overlayCategory,
+        defaultValue: 10,
+        settings: {
+          min: 2,
+          integer: true,
+        },
+        showIf: (opts) => opts.overlay?.enabled === true && opts.overlay?.type === OverlayType.MovingAverage,
+      });
 
     addAnnotationOptions(builder);
   })

--- a/public/app/plugins/panel/timeseries/panelcfg.cue
+++ b/public/app/plugins/panel/timeseries/panelcfg.cue
@@ -27,6 +27,14 @@ composableKinds: PanelCfg: lineage: {
 				enableFacetedFilter?: bool | *false
 				facetedFilterPinned?: bool | *false
 			} @cuetsy(kind="interface")
+
+			OverlayType: "movingAverage" | "linearRegression" @cuetsy(kind="enum")
+			TimeSeriesOverlayOptions: {
+				enabled?:    bool | *false
+				type?:       OverlayType | *"movingAverage"
+				windowSize?: int | *10
+			} @cuetsy(kind="interface")
+
 			Options: {
 				common.OptionsWithTimezones
 				common.OptionsWithAnnotations
@@ -37,6 +45,7 @@ composableKinds: PanelCfg: lineage: {
 				orientation?:           common.VizOrientation
 				annotations?:           common.VizAnnotations
 				disableKeyboardEvents?: bool
+				overlay?:               TimeSeriesOverlayOptions
 			} @cuetsy(kind="interface")
 
 			FieldConfig: common.GraphFieldConfig & {} @cuetsy(kind="interface")

--- a/public/app/plugins/panel/timeseries/panelcfg.gen.ts
+++ b/public/app/plugins/panel/timeseries/panelcfg.gen.ts
@@ -22,10 +22,28 @@ export const defaultTimeSeriesLegendOptions: Partial<TimeSeriesLegendOptions> = 
   facetedFilterPinned: false,
 };
 
+export enum OverlayType {
+  LinearRegression = 'linearRegression',
+  MovingAverage = 'movingAverage',
+}
+
+export interface TimeSeriesOverlayOptions {
+  enabled?: boolean;
+  type?: (OverlayType | 'movingAverage');
+  windowSize?: number;
+}
+
+export const defaultTimeSeriesOverlayOptions: Partial<TimeSeriesOverlayOptions> = {
+  enabled: false,
+  type: 'movingAverage',
+  windowSize: 10,
+};
+
 export interface Options extends common.OptionsWithTimezones, common.OptionsWithAnnotations {
   disableKeyboardEvents?: boolean;
   legend: TimeSeriesLegendOptions;
   orientation?: common.VizOrientation;
+  overlay?: TimeSeriesOverlayOptions;
   timeCompare?: common.TimeCompareOptions;
   tooltip: common.VizTooltipOptions;
 }

--- a/public/app/plugins/panel/timeseries/utils.test.ts
+++ b/public/app/plugins/panel/timeseries/utils.test.ts
@@ -1,7 +1,14 @@
 import { createTheme, FieldType, createDataFrame, toDataFrame } from '@grafana/data';
 import { LineInterpolation } from '@grafana/ui';
 
-import { getCompareSeriesIdentityKey, getTimezones, prepareGraphableFields, setClassicPaletteIdxs } from './utils';
+import { OverlayType } from './panelcfg.gen';
+import {
+  applyOverlays,
+  getCompareSeriesIdentityKey,
+  getTimezones,
+  prepareGraphableFields,
+  setClassicPaletteIdxs,
+} from './utils';
 
 describe('prepare timeseries graph', () => {
   it('errors with no time fields', () => {
@@ -285,6 +292,83 @@ describe('prepare timeseries graph', () => {
       // Second enum field values should be offset by the length of the first enum's text
       expect(frames![1].fields[1].values).toEqual([2, 3]);
     });
+  });
+});
+
+describe('applyOverlays', () => {
+  const makeFrame = (fields: Array<{ name: string; type: FieldType; values: unknown[] }>) =>
+    toDataFrame({ fields });
+
+  const timeField = { name: 'time', type: FieldType.time, values: [1, 2, 3, 4, 5] };
+
+  it('returns frames unchanged when the overlay is disabled', () => {
+    const frames = [makeFrame([timeField, { name: 'a', type: FieldType.number, values: [2, 4, 6, 8, 10] }])];
+
+    expect(applyOverlays(frames, undefined, createTheme())).toBe(frames);
+    expect(applyOverlays(frames, { enabled: false }, createTheme())).toBe(frames);
+
+    const out = applyOverlays(frames, { enabled: false, type: OverlayType.MovingAverage }, createTheme());
+    expect(out[0].fields).toHaveLength(2);
+  });
+
+  it('appends a trailing moving average field with the expected values and label', () => {
+    const frames = [makeFrame([timeField, { name: 'a', type: FieldType.number, values: [2, 4, 6, 8, 10] }])];
+
+    const out = applyOverlays(frames, { enabled: true, type: OverlayType.MovingAverage, windowSize: 2 }, createTheme());
+
+    expect(out[0].fields).toHaveLength(3);
+    const overlay = out[0].fields[2];
+    expect(overlay.config.displayName).toBe('a (MA 2)');
+    expect(overlay.type).toBe(FieldType.number);
+    expect(overlay.values).toEqual([2, 3, 5, 7, 9]);
+    expect(overlay.config.custom?.lineStyle).toEqual({ fill: 'dash', dash: [10, 10] });
+    expect(overlay.config.custom?.fillOpacity).toBe(0);
+    expect(overlay.config.color).toEqual({ mode: 'fixed', fixedColor: 'green' });
+    // Source field is untouched.
+    expect(out[0].fields[1].values).toEqual([2, 4, 6, 8, 10]);
+  });
+
+  it('clamps the moving-average window to a minimum of 2', () => {
+    const frames = [makeFrame([timeField, { name: 'a', type: FieldType.number, values: [2, 4, 6, 8, 10] }])];
+
+    const out = applyOverlays(frames, { enabled: true, type: OverlayType.MovingAverage, windowSize: 1 }, createTheme());
+
+    const overlay = out[0].fields[2];
+    expect(overlay.config.displayName).toBe('a (MA 2)');
+    expect(overlay.values).toEqual([2, 3, 5, 7, 9]);
+  });
+
+  it('appends an OLS trendline that matches the fit on a linear series', () => {
+    const frames = [makeFrame([timeField, { name: 'a', type: FieldType.number, values: [10, 20, 30, 40, 50] }])];
+
+    const out = applyOverlays(frames, { enabled: true, type: OverlayType.LinearRegression }, createTheme());
+
+    const overlay = out[0].fields[2];
+    expect(overlay.config.displayName).toBe('a (trend)');
+    const values = overlay.values as number[];
+    // Perfectly linear input -> trendline reproduces it (and is monotonically increasing).
+    values.forEach((v, i) => expect(v).toBeCloseTo(10 * (i + 1)));
+    for (let i = 1; i < values.length; i++) {
+      expect(values[i]).toBeGreaterThan(values[i - 1]);
+    }
+  });
+
+  it('adds an overlay for every numeric series in a frame', () => {
+    const frames = [
+      makeFrame([
+        timeField,
+        { name: 'a', type: FieldType.number, values: [1, 2, 3, 4, 5] },
+        { name: 'label', type: FieldType.string, values: ['a', 'b', 'c', 'd', 'e'] },
+        { name: 'b', type: FieldType.number, values: [5, 4, 3, 2, 1] },
+      ]),
+    ];
+
+    const out = applyOverlays(frames, { enabled: true, type: OverlayType.LinearRegression }, createTheme());
+
+    const overlayNames = out[0].fields.map((f) => f.config.displayName).filter(Boolean);
+    expect(overlayNames).toEqual(['a (trend)', 'b (trend)']);
+    // Original 4 fields + 2 overlays; string field is skipped.
+    expect(out[0].fields).toHaveLength(6);
   });
 });
 

--- a/public/app/plugins/panel/timeseries/utils.ts
+++ b/public/app/plugins/panel/timeseries/utils.ts
@@ -1,9 +1,13 @@
+import { SimpleLinearRegression } from 'ml-regression-simple-linear';
+
 import {
   type DataFrame,
   type Field,
+  FieldColorModeId,
   FieldType,
   formatLabels,
   getDisplayProcessor,
+  getFieldDisplayName,
   type GrafanaTheme2,
   isBooleanUnit,
   type TimeRange,
@@ -12,8 +16,10 @@ import {
   nullToValue,
 } from '@grafana/data';
 import { convertFieldType } from '@grafana/data/internal';
-import { type GraphFieldConfig, LineInterpolation } from '@grafana/schema';
+import { GraphDrawStyle, type GraphFieldConfig, GraphGradientMode, LineInterpolation } from '@grafana/schema';
 import { buildScaleKey } from '@grafana/ui/internal';
+
+import { OverlayType, type TimeSeriesOverlayOptions } from './panelcfg.gen';
 
 type ScaleKey = string;
 
@@ -350,4 +356,155 @@ export function getTimezones(timezones: string[] | undefined, defaultTimezone: s
     return [defaultTimezone];
   }
   return timezones.map((v) => (v?.length ? v : defaultTimezone));
+}
+
+// A moving-average window narrower than this is meaningless (it would just echo the source series).
+export const MIN_OVERLAY_WINDOW_SIZE = 2;
+
+// The overlay is drawn as a contrasting secondary line so it reads clearly over the classic-palette
+// source series. Green is picked to stand out against the blue that starts the classic palette.
+const OVERLAY_COLOR = 'green';
+
+/**
+ * Trailing simple moving average over the last `window` positions (by index, so nulls inside the
+ * window are skipped rather than treated as zero). Mirrors the trailing-mean logic used by the
+ * "Add field from calculation" transformer, but yields null when the window holds no finite values
+ * so the overlay line has a gap instead of a misleading flat zero.
+ */
+function trailingMovingAverage(values: unknown[], window: number): Array<number | null> {
+  const win = Math.max(MIN_OVERLAY_WINDOW_SIZE, Math.floor(window));
+  const out: Array<number | null> = [];
+  let sum = 0;
+  let count = 0;
+
+  for (let i = 0; i < values.length; i++) {
+    const current = values[i];
+    if (typeof current === 'number' && Number.isFinite(current)) {
+      sum += current;
+      count++;
+    }
+
+    if (i > win - 1) {
+      const leaving = values[i - win];
+      if (typeof leaving === 'number' && Number.isFinite(leaving)) {
+        sum -= leaving;
+        count--;
+      }
+    }
+
+    out.push(count === 0 ? null : sum / count);
+  }
+
+  return out;
+}
+
+/**
+ * Simple OLS linear regression predicted at each X. X is shifted by its first finite value before
+ * fitting so large time epochs don't blow up floating-point precision (the fit is shift-invariant).
+ */
+function linearRegressionLine(xValues: unknown[], yValues: unknown[]): Array<number | null> {
+  const xs: number[] = [];
+  const ys: number[] = [];
+
+  for (let i = 0; i < yValues.length; i++) {
+    const x = xValues[i];
+    const y = yValues[i];
+    if (typeof x === 'number' && Number.isFinite(x) && typeof y === 'number' && Number.isFinite(y)) {
+      xs.push(x);
+      ys.push(y);
+    }
+  }
+
+  if (xs.length < 2) {
+    return yValues.map(() => null);
+  }
+
+  const shift = xs[0];
+  const regression = new SimpleLinearRegression(
+    xs.map((x) => x - shift),
+    ys
+  );
+
+  return xValues.map((x) => (typeof x === 'number' && Number.isFinite(x) ? regression.predict(x - shift) : null));
+}
+
+/**
+ * Appends a derived overlay line (trailing moving average or OLS trendline) for every numeric value
+ * field, aligned to the frame's existing X field. Runs after prepareGraphableFields so the synthetic
+ * fields are already graphable; source fields are left untouched. No-op unless overlay.enabled.
+ */
+export function applyOverlays(
+  frames: DataFrame[],
+  overlay: TimeSeriesOverlayOptions | undefined,
+  theme: GrafanaTheme2
+): DataFrame[] {
+  if (overlay?.enabled !== true) {
+    return frames;
+  }
+
+  const type = overlay.type ?? OverlayType.MovingAverage;
+  const windowSize = Math.max(MIN_OVERLAY_WINDOW_SIZE, Math.floor(overlay.windowSize ?? 10));
+
+  return frames.map((frame, frameIndex) => {
+    const xField = frame.fields.find((f) => f.type === FieldType.time) ?? frame.fields[0];
+    if (!xField) {
+      return frame;
+    }
+
+    const overlayFields: Field[] = [];
+
+    frame.fields.forEach((field) => {
+      if (field === xField || field.type !== FieldType.number) {
+        return;
+      }
+
+      const sourceName = getFieldDisplayName(field, frame, frames);
+      let values: Array<number | null>;
+      let displayName: string;
+
+      if (type === OverlayType.LinearRegression) {
+        values = linearRegressionLine(xField.values, field.values);
+        displayName = `${sourceName} (trend)`;
+      } else {
+        values = trailingMovingAverage(field.values, windowSize);
+        displayName = `${sourceName} (MA ${windowSize})`;
+      }
+
+      const custom: GraphFieldConfig = {
+        ...field.config.custom,
+        drawStyle: GraphDrawStyle.Line,
+        lineWidth: 2,
+        lineStyle: { fill: 'dash', dash: [10, 10] },
+        fillOpacity: 0,
+        gradientMode: GraphGradientMode.None,
+      };
+
+      const overlayField: Field = {
+        ...field,
+        name: displayName,
+        labels: undefined,
+        values,
+        config: {
+          ...field.config,
+          displayName,
+          color: { mode: FieldColorModeId.Fixed, fixedColor: OVERLAY_COLOR },
+          custom,
+        },
+        // Point back at the source frame; drop the cached displayName so it recomputes from config.
+        state: { origin: { frameIndex, fieldIndex: frame.fields.length + overlayFields.length } },
+      };
+
+      overlayField.display = getDisplayProcessor({ field: overlayField, theme });
+      overlayFields.push(overlayField);
+    });
+
+    if (overlayFields.length === 0) {
+      return frame;
+    }
+
+    return {
+      ...frame,
+      fields: [...frame.fields, ...overlayFields],
+    };
+  });
 }

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -15989,6 +15989,18 @@
       "data-outside-time-range": "Data outside time range",
       "zoom-to-data": "Zoom to data"
     },
+    "overlay": {
+      "category": "Overlay",
+      "description-enabled": "Render an extra derived line per numeric series, computed from the visible data",
+      "description-window-size": "Number of trailing points averaged (minimum 2)",
+      "name-enabled": "Show overlay",
+      "name-type": "Overlay type",
+      "name-window-size": "Window size",
+      "type-options": {
+        "label-linear-regression": "Linear regression",
+        "label-moving-average": "Moving average"
+      }
+    },
     "presets": {
       "multi-many-points": "Lines with points",
       "multi-many-points-stacked": "Stacked lines",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
**What is this feature?**

Adds a client-side, panel-level overlay to the Time Series panel. When enabled, it renders one extra derived line per numeric series, computed entirely on the frontend from the already-graphable data:

- **Moving average** — trailing simple moving average over a configurable window (default 10, minimum 2).
- **Linear regression** — a simple OLS trendline (via `ml-regression-simple-linear`) fit over the visible series domain.

The overlay is disabled by default. Each overlay is drawn as a contrasting dashed green line (`fillOpacity: 0`, `lineWidth: 2`) with a clear legend label (`<series> (MA <n>)` or `<series> (trend)`), leaving the source series styling untouched.

**Why do we need this feature?**

Users frequently want a quick trend/smoothing reference for a time series without adding a transformation or a separate query. This provides a lightweight, per-panel toggle to visualize smoothing or a trendline directly.

**Who is this feature for?**

Anyone building Time Series panels who wants an at-a-glance smoothing or trend indicator.

**Which issue(s) does this PR fix?**:

Fixes #

**Special notes for your reviewer:**

- Frontend only. The only schema change is the panel config + generated panel types (`panelcfg.cue` → `make gen-cue`).
- New options live under a new **Overlay** category in the panel editor (switch / radio / number), with `showIf` gating and i18n strings extracted via `make i18n-extract`.
- `applyOverlays` runs after `prepareGraphableFields` (so synthetic fields are already graphable) and before `compareDiffMs` is built (so the tooltip's per-series diff array stays index-aligned).
- Validation: `yarn jest --no-watch public/app/plugins/panel/timeseries` (49 passing), `yarn eslint` on changed files (clean), `yarn typecheck` (only a pre-existing unrelated `theme-playground` error), and `make gen-cue` is idempotent against the committed generated files.

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a notable improvement, it's added to our What's New doc.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3ebeb55d-1219-46ae-a1e3-488ad08f74a8?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3ebeb55d-1219-46ae-a1e3-488ad08f74a8&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

