### PR TITLE
Dashboards: Add API migration fallback telemetry

### DIFF
--- a/pkg/services/dashboards/service/client/client.go
+++ b/pkg/services/dashboards/service/client/client.go
@@ -125,7 +125,9 @@ func (h *K8sClientWithFallback) Get(
 	)
 
 	span.AddEvent(fmt.Sprintf("%s Get", storedVersion))
-	return h.newClientFunc(spanCtx, storedVersion).Get(spanCtx, name, orgID, options, subresources...)
+	result, err = h.newClientFunc(spanCtx, storedVersion).Get(spanCtx, name, orgID, options, subresources...)
+	h.recordStoredVersionFallbackResult(dashboardv0.VERSION, storedVersion, "get", 1, err)
+	return result, err
 }
 
 // GetWithPreferredAPIVersion loads using the requested API version first. When preferredVersion is empty, delegates to Get.
@@ -150,7 +152,9 @@ func (h *K8sClientWithFallback) GetWithPreferredAPIVersion(
 	if err != nil {
 		h.log.Info("falling back to default API version after preferred get failed", "name", name, "preferredVersion", preferredVersion, "err", err)
 		span.SetAttributes(attribute.Bool("preferred_get_failed", true))
-		return h.Get(ctx, name, orgID, options, subresources...)
+		result, err = h.Get(ctx, name, orgID, options, subresources...)
+		h.metrics.preferredVersionFallbackCounter.WithLabelValues(preferredVersion, metricOutcome(err)).Inc()
+		return result, err
 	}
 
 	failed, storedVersion, conversionErr := getConversionStatus(result)
@@ -167,7 +171,24 @@ func (h *K8sClientWithFallback) GetWithPreferredAPIVersion(
 		attribute.String("fallback.conversion_error", conversionErr),
 	)
 
-	return h.newClientFunc(spanCtx, storedVersion).Get(spanCtx, name, orgID, options, subresources...)
+	result, err = h.newClientFunc(spanCtx, storedVersion).Get(spanCtx, name, orgID, options, subresources...)
+	h.recordStoredVersionFallbackResult(preferredVersion, storedVersion, "get", 1, err)
+	return result, err
+}
+
+func (h *K8sClientWithFallback) recordStoredVersionFallbackResult(
+	requestedVersion string, storedVersion string, operation string, count int, err error,
+) {
+	h.metrics.fallbackResultCounter.
+		WithLabelValues(requestedVersion, storedVersion, operation, metricOutcome(err)).
+		Add(float64(count))
+}
+
+func metricOutcome(err error) string {
+	if err != nil {
+		return "error"
+	}
+	return "success"
 }
 
 type nameAndResourceVersion struct {
@@ -240,6 +261,7 @@ func (h *K8sClientWithFallback) List(
 		)
 
 		items, err := h.fetchWithVersion(ctx, orgID, version, names...)
+		h.recordStoredVersionFallbackResult(dashboardv0.VERSION, version, "list", len(names), err)
 		if err != nil {
 			return nil, tracing.Error(span, err)
 		}

--- a/pkg/services/dashboards/service/client/client_test.go
+++ b/pkg/services/dashboards/service/client/client_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -152,6 +153,9 @@ func TestK8sHandlerWithFallback_Get(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, expectedResultFallback, result)
 		require.Equal(t, 1, setup.mockFactoryCalls[v2alpha1.VERSION], "Factory should be called once with v2alpha1")
+		require.Equal(t, float64(1), testutil.ToFloat64(setup.mockMetrics.fallbackResultCounter.WithLabelValues(
+			v0alpha1.VERSION, storedVersion, "get", "success",
+		)))
 
 		setup.mockClientV1.AssertExpectations(t)
 		setup.mockClientV2Alpha1.AssertExpectations(t)
@@ -210,6 +214,9 @@ func TestK8sHandlerWithFallback_Get(t *testing.T) {
 		require.Error(t, err)
 		require.Equal(t, fallbackErr, err)
 		require.Equal(t, 1, setup.mockFactoryCalls[v2alpha1.VERSION], "Factory should be called once with v2alpha1")
+		require.Equal(t, float64(1), testutil.ToFloat64(setup.mockMetrics.fallbackResultCounter.WithLabelValues(
+			v0alpha1.VERSION, storedVersion, "get", "error",
+		)))
 
 		setup.mockClientV1.AssertExpectations(t)
 		setup.mockClientV2Alpha1.AssertExpectations(t)
@@ -261,6 +268,27 @@ func TestK8sHandlerWithFallback_GetWithPreferredAPIVersion(t *testing.T) {
 		result, err := setup.handler.GetWithPreferredAPIVersion(ctx, name, orgID, options, v2beta1.VERSION)
 		require.NoError(t, err)
 		require.Equal(t, fallbackResult, result)
+		require.Equal(t, float64(1), testutil.ToFloat64(setup.mockMetrics.preferredVersionFallbackCounter.WithLabelValues(
+			v2beta1.VERSION, "success",
+		)))
+		setup.mockClientV2Beta1.AssertExpectations(t)
+		setup.mockClientV1.AssertExpectations(t)
+	})
+
+	t.Run("preferred Get and default fallback errors are tracked", func(t *testing.T) {
+		setup := setupTest(t)
+		ctx := context.Background()
+		name := "d-fallback-error"
+		orgID := int64(1)
+		options := metav1.GetOptions{}
+		setup.mockClientV2Beta1.On("Get", mock.Anything, name, orgID, options, mock.Anything).Return(nil, errors.New("preferred get failed")).Once()
+		setup.mockClientV1.On("Get", mock.Anything, name, orgID, options, mock.Anything).Return(nil, errors.New("default get failed")).Once()
+
+		_, err := setup.handler.GetWithPreferredAPIVersion(ctx, name, orgID, options, v2beta1.VERSION)
+		require.Error(t, err)
+		require.Equal(t, float64(1), testutil.ToFloat64(setup.mockMetrics.preferredVersionFallbackCounter.WithLabelValues(
+			v2beta1.VERSION, "error",
+		)))
 		setup.mockClientV2Beta1.AssertExpectations(t)
 		setup.mockClientV1.AssertExpectations(t)
 	})
@@ -290,6 +318,9 @@ func TestK8sHandlerWithFallback_GetWithPreferredAPIVersion(t *testing.T) {
 		result, err := setup.handler.GetWithPreferredAPIVersion(ctx, name, orgID, options, v2beta1.VERSION)
 		require.NoError(t, err)
 		require.Equal(t, ok, result)
+		require.Equal(t, float64(1), testutil.ToFloat64(setup.mockMetrics.fallbackResultCounter.WithLabelValues(
+			v2beta1.VERSION, storedVersion, "get", "success",
+		)))
 		setup.mockClientV2Beta1.AssertExpectations(t)
 		setup.mockClientV2Alpha1.AssertExpectations(t)
 	})
@@ -376,6 +407,9 @@ func TestK8sHandlerWithFallback_List(t *testing.T) {
 			fallbackResult,
 		}
 		require.ElementsMatch(t, expectedItems, result.Items)
+		require.Equal(t, float64(1), testutil.ToFloat64(setup.mockMetrics.fallbackResultCounter.WithLabelValues(
+			v0alpha1.VERSION, v2alpha1.VERSION, "list", "success",
+		)))
 
 		setup.mockClientV1.AssertExpectations(t)
 		setup.mockClientV2Alpha1.AssertExpectations(t)
@@ -465,6 +499,9 @@ func TestK8sHandlerWithFallback_List(t *testing.T) {
 		_, err := setup.handler.List(context.Background(), 6, metav1.ListOptions{})
 		require.Error(t, err)
 		require.Equal(t, fallbackErr, err)
+		require.Equal(t, float64(1), testutil.ToFloat64(setup.mockMetrics.fallbackResultCounter.WithLabelValues(
+			v0alpha1.VERSION, v2alpha1.VERSION, "list", "error",
+		)))
 
 		setup.mockClientV1.AssertExpectations(t)
 		setup.mockClientV2Alpha1.AssertExpectations(t)

--- a/pkg/services/dashboards/service/client/metrics.go
+++ b/pkg/services/dashboards/service/client/metrics.go
@@ -6,7 +6,9 @@ import (
 )
 
 type k8sClientMetrics struct {
-	fallbackCounter *prometheus.CounterVec
+	fallbackCounter                 *prometheus.CounterVec
+	fallbackResultCounter           *prometheus.CounterVec
+	preferredVersionFallbackCounter *prometheus.CounterVec
 }
 
 func newK8sClientMetrics(reg prometheus.Registerer) *k8sClientMetrics {
@@ -16,5 +18,15 @@ func newK8sClientMetrics(reg prometheus.Registerer) *k8sClientMetrics {
 			Name:      "dashboard_stored_version_fallback_total",
 			Help:      "Number of K8s dashboard client requests to storedVersion",
 		}, []string{"stored_version"}),
+		fallbackResultCounter: promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
+			Namespace: "grafana",
+			Name:      "dashboard_stored_version_fallback_result_total",
+			Help:      "Results of K8s dashboard client requests to storedVersion",
+		}, []string{"requested_version", "stored_version", "operation", "outcome"}),
+		preferredVersionFallbackCounter: promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
+			Namespace: "grafana",
+			Name:      "dashboard_preferred_version_fallback_total",
+			Help:      "Results of K8s dashboard client fallbacks after a preferred API version request failed",
+		}, []string{"preferred_version", "outcome"}),
 	}
 }


### PR DESCRIPTION
**What is this feature?**

Adds telemetry for dashboard API version fallback outcomes during the v1-to-v2 migration, including stored-version and preferred-version fallback results.

**Why do we need this feature?**

The migration needs measurable success and failure signals before changing API defaults or migrating stored dashboards.

**Who is this feature for?**

Grafana operators and engineers monitoring the dashboard API migration rollout.

**Which issue(s) does this PR fix?**:

N/A

**Special notes for your reviewer:**

Focused verification: `go test ./pkg/services/dashboards/service/client`

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.

Made with [Cursor](https://cursor.com)