### PR TITLE
test(panels): add unit tests, agent skills, and i18n coverage gate

### DIFF
--- a/.cursor/skills/code-review/SKILL.md
+++ b/.cursor/skills/code-review/SKILL.md
@@ -1,0 +1,93 @@
+---
+name: code-review
+description: Reviews Grafana code changes for correctness, security, tests, and project conventions. Use when the user asks for a code review, PR review, or review against Grafana standards.
+disable-model-invocation: true
+---
+
+# Grafana Code Review
+
+Review changes against Grafana conventions in `AGENTS.md`, `contribute/`, and directory-scoped `AGENTS.md` files. Focus on actionable findings, not style nits already enforced by linters.
+
+## Scope
+
+Determine what to review before reading code:
+
+| User intent | Diff source |
+|-------------|-------------|
+| Branch / PR / "my changes" | `git diff <base>...HEAD` (default base: repo default branch) |
+| Uncommitted / working tree | `git diff` + `git diff --cached` |
+| Specific PR | `gh pr diff <number>` or checkout PR branch first |
+| Specific files | Read files + nearby callers/tests |
+
+Run in parallel when useful: `git status`, `git diff`, `git log --oneline -5`, and `gh pr view` when a PR number is known.
+
+## Workflow
+
+1. **Identify touched areas** — frontend (`public/app/`), backend (`pkg/`), shared packages (`packages/`), docs (`docs/`), config (`conf/`), unified storage (`pkg/storage/unified/`).
+2. **Load area rules** — read the matching `AGENTS.md` when present (alerting, unified storage, docs, CUJ instrumentation).
+3. **Review dimensions** — correctness, security, tests, API/contract compatibility, UX/a11y, scope/focus.
+4. **Check PR hygiene** — title format, linked issue, tests included, docs/config updates when required.
+5. **Report findings** — use the output format below. Do not fix code unless the user asks.
+
+## Quick checklist
+
+- [ ] Logic handles edge cases and error paths
+- [ ] No XSS, SQL injection, or command injection at trust boundaries
+- [ ] Tests cover new/changed behavior (not snapshot tests)
+- [ ] Frontend/backend split respected when both are not required
+- [ ] Feature toggles for pre-GA behavior
+- [ ] Config changes update `conf/defaults.ini`, `conf/sample.ini`, and docs
+- [ ] Unified storage changes follow client/server compatibility rules
+- [ ] Comments explain non-obvious *why*, not obvious *what*
+- [ ] No secrets, internal URLs, or Jira/Slack links in code comments
+
+For detailed standards by area, see [STANDARDS.md](STANDARDS.md).
+
+## Output format
+
+Start with a one-line verdict: **Approve**, **Approve with nits**, **Request changes**, or **Block**.
+
+Then list findings sorted by severity:
+
+| Severity | Location | Finding | Suggestion |
+|----------|----------|---------|------------|
+| Critical | `path:line` | What is wrong | Concrete fix |
+| Major | `path:line` | What is wrong | Concrete fix |
+| Minor | `path:line` | What is wrong | Concrete fix |
+| Nit | `path:line` | Optional improvement | Optional |
+
+**Severity guide**
+
+- **Critical** — bug, security issue, data loss, broken compatibility, missing tests on a risky path
+- **Major** — convention violation, missing error handling, inadequate test coverage, scope creep
+- **Minor** — maintainability, missing docs for user-facing change, a11y gap
+- **Nit** — optional polish; linters or follow-up PR is fine
+
+End with:
+
+```markdown
+## Summary
+- N critical, N major, N minor, N nit
+
+## Test plan gaps
+- [ ] ...
+
+## PR hygiene
+- Title: `<Area>: <Summary>` — pass/fail + note
+- Linked issue: pass/fail
+- Docs/config: pass/fail/N/A
+```
+
+If no issues: say so explicitly and note any residual test-plan gaps.
+
+## Optional deep review
+
+For a second pass focused on regressions and acceptance criteria, launch one `code-skeptic` subagent after this review. Do not launch both in parallel on the same diff unless the user asks.
+
+## References
+
+- PR template: `.github/PULL_REQUEST_TEMPLATE.md`
+- Contribution guide: `contribute/create-pull-request.md`
+- Root agent guide: `AGENTS.md`
+- Backend: `contribute/backend/style-guide.md`
+- Frontend: `contribute/style-guides/frontend.md`

--- a/.cursor/skills/code-review/STANDARDS.md
+++ b/.cursor/skills/code-review/STANDARDS.md
@@ -1,0 +1,112 @@
+# Grafana review standards
+
+Use this reference during code review. Prefer linking to source docs over repeating them.
+
+## Cross-cutting
+
+From `AGENTS.md` and contribution docs:
+
+- Match surrounding patterns before introducing new abstractions
+- Keep PRs focused; split frontend and backend when they deploy independently
+- Wire DI changes need `make gen-go`; CUE schema changes need `make gen-cue`
+- Feature toggle changes need `make gen-feature-toggles`
+- Human review gate: do not suggest pushing without explicit user approval
+
+### Security
+
+- Validate/sanitize at trust boundaries
+- Parameterize SQL and shell usage
+- Prevent XSS in rendered HTML and panel content
+- Do not log secrets or credentials
+
+### Comments
+
+- Explain *why* for non-obvious logic only
+- No Slack, GitHub, Jira, or other links in code comments
+
+## Pull request hygiene
+
+**Title:** `<Area>: <Summary>` — both parts start with a capital letter. Examples: `Alerting: Fix rule list pagination`, `Docs: Change url to URL`.
+
+**Bug fixes:** description includes `Fixes #<issue>` or `Closes #<issue>` and a regression test.
+
+**Pre-GA features:** behind a feature toggle.
+
+**Config changes:** update all of:
+
+- `conf/defaults.ini`
+- `conf/sample.ini`
+- `docs/sources/administration/configuration.md`
+
+**Changelog / What's New:** user-impactful fixes and features need appropriate labels per `.github/PULL_REQUEST_TEMPLATE.md`.
+
+## Frontend (`public/app/`, `packages/`)
+
+From `contribute/create-pull-request.md` and style guides:
+
+| Rule | Review for |
+|------|------------|
+| Styling | Emotion via `useStyles2`; theme palette for colors |
+| Components | Small, composable; no large monolith components |
+| Data fetching | RTK Query or Redux actions — not raw backend calls from components |
+| Redux | `actionCreatorFactory` / `reducerFactory`; no state mutation; use selectors |
+| TypeScript | Avoid `any` and `{}` without reason |
+| Angular | Do not increase Angular codebase |
+| Tests | React Testing Library; `userEvent.setup()`; prefer `*ByRole` queries |
+| Snapshots | Do not add snapshot tests |
+| Enzyme | Migrate to RTL when touching tests (except minimal bugfix-only PRs) |
+| a11y | Semantic HTML; ARIA only when semantics are insufficient |
+| ESLint | Suppressions must stay accurate; mention `yarn lint:prune` if suppressions look stale |
+
+### Directory-specific
+
+- **Alerting** (`public/app/features/alerting/unified/`): read `AGENTS.md` — prefer `@grafana/alerting`, `@grafana/api-clients`, MSW in tests, RTK Query over new Redux
+- **CUJ instrumentation** (`public/app/core/journeys/`): read `AGENTS.md`
+
+## Backend (`pkg/`, `apps/`)
+
+From `contribute/backend/style-guide.md` and `recommended-practices.md`:
+
+| Rule | Review for |
+|------|------------|
+| Idiomatic Go | Effective Go + Go Code Review Comments |
+| Testing | `testing` + testify; avoid GoConvey in new tests |
+| DB tests | Package has `TestMain` calling `testsuite.Run(m)` when using DB |
+| Global state | Avoid new globals; prefer Wire DI |
+| `init()` | Only for registering services/implementations |
+| Settings | Inject `setting.Cfg`, not package-level vars |
+| Errors | Follow `contribute/backend/errors.md` patterns |
+| Lint | Must pass `make lint-go` / `.golangci.yml` |
+
+### API handlers
+
+- Business logic belongs in `pkg/services/<domain>/`, not handlers
+- New endpoints need tests (see workspace test-case rule)
+- Handlers stay thin; validate input at boundaries
+
+## Unified storage (`pkg/storage/unified/`)
+
+Read `pkg/storage/unified/AGENTS.md`. Critical checks:
+
+1. Do not move responsibility between client and server in one PR
+2. Proto/contract changes must be additive
+3. New client behavior must fall back for old servers
+4. PRs touching both client and server sides need justification or the `no-check-unified-storage-compatibility` label
+
+## Documentation (`docs/`)
+
+Read `docs/AGENTS.md` for style. User-facing changes need docs updates in the same PR when behavior changes.
+
+## Tests to flag as missing
+
+- Bug fix without regression test
+- New API route/handler without test
+- Permission/RBAC UI change without ability checks tested
+- Refactor that changes behavior without updated tests
+- Feature toggle default change without coverage of both paths
+
+## Common false positives (skip unless relevant)
+
+- Formatting nits already caught by Prettier, ESLint, or `make lint-go`
+- Commit message style when reviewing uncommitted diffs only
+- Legacy patterns in untouched lines (note as follow-up only if the PR expands them)

--- a/.cursor/skills/confluence-implementation-overview/SKILL.md
+++ b/.cursor/skills/confluence-implementation-overview/SKILL.md
@@ -1,0 +1,111 @@
+---
+name: confluence-implementation-overview
+description: Creates Confluence implementation-overview pages from GRAF Jira tickets using Atlassian MCP. Use when the user asks to write a Confluence page, implementation overview, epic breakdown, or handoff doc from a Jira ticket or GRAF work item.
+---
+
+# Confluence Implementation Overview
+
+Write a Confluence page that explains **what to build, in what order, and how to verify** — sourced from Jira ticket(s) and the Grafana codebase.
+
+## When to use
+
+- User asks for a Confluence page from a Jira ticket (e.g. "Take GRAF-236 and write a Confluence page")
+- User wants an implementation overview, epic breakdown, or verification handoff doc
+- User mentions Confluence + Jira/GRAF together
+
+Do **not** use for generic docs under `docs/` — those follow `docs/AGENTS.md`.
+
+## Context
+
+| Item | Value |
+|------|-------|
+| Repo | `fieldsphere/grafana` |
+| Jira project | **GRAF** on `fe-anysphere-demo.atlassian.net` |
+| Confluence site | `fe-anysphere-demo.atlassian.net` |
+| Default space | **GRAF** (space key; resolved automatically by MCP) |
+| Cloud ID | From `getAccessibleAtlassianResources` |
+
+## Workflow
+
+### 1. Resolve Jira context
+
+Run in parallel:
+
+1. `getAccessibleAtlassianResources` — `cloudId`
+2. `getJiraIssue` — primary ticket (`summary`, `description`, `status`, `labels`, `issuelinks`, `parent`)
+3. `searchJiraIssuesUsingJql` — related tickets (epic siblings, same label, or epic children)
+
+**Related-ticket JQL patterns** (pick what fits):
+
+```jql
+project = GRAF AND labels = {label} ORDER BY created ASC
+project = GRAF AND parent = {EPIC-KEY} ORDER BY created ASC
+project = GRAF AND key in ({KEY-1}, {KEY-2}, ...) ORDER BY key ASC
+```
+
+Use `responseContentFormat: "markdown"` for issue bodies.
+
+### 2. Enrich from codebase (when paths are named in tickets)
+
+Search/read files mentioned in ticket descriptions (settings, binding, middleware, API routes). Confirm:
+
+- Which steps are already merged vs. still planned
+- Exact package paths and config keys
+- High-risk compatibility paths called out in tickets
+
+Keep codebase notes brief — the page is an implementation guide, not a code walkthrough.
+
+### 3. Find or pick Confluence space
+
+1. `getConfluenceSpaces` with the `cloudId` — confirm **GRAF** exists
+2. If the user named a parent page or space, use that; otherwise default to space **GRAF**
+
+### 4. Create the page
+
+Use `createConfluencePage`:
+
+| Field | Value |
+|-------|-------|
+| `cloudId` | From step 1 |
+| `spaceId` | `GRAF` (or user-specified space key/ID) |
+| `contentType` | `page` |
+| `contentFormat` | `html` (preferred for tables, panels, task lists) |
+| `status` | `current` unless user asks for draft |
+| `title` | `{TICKET-KEY}: {Short topic} Implementation Overview` |
+| `parentId` | Only if user specifies a parent page |
+
+Follow the page structure in [reference.md](reference.md). Adapt sections to the ticket type:
+
+- **Verification ticket** (like GRAF-236): emphasize prerequisite gate, test commands, compatibility checklist
+- **Implementation ticket**: emphasize changes, acceptance criteria, tests, risks
+- **Epic**: emphasize child-ticket sequence table and epic-level acceptance criteria
+
+Link every Jira key: `https://fe-anysphere-demo.atlassian.net/browse/{KEY}`
+
+### 5. Report back
+
+Return:
+
+- Confluence page URL from the MCP response
+- One-line summary of what was documented
+- Any blockers (missing related tickets, MCP auth failure, prerequisite code not in repo)
+
+## MCP failure handling
+
+If Atlassian MCP times out or auth fails:
+
+1. Call `mcp_auth` for `plugin-atlassian-atlassian`, retry once
+2. If still failing, deliver the full page body as markdown in chat (using [reference.md](reference.md) structure) and note the page was **not** published
+3. Offer to publish when MCP reconnects
+
+## Guardrails
+
+- Do not create, edit, or transition Jira issues unless explicitly asked
+- Do not invent ticket scope — derive steps from Jira descriptions and codebase paths cited there
+- Do not expand a verification ticket into implementation work in the Confluence doc
+- Keep operator escape hatches and compatibility risks visible when tickets mention them
+
+## Additional resources
+
+- Page HTML template and section checklist: [reference.md](reference.md)
+- Pull assigned tickets first: [pull-jira-tickets](../pull-jira-tickets/SKILL.md)

--- a/.cursor/skills/confluence-implementation-overview/reference.md
+++ b/.cursor/skills/confluence-implementation-overview/reference.md
@@ -1,0 +1,115 @@
+# Confluence Page Template
+
+Use this structure when creating implementation-overview pages. Omit sections that do not apply.
+
+## Title pattern
+
+```
+{TICKET-KEY}: {Topic} Implementation Overview
+```
+
+Example: `GRAF-236: API Hardening Implementation Overview`
+
+## Required sections
+
+1. **Intro** — link primary ticket + epic (if any); state the goal in one sentence
+2. **Epic scope** — settings/behavior summary table; in-scope vs out-of-scope bullets
+3. **Implementation sequence** — ordered table: Order | Ticket | Summary | Status | Owner | Key files
+4. **Per-step detail** — one `h2` per implementation ticket (`Step N — {summary} ({KEY})`):
+   - Changes (bullets with file paths and config keys)
+   - Tests (task list or acceptance criteria from Jira)
+   - Test command if the ticket specifies one
+5. **Verification step** (when primary ticket is verification/handoff):
+   - Prerequisite panel (block if upstream tickets not merged)
+   - Automated verification steps
+   - Manual compatibility checklist table
+   - Handoff deliverable (pass/fail/blocked matrix + residual risks)
+6. **Architecture** — short ASCII or code-block flow from config → settings → enforcement → API/logging → verification
+7. **Risks and mitigations** — table from Jira or synthesized from ticket risks sections
+8. **Related links** — bullet list of all linked Jira keys
+
+## HTML patterns (contentFormat: html)
+
+**Info panel (goal/context):**
+
+```html
+<div data-type="panel-info"><p><strong>Goal:</strong> …</p></div>
+```
+
+**Warning panel (prerequisite/blocker):**
+
+```html
+<div data-type="panel-warning"><p><strong>Prerequisite:</strong> …</p></div>
+```
+
+**Status in table cells:**
+
+```html
+<span data-type="status" data-color="green">Done</span>
+<span data-type="status" data-color="yellow">In Progress</span>
+<span data-type="status" data-color="neutral">To Do</span>
+```
+
+**Task list (acceptance criteria):**
+
+```html
+<ul data-type="task-list">
+  <li data-type="task-item"><input type="checkbox"> Unchecked item</li>
+  <li data-type="task-item"><input type="checkbox" checked="true" disabled="true"> Done item</li>
+</ul>
+```
+
+**Jira link:**
+
+```html
+<a href="https://fe-anysphere-demo.atlassian.net/browse/GRAF-236">GRAF-236</a>
+```
+
+## Implementation sequence table (HTML skeleton)
+
+```html
+<table data-layout="default">
+<thead>
+<tr><th>Order</th><th>Ticket</th><th>Summary</th><th>Status</th><th>Owner</th><th>Key files</th></tr>
+</thead>
+<tbody>
+<tr>
+  <td>1</td>
+  <td><a href="https://fe-anysphere-demo.atlassian.net/browse/GRAF-234">GRAF-234</a></td>
+  <td>Add server settings for API request hardening</td>
+  <td><span data-type="status" data-color="green">Done</span></td>
+  <td>Name</td>
+  <td><code>pkg/setting/setting.go</code></td>
+</tr>
+</tbody>
+</table>
+```
+
+## Compatibility checklist table (verification tickets)
+
+| Area | What to verify |
+|------|----------------|
+| Large JSON APIs | Below-limit success; oversized → 413; disable escape hatch |
+| Multipart uploads | JSON binding changes do not affect upload handlers |
+| Datasource proxy | Proxy routes bypass `web.Bind` |
+| Logging defaults | Disabled threshold is a no-op |
+| Operator docs | `conf/defaults.ini` and configure-grafana docs updated |
+
+## Architecture block (plain pre/code)
+
+```
+conf/defaults.ini
+    └── [server] settings
+            ↓
+    pkg/setting/setting.go (Cfg)
+            ↓
+    enforcement layer (e.g. pkg/web/binding.go)
+            ↓
+    API wiring (e.g. pkg/web/context.go)
+            ↓
+    verification ticket steps
+```
+
+## Markdown fallback (when MCP publish fails)
+
+If `createConfluencePage` fails, deliver the same sections as markdown in chat so the user can paste manually. Use the table and checklist formats from this file.

--- a/.cursor/skills/pull-jira-tickets/SKILL.md
+++ b/.cursor/skills/pull-jira-tickets/SKILL.md
@@ -1,0 +1,79 @@
+---
+name: pull-jira-tickets
+description: Pull the current user's JIRA tickets for this Grafana repo via Atlassian MCP. Use when the user asks for their JIRA tickets, backlog, assigned issues, or tasks for this repo or project.
+---
+
+# Pull JIRA Tickets for This Repo
+
+## Instructions
+
+When the user asks for their JIRA tickets for this repo, use Atlassian MCP tools. Do not ask the user to look them up manually.
+
+### 1. Resolve context
+
+Run in parallel:
+
+1. `atlassianUserInfo` — confirm the authenticated user
+2. `getAccessibleAtlassianResources` — get the `cloudId` for Jira queries
+3. `git remote -v` — confirm repo is `fieldsphere/grafana`
+
+**Project mapping:** `fieldsphere/grafana` → Jira project **GRAF** (GRAFANA) on `fe-anysphere-demo.atlassian.net`.
+
+### 2. Search Jira
+
+Use `searchJiraIssuesUsingJql` with the resolved `cloudId`.
+
+**Primary query** (assigned tickets in the Grafana project):
+
+```jql
+project = GRAF AND assignee = currentUser() ORDER BY updated DESC
+```
+
+**Fallback query** (if primary returns nothing or user asks broadly):
+
+```jql
+assignee = currentUser() AND (text ~ "grafana" OR summary ~ "grafana") ORDER BY updated DESC
+```
+
+Request fields: `summary`, `status`, `issuetype`, `priority`, `created`, `updated`, `assignee`, `reporter`, `labels`, `description`.
+
+### 3. Present results
+
+Use this format:
+
+```markdown
+## Assigned to you (N)
+
+| Key | Summary | Status | Priority | Updated | Labels |
+|-----|---------|--------|----------|---------|--------|
+| [GRAF-XXX](https://fe-anysphere-demo.atlassian.net/browse/GRAF-XXX) | ... | ... | ... | ... | ... |
+
+---
+
+### GRAF-XXX — [Summary]
+**Reporter:** [Name]
+
+[Brief scope from description: context, acceptance criteria, or key packages]
+```
+
+- Link each ticket: `https://fe-anysphere-demo.atlassian.net/browse/{KEY}`
+- Group by status if more than ~5 tickets
+- If no tickets found, say so and note which queries were run
+- Offer to pull full details or start work on a ticket
+
+### 4. Optional follow-ups
+
+Only when asked:
+
+- **Single ticket details:** `getJiraIssue` with the ticket key
+- **Tickets you reported but didn't assign to yourself:**
+
+```jql
+project = GRAF AND reporter = currentUser() AND assignee != currentUser() ORDER BY updated DESC
+```
+
+## Notes
+
+- Prefer the **GRAF** project over broad text search — it is the canonical Jira project for this repo.
+- Do not create, edit, or transition Jira issues unless the user explicitly asks.
+- If Atlassian MCP auth fails, call `mcp_auth` for the Atlassian server and retry once.

--- a/.github/workflows/i18n-coverage.yml
+++ b/.github/workflows/i18n-coverage.yml
@@ -1,0 +1,44 @@
+# Fieldsphere fork: i18n coverage gate for PRs touching public/app UI (GRAF-212).
+name: i18n coverage
+
+on:
+  pull_request:
+    branches:
+      - main
+      - 'release-*.*.*'
+    paths:
+      - 'public/app/**'
+      - 'packages/grafana-ui/**'
+      - 'packages/grafana-data/**'
+      - 'packages/grafana-sql/**'
+      - 'packages/grafana-alerting/**'
+      - 'i18next.config.ts'
+      - 'public/locales/en-US/**'
+      - '.github/workflows/i18n-coverage.yml'
+
+concurrency:
+  group: i18n-coverage-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  i18n-coverage:
+    name: i18n coverage
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          persist-credentials: false
+      - uses: ./.github/actions/setup-node
+      - uses: ./.github/actions/yarn-install
+      - name: Extract i18n messages
+        run: yarn i18n-extract
+      - name: Verify translations were extracted and committed
+        run: |
+          if ! git diff --exit-code; then
+            echo "::error title=i18n coverage::New/changed user-facing strings are not extracted. Run 'make i18n-extract', commit the updated public/locales/en-US files, and push. See contribute/internationalization.md"
+            exit 1
+          fi

--- a/contribute/fieldsphere-fork-ci.md
+++ b/contribute/fieldsphere-fork-ci.md
@@ -6,6 +6,7 @@ This repository fork uses a **minimal GitHub Actions workflow** ([`.github/workf
 
 - **Backend:** Four **parallel** shards (`./scripts/ci/backend-tests/shard.sh -N1/4` … `-N4/4`), each running `CGO_ENABLED=0 go test -short` on its package subset (~quarter of the tree), so wall time is roughly the slowest shard instead of one long `./...` run. A final job **Backend unit tests (short)** fails the workflow if any shard fails (single check name for branch protection).
 - **Frontend:** `yarn run prettier:check`, `yarn run lint`, then `yarn workspace @grafana/data themes-schema` (generates `schema.generated.json`, which is gitignored but required by `tsc`), then `yarn run typecheck`. Typecheck uses `NODE_OPTIONS=--max-old-space-size=6144` so `tsc` / Nx do not hit the default heap limit on standard runners.
+- **i18n coverage:** On pull requests that touch `public/app/**` (or related extraction inputs), [`.github/workflows/i18n-coverage.yml`](../.github/workflows/i18n-coverage.yml) runs `yarn i18n-extract` and fails if locale catalogs are not committed. Fix by running `make i18n-extract`, committing the updated `public/locales/en-US/` files, and pushing again. See [internationalization.md](internationalization.md) for markup and extraction guidance.
 
 Fork-local paths (`.cursor/`, `.vscode/`, and root `manifest.json`) are listed in [`.prettierignore`](../.prettierignore) so `prettier:check` matches upstream expectations without formatting IDE tooling.
 
@@ -44,9 +45,10 @@ After this workflow is on your default branch:
 
 1. Open **Settings → Rules** (or **Branches → Branch protection**) for `main`.
 2. Remove required status checks that pointed at **removed** jobs (for example old matrix shards or Grafana-specific names).
-3. Add required checks that match **Fieldsphere CI** job names in GitHub’s picker, for example:
+3. Add required checks that match **Fieldsphere CI** and **i18n coverage** job names in GitHub’s picker, for example:
    - `Backend unit tests (short)`
    - `Frontend lint and typecheck`
+   - `i18n coverage`
 
 Names must match what the Actions UI shows for the workflow run (they use the `name:` field on each job).
 

--- a/public/app/plugins/panel/debug/CursorView.test.tsx
+++ b/public/app/plugins/panel/debug/CursorView.test.tsx
@@ -1,0 +1,53 @@
+import { act, render, screen, waitFor } from '@testing-library/react';
+import { Subscription } from 'rxjs';
+
+import { DataHoverEvent, EventBusSrv } from '@grafana/data';
+
+import { CursorView } from './CursorView';
+
+jest.mock('app/features/visualization/data-hover/DataHoverView', () => ({
+  DataHoverView: () => <div data-testid="data-hover-view" />,
+}));
+
+jest.mock('@grafana/ui', () => ({
+  ...jest.requireActual('@grafana/ui'),
+  CustomScrollbar: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}));
+
+describe('CursorView', () => {
+  it('shows no events message before any event is published', () => {
+    const eventBus = new EventBusSrv();
+    render(<CursorView eventBus={eventBus} />);
+
+    expect(screen.getByText('No events yet')).toBeInTheDocument();
+  });
+
+  it('renders event type and origin path after DataHoverEvent', async () => {
+    const eventBus = new EventBusSrv();
+    const scopedBus = eventBus.newScopedBus('debug-panel');
+
+    render(<CursorView eventBus={eventBus} />);
+
+    act(() => {
+      scopedBus.publish(new DataHoverEvent({ point: { time: 42 } }));
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText('event.type: data-hover')).toBeInTheDocument();
+    });
+    expect(screen.getByRole('heading', { name: /event\.origin:/ })).toHaveTextContent('debug-panel');
+  });
+
+  it('unsubscribes from the event bus on unmount', () => {
+    const unsubscribeSpy = jest.spyOn(Subscription.prototype, 'unsubscribe');
+    const eventBus = new EventBusSrv();
+
+    const { unmount } = render(<CursorView eventBus={eventBus} />);
+
+    expect(unsubscribeSpy).not.toHaveBeenCalled();
+    unmount();
+    expect(unsubscribeSpy).toHaveBeenCalled();
+
+    unsubscribeSpy.mockRestore();
+  });
+});

--- a/public/app/plugins/panel/debug/DebugPanel.test.tsx
+++ b/public/app/plugins/panel/debug/DebugPanel.test.tsx
@@ -1,0 +1,65 @@
+import { render, screen } from '@testing-library/react';
+
+import { EventBusSrv, LoadingState, type PanelProps } from '@grafana/data';
+
+import { DebugPanel } from './DebugPanel';
+import { DebugMode, type Options } from './panelcfg.gen';
+
+jest.mock('./RenderInfoViewer', () => ({
+  RenderInfoViewer: () => <div data-testid="render-info-viewer" />,
+}));
+
+jest.mock('./CursorView', () => ({
+  CursorView: () => <div data-testid="cursor-view" />,
+}));
+
+jest.mock('./EventBusLogger', () => ({
+  EventBusLoggerPanel: () => <div data-testid="event-bus-logger" />,
+}));
+
+jest.mock('./StateView', () => ({
+  StateView: () => <div data-testid="state-view" />,
+}));
+
+function renderDebugPanel(mode: DebugMode) {
+  const props = {
+    data: {
+      series: [],
+      state: LoadingState.Done,
+    },
+    options: { mode } satisfies Options,
+    eventBus: new EventBusSrv(),
+  } as unknown as PanelProps<Options>;
+
+  return render(<DebugPanel {...props} />);
+}
+
+describe('DebugPanel', () => {
+  it('routes Events mode to EventBusLoggerPanel', () => {
+    renderDebugPanel(DebugMode.Events);
+    expect(screen.getByTestId('event-bus-logger')).toBeInTheDocument();
+  });
+
+  it('routes Cursor mode to CursorView', () => {
+    renderDebugPanel(DebugMode.Cursor);
+    expect(screen.getByTestId('cursor-view')).toBeInTheDocument();
+  });
+
+  it('routes State mode to StateView', () => {
+    renderDebugPanel(DebugMode.State);
+    expect(screen.getByTestId('state-view')).toBeInTheDocument();
+  });
+
+  it('falls through to RenderInfoViewer for Render mode', () => {
+    renderDebugPanel(DebugMode.Render);
+    expect(screen.getByTestId('render-info-viewer')).toBeInTheDocument();
+  });
+
+  it('throws when mode is ThrowError', () => {
+    const consoleSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+    expect(() => renderDebugPanel(DebugMode.ThrowError)).toThrow('I failed you and for that i am deeply sorry');
+
+    consoleSpy.mockRestore();
+  });
+});

--- a/public/app/plugins/panel/debug/EventBusLogger.test.tsx
+++ b/public/app/plugins/panel/debug/EventBusLogger.test.tsx
@@ -1,0 +1,40 @@
+import { act, render, screen, waitFor } from '@testing-library/react';
+
+import { DataHoverEvent, EventBusSrv } from '@grafana/data';
+
+import { EventBusLoggerPanel } from './EventBusLogger';
+
+jest.mock('@grafana/ui', () => ({
+  ...jest.requireActual('@grafana/ui'),
+  CustomScrollbar: ({ children }: { children: React.ReactNode }) => <div data-testid="scroll">{children}</div>,
+}));
+
+function publishHover(eventBus: EventBusSrv, scopedPath: string, x: number, y: number) {
+  const scoped = eventBus.newScopedBus(scopedPath);
+  const event = new DataHoverEvent({ point: { time: x } });
+  Object.assign(event.payload, { x, y });
+  scoped.publish(event);
+}
+
+describe('EventBusLoggerPanel', () => {
+  it('keeps only the last 40 events, newest first', async () => {
+    const eventBus = new EventBusSrv();
+    render(<EventBusLoggerPanel eventBus={eventBus} />);
+
+    act(() => {
+      for (let i = 0; i < 45; i++) {
+        publishHover(eventBus, `path-${i}`, i, i + 1000);
+      }
+    });
+
+    await waitFor(() => {
+      const rows = screen.getByTestId('scroll').querySelectorAll('div');
+      expect(rows.length).toBe(40);
+    });
+
+    expect(screen.getByText(/"path-44".*data-hover.*X:44.*Y:1044/)).toBeInTheDocument();
+    expect(screen.queryByText(/"path-0"/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/"path-4"/)).not.toBeInTheDocument();
+    expect(screen.getByText(/"path-5"/)).toBeInTheDocument();
+  });
+});

--- a/public/app/plugins/panel/debug/RenderInfoViewer.test.tsx
+++ b/public/app/plugins/panel/debug/RenderInfoViewer.test.tsx
@@ -1,0 +1,135 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+
+import {
+  createDataFrame,
+  FieldType,
+  getDefaultTimeRange,
+  LoadingState,
+  type PanelData,
+  type PanelProps,
+} from '@grafana/data';
+
+import { RenderInfoViewer } from './RenderInfoViewer';
+import { DebugMode, type Options } from './panelcfg.gen';
+
+const defaultOptions: Options = {
+  mode: DebugMode.Render,
+  counters: {
+    render: true,
+    dataChanged: true,
+    schemaChanged: true,
+  },
+};
+
+function makeProps(data: PanelData, options: Options = defaultOptions): PanelProps<Options> {
+  return {
+    data,
+    options,
+    timeRange: getDefaultTimeRange(),
+  } as unknown as PanelProps<Options>;
+}
+
+const frameWithFields = createDataFrame({
+  refId: 'A',
+  fields: [
+    { name: 'timestamp', type: FieldType.time, values: [1, 2, 3] },
+    { name: 'value', type: FieldType.number, values: [10, 20, 30] },
+  ],
+});
+
+describe('RenderInfoViewer', () => {
+  it('increments the render counter across rerenders', () => {
+    const data: PanelData = { state: LoadingState.Done, series: [frameWithFields], timeRange: getDefaultTimeRange() };
+    const { rerender } = render(<RenderInfoViewer {...makeProps(data)} />);
+
+    expect(screen.getByText(/Render:\s*1/)).toBeInTheDocument();
+
+    rerender(<RenderInfoViewer {...makeProps(data)} />);
+    expect(screen.getByText(/Render:\s*2/)).toBeInTheDocument();
+
+    rerender(<RenderInfoViewer {...makeProps(data)} />);
+    expect(screen.getByText(/Render:\s*3/)).toBeInTheDocument();
+  });
+
+  it('increments dataChanged only when the data prop identity changes', () => {
+    const dataA: PanelData = { state: LoadingState.Done, series: [frameWithFields], timeRange: getDefaultTimeRange() };
+    const dataSameRef = dataA;
+    const dataB: PanelData = {
+      state: LoadingState.Done,
+      series: [frameWithFields],
+      timeRange: getDefaultTimeRange(),
+    };
+
+    const { rerender } = render(<RenderInfoViewer {...makeProps(dataA)} />);
+
+    expect(screen.getByText(/Data:\s*0/)).toBeInTheDocument();
+
+    rerender(<RenderInfoViewer {...makeProps(dataSameRef)} />);
+    expect(screen.getByText(/Data:\s*0/)).toBeInTheDocument();
+
+    rerender(<RenderInfoViewer {...makeProps(dataB)} />);
+    expect(screen.getByText(/Data:\s*1/)).toBeInTheDocument();
+  });
+
+  it('increments schemaChanged when enabled and frame structure differs', () => {
+    const frameA = createDataFrame({
+      fields: [{ name: 'a', type: FieldType.number, values: [1] }],
+    });
+    const frameSameStructure = createDataFrame({
+      fields: [{ name: 'a', type: FieldType.number, values: [99] }],
+    });
+    const frameDifferentStructure = createDataFrame({
+      fields: [
+        { name: 'a', type: FieldType.number, values: [1] },
+        { name: 'b', type: FieldType.number, values: [2] },
+      ],
+    });
+
+    const data1: PanelData = { state: LoadingState.Done, series: [frameA], timeRange: getDefaultTimeRange() };
+    const data2: PanelData = {
+      state: LoadingState.Done,
+      series: [frameSameStructure],
+      timeRange: getDefaultTimeRange(),
+    };
+    const data3: PanelData = {
+      state: LoadingState.Done,
+      series: [frameDifferentStructure],
+      timeRange: getDefaultTimeRange(),
+    };
+
+    const { rerender } = render(<RenderInfoViewer {...makeProps(data1)} />);
+    expect(screen.getByText(/Schema:\s*0/)).toBeInTheDocument();
+
+    rerender(<RenderInfoViewer {...makeProps(data2)} />);
+    expect(screen.getByText(/Schema:\s*0/)).toBeInTheDocument();
+
+    rerender(<RenderInfoViewer {...makeProps(data3)} />);
+    expect(screen.getByText(/Schema:\s*1/)).toBeInTheDocument();
+  });
+
+  it('resets all counters when the reset button is clicked', () => {
+    const data: PanelData = { state: LoadingState.Done, series: [frameWithFields], timeRange: getDefaultTimeRange() };
+    const { rerender } = render(<RenderInfoViewer {...makeProps(data)} />);
+
+    rerender(<RenderInfoViewer {...makeProps(data)} />);
+    expect(screen.getByText(/Render:\s*2/)).toBeInTheDocument();
+
+    fireEvent.click(screen.getByTitle('Reset counters'));
+
+    expect(screen.getByText(/Render:\s*1/)).toBeInTheDocument();
+    expect(screen.getByText(/Data:\s*0/)).toBeInTheDocument();
+    expect(screen.getByText(/Schema:\s*0/)).toBeInTheDocument();
+  });
+
+  it('renders a field table row per field with name, type, and lastNotNull value', () => {
+    const data: PanelData = { state: LoadingState.Done, series: [frameWithFields], timeRange: getDefaultTimeRange() };
+    render(<RenderInfoViewer {...makeProps(data)} />);
+
+    expect(screen.getByText('timestamp')).toBeInTheDocument();
+    expect(screen.getByText('value')).toBeInTheDocument();
+    expect(screen.getByText('time')).toBeInTheDocument();
+    expect(screen.getByText('number')).toBeInTheDocument();
+    expect(screen.getByText('3')).toBeInTheDocument();
+    expect(screen.getByText('30')).toBeInTheDocument();
+  });
+});

--- a/public/app/plugins/panel/flamegraph/FlameGraphPanel.test.tsx
+++ b/public/app/plugins/panel/flamegraph/FlameGraphPanel.test.tsx
@@ -1,0 +1,115 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+
+import { CoreApp, LoadingState, type PanelProps } from '@grafana/data';
+import { checkFields, FlameGraph, getMessageCheckFieldsResult } from '@grafana/flamegraph';
+import { config, reportInteraction } from '@grafana/runtime';
+
+import { FlameGraphPanel } from './FlameGraphPanel';
+import { type Options } from './types';
+
+jest.mock('@grafana/flamegraph', () => ({
+  FlameGraph: jest.fn(
+    (props: {
+      stickyHeader?: boolean;
+      showFlameGraphOnly?: boolean;
+      onTableSymbolClick?: () => void;
+      onViewSelected?: (view: string) => void;
+    }) => (
+      <div data-testid="flame-graph">
+        <span data-testid="sticky-header">{String(props.stickyHeader)}</span>
+        <span data-testid="show-flamegraph-only">{String(props.showFlameGraphOnly)}</span>
+        <button type="button" data-testid="table-symbol-click" onClick={() => props.onTableSymbolClick?.()}>
+          table
+        </button>
+        <button
+          type="button"
+          data-testid="view-selected"
+          onClick={() => props.onViewSelected?.('cpu-profile')}
+        >
+          view
+        </button>
+      </div>
+    )
+  ),
+  checkFields: jest.fn(),
+  getMessageCheckFieldsResult: jest.fn((wrong: string) => `check-fields: ${wrong}`),
+}));
+
+jest.mock('@grafana/runtime', () => ({
+  ...jest.requireActual('@grafana/runtime'),
+  PanelDataErrorView: (props: { message?: string }) => <div data-testid="error-view">{props.message}</div>,
+  reportInteraction: jest.fn(),
+}));
+
+const mockCheckFields = checkFields as jest.Mock;
+const mockGetMessage = getMessageCheckFieldsResult as jest.Mock;
+const mockReportInteraction = reportInteraction as jest.Mock;
+const mockFlameGraph = FlameGraph as jest.Mock;
+
+function panelProps(overrides?: Partial<PanelProps<Options>>): PanelProps<Options> {
+  return {
+    id: 1,
+    data: {
+      series: [{ fields: [], length: 0 }],
+      state: LoadingState.Done,
+    },
+    ...overrides,
+  } as unknown as PanelProps<Options>;
+}
+
+describe('FlameGraphPanel', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockCheckFields.mockReturnValue(undefined);
+  });
+
+  it('renders PanelDataErrorView when checkFields fails', () => {
+    mockCheckFields.mockReturnValue('wrong-shape');
+    mockGetMessage.mockReturnValue('Need profile fields');
+
+    render(<FlameGraphPanel {...panelProps()} />);
+
+    expect(screen.getByTestId('error-view')).toHaveTextContent('Need profile fields');
+    expect(mockGetMessage).toHaveBeenCalledWith('wrong-shape');
+    expect(mockFlameGraph).not.toHaveBeenCalled();
+  });
+
+  it('renders FlameGraph with stickyHeader false and showFlameGraphOnly default false', () => {
+    render(<FlameGraphPanel {...panelProps()} />);
+
+    expect(screen.getByTestId('flame-graph')).toBeInTheDocument();
+    expect(screen.getByTestId('sticky-header')).toHaveTextContent('false');
+    expect(screen.getByTestId('show-flamegraph-only')).toHaveTextContent('false');
+
+    expect(mockFlameGraph).toHaveBeenCalledWith(
+      expect.objectContaining({
+        stickyHeader: false,
+        showFlameGraphOnly: false,
+      }),
+      expect.anything()
+    );
+  });
+
+  it('reports table_item_selected when onTableSymbolClick fires', () => {
+    render(<FlameGraphPanel {...panelProps()} />);
+
+    fireEvent.click(screen.getByTestId('table-symbol-click'));
+
+    expect(mockReportInteraction).toHaveBeenCalledWith('grafana_flamegraph_table_item_selected', {
+      app: CoreApp.Unknown,
+      grafana_version: config.buildInfo.version,
+    });
+  });
+
+  it('reports view_selected with the selected view', () => {
+    render(<FlameGraphPanel {...panelProps()} />);
+
+    fireEvent.click(screen.getByTestId('view-selected'));
+
+    expect(mockReportInteraction).toHaveBeenCalledWith('grafana_flamegraph_view_selected', {
+      app: CoreApp.Unknown,
+      grafana_version: config.buildInfo.version,
+      view: 'cpu-profile',
+    });
+  });
+});

--- a/public/app/plugins/panel/flamegraph/module.test.ts
+++ b/public/app/plugins/panel/flamegraph/module.test.ts
@@ -1,0 +1,41 @@
+import { createDataFrame, getPanelDataSummary } from '@grafana/data';
+import { checkFields } from '@grafana/flamegraph';
+
+jest.mock('@grafana/flamegraph', () => ({
+  FlameGraph: () => null,
+  checkFields: jest.fn(),
+  getMessageCheckFieldsResult: jest.fn(),
+}));
+
+const mockCheckFields = checkFields as jest.MockedFunction<typeof checkFields>;
+
+import { plugin } from './module';
+
+describe('flamegraph module', () => {
+  beforeEach(() => {
+    mockCheckFields.mockReset();
+  });
+
+  it('returns undefined when no raw frame passes checkFields', () => {
+    mockCheckFields.mockReturnValue('invalid');
+
+    const summary = getPanelDataSummary([createDataFrame({ fields: [] })]);
+
+    expect(plugin.getSuggestions(summary)).toBeUndefined();
+    expect(mockCheckFields).toHaveBeenCalled();
+  });
+
+  it('returns a suggestion whose previewModifier sets showFlameGraphOnly when a frame is valid', () => {
+    mockCheckFields.mockReturnValue(undefined);
+
+    const summary = getPanelDataSummary([createDataFrame({ fields: [] })]);
+    const suggestions = plugin.getSuggestions(summary);
+
+    expect(suggestions).toHaveLength(1);
+
+    const suggestionState: { options?: { showFlameGraphOnly?: boolean } } = {};
+    suggestions![0].cardOptions?.previewModifier?.(suggestionState as never);
+
+    expect(suggestionState.options?.showFlameGraphOnly).toBe(true);
+  });
+});

--- a/public/app/plugins/panel/live/LiveChannelEditor.test.tsx
+++ b/public/app/plugins/panel/live/LiveChannelEditor.test.tsx
@@ -1,0 +1,124 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import selectEvent from 'react-select-event';
+
+import { LiveChannelScope, type StandardEditorContext, type StandardEditorsRegistryItem } from '@grafana/data';
+import { getManagedChannelInfo } from 'app/features/live/info';
+import {
+  discoveryResources,
+  getAPIGroupDiscoveryList,
+} from 'app/features/apiserver/discovery';
+
+import { LiveChannelEditor } from './LiveChannelEditor';
+import { type LivePanelOptions } from './types';
+
+jest.mock('app/features/live/info', () => ({
+  getManagedChannelInfo: jest.fn(),
+}));
+
+jest.mock('app/features/apiserver/discovery', () => ({
+  getAPIGroupDiscoveryList: jest.fn(),
+  discoveryResources: jest.fn(),
+}));
+
+const mockGetManagedChannelInfo = getManagedChannelInfo as jest.Mock;
+const mockGetAPIGroupDiscoveryList = getAPIGroupDiscoveryList as jest.Mock;
+const mockDiscoveryResources = discoveryResources as jest.Mock;
+
+const mockContext: StandardEditorContext<LivePanelOptions> = {
+  data: [],
+  options: {},
+};
+
+const mockItem = {} as StandardEditorsRegistryItem<unknown>;
+
+const managedChannels = {
+  channels: [
+    { value: 'plugin/testdata/alpha', label: 'plugin/testdata/alpha [1 msg/min]' },
+    { value: 'plugin/testdata/beta', label: 'plugin/testdata/beta [2 msg/min]' },
+    { value: 'ds/other/other-path', label: 'ds/other/other-path [0 msg/min]' },
+  ],
+  channelFields: {},
+};
+
+describe('LiveChannelEditor', () => {
+  beforeEach(() => {
+    mockGetManagedChannelInfo.mockResolvedValue(managedChannels);
+    mockGetAPIGroupDiscoveryList.mockResolvedValue([]);
+    mockDiscoveryResources.mockReturnValue([]);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('clears stream and path when scope changes', async () => {
+    const onChange = jest.fn();
+    render(
+      <LiveChannelEditor
+        value={{ scope: LiveChannelScope.Plugin, stream: 'testdata', path: 'alpha' }}
+        onChange={onChange}
+        context={mockContext}
+        item={mockItem}
+      />
+    );
+
+    await waitFor(() => expect(mockGetManagedChannelInfo).toHaveBeenCalled());
+
+    const selects = screen.getAllByRole('combobox');
+    await selectEvent.select(selects[0], 'Stream', { container: document.body });
+
+    expect(onChange).toHaveBeenCalledWith({
+      scope: LiveChannelScope.Stream,
+      stream: undefined,
+      path: undefined,
+    });
+  });
+
+  it('derives namespace and path options from managed channels for the selected scope', async () => {
+    render(
+      <LiveChannelEditor
+        value={{ scope: LiveChannelScope.Plugin, stream: 'testdata', path: 'alpha' }}
+        onChange={jest.fn()}
+        context={mockContext}
+        item={mockItem}
+      />
+    );
+
+    await waitFor(() => expect(mockGetManagedChannelInfo).toHaveBeenCalled());
+
+    expect(await screen.findByText('testdata')).toBeInTheDocument();
+    expect(screen.getByText('plugin/testdata/alpha [1 msg/min]')).toBeInTheDocument();
+
+    const namespaceSelect = screen.getAllByRole('combobox')[1];
+    await selectEvent.openMenu(namespaceSelect, { container: document.body });
+    expect(screen.queryByText('other')).not.toBeInTheDocument();
+  });
+
+  it('keeps a custom path value when it is not in the fetched path options', async () => {
+    render(
+      <LiveChannelEditor
+        value={{ scope: LiveChannelScope.Plugin, stream: 'testdata', path: 'custom-path' }}
+        onChange={jest.fn()}
+        context={mockContext}
+        item={mockItem}
+      />
+    );
+
+    await waitFor(() => expect(mockGetManagedChannelInfo).toHaveBeenCalled());
+
+    expect(await screen.findByText('custom-path')).toBeInTheDocument();
+  });
+
+  it('shows the watchable resource combobox for watch scope', async () => {
+    render(
+      <LiveChannelEditor
+        value={{ scope: LiveChannelScope.Watch }}
+        onChange={jest.fn()}
+        context={mockContext}
+        item={mockItem}
+      />
+    );
+
+    expect(await screen.findByPlaceholderText('Select watchable resource')).toBeInTheDocument();
+  });
+});

--- a/public/app/plugins/panel/live/LiveChannelEditor.test.tsx
+++ b/public/app/plugins/panel/live/LiveChannelEditor.test.tsx
@@ -2,11 +2,11 @@ import { render, screen, waitFor } from '@testing-library/react';
 import selectEvent from 'react-select-event';
 
 import { LiveChannelScope, type StandardEditorContext, type StandardEditorsRegistryItem } from '@grafana/data';
-import { getManagedChannelInfo } from 'app/features/live/info';
 import {
   discoveryResources,
   getAPIGroupDiscoveryList,
 } from 'app/features/apiserver/discovery';
+import { getManagedChannelInfo } from 'app/features/live/info';
 
 import { LiveChannelEditor } from './LiveChannelEditor';
 import { type LivePanelOptions } from './types';

--- a/public/app/plugins/panel/live/LivePanel.test.tsx
+++ b/public/app/plugins/panel/live/LivePanel.test.tsx
@@ -1,0 +1,141 @@
+import { act, render, screen, waitFor } from '@testing-library/react';
+
+import {
+  LiveChannelConnectionState,
+  LiveChannelEventType,
+  LiveChannelScope,
+  LoadingState,
+  type PanelProps,
+} from '@grafana/data';
+import { getGrafanaLiveSrv } from '@grafana/runtime';
+
+import { LivePanel } from './LivePanel';
+import { type LivePanelOptions, MessageDisplayMode, MessagePublishMode } from './types';
+
+jest.mock('@grafana/runtime', () => ({
+  ...jest.requireActual('@grafana/runtime'),
+  getGrafanaLiveSrv: jest.fn(),
+}));
+
+jest.mock('../table/TablePanel', () => ({
+  TablePanel: () => <div data-testid="table-panel" />,
+}));
+
+const mockGetGrafanaLiveSrv = getGrafanaLiveSrv as jest.Mock;
+
+const validChannel = {
+  scope: LiveChannelScope.DataSource,
+  stream: 'test-ds',
+  path: 'metrics',
+};
+
+function panelProps(overrides: Partial<PanelProps<LivePanelOptions>> = {}): PanelProps<LivePanelOptions> {
+  return {
+    id: 1,
+    width: 400,
+    height: 300,
+    data: { series: [], state: LoadingState.Done },
+    options: {
+      channel: validChannel,
+      display: MessageDisplayMode.Raw,
+      publish: MessagePublishMode.None,
+    },
+    replaceVariables: (v: string) => v,
+    ...overrides,
+  } as unknown as PanelProps<LivePanelOptions>;
+}
+
+describe('LivePanel', () => {
+  let unsubscribe: jest.Mock;
+  let subscribe: jest.Mock;
+  let getStream: jest.Mock;
+  let capturedObserver: { next?: (event: unknown) => void };
+  let consoleLogSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    consoleLogSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+    unsubscribe = jest.fn();
+    subscribe = jest.fn((observer) => {
+      capturedObserver = observer;
+      return { unsubscribe };
+    });
+    getStream = jest.fn(() => ({ subscribe }));
+    mockGetGrafanaLiveSrv.mockReturnValue({ getStream });
+    capturedObserver = {};
+  });
+
+  afterEach(() => {
+    consoleLogSpy.mockRestore();
+    jest.clearAllMocks();
+  });
+
+  it('shows feature flag alert when Grafana Live is unavailable', () => {
+    mockGetGrafanaLiveSrv.mockReturnValue(undefined);
+
+    render(<LivePanel {...panelProps()} />);
+
+    expect(screen.getByText(/Grafana live requires a feature flag to run/i)).toBeInTheDocument();
+  });
+
+  it('prompts to pick a channel when the address is invalid', () => {
+    render(<LivePanel {...panelProps({ options: { channel: { scope: LiveChannelScope.DataSource } } })} />);
+
+    expect(screen.getByText(/Use the panel editor to pick a channel/i)).toBeInTheDocument();
+  });
+
+  it('subscribes on mount and unsubscribes on unmount', async () => {
+    const { unmount } = render(<LivePanel {...panelProps()} />);
+
+    await waitFor(() => {
+      expect(getStream).toHaveBeenCalledWith(validChannel);
+      expect(subscribe).toHaveBeenCalled();
+    });
+
+    unmount();
+    expect(unsubscribe).toHaveBeenCalled();
+  });
+
+  it('shows error when getStream throws', async () => {
+    const loadChannelSpy = jest.spyOn(LivePanel.prototype, 'loadChannel').mockImplementation(function (this: LivePanel) {
+      this.setState({ addr: validChannel, error: 'stream failed' });
+    });
+
+    render(<LivePanel {...panelProps()} />);
+
+    await screen.findByText('Error');
+    expect(screen.getByText('"stream failed"')).toBeInTheDocument();
+
+    loadChannelSpy.mockRestore();
+  });
+
+  it('renders raw status JSON when display mode is None', async () => {
+    const status = {
+      type: LiveChannelEventType.Status,
+      id: 'ds/test-ds/metrics',
+      timestamp: 1_700_000_000_000,
+      state: LiveChannelConnectionState.Pending,
+    };
+
+    render(
+      <LivePanel
+        {...panelProps({
+          options: {
+            channel: validChannel,
+            display: MessageDisplayMode.None,
+            publish: MessagePublishMode.None,
+          },
+        })}
+      />
+    );
+
+    await waitFor(() => expect(subscribe).toHaveBeenCalled());
+
+    act(() => {
+      capturedObserver.next?.(status);
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText(JSON.stringify(status))).toBeInTheDocument();
+    });
+  });
+});

--- a/public/app/plugins/panel/live/LivePublish.test.tsx
+++ b/public/app/plugins/panel/live/LivePublish.test.tsx
@@ -1,0 +1,170 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import { LiveChannelScope, type LiveChannelAddress } from '@grafana/data';
+import { getBackendSrv, getGrafanaLiveSrv } from '@grafana/runtime';
+
+import { LivePublish } from './LivePublish';
+import { MessagePublishMode } from './types';
+
+jest.mock('@grafana/runtime', () => ({
+  ...jest.requireActual('@grafana/runtime'),
+  getBackendSrv: jest.fn(),
+  getGrafanaLiveSrv: jest.fn(),
+}));
+
+jest.mock('@grafana/ui', () => {
+  const actual = jest.requireActual('@grafana/ui');
+  return {
+    ...actual,
+    CodeEditor: ({
+      value,
+      onBlur,
+      onSave,
+    }: {
+      value: string;
+      onBlur: (v: string) => void;
+      onSave: (v: string) => void;
+    }) => (
+      <textarea
+        data-testid="code-editor"
+        value={value}
+        onChange={(e) => {
+          onBlur(e.target.value);
+          onSave(e.target.value);
+        }}
+      />
+    ),
+  };
+});
+
+const mockGetBackendSrv = getBackendSrv as jest.Mock;
+const mockGetGrafanaLiveSrv = getGrafanaLiveSrv as jest.Mock;
+
+const streamAddr: LiveChannelAddress = {
+  scope: LiveChannelScope.Stream,
+  stream: 'influx-stream',
+  path: 'write',
+};
+
+const dsAddr: LiveChannelAddress = {
+  scope: LiveChannelScope.DataSource,
+  stream: 'prom',
+  path: 'metrics',
+};
+
+describe('LivePublish', () => {
+  const alertSpy = jest.spyOn(window, 'alert').mockImplementation(() => {});
+
+  beforeEach(() => {
+    mockGetBackendSrv.mockReturnValue({ post: jest.fn().mockResolvedValue({}) });
+    mockGetGrafanaLiveSrv.mockReturnValue({ publish: jest.fn().mockResolvedValue({}) });
+    alertSpy.mockClear();
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('stringifies JSON body and uses empty object placeholder when body is empty', () => {
+    render(
+      <LivePublish height={200} mode={MessagePublishMode.JSON} body={{ foo: 1 }} addr={dsAddr} onSave={jest.fn()} />
+    );
+
+    expect(screen.getByTestId('code-editor')).toHaveValue(
+      JSON.stringify({ foo: 1 }, null, 2)
+    );
+
+    render(<LivePublish height={200} mode={MessagePublishMode.JSON} addr={dsAddr} onSave={jest.fn()} />);
+
+    expect(screen.getAllByTestId('code-editor').pop()).toHaveValue('{ }');
+  });
+
+  it('parses JSON on save in JSON mode and passes raw text in influx mode', async () => {
+    const onSaveJson = jest.fn();
+    render(
+      <LivePublish height={200} mode={MessagePublishMode.JSON} body={{ a: 1 }} addr={dsAddr} onSave={onSaveJson} />
+    );
+
+    fireEvent.change(screen.getByTestId('code-editor'), { target: { value: '{"b":2}' } });
+    await waitFor(() => expect(onSaveJson).toHaveBeenCalledWith({ b: 2 }));
+
+    const onSaveInflux = jest.fn();
+    render(
+      <LivePublish
+        height={200}
+        mode={MessagePublishMode.Influx}
+        body="cpu,host=a value=1"
+        addr={streamAddr}
+        onSave={onSaveInflux}
+      />
+    );
+
+    fireEvent.change(screen.getAllByTestId('code-editor').pop()!, {
+      target: { value: 'cpu,host=b value=2' },
+    });
+    await waitFor(() => expect(onSaveInflux).toHaveBeenCalledWith('cpu,host=b value=2'));
+  });
+
+  it('posts to the live push API for influx mode with stream scope', async () => {
+    const post = jest.fn().mockResolvedValue({});
+    mockGetBackendSrv.mockReturnValue({ post });
+    const user = userEvent.setup();
+
+    render(
+      <LivePublish
+        height={200}
+        mode={MessagePublishMode.Influx}
+        body="line protocol"
+        addr={streamAddr}
+        onSave={jest.fn()}
+      />
+    );
+
+    await user.click(screen.getByRole('button', { name: /Publish/i }));
+
+    expect(post).toHaveBeenCalledWith('api/live/push/influx-stream', 'line protocol');
+  });
+
+  it('alerts and does not post when influx mode has non-stream scope', async () => {
+    const post = jest.fn();
+    mockGetBackendSrv.mockReturnValue({ post });
+    const user = userEvent.setup();
+
+    render(
+      <LivePublish
+        height={200}
+        mode={MessagePublishMode.Influx}
+        body="line"
+        addr={dsAddr}
+        onSave={jest.fn()}
+      />
+    );
+
+    await user.click(screen.getByRole('button', { name: /Publish/i }));
+
+    expect(alertSpy).toHaveBeenCalledWith('expected stream scope!');
+    expect(post).not.toHaveBeenCalled();
+  });
+
+  it('alerts instead of publishing when the address is invalid', async () => {
+    const publish = jest.fn();
+    mockGetGrafanaLiveSrv.mockReturnValue({ publish });
+    const user = userEvent.setup();
+
+    render(
+      <LivePublish
+        height={200}
+        mode={MessagePublishMode.JSON}
+        body="{}"
+        addr={{ scope: LiveChannelScope.DataSource, stream: 'only-stream' }}
+        onSave={jest.fn()}
+      />
+    );
+
+    await user.click(screen.getByRole('button', { name: /Publish/i }));
+
+    expect(alertSpy).toHaveBeenCalledWith('invalid address');
+    expect(publish).not.toHaveBeenCalled();
+  });
+});

--- a/public/app/plugins/panel/welcome/Welcome.test.tsx
+++ b/public/app/plugins/panel/welcome/Welcome.test.tsx
@@ -1,0 +1,44 @@
+import { render, screen } from '@testing-library/react';
+
+import { WelcomeBanner } from './Welcome';
+
+const helpLinks = [
+  {
+    label: 'Documentation',
+    href: 'https://grafana.com/docs/grafana/latest?utm_source=grafana_gettingstarted',
+  },
+  {
+    label: 'Tutorials',
+    href: 'https://grafana.com/tutorials?utm_source=grafana_gettingstarted',
+  },
+  {
+    label: 'Community',
+    href: 'https://community.grafana.com?utm_source=grafana_gettingstarted',
+  },
+  {
+    label: 'Public Slack',
+    href: 'http://slack.grafana.com?utm_source=grafana_gettingstarted',
+  },
+];
+
+describe('WelcomeBanner', () => {
+  it('renders the welcome heading and need help subheading', () => {
+    render(<WelcomeBanner />);
+
+    expect(screen.getByRole('heading', { level: 1, name: /welcome to grafana/i })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { level: 2, name: /need help\?/i })).toBeInTheDocument();
+  });
+
+  it('renders all help links with utm_source on hrefs as external links', () => {
+    render(<WelcomeBanner />);
+
+    for (const { label, href } of helpLinks) {
+      const link = screen.getByRole('link', { name: label });
+      expect(link).toHaveAttribute('href', href);
+      expect(link).toHaveAttribute('target', '_blank');
+      expect(link).toHaveAttribute('rel', 'noreferrer');
+    }
+
+    expect(screen.getAllByRole('link')).toHaveLength(helpLinks.length);
+  });
+});


### PR DESCRIPTION
## Summary
- Add unit tests for welcome, flamegraph, debug, and live panel plugins
- Add Cursor agent skills for code review, Confluence implementation overviews, and Jira ticket pull
- Add Fieldsphere `i18n-coverage` GitHub Actions workflow (GRAF-212) that fails PRs when `yarn i18n-extract` locale catalogs are not committed, and document the required check in fork CI docs

## Test plan
- [ ] Confirm panel unit tests pass: `yarn jest --no-watch public/app/plugins/panel/{welcome,flamegraph,debug,live}`
- [ ] Open a PR that only touches docs/workflows and confirm i18n coverage is skipped (path filter)
- [ ] Open or simulate a PR touching `public/app/**` without committing locale updates and confirm `i18n coverage` fails with the extract guidance
- [ ] After `make i18n-extract` and committing `public/locales/en-US/`, confirm the check passes
- [ ] Verify branch protection docs list `i18n coverage` alongside existing Fieldsphere CI checks


Made with [Cursor](https://cursor.com)