### PR TITLE
Frontend: Replace console calls with structured logging

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -255,6 +255,20 @@ module.exports = [
     },
   },
   {
+    name: 'grafana/no-unstructured-console-logging',
+    files: ['public/app/**/*.{ts,tsx,js,jsx}'],
+    ignores: [
+      ...commonTestIgnores,
+      '**/*.{story,mock}.{ts,tsx,js,jsx}',
+      'public/app/core/services/echo/backends/analytics/BrowseConsoleBackend.ts',
+      'public/app/core/utils/debugLog.ts',
+      'public/app/features/dashboard/services/performanceUtils.ts',
+    ],
+    rules: {
+      'no-console': 'error',
+    },
+  },
+  {
     name: 'grafana/uplot-overrides',
     files: ['packages/grafana-ui/src/components/uPlot/**/*.{ts,tsx}'],
     rules: {

--- a/packages/grafana-runtime/src/index.ts
+++ b/packages/grafana-runtime/src/index.ts
@@ -22,9 +22,11 @@ export {
   logDebug,
   logWarning,
   logError,
+  logStructured,
   createMonitoringLogger,
   logMeasurement,
   type MonitoringLogger,
+  type StructuredLogLevel,
 } from './utils/logging';
 export { TracedError } from './utils/TracedError';
 export {

--- a/packages/grafana-runtime/src/utils/logging.test.ts
+++ b/packages/grafana-runtime/src/utils/logging.test.ts
@@ -1,0 +1,76 @@
+import { LogLevel } from '@grafana/faro-web-sdk';
+
+import { logStructured } from './logging';
+import { TracedError } from './TracedError';
+
+const mockPushLog = jest.fn();
+const mockPushError = jest.fn();
+
+jest.mock('@grafana/faro-web-sdk', () => ({
+  ...jest.requireActual('@grafana/faro-web-sdk'),
+  faro: {
+    api: {
+      pushLog: (...args: unknown[]) => mockPushLog(...args),
+      pushError: (...args: unknown[]) => mockPushError(...args),
+    },
+  },
+}));
+
+jest.mock('../config', () => ({
+  config: {
+    grafanaJavascriptAgent: { enabled: true },
+  },
+}));
+
+describe('logStructured', () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it('records additional values as structured context', () => {
+    logStructured('features.example', 'warn', 'Request failed', { status: 503 }, 2n);
+
+    expect(mockPushLog).toHaveBeenCalledWith(['Request failed'], {
+      level: LogLevel.WARN,
+      context: {
+        source: 'features.example',
+        argument1: '{"status":503}',
+        argument2: '2',
+      },
+    });
+  });
+
+  it('preserves the original stack when recording an error', () => {
+    const cause = new Error('connection refused');
+
+    logStructured('features.example', 'error', 'Unable to load data', cause, { retry: true });
+
+    expect(mockPushError).toHaveBeenCalledWith(
+      expect.objectContaining<Partial<TracedError>>({
+        message: 'Unable to load data',
+        cause,
+        stack: cause.stack,
+      }),
+      {
+        context: {
+          source: 'features.example',
+          argument2: '{"retry":true}',
+        },
+      }
+    );
+  });
+
+  it('uses an error as the message when no description is provided', () => {
+    const error = new Error('bad response');
+
+    logStructured('features.example', 'error', error);
+
+    expect(mockPushError).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: 'Error: bad response',
+        cause: error,
+      }),
+      { context: { source: 'features.example' } }
+    );
+  });
+});

--- a/packages/grafana-runtime/src/utils/logging.test.ts
+++ b/packages/grafana-runtime/src/utils/logging.test.ts
@@ -1,7 +1,7 @@
 import { LogLevel } from '@grafana/faro-web-sdk';
 
+import { type TracedError } from './TracedError';
 import { logStructured } from './logging';
-import { TracedError } from './TracedError';
 
 const mockPushLog = jest.fn();
 const mockPushError = jest.fn();
@@ -28,7 +28,7 @@ describe('logStructured', () => {
   });
 
   it('records additional values as structured context', () => {
-    logStructured('features.example', 'warn', 'Request failed', { status: 503 }, 2n);
+    logStructured('features.example', 'warn', 'Request failed', { status: 503 }, BigInt(2));
 
     expect(mockPushLog).toHaveBeenCalledWith(['Request failed'], {
       level: LogLevel.WARN,

--- a/packages/grafana-runtime/src/utils/logging.ts
+++ b/packages/grafana-runtime/src/utils/logging.ts
@@ -95,7 +95,8 @@ function formatLogValue(value: unknown): string {
  */
 export function logStructured(source: string, level: StructuredLogLevel, ...values: unknown[]): void {
   const errorIndex = values.findIndex((value) => value instanceof Error);
-  const error = errorIndex >= 0 ? (values[errorIndex] as Error) : undefined;
+  const errorValue = values[errorIndex];
+  const error = errorValue instanceof Error ? errorValue : undefined;
   const messageIndex = values.findIndex((_value, index) => index !== errorIndex);
   const messageValue = messageIndex >= 0 ? values[messageIndex] : undefined;
   const message = formatLogValue(messageValue ?? error ?? 'No log message provided');

--- a/packages/grafana-runtime/src/utils/logging.ts
+++ b/packages/grafana-runtime/src/utils/logging.ts
@@ -2,6 +2,10 @@ import { faro, type LogContext, LogLevel } from '@grafana/faro-web-sdk';
 
 import { config } from '../config';
 
+import { TracedError } from './TracedError';
+
+export type StructuredLogLevel = 'debug' | 'info' | 'warn' | 'error';
+
 /**
  * Log a message at INFO level
  * @public
@@ -53,6 +57,71 @@ export function logError(err: Error, contexts?: LogContext) {
     faro.api.pushError(err, {
       context: contexts,
     });
+  }
+}
+
+function formatLogValue(value: unknown): string {
+  if (typeof value === 'string') {
+    return value;
+  }
+
+  if (value instanceof Error) {
+    return `${value.name}: ${value.message}`;
+  }
+
+  if (value === undefined) {
+    return 'undefined';
+  }
+
+  if (typeof value === 'bigint') {
+    return value.toString();
+  }
+
+  try {
+    return (
+      JSON.stringify(value, (_key, nestedValue) =>
+        typeof nestedValue === 'bigint' ? nestedValue.toString() : nestedValue
+      ) ?? String(value)
+    );
+  } catch {
+    return String(value);
+  }
+}
+
+/**
+ * Sends console-style values to the monitoring backend as a structured log.
+ *
+ * @public
+ */
+export function logStructured(source: string, level: StructuredLogLevel, ...values: unknown[]): void {
+  const errorIndex = values.findIndex((value) => value instanceof Error);
+  const error = errorIndex >= 0 ? (values[errorIndex] as Error) : undefined;
+  const messageIndex = values.findIndex((_value, index) => index !== errorIndex);
+  const messageValue = messageIndex >= 0 ? values[messageIndex] : undefined;
+  const message = formatLogValue(messageValue ?? error ?? 'No log message provided');
+  const context = values.reduce<LogContext>(
+    (result, value, index) => {
+      if (index !== messageIndex && index !== errorIndex) {
+        result[`argument${index}`] = formatLogValue(value);
+      }
+      return result;
+    },
+    { source }
+  );
+
+  switch (level) {
+    case 'debug':
+      logDebug(message, context);
+      break;
+    case 'info':
+      logInfo(message, context);
+      break;
+    case 'warn':
+      logWarning(message, context);
+      break;
+    case 'error':
+      logError(error ? new TracedError(message, error) : new Error(message), context);
+      break;
   }
 }
 

--- a/public/app/AppWrapper.tsx
+++ b/public/app/AppWrapper.tsx
@@ -6,7 +6,7 @@ import CacheProvider from 'react-inlinesvg/provider';
 import { Provider } from 'react-redux';
 import { Route, Routes } from 'react-router-dom-v5-compat';
 
-import { config, navigationLogger, reportInteraction } from '@grafana/runtime';
+import { logStructured as structuredLog, config, navigationLogger, reportInteraction } from '@grafana/runtime';
 import { getFeatureFlagClient } from '@grafana/runtime/internal';
 import { ErrorBoundaryAlert, getPortalContainer, GlobalStyles, PortalContainer, TimeRangeProvider } from '@grafana/ui';
 import { BrandingContext, type BrandingContextValue } from '@grafana/ui/internal';
@@ -87,7 +87,7 @@ export function AppWrapper({ context }: AppWrapperProps) {
     if (preloader) {
       preloader.remove();
     } else {
-      console.warn('Preloader element not found');
+      structuredLog('grafana/frontend.AppWrapper', 'warn', 'Preloader element not found');
     }
   }
 

--- a/public/app/api/clients/provisioning/utils/createOnCacheEntryAdded.ts
+++ b/public/app/api/clients/provisioning/utils/createOnCacheEntryAdded.ts
@@ -1,3 +1,5 @@
+import { logStructured as structuredLog } from '@grafana/runtime';
+
 import { type ThunkDispatch, type UnknownAction } from '@reduxjs/toolkit';
 import { type Subscription } from 'rxjs';
 
@@ -108,7 +110,12 @@ export function createOnCacheEntryAdded<Spec, Status>(
           },
         });
     } catch (error) {
-      console.error('Error in onCacheEntryAdded:', error);
+      structuredLog(
+        'grafana/frontend.api.clients.provisioning.utils.createOnCacheEntryAdded',
+        'error',
+        'Error in onCacheEntryAdded:',
+        error
+      );
       return;
     }
 

--- a/public/app/api/clients/provisioning/utils/createOnCacheEntryAdded.ts
+++ b/public/app/api/clients/provisioning/utils/createOnCacheEntryAdded.ts
@@ -1,8 +1,7 @@
-import { logStructured as structuredLog } from '@grafana/runtime';
-
 import { type ThunkDispatch, type UnknownAction } from '@reduxjs/toolkit';
 import { type Subscription } from 'rxjs';
 
+import { logStructured as structuredLog } from '@grafana/runtime';
 import { ScopedResourceClient } from 'app/features/apiserver/client';
 import { type ListOptions, type GeneratedResourceList as ResourceList } from 'app/features/apiserver/types';
 

--- a/public/app/api/clients/provisioning/v0alpha1/index.ts
+++ b/public/app/api/clients/provisioning/v0alpha1/index.ts
@@ -10,7 +10,7 @@ import {
   type Status,
 } from '@grafana/api-clients/rtkq/provisioning/v0alpha1';
 import { t } from '@grafana/i18n';
-import { isFetchError } from '@grafana/runtime';
+import { logStructured as structuredLog, isFetchError } from '@grafana/runtime';
 import { clearFolders } from 'app/features/browse-dashboards/state/slice';
 import { getState } from 'app/store/store';
 import { type ThunkDispatch } from 'app/types/store';
@@ -271,7 +271,12 @@ export const provisioningAPIv0alpha1 = generatedAPI.enhanceEndpoints({
             dispatch(clearFolders(childrenKeys));
           }
         } catch (e) {
-          console.error('Error in getRepositoryJobsWithPath:', e);
+          structuredLog(
+            'grafana/frontend.api.clients.provisioning.v0alpha1.index',
+            'error',
+            'Error in getRepositoryJobsWithPath:',
+            e
+          );
         }
       },
     },

--- a/public/app/app.ts
+++ b/public/app/app.ts
@@ -22,6 +22,7 @@ import {
 import { DEFAULT_LANGUAGE } from '@grafana/i18n';
 import { initializeI18n, loadNamespacedResources } from '@grafana/i18n/internal';
 import {
+  logStructured as structuredLog,
   HistoryWrapper,
   locationService,
   setBackendSrv,
@@ -169,7 +170,7 @@ export class GrafanaApp {
         try {
           await initOpenFeature();
         } catch (err) {
-          console.error('Failed to initialize OpenFeature provider', err);
+          structuredLog('grafana/frontend.app', 'error', 'Failed to initialize OpenFeature provider', err);
         }
       }
 
@@ -338,7 +339,7 @@ export class GrafanaApp {
       try {
         cleanupOldExpandedFolders();
       } catch (err) {
-        console.warn('Failed to clean up old expanded folders', err);
+        structuredLog('grafana/frontend.app', 'warn', 'Failed to clean up old expanded folders', err);
       }
 
       this.context = {
@@ -368,7 +369,7 @@ export class GrafanaApp {
 
       await postInitTasks();
     } catch (error) {
-      console.error('Failed to start Grafana', error);
+      structuredLog('grafana/frontend.app', 'error', 'Failed to start Grafana', error);
       window.__grafana_load_failed(error);
     } finally {
       stopMeasure('frontend_app_init');

--- a/public/app/core/components/AccessControl/Permissions.tsx
+++ b/public/app/core/components/AccessControl/Permissions.tsx
@@ -1,3 +1,5 @@
+import { logStructured as structuredLog } from '@grafana/runtime';
+
 import { css } from '@emotion/css';
 import { sortBy } from 'lodash';
 import { useEffect, useMemo, useState } from 'react';
@@ -239,7 +241,12 @@ const getDescription = async (resource: string, queryParams?: Record<string, str
   try {
     return await getBackendSrv().get(`/api/access-control/${resource}/description`, queryParams);
   } catch (e) {
-    console.error('failed to load resource description: ', e);
+    structuredLog(
+      'grafana/frontend.core.components.AccessControl.Permissions',
+      'error',
+      'failed to load resource description: ',
+      e
+    );
     return INITIAL_DESCRIPTION;
   }
 };

--- a/public/app/core/components/AccessControl/Permissions.tsx
+++ b/public/app/core/components/AccessControl/Permissions.tsx
@@ -1,5 +1,3 @@
-import { logStructured as structuredLog } from '@grafana/runtime';
-
 import { css } from '@emotion/css';
 import { sortBy } from 'lodash';
 import { useEffect, useMemo, useState } from 'react';
@@ -8,6 +6,7 @@ import useAsyncFn from 'react-use/lib/useAsyncFn';
 
 import { type GrafanaTheme2 } from '@grafana/data';
 import { Trans, t } from '@grafana/i18n';
+import { logStructured as structuredLog } from '@grafana/runtime';
 import { Text, Box, Button, useStyles2, LoadingPlaceholder } from '@grafana/ui';
 import { SlideDown } from 'app/core/components/Animations/SlideDown';
 import { getBackendSrv } from 'app/core/services/backend_srv';

--- a/public/app/core/components/AppChrome/TopBar/InviteUserButton.tsx
+++ b/public/app/core/components/AppChrome/TopBar/InviteUserButton.tsx
@@ -2,7 +2,7 @@ import { skipToken } from '@reduxjs/toolkit/query';
 
 import { PluginExtensionPoints } from '@grafana/data';
 import { t } from '@grafana/i18n';
-import { renderLimitedComponents } from '@grafana/runtime';
+import { logStructured as structuredLog, renderLimitedComponents } from '@grafana/runtime';
 import { ToolbarButton } from '@grafana/ui';
 import { useGetCurrentOrgQuotaQuery } from 'app/api/clients/legacy';
 import { SETUPGUIDE_PLUGIN_ID } from 'app/core/constants';
@@ -61,7 +61,12 @@ function InviteUserButton() {
         performInviteUserClick('top_bar_right', 'invite-user-top-bar');
       }
     } catch (error) {
-      console.error('Failed to handle invite/upgrade user click:', error);
+      structuredLog(
+        'grafana/frontend.core.components.AppChrome.TopBar.InviteUserButton',
+        'error',
+        'Failed to handle invite/upgrade user click:',
+        error
+      );
     }
   };
 

--- a/public/app/core/components/Login/LoginCtrl.tsx
+++ b/public/app/core/components/Login/LoginCtrl.tsx
@@ -1,7 +1,7 @@
 import { memo, useState, useCallback, type JSX } from 'react';
 
 import { t } from '@grafana/i18n';
-import { type FetchError, getBackendSrv, isFetchError } from '@grafana/runtime';
+import { logStructured as structuredLog, type FetchError, getBackendSrv, isFetchError } from '@grafana/runtime';
 import config from 'app/core/config';
 
 import { type LoginDTO } from './types';
@@ -88,7 +88,7 @@ const LoginCtrl = memo(({ resetCode, children }: Props) => {
           .then(() => {
             toGrafana();
           })
-          .catch((err) => console.error(err));
+          .catch((err) => structuredLog('grafana/frontend.core.components.Login.LoginCtrl', 'error', err));
       }
     },
     [resetCode, toGrafana]

--- a/public/app/core/components/NavLandingPage/NavLandingPage.tsx
+++ b/public/app/core/components/NavLandingPage/NavLandingPage.tsx
@@ -2,7 +2,7 @@ import { css } from '@emotion/css';
 import * as React from 'react';
 
 import { type GrafanaTheme2, type NavModelItem } from '@grafana/data';
-import { usePluginComponents, usePluginLinks } from '@grafana/runtime';
+import { logStructured as structuredLog, usePluginComponents, usePluginLinks } from '@grafana/runtime';
 import { useStyles2 } from '@grafana/ui';
 import { Page } from 'app/core/components/Page/Page';
 import { useNavModel } from 'app/core/hooks/useNavModel';
@@ -36,7 +36,9 @@ export function NavLandingPage({ navId, header }: Props) {
   // Warn if both extension points are being used (they are mutually exclusive)
   React.useEffect(() => {
     if (components && components.length > 0 && additionalCards && additionalCards.length > 0) {
-      console.warn(
+      structuredLog(
+        'grafana/frontend.core.components.NavLandingPage.NavLandingPage',
+        'warn',
         `[NavLandingPage] Both NavLandingPage and NavLandingPageCards extensions are registered for "${node.id}". ` +
           `The NavLandingPage extension will take precedence and NavLandingPageCards will be ignored. ` +
           `Please use only one extension point.`

--- a/public/app/core/components/RolePicker/TeamRolePicker.tsx
+++ b/public/app/core/components/RolePicker/TeamRolePicker.tsx
@@ -1,3 +1,5 @@
+import { logStructured as structuredLog } from '@grafana/runtime';
+
 import { skipToken } from '@reduxjs/toolkit/query';
 import { useMemo } from 'react';
 
@@ -79,7 +81,12 @@ export const TeamRolePicker = ({
           },
         }).unwrap();
       } catch (error) {
-        console.error('Error updating team roles', error);
+        structuredLog(
+          'grafana/frontend.core.components.RolePicker.TeamRolePicker',
+          'error',
+          'Error updating team roles',
+          error
+        );
       }
     } else if (onApplyRoles) {
       onApplyRoles(newRoles);

--- a/public/app/core/components/RolePicker/TeamRolePicker.tsx
+++ b/public/app/core/components/RolePicker/TeamRolePicker.tsx
@@ -1,8 +1,7 @@
-import { logStructured as structuredLog } from '@grafana/runtime';
-
 import { skipToken } from '@reduxjs/toolkit/query';
 import { useMemo } from 'react';
 
+import { logStructured as structuredLog } from '@grafana/runtime';
 import { useListTeamRolesQuery, useSetTeamRolesMutation } from 'app/api/clients/roles';
 import { contextSrv } from 'app/core/services/context_srv';
 import { AccessControlAction, type Role } from 'app/types/accessControl';

--- a/public/app/core/components/RolePicker/UserRolePicker.tsx
+++ b/public/app/core/components/RolePicker/UserRolePicker.tsx
@@ -1,9 +1,8 @@
-import { logStructured as structuredLog } from '@grafana/runtime';
-
 import { skipToken } from '@reduxjs/toolkit/query';
 import { useMemo } from 'react';
 
 import { type OrgRole } from '@grafana/data';
+import { logStructured as structuredLog } from '@grafana/runtime';
 import { useListUserRolesQuery, useSetUserRolesMutation } from 'app/api/clients/roles';
 import { contextSrv } from 'app/core/services/context_srv';
 import { AccessControlAction, type Role } from 'app/types/accessControl';

--- a/public/app/core/components/RolePicker/UserRolePicker.tsx
+++ b/public/app/core/components/RolePicker/UserRolePicker.tsx
@@ -1,3 +1,5 @@
+import { logStructured as structuredLog } from '@grafana/runtime';
+
 import { skipToken } from '@reduxjs/toolkit/query';
 import { useMemo } from 'react';
 
@@ -90,7 +92,12 @@ export const UserRolePicker = ({
           },
         }).unwrap();
       } catch (error) {
-        console.error('Error updating user roles', error);
+        structuredLog(
+          'grafana/frontend.core.components.RolePicker.UserRolePicker',
+          'error',
+          'Error updating user roles',
+          error
+        );
       }
     } else if (onApplyRoles) {
       onApplyRoles(newRoles, userId, orgId);

--- a/public/app/core/components/TimePicker/TimePickerWithHistory.tsx
+++ b/public/app/core/components/TimePicker/TimePickerWithHistory.tsx
@@ -1,5 +1,3 @@
-import { logStructured as structuredLog } from '@grafana/runtime';
-
 import { uniqBy } from 'lodash';
 
 import {
@@ -11,6 +9,7 @@ import {
   rangeUtil,
 } from '@grafana/data';
 import { t } from '@grafana/i18n';
+import { logStructured as structuredLog } from '@grafana/runtime';
 import { type TimeRangePickerProps, TimeRangePicker } from '@grafana/ui';
 import { appEvents } from 'app/core/app_events';
 

--- a/public/app/core/components/TimePicker/TimePickerWithHistory.tsx
+++ b/public/app/core/components/TimePicker/TimePickerWithHistory.tsx
@@ -1,3 +1,5 @@
+import { logStructured as structuredLog } from '@grafana/runtime';
+
 import { uniqBy } from 'lodash';
 
 import {
@@ -136,7 +138,11 @@ function convertToISOString(value: DateTime | string): string {
   }
 
   if (!value?.toISOString) {
-    throw console.error('Invalid DateTime object passed to convertToISOString');
+    throw structuredLog(
+      'grafana/frontend.core.components.TimePicker.TimePickerWithHistory',
+      'error',
+      'Invalid DateTime object passed to convertToISOString'
+    );
   }
 
   return value.toISOString();

--- a/public/app/core/history/RichHistoryIndexedDBStorage.ts
+++ b/public/app/core/history/RichHistoryIndexedDBStorage.ts
@@ -2,7 +2,7 @@ import { openDB, type DBSchema, type IDBPDatabase } from 'idb';
 import { isEqual, omit } from 'lodash';
 
 import { type DataQuery, generateUUID } from '@grafana/data';
-import { reportInteraction } from '@grafana/runtime';
+import { logStructured as structuredLog, reportInteraction } from '@grafana/runtime';
 import {
   DEFAULT_RICH_HISTORY_SETTINGS as DEFAULT_SETTINGS,
   type RichHistorySearchBackendFilters,
@@ -126,7 +126,12 @@ export default class RichHistoryIndexedDBStorage implements RichHistoryStorage, 
     if (!this.migrationPromise) {
       this.migrationPromise = migrateToIndexedDB(this).catch((error) => {
         // Log but don't block — user can still use storage
-        console.error('Query history migration failed:', error);
+        structuredLog(
+          'grafana/frontend.core.history.RichHistoryIndexedDBStorage',
+          'error',
+          'Query history migration failed:',
+          error
+        );
         // Reset so it retries on next access
         this.migrationPromise = undefined;
       });
@@ -228,7 +233,12 @@ export default class RichHistoryIndexedDBStorage implements RichHistoryStorage, 
     // (the no-time-range branch, or a time range wider than the retention
     // window); this self-heals once the next cleanup commits. Acceptable for GC.
     void this.maybeRunRetentionCleanup(db).catch((error) => {
-      console.error('Query history retention cleanup failed:', error);
+      structuredLog(
+        'grafana/frontend.core.history.RichHistoryIndexedDBStorage',
+        'error',
+        'Query history retention cleanup failed:',
+        error
+      );
     });
 
     // 1. Index-based retrieval — narrow at the DB level

--- a/public/app/core/history/indexedDBMigration.ts
+++ b/public/app/core/history/indexedDBMigration.ts
@@ -1,7 +1,7 @@
 import { lastValueFrom } from 'rxjs';
 
 import { type DataQuery, generateUUID, store } from '@grafana/data';
-import { config, getBackendSrv, reportInteraction } from '@grafana/runtime';
+import { logStructured as structuredLog, config, getBackendSrv, reportInteraction } from '@grafana/runtime';
 import { getDataSourceInstanceSettings } from '@grafana/runtime/unstable';
 import { DEFAULT_RICH_HISTORY_SETTINGS } from 'app/core/utils/richHistoryTypes';
 
@@ -136,7 +136,9 @@ async function runMigration(indexedDBStorage: IndexedDBMigrationAccess): Promise
 
   if (currentAttempts >= MAX_MIGRATION_ATTEMPTS) {
     reportInteraction('grafana_query_history_migration_abandoned', { attempts: currentAttempts });
-    console.warn(
+    structuredLog(
+      'grafana/frontend.core.history.indexedDBMigration',
+      'warn',
       `Query history migration to IndexedDB did not succeed after ${MAX_MIGRATION_ATTEMPTS} attempts. ` +
         `Existing query history remains in localStorage and/or the remote API. ` +
         `Set localStorage key '${RESET_MIGRATION_KEY}' to true and reload to retry the migration.`

--- a/public/app/core/journeys/utils.ts
+++ b/public/app/core/journeys/utils.ts
@@ -1,4 +1,4 @@
-import { type JourneyHandle, locationService } from '@grafana/runtime';
+import { logStructured as structuredLog, type JourneyHandle, locationService } from '@grafana/runtime';
 
 /**
  * Collects cleanup functions so journey wiring doesn't need
@@ -54,7 +54,9 @@ function warnUnsupported(kind: string): void {
     return;
   }
   warnedTypes.add(kind);
-  console.warn(
+  structuredLog(
+    'grafana/frontend.core.journeys.utils',
+    'warn',
     `[CUJ] str() received unsupported value of type "${kind}"; coerced to ''. ` +
       `Pass primitives (string/number/boolean) to reportInteraction so journey attributes stay queryable in Tempo.`
   );

--- a/public/app/core/navigation/errorModels.ts
+++ b/public/app/core/navigation/errorModels.ts
@@ -1,6 +1,5 @@
-import { logStructured as structuredLog } from '@grafana/runtime';
-
 import { type NavModel, type NavModelItem } from '@grafana/data';
+import { logStructured as structuredLog } from '@grafana/runtime';
 
 export function getExceptionNav(error: unknown): NavModel {
   structuredLog('grafana/frontend.core.navigation.errorModels', 'error', error);

--- a/public/app/core/navigation/errorModels.ts
+++ b/public/app/core/navigation/errorModels.ts
@@ -1,7 +1,9 @@
+import { logStructured as structuredLog } from '@grafana/runtime';
+
 import { type NavModel, type NavModelItem } from '@grafana/data';
 
 export function getExceptionNav(error: unknown): NavModel {
-  console.error(error);
+  structuredLog('grafana/frontend.core.navigation.errorModels', 'error', error);
   return getWarningNav('Exception thrown', 'See console for details');
 }
 

--- a/public/app/core/reducers/appNotification.ts
+++ b/public/app/core/reducers/appNotification.ts
@@ -1,3 +1,5 @@
+import { logStructured as structuredLog } from '@grafana/runtime';
+
 import { createSelector, createSlice, type PayloadAction } from '@reduxjs/toolkit';
 
 import { store } from '@grafana/data';
@@ -121,7 +123,11 @@ function serializeNotifications(notifs: Record<string, StoredNotification>) {
   try {
     store.set(STORAGE_KEY, JSON.stringify(reducedNotifs));
   } catch (err) {
-    console.error('Unable to persist notifications to local storage');
-    console.error(err);
+    structuredLog(
+      'grafana/frontend.core.reducers.appNotification',
+      'error',
+      'Unable to persist notifications to local storage'
+    );
+    structuredLog('grafana/frontend.core.reducers.appNotification', 'error', err);
   }
 }

--- a/public/app/core/reducers/appNotification.ts
+++ b/public/app/core/reducers/appNotification.ts
@@ -1,8 +1,7 @@
-import { logStructured as structuredLog } from '@grafana/runtime';
-
 import { createSelector, createSlice, type PayloadAction } from '@reduxjs/toolkit';
 
 import { store } from '@grafana/data';
+import { logStructured as structuredLog } from '@grafana/runtime';
 import { type AppNotification, AppNotificationSeverity, type AppNotificationsState } from 'app/types/appNotifications';
 
 const MAX_STORED_NOTIFICATIONS = 25;

--- a/public/app/core/services/FetchQueue.ts
+++ b/public/app/core/services/FetchQueue.ts
@@ -1,6 +1,6 @@
 import { type Observable, Subject } from 'rxjs';
 
-import { type BackendSrvRequest } from '@grafana/runtime';
+import { logStructured as structuredLog, type BackendSrvRequest } from '@grafana/runtime';
 
 export interface QueueState extends Record<string, { state: FetchStatus; options: BackendSrvRequest }> {}
 
@@ -90,8 +90,8 @@ export class FetchQueue {
       []
     );
 
-    console.log('FetchQueue noOfStarted', update.noOfInProgress);
-    console.log('FetchQueue noOfNotStarted', update.noOfPending);
-    console.log('FetchQueue state', entriesWithoutOptions);
+    structuredLog('grafana/frontend.core.services.FetchQueue', 'info', 'FetchQueue noOfStarted', update.noOfInProgress);
+    structuredLog('grafana/frontend.core.services.FetchQueue', 'info', 'FetchQueue noOfNotStarted', update.noOfPending);
+    structuredLog('grafana/frontend.core.services.FetchQueue', 'info', 'FetchQueue state', entriesWithoutOptions);
   };
 }

--- a/public/app/core/services/backend_srv.ts
+++ b/public/app/core/services/backend_srv.ts
@@ -27,6 +27,7 @@ import {
 
 import { AppEvents, DataQueryErrorType, deprecationWarning, generateUUID } from '@grafana/data';
 import {
+  logStructured as structuredLog,
   type BackendSrv as BackendService,
   type BackendSrvRequest,
   config,
@@ -115,7 +116,7 @@ export class BackendSrv implements BackendService {
       const result = await fp.get();
       this.deviceID = result.visitorId;
     } catch (error) {
-      console.error(error);
+      structuredLog('grafana/frontend.core.services.backend_srv', 'error', error);
     }
   }
 
@@ -240,7 +241,7 @@ export class BackendSrv implements BackendService {
             observer.complete();
           }) // runs in background
           .catch((e) => {
-            console.log(requestId, 'catch', e);
+            structuredLog('grafana/frontend.core.services.backend_srv', 'info', requestId, 'catch', e);
             observer.error(e);
           }); // from abort
       },

--- a/public/app/core/services/context_srv.ts
+++ b/public/app/core/services/context_srv.ts
@@ -9,7 +9,7 @@ import {
   userHasPermissionInMetadata,
   userHasAnyPermission,
 } from '@grafana/data';
-import { featureEnabled, getBackendSrv } from '@grafana/runtime';
+import { logStructured as structuredLog, featureEnabled, getBackendSrv } from '@grafana/runtime';
 import { getSessionExpiry } from 'app/core/utils/auth';
 import { type UserPermission, AccessControlAction } from 'app/types/accessControl';
 import { type CurrentUserInternal } from 'app/types/config';
@@ -108,7 +108,7 @@ export class ContextSrv {
         reloadcache: true,
       });
     } catch (e) {
-      console.error(e);
+      structuredLog('grafana/frontend.core.services.context_srv', 'error', e);
     }
   }
 
@@ -258,7 +258,7 @@ export class ContextSrv {
         }
       })
       .catch((e) => {
-        console.error(e);
+        structuredLog('grafana/frontend.core.services.context_srv', 'error', e);
       });
   }
 }

--- a/public/app/core/services/echo/Echo.ts
+++ b/public/app/core/services/echo/Echo.ts
@@ -1,4 +1,5 @@
 import {
+  logStructured as structuredLog,
   type EchoBackend,
   type EchoMeta,
   type EchoEvent,
@@ -76,7 +77,12 @@ export class Echo implements EchoSrv {
             try {
               cb(payload.properties ?? {});
             } catch (err) {
-              console.error(`[Echo] onInteraction subscriber error for "${payload.interactionName}":`, err);
+              structuredLog(
+                'grafana/frontend.core.services.echo.Echo',
+                'error',
+                `[Echo] onInteraction subscriber error for "${payload.interactionName}":`,
+                err
+              );
             }
           }
         }

--- a/public/app/core/services/echo/init.ts
+++ b/public/app/core/services/echo/init.ts
@@ -1,4 +1,4 @@
-import { config, registerEchoBackend, setEchoSrv } from '@grafana/runtime';
+import { logStructured as structuredLog, config, registerEchoBackend, setEchoSrv } from '@grafana/runtime';
 import { reportMetricPerformanceMark } from 'app/core/utils/metrics';
 
 import { contextSrv } from '../context_srv';
@@ -28,49 +28,89 @@ export async function initEchoSrv() {
   try {
     await initPerformanceBackend();
   } catch (error) {
-    console.error('Error initializing EchoSrv Performance backend', error);
+    structuredLog(
+      'grafana/frontend.core.services.echo.init',
+      'error',
+      'Error initializing EchoSrv Performance backend',
+      error
+    );
   }
 
   try {
     await initFaroBackend();
   } catch (error) {
-    console.error('Error initializing EchoSrv Faro backend', error);
+    structuredLog(
+      'grafana/frontend.core.services.echo.init',
+      'error',
+      'Error initializing EchoSrv Faro backend',
+      error
+    );
   }
 
   try {
     await initGoogleAnalyticsBackend();
   } catch (error) {
-    console.error('Error initializing EchoSrv GoogleAnalytics backend', error);
+    structuredLog(
+      'grafana/frontend.core.services.echo.init',
+      'error',
+      'Error initializing EchoSrv GoogleAnalytics backend',
+      error
+    );
   }
 
   try {
     await initGoogleAnalaytics4Backend();
   } catch (error) {
-    console.error('Error initializing EchoSrv GoogleAnalaytics4 backend', error);
+    structuredLog(
+      'grafana/frontend.core.services.echo.init',
+      'error',
+      'Error initializing EchoSrv GoogleAnalaytics4 backend',
+      error
+    );
   }
 
   try {
     await initRudderstackBackend();
   } catch (error) {
-    console.error('Error initializing EchoSrv Rudderstack backend', error);
+    structuredLog(
+      'grafana/frontend.core.services.echo.init',
+      'error',
+      'Error initializing EchoSrv Rudderstack backend',
+      error
+    );
   }
 
   try {
     await initAzureAppInsightsBackend();
   } catch (error) {
-    console.error('Error initializing EchoSrv AzureAppInsights backend', error);
+    structuredLog(
+      'grafana/frontend.core.services.echo.init',
+      'error',
+      'Error initializing EchoSrv AzureAppInsights backend',
+      error
+    );
   }
 
   try {
     await initPostHogBackend();
   } catch (error) {
-    console.error('Error initializing EchoSrv PostHog backend', error);
+    structuredLog(
+      'grafana/frontend.core.services.echo.init',
+      'error',
+      'Error initializing EchoSrv PostHog backend',
+      error
+    );
   }
 
   try {
     await initConsoleBackend();
   } catch (error) {
-    console.error('Error initializing EchoSrv Console backend', error);
+    structuredLog(
+      'grafana/frontend.core.services.echo.init',
+      'error',
+      'Error initializing EchoSrv Console backend',
+      error
+    );
   }
 }
 

--- a/public/app/core/services/journey/JourneyRegistryImpl.ts
+++ b/public/app/core/services/journey/JourneyRegistryImpl.ts
@@ -1,4 +1,5 @@
 import {
+  logStructured as structuredLog,
   type JourneyHandle,
   type JourneyMeta,
   type JourneyRegistry,
@@ -150,7 +151,9 @@ export class JourneyRegistryImpl implements JourneyRegistry {
     }
     for (const [type] of this.metadata) {
       if (!this.registeredTriggers.has(type)) {
-        console.warn(
+        structuredLog(
+          'grafana/frontend.core.services.journey.JourneyRegistryImpl',
+          'warn',
           `[JourneyRegistry] Registry entry "${type}" has no triggers registered. ` +
             `Did you forget to import its wiring module?`
         );

--- a/public/app/core/services/journey/JourneyTrackerImpl.ts
+++ b/public/app/core/services/journey/JourneyTrackerImpl.ts
@@ -1,6 +1,7 @@
 import { type Span, type Tracer, context, trace, SpanStatusCode, type Link } from '@opentelemetry/api';
 
 import {
+  logStructured as structuredLog,
   type JourneyHandle,
   type JourneyOutcome,
   type JourneyTracker,
@@ -422,7 +423,12 @@ class JourneyHandleImpl implements JourneyHandle {
       try {
         cb();
       } catch (err) {
-        console.error(`[JourneyTracker] onEnd callback error for "${this.journeyType}":`, err);
+        structuredLog(
+          'grafana/frontend.core.services.journey.JourneyTrackerImpl',
+          'error',
+          `[JourneyTracker] onEnd callback error for "${this.journeyType}":`,
+          err
+        );
       }
     }
   }

--- a/public/app/core/services/meticulous.ts
+++ b/public/app/core/services/meticulous.ts
@@ -1,3 +1,5 @@
+import { logStructured as structuredLog } from '@grafana/runtime';
+
 const AUTH_PATH_PREFIXES = ['/login', '/signup', '/invite/', '/verify', '/user/password/', '/profile/password'];
 
 function isAuthPath(pathname: string): boolean {
@@ -18,6 +20,6 @@ export async function updateMeticulousRecording(pathname: string): Promise<void>
   try {
     window.__meticulous.stopRecording();
   } catch (error) {
-    console.error('Error stopping Meticulous recording:', error);
+    structuredLog('grafana/frontend.core.services.meticulous', 'error', 'Error stopping Meticulous recording:', error);
   }
 }

--- a/public/app/core/trustedTypePolicies.ts
+++ b/public/app/core/trustedTypePolicies.ts
@@ -1,5 +1,5 @@
 import { textUtil } from '@grafana/data';
-import { config } from '@grafana/runtime';
+import { logStructured as structuredLog, config } from '@grafana/runtime';
 
 const CSP_REPORT_ONLY_ENABLED = config.cspReportOnlyEnabled;
 
@@ -8,7 +8,14 @@ export const defaultTrustedTypesPolicy = {
     if (!CSP_REPORT_ONLY_ENABLED) {
       return string.replace(/<script/gi, '&lt;script');
     }
-    console.error('[HTML not sanitized with Trusted Types]', string, source, sink);
+    structuredLog(
+      'grafana/frontend.core.trustedTypePolicies',
+      'error',
+      '[HTML not sanitized with Trusted Types]',
+      string,
+      source,
+      sink
+    );
     return string;
   },
   createScript: (string: string) => string,
@@ -16,7 +23,14 @@ export const defaultTrustedTypesPolicy = {
     if (!CSP_REPORT_ONLY_ENABLED) {
       return textUtil.sanitizeUrl(string);
     }
-    console.error('[ScriptURL not sanitized with Trusted Types]', string, source, sink);
+    structuredLog(
+      'grafana/frontend.core.trustedTypePolicies',
+      'error',
+      '[ScriptURL not sanitized with Trusted Types]',
+      string,
+      source,
+      sink
+    );
     return string;
   },
 };

--- a/public/app/core/utils/explore.ts
+++ b/public/app/core/utils/explore.ts
@@ -1,5 +1,3 @@
-import { logStructured as structuredLog } from '@grafana/runtime';
-
 import { customAlphabet } from 'nanoid';
 import { type Unsubscribable } from 'rxjs';
 
@@ -26,6 +24,7 @@ import {
   urlUtil,
   generateUUID,
 } from '@grafana/data';
+import { logStructured as structuredLog } from '@grafana/runtime';
 import { getDataSourceInstance } from '@grafana/runtime/unstable';
 import { RefreshPicker } from '@grafana/ui';
 import { ExpressionDatasourceUID } from 'app/features/expressions/types';

--- a/public/app/core/utils/explore.ts
+++ b/public/app/core/utils/explore.ts
@@ -1,3 +1,5 @@
+import { logStructured as structuredLog } from '@grafana/runtime';
+
 import { customAlphabet } from 'nanoid';
 import { type Unsubscribable } from 'rxjs';
 
@@ -159,7 +161,7 @@ export const safeStringifyValue = (value: unknown, space?: number) => {
   try {
     return JSON.stringify(value, null, space);
   } catch (error) {
-    console.error(error);
+    structuredLog('grafana/frontend.core.utils.explore', 'error', error);
   }
 
   return '';
@@ -232,7 +234,11 @@ export async function ensureQueries(
         try {
           await getDataSourceInstance(query.datasource.uid);
         } catch {
-          console.error(`One of the queries has a datasource that is no longer available and was removed.`);
+          structuredLog(
+            'grafana/frontend.core.utils.explore',
+            'error',
+            `One of the queries has a datasource that is no longer available and was removed.`
+          );
           validDS = false;
         }
       }

--- a/public/app/core/utils/fetch.test.ts
+++ b/public/app/core/utils/fetch.test.ts
@@ -1,4 +1,5 @@
 import { PathValidationError } from '@grafana/data';
+import { logStructured } from '@grafana/runtime';
 
 import {
   isContentTypeJson,
@@ -13,6 +14,10 @@ import {
 jest.mock('@grafana/data', () => ({
   ...jest.requireActual('@grafana/data'),
   deprecationWarning: () => {},
+}));
+jest.mock('@grafana/runtime', () => ({
+  ...jest.requireActual('@grafana/runtime'),
+  logStructured: jest.fn(),
 }));
 
 describe('parseUrlFromOptions', () => {
@@ -192,7 +197,11 @@ describe('parseResponseBody', () => {
 
     expect(body).toEqual({});
     expect(json).not.toHaveBeenCalled();
-    expect(console.warn).toHaveBeenCalledTimes(1);
+    expect(logStructured).toHaveBeenCalledWith(
+      'grafana/frontend.core.utils.fetch',
+      'warn',
+      expect.stringContaining('returned an invalid JSON')
+    );
   });
 
   it('parses text', async () => {

--- a/public/app/core/utils/fetch.ts
+++ b/public/app/core/utils/fetch.ts
@@ -2,7 +2,7 @@ import { omitBy } from 'lodash';
 import { type Observable, of, throwError } from 'rxjs';
 
 import { deprecationWarning, validatePath } from '@grafana/data';
-import { type BackendSrvRequest } from '@grafana/runtime';
+import { logStructured as structuredLog, type BackendSrvRequest } from '@grafana/runtime';
 
 export const parseInitFromOptions = (options: BackendSrvRequest): RequestInit => {
   const method = options.method;
@@ -139,7 +139,7 @@ export async function parseResponseBody<T>(
         // An empty string is not a valid JSON.
         // Sometimes (unfortunately) our APIs declare their Content-Type as JSON, however they return an empty body.
         if (response.headers.get('Content-Length') === '0') {
-          console.warn(`${response.url} returned an invalid JSON`);
+          structuredLog('grafana/frontend.core.utils.fetch', 'warn', `${response.url} returned an invalid JSON`);
           return {} as T;
         }
         return await response.json();

--- a/public/app/core/utils/metrics.ts
+++ b/public/app/core/utils/metrics.ts
@@ -1,3 +1,5 @@
+import { logStructured as structuredLog } from '@grafana/runtime';
+
 import { reportPerformance } from '../services/echo/EchoSrv';
 
 export function startMeasure(eventName: string) {
@@ -8,7 +10,12 @@ export function startMeasure(eventName: string) {
   try {
     performance.mark(`${eventName}_started`);
   } catch (error) {
-    console.error(`[Metrics] Failed to startMeasure ${eventName}`, error);
+    structuredLog(
+      'grafana/frontend.core.utils.metrics',
+      'error',
+      `[Metrics] Failed to startMeasure ${eventName}`,
+      error
+    );
   }
 }
 
@@ -31,7 +38,12 @@ export function stopMeasure(eventName: string) {
     performance.clearMeasures(measured);
     return measure;
   } catch (error) {
-    console.error(`[Metrics] Failed to stopMeasure ${eventName}`, error);
+    structuredLog(
+      'grafana/frontend.core.utils.metrics',
+      'error',
+      `[Metrics] Failed to stopMeasure ${eventName}`,
+      error
+    );
     return;
   }
 }

--- a/public/app/core/utils/shortLinks.ts
+++ b/public/app/core/utils/shortLinks.ts
@@ -2,7 +2,7 @@ import memoizeOne from 'memoize-one';
 
 import { type AbsoluteTimeRange, type LogRowModel, type UrlQueryMap } from '@grafana/data';
 import { t } from '@grafana/i18n';
-import { getBackendSrv, config, locationService } from '@grafana/runtime';
+import { logStructured as structuredLog, getBackendSrv, config, locationService } from '@grafana/runtime';
 import { FlagKeys, getFeatureFlagClient } from '@grafana/runtime/internal';
 import { sceneGraph, type SceneTimeRangeLike, type VizPanel } from '@grafana/scenes';
 import { shortURLAPIv1beta1 } from 'app/api/clients/shorturl/v1beta1';
@@ -74,7 +74,7 @@ export const createShortLink = memoizeOne(async (path: string): Promise<string> 
       return await createShortLinkLegacy(path);
     }
   } catch (err) {
-    console.error('Error when creating shortened link: ', err);
+    structuredLog('grafana/frontend.core.utils.shortLinks', 'error', 'Error when creating shortened link: ', err);
     dispatch(notifyApp(createErrorNotification('Error generating shortened link')));
     createShortLink.clear();
     throw err; // Re-throw so callers know it failed
@@ -105,7 +105,7 @@ export const createAndCopyShortLink = async (path: string) => {
     }
   } catch (error) {
     // createShortLink already handles error notifications, just log
-    console.error('Error in createAndCopyShortLink:', error);
+    structuredLog('grafana/frontend.core.utils.shortLinks', 'error', 'Error in createAndCopyShortLink:', error);
   }
 };
 

--- a/public/app/core/utils/timeRegions.ts
+++ b/public/app/core/utils/timeRegions.ts
@@ -1,3 +1,5 @@
+import { logStructured as structuredLog } from '@grafana/runtime';
+
 import { Cron } from 'croner';
 
 import { type AbsoluteTimeRange, type TimeRange, durationToMilliseconds, parseDuration } from '@grafana/data';
@@ -160,7 +162,7 @@ export function calculateTimesWithin(cfg: TimeRegionConfig, tRange: TimeRange): 
     }
   } catch (e) {
     // invalid expression
-    console.error(e);
+    structuredLog('grafana/frontend.core.utils.timeRegions', 'error', e);
   }
 
   return ranges;

--- a/public/app/core/utils/timeRegions.ts
+++ b/public/app/core/utils/timeRegions.ts
@@ -1,8 +1,7 @@
-import { logStructured as structuredLog } from '@grafana/runtime';
-
 import { Cron } from 'croner';
 
 import { type AbsoluteTimeRange, type TimeRange, durationToMilliseconds, parseDuration } from '@grafana/data';
+import { logStructured as structuredLog } from '@grafana/runtime';
 
 export type TimeRegionMode = null | 'cron';
 export interface TimeRegionConfig {

--- a/public/app/features/actions/utils.ts
+++ b/public/app/features/actions/utils.ts
@@ -16,7 +16,12 @@ import {
   textUtil,
   type ValueLinkConfig,
 } from '@grafana/data';
-import { type BackendSrvRequest, config as grafanaConfig, getBackendSrv } from '@grafana/runtime';
+import {
+  logStructured as structuredLog,
+  type BackendSrvRequest,
+  config as grafanaConfig,
+  getBackendSrv,
+} from '@grafana/runtime';
 import { appEvents } from 'app/core/app_events';
 
 import { HttpRequestMethod } from '../../plugins/panel/canvas/panelcfg.gen';
@@ -120,7 +125,7 @@ export const getActions = (
                   appEvents.emit(AppEvents.alertError, [
                     'An error has occurred. Check console output for more details.',
                   ]);
-                  console.error(error);
+                  structuredLog('grafana/frontend.features.actions.utils', 'error', error);
                 },
                 complete: () => {
                   appEvents.emit(AppEvents.alertSuccess, ['API call was successful']);
@@ -128,7 +133,7 @@ export const getActions = (
               });
           } catch (error) {
             appEvents.emit(AppEvents.alertError, ['An error has occurred. Check console output for more details.']);
-            console.error(error);
+            structuredLog('grafana/frontend.features.actions.utils', 'error', error);
             return;
           }
         },

--- a/public/app/features/admin/UserOrgs.tsx
+++ b/public/app/features/admin/UserOrgs.tsx
@@ -1,3 +1,5 @@
+import { logStructured as structuredLog } from '@grafana/runtime';
+
 import { css, cx } from '@emotion/css';
 import { memo, type ReactElement, useEffect, useRef, useState } from 'react';
 
@@ -128,7 +130,7 @@ const OrgRow = memo(({ user, org, isExternalUser, onOrgRemove, onOrgRoleChange }
       if (contextSrv.hasPermission(AccessControlAction.ActionRolesList)) {
         fetchRoleOptions(org.orgId)
           .then((roles) => setRoleOptions(roles))
-          .catch((e) => console.error(e));
+          .catch((e) => structuredLog('grafana/frontend.features.admin.UserOrgs', 'error', e));
       }
     }
   }, [org.orgId]);
@@ -266,7 +268,7 @@ const AddToOrgModal = memo(({ isOpen, user, userOrgs, onOrgAdd, onDismiss }: Add
       if (contextSrv.hasPermission(AccessControlAction.ActionRolesList)) {
         fetchRoleOptions(org.value?.id)
           .then((roles) => setRoleOptions(roles))
-          .catch((e) => console.error(e));
+          .catch((e) => structuredLog('grafana/frontend.features.admin.UserOrgs', 'error', e));
       }
     }
   };

--- a/public/app/features/admin/UserOrgs.tsx
+++ b/public/app/features/admin/UserOrgs.tsx
@@ -1,10 +1,9 @@
-import { logStructured as structuredLog } from '@grafana/runtime';
-
 import { css, cx } from '@emotion/css';
 import { memo, type ReactElement, useEffect, useRef, useState } from 'react';
 
 import { type GrafanaTheme2, OrgRole } from '@grafana/data';
 import { Trans, t } from '@grafana/i18n';
+import { logStructured as structuredLog } from '@grafana/runtime';
 import { Button, ConfirmButton, Field, Icon, Modal, Tooltip, useStyles2, Stack, TextLink } from '@grafana/ui';
 import { UserRolePicker } from 'app/core/components/RolePicker/UserRolePicker';
 import { fetchRoleOptions, updateUserRoles } from 'app/core/components/RolePicker/api';

--- a/public/app/features/admin/Users/OrgUsersTable.tsx
+++ b/public/app/features/admin/Users/OrgUsersTable.tsx
@@ -3,7 +3,7 @@ import { useEffect, useMemo, useState } from 'react';
 import { type OrgRole } from '@grafana/data';
 import { selectors as e2eSelectors } from '@grafana/e2e-selectors';
 import { Trans, t } from '@grafana/i18n';
-import { config } from '@grafana/runtime';
+import { logStructured as structuredLog, config } from '@grafana/runtime';
 import {
   Avatar,
   Box,
@@ -79,7 +79,7 @@ export const OrgUsersTable = ({
           setRoleOptions(options);
         }
       } catch (e) {
-        console.error('Error loading options');
+        structuredLog('grafana/frontend.features.admin.Users.OrgUsersTable', 'error', 'Error loading options');
       }
     }
     if (contextSrv.licensedAccessControlEnabled()) {

--- a/public/app/features/admin/state/actions.ts
+++ b/public/app/features/admin/state/actions.ts
@@ -1,7 +1,13 @@
 import { debounce } from 'lodash';
 
 import { dateTimeFormatTimeAgo } from '@grafana/data';
-import { featureEnabled, getBackendSrv, isFetchError, locationService } from '@grafana/runtime';
+import {
+  logStructured as structuredLog,
+  featureEnabled,
+  getBackendSrv,
+  isFetchError,
+  locationService,
+} from '@grafana/runtime';
 import { type FetchDataArgs } from '@grafana/ui';
 import config from 'app/core/config';
 import { contextSrv } from 'app/core/services/context_srv';
@@ -50,7 +56,7 @@ export function loadAdminUserPage(userUid: string): ThunkResult<void> {
       }
       dispatch(userAdminPageLoadedAction(true));
     } catch (error) {
-      console.error(error);
+      structuredLog('grafana/frontend.features.admin.state.actions', 'error', error);
 
       if (isFetchError(error)) {
         const userError = {
@@ -300,7 +306,7 @@ export function fetchUsers(): ThunkResult<void> {
       dispatch(usersFetched(result));
     } catch (error) {
       usersFetchEnd();
-      console.error(error);
+      structuredLog('grafana/frontend.features.admin.state.actions', 'error', error);
     }
   };
 }
@@ -366,7 +372,7 @@ export function fetchUsersAnonymousDevices(): ThunkResult<void> {
       const result = await getBackendSrv().get(url);
       dispatch(usersAnonymousDevicesFetched(result));
     } catch (error) {
-      console.error(error);
+      structuredLog('grafana/frontend.features.admin.state.actions', 'error', error);
     }
   };
 }

--- a/public/app/features/admin/state/apis.tsx
+++ b/public/app/features/admin/state/apis.tsx
@@ -1,4 +1,4 @@
-import { getBackendSrv } from '@grafana/runtime';
+import { logStructured as structuredLog, getBackendSrv } from '@grafana/runtime';
 
 interface AnonServerStat {
   activeDevices?: number;
@@ -28,7 +28,7 @@ export const getServerStats = async (): Promise<ServerStat | null> => {
   return getBackendSrv()
     .get('api/admin/stats')
     .catch((err) => {
-      console.error(err);
+      structuredLog('grafana/frontend.features.admin.state.apis', 'error', err);
       return null;
     });
 };

--- a/public/app/features/alerting/unified/components/receivers/form/fields/OptionField.tsx
+++ b/public/app/features/alerting/unified/components/receivers/form/fields/OptionField.tsx
@@ -1,5 +1,3 @@
-import { logStructured as structuredLog } from '@grafana/runtime';
-
 import { css } from '@emotion/css';
 import { type FC } from 'react';
 import { Controller, type DeepMap, type FieldError, useFormContext } from 'react-hook-form';
@@ -7,6 +5,7 @@ import { Controller, type DeepMap, type FieldError, useFormContext } from 'react
 import { type GrafanaTheme2 } from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';
 import { t } from '@grafana/i18n';
+import { logStructured as structuredLog } from '@grafana/runtime';
 import {
   Checkbox,
   Field,

--- a/public/app/features/alerting/unified/components/receivers/form/fields/OptionField.tsx
+++ b/public/app/features/alerting/unified/components/receivers/form/fields/OptionField.tsx
@@ -1,3 +1,5 @@
+import { logStructured as structuredLog } from '@grafana/runtime';
+
 import { css } from '@emotion/css';
 import { type FC } from 'react';
 import { Controller, type DeepMap, type FieldError, useFormContext } from 'react-hook-form';
@@ -319,7 +321,12 @@ const OptionInput: FC<Props & { id: string }> = ({
       );
 
     default:
-      console.error('Element not supported', option.element);
+      structuredLog(
+        'grafana/frontend.features.alerting.unified.components.receivers.form.fields.OptionField',
+        'error',
+        'Element not supported',
+        option.element
+      );
       return null;
   }
 };

--- a/public/app/features/alerting/unified/components/rule-editor/labels/LabelsField.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/labels/LabelsField.tsx
@@ -1,3 +1,5 @@
+import { logStructured as structuredLog } from '@grafana/runtime';
+
 import { css, cx } from '@emotion/css';
 import { type FC, useCallback, useMemo } from 'react';
 import { Controller, FormProvider, useFieldArray, useForm, useFormContext } from 'react-hook-form';
@@ -183,7 +185,13 @@ function useCombinedLabels(
               opsValues = result.values.map((value) => value.name);
             }
           } catch (error) {
-            console.error('Failed to fetch label values for key:', key, error);
+            structuredLog(
+              'grafana/frontend.features.alerting.unified.components.rule-editor.labels.LabelsField',
+              'error',
+              'Failed to fetch label values for key:',
+              key,
+              error
+            );
           }
         }
 

--- a/public/app/features/alerting/unified/components/rule-editor/labels/LabelsField.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/labels/LabelsField.tsx
@@ -1,5 +1,3 @@
-import { logStructured as structuredLog } from '@grafana/runtime';
-
 import { css, cx } from '@emotion/css';
 import { type FC, useCallback, useMemo } from 'react';
 import { Controller, FormProvider, useFieldArray, useForm, useFormContext } from 'react-hook-form';
@@ -7,6 +5,7 @@ import { Controller, FormProvider, useFieldArray, useForm, useFormContext } from
 import { AlertLabels } from '@grafana/alerting/unstable';
 import { type GrafanaTheme2, type SelectableValue } from '@grafana/data';
 import { Trans, t } from '@grafana/i18n';
+import { logStructured as structuredLog } from '@grafana/runtime';
 import { Button, type ComboboxOption, Field, InlineLabel, Input, Space, Stack, Text, useStyles2 } from '@grafana/ui';
 
 import { labelsApi } from '../../../api/labelsApi';

--- a/public/app/features/alerting/unified/components/rule-editor/useDashboardQuery.ts
+++ b/public/app/features/alerting/unified/components/rule-editor/useDashboardQuery.ts
@@ -1,3 +1,5 @@
+import { logStructured as structuredLog } from '@grafana/runtime';
+
 import memoizeOne from 'memoize-one';
 import { useEffect, useState } from 'react';
 
@@ -36,11 +38,20 @@ export function useDashboardQuery(dashboardUid?: string) {
           } else if (isDashboardV2Resource(dashboardDTO)) {
             setDashboard(dashboardDTO);
           } else {
-            console.error('Something went wrong, unexpected dashboard format');
+            structuredLog(
+              'grafana/frontend.features.alerting.unified.components.rule-editor.useDashboardQuery',
+              'error',
+              'Something went wrong, unexpected dashboard format'
+            );
           }
         })
         .catch((error) => {
-          console.error('Failed to fetch dashboard', error);
+          structuredLog(
+            'grafana/frontend.features.alerting.unified.components.rule-editor.useDashboardQuery',
+            'error',
+            'Failed to fetch dashboard',
+            error
+          );
         })
         .finally(() => {
           setIsFetching(false);

--- a/public/app/features/alerting/unified/components/rule-editor/useDashboardQuery.ts
+++ b/public/app/features/alerting/unified/components/rule-editor/useDashboardQuery.ts
@@ -1,8 +1,7 @@
-import { logStructured as structuredLog } from '@grafana/runtime';
-
 import memoizeOne from 'memoize-one';
 import { useEffect, useState } from 'react';
 
+import { logStructured as structuredLog } from '@grafana/runtime';
 import { type Spec as DashboardV2Spec } from '@grafana/schema/apis/dashboard.grafana.app/v2';
 import { getDashboardAPI } from 'app/features/dashboard/api/dashboard_api';
 import { type DashboardWithAccessInfo } from 'app/features/dashboard/api/types';

--- a/public/app/features/alerting/unified/components/rule-editor/util.ts
+++ b/public/app/features/alerting/unified/components/rule-editor/util.ts
@@ -8,7 +8,7 @@ import {
   ThresholdsMode,
   isTimeSeriesFrames,
 } from '@grafana/data';
-import { logStructured as structuredLog, config } from '@grafana/runtime';
+import { config, logStructured as structuredLog } from '@grafana/runtime';
 import { GraphThresholdsStyleMode } from '@grafana/schema';
 import { EvalFunction } from 'app/features/alerting/state/alertDef';
 import { isExpressionQuery } from 'app/features/expressions/guards';

--- a/public/app/features/alerting/unified/components/rule-editor/util.ts
+++ b/public/app/features/alerting/unified/components/rule-editor/util.ts
@@ -8,7 +8,7 @@ import {
   ThresholdsMode,
   isTimeSeriesFrames,
 } from '@grafana/data';
-import { config } from '@grafana/runtime';
+import { logStructured as structuredLog, config } from '@grafana/runtime';
 import { GraphThresholdsStyleMode } from '@grafana/schema';
 import { EvalFunction } from 'app/features/alerting/state/alertDef';
 import { isExpressionQuery } from 'app/features/expressions/guards';
@@ -216,7 +216,12 @@ export function getThresholdsForQueries(queries: AlertQuery[], condition: string
           }
         });
       } catch (err) {
-        console.error('Failed to parse thresholds', err);
+        structuredLog(
+          'grafana/frontend.features.alerting.unified.components.rule-editor.util',
+          'error',
+          'Failed to parse thresholds',
+          err
+        );
         return;
       }
     });

--- a/public/app/features/alerting/unified/rule-list/hooks/grafanaFilter.ts
+++ b/public/app/features/alerting/unified/rule-list/hooks/grafanaFilter.ts
@@ -1,3 +1,5 @@
+import { logStructured as structuredLog } from '@grafana/runtime';
+
 import { attempt, isError } from 'lodash';
 
 import { type PromRuleDTO, type PromRuleGroupDTO } from 'app/types/unified-alerting-dto';
@@ -154,7 +156,13 @@ function labelMatchersToBackendFormat(labels: string[]): string[] {
     const result = attempt(() => JSON.stringify(parseMatcher(label)));
 
     if (isError(result)) {
-      console.warn('Failed to parse label matcher:', label, result);
+      structuredLog(
+        'grafana/frontend.features.alerting.unified.rule-list.hooks.grafanaFilter',
+        'warn',
+        'Failed to parse label matcher:',
+        label,
+        result
+      );
     } else {
       acc.push(result);
     }

--- a/public/app/features/alerting/unified/rule-list/hooks/grafanaFilter.ts
+++ b/public/app/features/alerting/unified/rule-list/hooks/grafanaFilter.ts
@@ -1,7 +1,6 @@
-import { logStructured as structuredLog } from '@grafana/runtime';
-
 import { attempt, isError } from 'lodash';
 
+import { logStructured as structuredLog } from '@grafana/runtime';
 import { type PromRuleDTO, type PromRuleGroupDTO } from 'app/types/unified-alerting-dto';
 
 import { type GrafanaPromRulesOptions } from '../../api/prometheusApi';

--- a/public/app/features/alerting/unified/state/AlertingQueryRunner.ts
+++ b/public/app/features/alerting/unified/state/AlertingQueryRunner.ts
@@ -16,10 +16,10 @@ import {
 } from '@grafana/data';
 import { t } from '@grafana/i18n';
 import {
-  logStructured as structuredLog,
   DataSourceWithBackend,
   type FetchResponse,
   getDataSourceSrv,
+  logStructured as structuredLog,
   toDataQueryError,
 } from '@grafana/runtime';
 import { type BackendSrv, getBackendSrv } from 'app/core/services/backend_srv';

--- a/public/app/features/alerting/unified/state/AlertingQueryRunner.ts
+++ b/public/app/features/alerting/unified/state/AlertingQueryRunner.ts
@@ -15,7 +15,13 @@ import {
   withLoadingIndicator,
 } from '@grafana/data';
 import { t } from '@grafana/i18n';
-import { DataSourceWithBackend, type FetchResponse, getDataSourceSrv, toDataQueryError } from '@grafana/runtime';
+import {
+  logStructured as structuredLog,
+  DataSourceWithBackend,
+  type FetchResponse,
+  getDataSourceSrv,
+  toDataQueryError,
+} from '@grafana/runtime';
 import { type BackendSrv, getBackendSrv } from 'app/core/services/backend_srv';
 import { isExpressionQuery } from 'app/features/expressions/guards';
 import { cancelNetworkRequestsOnUnsubscribe } from 'app/features/query/state/processing/canceler';
@@ -210,7 +216,11 @@ const getTimeRange = (query: AlertQuery, queries: AlertQuery[]): TimeRange => {
   }
 
   if (!query.relativeTimeRange) {
-    console.warn(`Query with refId: ${query.refId} did not have any relative time range, using default.`);
+    structuredLog(
+      'grafana/frontend.features.alerting.unified.state.AlertingQueryRunner',
+      'warn',
+      `Query with refId: ${query.refId} did not have any relative time range, using default.`
+    );
     return getDefaultTimeRange();
   }
 

--- a/public/app/features/annotations/components/StandardAnnotationQueryEditor.tsx
+++ b/public/app/features/annotations/components/StandardAnnotationQueryEditor.tsx
@@ -1,3 +1,5 @@
+import { logStructured as structuredLog } from '@grafana/runtime';
+
 import { memo, useCallback, useEffect, useRef, useState, type ReactElement } from 'react';
 import { lastValueFrom } from 'rxjs';
 
@@ -211,7 +213,12 @@ export default memo(function StandardAnnotationQueryEditor({
       skipNextVerificationRef.current = true;
       onChange(preparedAnnotation);
     } catch (error) {
-      console.error('Failed to replace annotation query:', error);
+      structuredLog(
+        'grafana/frontend.features.annotations.components.StandardAnnotationQueryEditor',
+        'error',
+        'Failed to replace annotation query:',
+        error
+      );
       // On error, reset the replacing state but don't change the annotation
     }
   };

--- a/public/app/features/annotations/components/StandardAnnotationQueryEditor.tsx
+++ b/public/app/features/annotations/components/StandardAnnotationQueryEditor.tsx
@@ -1,5 +1,3 @@
-import { logStructured as structuredLog } from '@grafana/runtime';
-
 import { memo, useCallback, useEffect, useRef, useState, type ReactElement } from 'react';
 import { lastValueFrom } from 'rxjs';
 
@@ -13,6 +11,7 @@ import {
 } from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';
 import { Trans, t } from '@grafana/i18n';
+import { logStructured as structuredLog } from '@grafana/runtime';
 import { type DataQuery } from '@grafana/schema';
 import { Alert, type AlertVariant, Button, Space, Spinner } from '@grafana/ui';
 import { getDashboardSrv } from 'app/features/dashboard/services/DashboardSrv';

--- a/public/app/features/annotations/standardAnnotationSupport.ts
+++ b/public/app/features/annotations/standardAnnotationSupport.ts
@@ -19,7 +19,7 @@ import {
   standardTransformersRegistry,
 } from '@grafana/data';
 import { t } from '@grafana/i18n';
-import { config } from '@grafana/runtime';
+import { logStructured as structuredLog, config } from '@grafana/runtime';
 
 export const standardAnnotationSupport: AnnotationSupport = {
   /**
@@ -232,7 +232,11 @@ export function getAnnotationsFromData(
       }
 
       if (!hasTime || !hasText) {
-        console.error('Cannot process annotation fields. No time or text present.');
+        structuredLog(
+          'grafana/frontend.features.annotations.standardAnnotationSupport',
+          'error',
+          'Cannot process annotation fields. No time or text present.'
+        );
         return [];
       }
 

--- a/public/app/features/annotations/utils/savedQueryUtils.ts
+++ b/public/app/features/annotations/utils/savedQueryUtils.ts
@@ -5,7 +5,7 @@ import {
   hasQueryExportSupport,
   hasQueryImportSupport,
 } from '@grafana/data';
-import { getDataSourceSrv } from '@grafana/runtime';
+import { logStructured as structuredLog, getDataSourceSrv } from '@grafana/runtime';
 import { type DataQuery } from '@grafana/schema';
 
 import { standardAnnotationSupport } from '../standardAnnotationSupport';
@@ -128,7 +128,12 @@ export async function updateAnnotationFromSavedQuery(
 
     return preparedAnnotation;
   } catch (error) {
-    console.warn('Could not prepare annotation with new datasource:', error);
+    structuredLog(
+      'grafana/frontend.features.annotations.utils.savedQueryUtils',
+      'warn',
+      'Could not prepare annotation with new datasource:',
+      error
+    );
     // Return structurally correct annotation even if preparation fails
     const { datasource, ...queryFields } = replacedQuery;
     return { ...cleanAnnotation, target: queryFields };

--- a/public/app/features/apiserver/client.ts
+++ b/public/app/features/apiserver/client.ts
@@ -1,7 +1,7 @@
 import { Observable, from, retry, catchError, filter, map, mergeMap } from 'rxjs';
 
 import { isLiveChannelMessageEvent, isLiveChannelStatusEvent, LiveChannelScope } from '@grafana/data';
-import { config, getBackendSrv, getGrafanaLiveSrv } from '@grafana/runtime';
+import { logStructured as structuredLog, config, getBackendSrv, getGrafanaLiveSrv } from '@grafana/runtime';
 import { contextSrv } from 'app/core/services/context_srv';
 
 import { getAPINamespace } from '../../api/utils';
@@ -70,7 +70,12 @@ export class ScopedResourceClient<T = object, S = object, K = string> implements
           filter((event) => isLiveChannelMessageEvent(event)),
           map((event) => event.message),
           catchError((error) => {
-            console.warn('Live channel watch failed, falling back to polling:', error);
+            structuredLog(
+              'grafana/frontend.features.apiserver.client',
+              'warn',
+              'Live channel watch failed, falling back to polling:',
+              error
+            );
             return this.createPollingFallback(params, error);
           })
         );
@@ -101,14 +106,20 @@ export class ScopedResourceClient<T = object, S = object, K = string> implements
           try {
             return JSON.parse(line);
           } catch (e) {
-            console.warn('Invalid JSON in watch stream:', e, line);
+            structuredLog(
+              'grafana/frontend.features.apiserver.client',
+              'warn',
+              'Invalid JSON in watch stream:',
+              e,
+              line
+            );
             return null;
           }
         }),
         filter((event): event is ResourceEvent<T, S, K> => event !== null),
         retry({ count: 3, delay: 1000 }),
         catchError((error) => {
-          console.error('Watch stream error:', error);
+          structuredLog('grafana/frontend.features.apiserver.client', 'error', 'Watch stream error:', error);
           throw error;
         })
       );
@@ -262,7 +273,9 @@ export class ScopedResourceClient<T = object, S = object, K = string> implements
             return;
           }
           // Transient failure: log and retry next cycle.
-          console.warn(
+          structuredLog(
+            'grafana/frontend.features.apiserver.client',
+            'warn',
             `Polling fallback error (${consecutiveFailures}/${ScopedResourceClient.MAX_CONSECUTIVE_POLL_FAILURES}):`,
             pollError
           );

--- a/public/app/features/auth-config/FieldRenderer.tsx
+++ b/public/app/features/auth-config/FieldRenderer.tsx
@@ -1,3 +1,5 @@
+import { logStructured as structuredLog } from '@grafana/runtime';
+
 import { css } from '@emotion/css';
 import { useEffect, useState } from 'react';
 import { type UseFormReturn, Controller } from 'react-hook-form';
@@ -78,7 +80,7 @@ export const FieldRenderer = ({
   }, [isDisabled, disabledWhen?.disabledValue, name, setValue]);
 
   if (!field) {
-    console.log('missing field:', name);
+    structuredLog('grafana/frontend.features.auth-config.FieldRenderer', 'info', 'missing field:', name);
     return null;
   }
 
@@ -190,7 +192,11 @@ export const FieldRenderer = ({
         </Field>
       );
     default:
-      console.error(`Unknown field type: ${fieldData.type}`);
+      structuredLog(
+        'grafana/frontend.features.auth-config.FieldRenderer',
+        'error',
+        `Unknown field type: ${fieldData.type}`
+      );
       return null;
   }
 };

--- a/public/app/features/auth-config/FieldRenderer.tsx
+++ b/public/app/features/auth-config/FieldRenderer.tsx
@@ -1,10 +1,9 @@
-import { logStructured as structuredLog } from '@grafana/runtime';
-
 import { css } from '@emotion/css';
 import { useEffect, useState } from 'react';
 import { type UseFormReturn, Controller } from 'react-hook-form';
 
 import { type SelectableValue } from '@grafana/data';
+import { logStructured as structuredLog } from '@grafana/runtime';
 import { Checkbox, Field, Input, SecretInput, Select, Switch, useTheme2 } from '@grafana/ui';
 
 import { fieldMap } from './fields';

--- a/public/app/features/auth-config/state/actions.ts
+++ b/public/app/features/auth-config/state/actions.ts
@@ -1,6 +1,6 @@
 import { lastValueFrom } from 'rxjs';
 
-import { getBackendSrv, isFetchError } from '@grafana/runtime';
+import { logStructured as structuredLog, getBackendSrv, isFetchError } from '@grafana/runtime';
 import { contextSrv } from 'app/core/services/context_srv';
 import { AccessControlAction } from 'app/types/accessControl';
 import { type Settings, type UpdateSettingsQuery } from 'app/types/settings';
@@ -78,7 +78,7 @@ export function saveSettings(data: UpdateSettingsQuery): ThunkResult<Promise<boo
         dispatch(resetError());
         return true;
       } catch (error) {
-        console.log(error);
+        structuredLog('grafana/frontend.features.auth-config.state.actions', 'info', error);
         if (isFetchError(error)) {
           error.isHandled = true;
           const updateErr: SettingsError = {

--- a/public/app/features/browse-dashboards/api/browseDashboardsAPI.ts
+++ b/public/app/features/browse-dashboards/api/browseDashboardsAPI.ts
@@ -6,7 +6,7 @@ import { createBaseQuery } from '@grafana/api-clients/rtkq';
 import { invalidateQuotaUsage } from '@grafana/api-clients/rtkq/quotas/v0alpha1';
 import { AppEvents, locationUtil } from '@grafana/data';
 import { t } from '@grafana/i18n';
-import { config, getBackendSrv } from '@grafana/runtime';
+import { logStructured as structuredLog, config, getBackendSrv } from '@grafana/runtime';
 import { type Dashboard } from '@grafana/schema';
 import { type Spec as DashboardV2Spec } from '@grafana/schema/apis/dashboard.grafana.app/v2';
 import { isProvisionedFolderCheck } from 'app/api/clients/folder/v1beta1/utils';
@@ -494,7 +494,12 @@ export const browseDashboardsAPI = createApi({
           try {
             await contextSrv.fetchUserPermissions();
           } catch (err) {
-            console.error('Failed to refresh user permissions after save', err);
+            structuredLog(
+              'grafana/frontend.features.browse-dashboards.api.browseDashboardsAPI',
+              'error',
+              'Failed to refresh user permissions after save',
+              err
+            );
           }
           dispatch(
             refetchChildren({

--- a/public/app/features/browse-dashboards/api/recentlyViewed.ts
+++ b/public/app/features/browse-dashboards/api/recentlyViewed.ts
@@ -1,3 +1,5 @@
+import { logStructured as structuredLog } from '@grafana/runtime';
+
 import impressionSrv from 'app/core/services/impression_srv';
 import { getGrafanaSearcher } from 'app/features/search/service/searcher';
 import { type DashboardQueryResult } from 'app/features/search/service/types';
@@ -30,7 +32,12 @@ export async function getRecentlyViewedDashboards(maxItems = 5): Promise<Dashboa
     dashboards.sort((a, b) => order(a.uid) - order(b.uid));
     return dashboards;
   } catch (error) {
-    console.error('Failed to load recently viewed dashboards', error);
+    structuredLog(
+      'grafana/frontend.features.browse-dashboards.api.recentlyViewed',
+      'error',
+      'Failed to load recently viewed dashboards',
+      error
+    );
     return [];
   }
 }

--- a/public/app/features/browse-dashboards/api/recentlyViewed.ts
+++ b/public/app/features/browse-dashboards/api/recentlyViewed.ts
@@ -1,5 +1,4 @@
 import { logStructured as structuredLog } from '@grafana/runtime';
-
 import impressionSrv from 'app/core/services/impression_srv';
 import { getGrafanaSearcher } from 'app/features/search/service/searcher';
 import { type DashboardQueryResult } from 'app/features/search/service/types';

--- a/public/app/features/browse-dashboards/api/useRecentlyDeletedStateManager.ts
+++ b/public/app/features/browse-dashboards/api/useRecentlyDeletedStateManager.ts
@@ -1,7 +1,6 @@
-import { logStructured as structuredLog } from '@grafana/runtime';
-
 import { type SelectableValue, store } from '@grafana/data';
 import { t } from '@grafana/i18n';
+import { logStructured as structuredLog } from '@grafana/runtime';
 import { type TermCount } from 'app/core/components/TagFilter/TagFilter';
 import {
   RECENTLY_DELETED_SORT_VALUES,

--- a/public/app/features/browse-dashboards/api/useRecentlyDeletedStateManager.ts
+++ b/public/app/features/browse-dashboards/api/useRecentlyDeletedStateManager.ts
@@ -1,3 +1,5 @@
+import { logStructured as structuredLog } from '@grafana/runtime';
+
 import { type SelectableValue, store } from '@grafana/data';
 import { t } from '@grafana/i18n';
 import { type TermCount } from 'app/core/components/TagFilter/TagFilter';
@@ -83,7 +85,12 @@ export class TrashStateManager extends SearchStateManager {
 
       return termCounts.sort((a, b) => b.count - a.count);
     } catch (error) {
-      console.error('Failed to get tags from deleted dashboards:', error);
+      structuredLog(
+        'grafana/frontend.features.browse-dashboards.api.useRecentlyDeletedStateManager',
+        'error',
+        'Failed to get tags from deleted dashboards:',
+        error
+      );
       return [];
     }
   };

--- a/public/app/features/browse-dashboards/state/actions.ts
+++ b/public/app/features/browse-dashboards/state/actions.ts
@@ -1,3 +1,5 @@
+import { logStructured as structuredLog } from '@grafana/runtime';
+
 import { STARRED_FOLDERS_UID, TEAM_FOLDERS_UID, isRootFolderUID } from 'app/features/search/constants';
 import { type DashboardViewItem, type DashboardViewItemKind } from 'app/features/search/types';
 import { createAsyncThunk } from 'app/types/store';
@@ -13,7 +15,12 @@ async function listSafe(label: string, load: () => Promise<DashboardViewItem[]>)
   try {
     return await load();
   } catch (error) {
-    console.error(`Failed to load ${label}`, error);
+    structuredLog(
+      'grafana/frontend.features.browse-dashboards.state.actions',
+      'error',
+      `Failed to load ${label}`,
+      error
+    );
     return [];
   }
 }
@@ -173,7 +180,11 @@ export const fetchNextChildrenPage = createAsyncThunk(
       fetchKind = 'folder';
     } else if (collection.lastFetchedKind === 'dashboard' && !collection.lastKindHasMoreItems) {
       // There's nothing to load at all
-      console.warn(`fetchNextChildrenPage called for ${uid} but that collection is fully loaded`);
+      structuredLog(
+        'grafana/frontend.features.browse-dashboards.state.actions',
+        'warn',
+        `fetchNextChildrenPage called for ${uid} but that collection is fully loaded`
+      );
       // return;
     } else if (collection.lastFetchedKind === 'folder' && collection.lastKindHasMoreItems) {
       // Load additional pages of folders

--- a/public/app/features/browse-dashboards/state/actions.ts
+++ b/public/app/features/browse-dashboards/state/actions.ts
@@ -1,5 +1,4 @@
 import { logStructured as structuredLog } from '@grafana/runtime';
-
 import { STARRED_FOLDERS_UID, TEAM_FOLDERS_UID, isRootFolderUID } from 'app/features/search/constants';
 import { type DashboardViewItem, type DashboardViewItemKind } from 'app/features/search/types';
 import { createAsyncThunk } from 'app/types/store';

--- a/public/app/features/canvas/runtime/frame.tsx
+++ b/public/app/features/canvas/runtime/frame.tsx
@@ -1,7 +1,6 @@
-import { logStructured as structuredLog } from '@grafana/runtime';
-
 import { cloneDeep } from 'lodash';
 
+import { logStructured as structuredLog } from '@grafana/runtime';
 import { notFoundItem } from 'app/features/canvas/elements/notFound';
 import { type DimensionContext } from 'app/features/dimensions/context';
 import { HorizontalConstraint, type Placement, VerticalConstraint } from 'app/plugins/panel/canvas/panelcfg.gen';

--- a/public/app/features/canvas/runtime/frame.tsx
+++ b/public/app/features/canvas/runtime/frame.tsx
@@ -1,3 +1,5 @@
+import { logStructured as structuredLog } from '@grafana/runtime';
+
 import { cloneDeep } from 'lodash';
 
 import { notFoundItem } from 'app/features/canvas/elements/notFound';
@@ -129,7 +131,13 @@ export class FrameState extends ElementState {
         break;
       case LayerActionID.Duplicate:
         if (element.item.id === 'frame') {
-          console.log('Can not duplicate frames (yet)', action, element);
+          structuredLog(
+            'grafana/frontend.features.canvas.runtime.frame',
+            'info',
+            'Can not duplicate frames (yet)',
+            action,
+            element
+          );
           return;
         }
         const opts = cloneDeep(element.options);
@@ -239,7 +247,7 @@ export class FrameState extends ElementState {
         break;
 
       default:
-        console.log('DO action', action, element);
+        structuredLog('grafana/frontend.features.canvas.runtime.frame', 'info', 'DO action', action, element);
         return;
     }
   };

--- a/public/app/features/commandPalette/actions/deepSearchActions.ts
+++ b/public/app/features/commandPalette/actions/deepSearchActions.ts
@@ -1,8 +1,7 @@
-import { logStructured as structuredLog } from '@grafana/runtime';
-
 import debounce from 'debounce-promise';
 import { useEffect, useMemo, useRef, useState } from 'react';
 
+import { logStructured as structuredLog } from '@grafana/runtime';
 import { getGrafanaSearcher } from 'app/features/search/service/searcher';
 
 import { type DeepSearchPanelResult, searchDashboardVector } from '../api/deepSearch';

--- a/public/app/features/commandPalette/actions/deepSearchActions.ts
+++ b/public/app/features/commandPalette/actions/deepSearchActions.ts
@@ -1,3 +1,5 @@
+import { logStructured as structuredLog } from '@grafana/runtime';
+
 import debounce from 'debounce-promise';
 import { useEffect, useMemo, useRef, useState } from 'react';
 
@@ -253,7 +255,12 @@ export function useDeepSearchResults({ searchQuery, show, enabled }: UseDeepSear
         // The vector backend may be unconfigured (501) or the feature toggle
         // off (404) — callers gate on the toggle via the enabled flag, so
         // degrade to an empty column but log for anyone calling without the gate
-        console.error('Deep search failed. The vector search backend may be unavailable.', error);
+        structuredLog(
+          'grafana/frontend.features.commandPalette.actions.deepSearchActions',
+          'error',
+          'Deep search failed. The vector search backend may be unavailable.',
+          error
+        );
       }
 
       // Skip state updates when the effect has been cleaned up, and only keep

--- a/public/app/features/commandPalette/actions/useActions.tsx
+++ b/public/app/features/commandPalette/actions/useActions.tsx
@@ -1,7 +1,7 @@
-import { logStructured as structuredLog } from '@grafana/runtime';
-
 import { useRegisterActions } from 'kbar';
 import { useEffect, useMemo, useState } from 'react';
+
+import { logStructured as structuredLog } from '@grafana/runtime';
 
 import { type CommandPaletteAction } from '../types';
 

--- a/public/app/features/commandPalette/actions/useActions.tsx
+++ b/public/app/features/commandPalette/actions/useActions.tsx
@@ -1,3 +1,5 @@
+import { logStructured as structuredLog } from '@grafana/runtime';
+
 import { useRegisterActions } from 'kbar';
 import { useEffect, useMemo, useState } from 'react';
 
@@ -27,7 +29,12 @@ export function useRegisterRecentDashboardsActions() {
     getRecentDashboardActions()
       .then((recentDashboardActions) => setRecentDashboardActions(recentDashboardActions))
       .catch((err) => {
-        console.error('Error loading recent dashboard actions', err);
+        structuredLog(
+          'grafana/frontend.features.commandPalette.actions.useActions',
+          'error',
+          'Error loading recent dashboard actions',
+          err
+        );
       });
   }, []);
 

--- a/public/app/features/dashboard-scene/behaviors/DashboardAnalyticsInitializerBehavior.ts
+++ b/public/app/features/dashboard-scene/behaviors/DashboardAnalyticsInitializerBehavior.ts
@@ -1,3 +1,5 @@
+import { logStructured as structuredLog } from '@grafana/runtime';
+
 import { writePerformanceLog } from '@grafana/scenes';
 
 import { getDashboardAnalyticsAggregator } from '../../dashboard/services/DashboardAnalyticsAggregator';
@@ -15,7 +17,11 @@ export function dashboardAnalyticsInitializer(dashboard: DashboardScene) {
   const { uid, title } = dashboard.state;
 
   if (!uid) {
-    console.warn('dashboardAnalyticsInitializer: Dashboard UID is missing');
+    structuredLog(
+      'grafana/frontend.features.dashboard-scene.behaviors.DashboardAnalyticsInitializerBehavior',
+      'warn',
+      'dashboardAnalyticsInitializer: Dashboard UID is missing'
+    );
     return;
   }
 

--- a/public/app/features/dashboard-scene/behaviors/DashboardAnalyticsInitializerBehavior.ts
+++ b/public/app/features/dashboard-scene/behaviors/DashboardAnalyticsInitializerBehavior.ts
@@ -1,5 +1,4 @@
 import { logStructured as structuredLog } from '@grafana/runtime';
-
 import { writePerformanceLog } from '@grafana/scenes';
 
 import { getDashboardAnalyticsAggregator } from '../../dashboard/services/DashboardAnalyticsAggregator';

--- a/public/app/features/dashboard-scene/behaviors/DefaultControlsBehavior.ts
+++ b/public/app/features/dashboard-scene/behaviors/DefaultControlsBehavior.ts
@@ -1,7 +1,6 @@
-import { logStructured as structuredLog } from '@grafana/runtime';
-
 import { type Subscription } from 'rxjs';
 
+import { logStructured as structuredLog } from '@grafana/runtime';
 import { SceneObjectBase, type SceneObjectState } from '@grafana/scenes';
 
 import { loadDefaultControlsShared$, loadDefaultLinks$, loadDefaultVariables$ } from '../utils/dashboardControls';

--- a/public/app/features/dashboard-scene/behaviors/DefaultControlsBehavior.ts
+++ b/public/app/features/dashboard-scene/behaviors/DefaultControlsBehavior.ts
@@ -1,3 +1,5 @@
+import { logStructured as structuredLog } from '@grafana/runtime';
+
 import { type Subscription } from 'rxjs';
 
 import { SceneObjectBase, type SceneObjectState } from '@grafana/scenes';
@@ -32,7 +34,12 @@ export class DefaultControlsBehavior extends SceneObjectBase<SceneObjectState> {
     this._variablesSub = loadDefaultVariables$(shared$).subscribe({
       next: (vars) => dashboard.setDefaultVariables(vars),
       error: (err) => {
-        console.warn('Failed to load default variables', err);
+        structuredLog(
+          'grafana/frontend.features.dashboard-scene.behaviors.DefaultControlsBehavior',
+          'warn',
+          'Failed to load default variables',
+          err
+        );
         dashboard.setState({ defaultVariablesLoading: false });
       },
       complete: () => dashboard.setState({ defaultVariablesLoading: false }),
@@ -41,7 +48,12 @@ export class DefaultControlsBehavior extends SceneObjectBase<SceneObjectState> {
     this._linksSub = loadDefaultLinks$(shared$).subscribe({
       next: (links) => dashboard.setDefaultLinks(links),
       error: (err) => {
-        console.warn('Failed to load default links', err);
+        structuredLog(
+          'grafana/frontend.features.dashboard-scene.behaviors.DefaultControlsBehavior',
+          'warn',
+          'Failed to load default links',
+          err
+        );
         dashboard.setState({ defaultLinksLoading: false });
       },
       complete: () => dashboard.setState({ defaultLinksLoading: false }),

--- a/public/app/features/dashboard-scene/inspect/HelpWizard/SupportSnapshotService.ts
+++ b/public/app/features/dashboard-scene/inspect/HelpWizard/SupportSnapshotService.ts
@@ -1,3 +1,5 @@
+import { logStructured as structuredLog } from '@grafana/runtime';
+
 import saveAs from 'file-saver';
 
 import { dateTimeFormat, formattedValueToString, getValueFormat, type SelectableValue } from '@grafana/data';
@@ -84,7 +86,12 @@ export class SupportSnapshotService extends StateManagerBase<SupportSnapshotStat
         const dash = transformSaveModelToScene({ dashboard: snapshot, meta: { isEmbedded: true } });
         scene = dash.state.body; // skip the wrappers
       } catch (ex) {
-        console.log('Error creating scene:', ex);
+        structuredLog(
+          'grafana/frontend.features.dashboard-scene.inspect.HelpWizard.SupportSnapshotService',
+          'info',
+          'Error creating scene:',
+          ex
+        );
       }
     }
 

--- a/public/app/features/dashboard-scene/inspect/HelpWizard/SupportSnapshotService.ts
+++ b/public/app/features/dashboard-scene/inspect/HelpWizard/SupportSnapshotService.ts
@@ -1,9 +1,8 @@
-import { logStructured as structuredLog } from '@grafana/runtime';
-
 import saveAs from 'file-saver';
 
 import { dateTimeFormat, formattedValueToString, getValueFormat, type SelectableValue } from '@grafana/data';
 import { t } from '@grafana/i18n';
+import { logStructured as structuredLog } from '@grafana/runtime';
 import { sceneGraph, type SceneObject, type VizPanel } from '@grafana/scenes';
 import { StateManagerBase } from 'app/core/services/StateManagerBase';
 

--- a/public/app/features/dashboard-scene/inspect/InspectJsonTab.tsx
+++ b/public/app/features/dashboard-scene/inspect/InspectJsonTab.tsx
@@ -1,11 +1,10 @@
-import { logStructured as structuredLog } from '@grafana/runtime';
-
 import { isEqual } from 'lodash';
 import AutoSizer from 'react-virtualized-auto-sizer';
 
 import { type SelectableValue } from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';
 import { Trans, t } from '@grafana/i18n';
+import { logStructured as structuredLog } from '@grafana/runtime';
 import {
   type SceneComponentProps,
   SceneDataTransformer,

--- a/public/app/features/dashboard-scene/inspect/InspectJsonTab.tsx
+++ b/public/app/features/dashboard-scene/inspect/InspectJsonTab.tsx
@@ -1,3 +1,5 @@
+import { logStructured as structuredLog } from '@grafana/runtime';
+
 import { isEqual } from 'lodash';
 import AutoSizer from 'react-virtualized-auto-sizer';
 
@@ -165,7 +167,11 @@ export class InspectJsonTab extends SceneObjectBase<InspectJsonTabState> {
     const gridItem = panel.parent;
 
     if (!(gridItem instanceof DashboardGridItem)) {
-      console.error('Cannot update layout: panel parent is not a DashboardGridItem');
+      structuredLog(
+        'grafana/frontend.features.dashboard-scene.inspect.InspectJsonTab',
+        'error',
+        'Cannot update layout: panel parent is not a DashboardGridItem'
+      );
       return;
     }
 
@@ -259,7 +265,13 @@ export class InspectJsonTab extends SceneObjectBase<InspectJsonTabState> {
     const newState = sceneUtils.cloneSceneObjectState(gridItem.state);
 
     if (!(panel.parent instanceof DashboardGridItem)) {
-      console.error('Cannot update state of panel', panel, gridItem);
+      structuredLog(
+        'grafana/frontend.features.dashboard-scene.inspect.InspectJsonTab',
+        'error',
+        'Cannot update state of panel',
+        panel,
+        gridItem
+      );
       return;
     }
 

--- a/public/app/features/dashboard-scene/pages/DashboardScenePage.tsx
+++ b/public/app/features/dashboard-scene/pages/DashboardScenePage.tsx
@@ -3,7 +3,7 @@ import { type Params, useParams } from 'react-router-dom-v5-compat';
 import { usePrevious } from 'react-use';
 
 import { PageLayoutType } from '@grafana/data';
-import { locationService } from '@grafana/runtime';
+import { logStructured as structuredLog, locationService } from '@grafana/runtime';
 import { UrlSyncContextProvider } from '@grafana/scenes';
 import { Box } from '@grafana/ui';
 import { Page } from 'app/core/components/Page/Page';
@@ -147,7 +147,7 @@ export function DashboardScenePage({ route, queryParams, location }: Props) {
   // A bit tricky for transition to or from Home dashboard that does not have a uid in the url (but could have it in the dashboard model)
   // if prevMatch is undefined we are going from normal route to home route or vice versa
   if (type !== 'snapshot' && (!prevMatch || uid !== prevMatch?.params.uid)) {
-    console.log('skipping rendering');
+    structuredLog('grafana/frontend.features.dashboard-scene.pages.DashboardScenePage', 'info', 'skipping rendering');
     return null;
   }
 

--- a/public/app/features/dashboard-scene/pages/DashboardScenePageStateManager.ts
+++ b/public/app/features/dashboard-scene/pages/DashboardScenePageStateManager.ts
@@ -1,6 +1,13 @@
 import { locationUtil, type UrlQueryMap } from '@grafana/data';
 import { t } from '@grafana/i18n';
-import { config, getBackendSrv, getDataSourceSrv, isFetchError, locationService } from '@grafana/runtime';
+import {
+  logStructured as structuredLog,
+  config,
+  getBackendSrv,
+  getDataSourceSrv,
+  isFetchError,
+  locationService,
+} from '@grafana/runtime';
 import { FlagKeys, getFeatureFlagClient, UserStorage } from '@grafana/runtime/internal';
 import { sceneGraph } from '@grafana/scenes';
 import {
@@ -507,7 +514,12 @@ abstract class DashboardScenePageStateManagerBase<T>
       });
 
       if (!isFetchError(err)) {
-        console.error('Error loading dashboard:', err);
+        structuredLog(
+          'grafana/frontend.features.dashboard-scene.pages.DashboardScenePageStateManager',
+          'error',
+          'Error loading dashboard:',
+          err
+        );
       }
 
       // If the error is a DashboardVersionError, we want to throw it so that the error boundary is triggered

--- a/public/app/features/dashboard-scene/pages/utils.ts
+++ b/public/app/features/dashboard-scene/pages/utils.ts
@@ -1,5 +1,5 @@
 import { type UrlQueryMap, getTimeZone, getDefaultTimeRange, dateMath } from '@grafana/data';
-import { locationService } from '@grafana/runtime';
+import { logStructured as structuredLog, locationService } from '@grafana/runtime';
 import { getFolderByUidFacade } from 'app/api/clients/folder/v1beta1/hooks';
 import { updateNavIndex } from 'app/core/reducers/navModel';
 import { buildNavModel } from 'app/features/folders/state/navModel';
@@ -10,7 +10,14 @@ export async function updateNavModel(folderUid: string) {
     const folder = await getFolderByUidFacade(folderUid);
     store.dispatch(updateNavIndex(buildNavModel(folder)));
   } catch (err) {
-    console.warn('Error fetching parent folder', folderUid, 'for dashboard', err);
+    structuredLog(
+      'grafana/frontend.features.dashboard-scene.pages.utils',
+      'warn',
+      'Error fetching parent folder',
+      folderUid,
+      'for dashboard',
+      err
+    );
   }
 }
 

--- a/public/app/features/dashboard-scene/panel-edit/PanelDataPane/PanelDataQueriesTab.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelDataPane/PanelDataQueriesTab.tsx
@@ -3,7 +3,7 @@ import { useCallback, useMemo } from 'react';
 import { CoreApp, type DataSourceApi, type DataSourceInstanceSettings, getDataSourceRef } from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';
 import { t, Trans } from '@grafana/i18n';
-import { config, getDataSourceSrv, reportInteraction } from '@grafana/runtime';
+import { logStructured as structuredLog, config, getDataSourceSrv, reportInteraction } from '@grafana/runtime';
 import {
   SafeSerializableSceneObject,
   type SceneComponentProps,
@@ -165,7 +165,11 @@ export class PanelDataQueriesTab extends SceneObjectBase<PanelDataQueriesTabStat
         });
       }
 
-      console.error(err);
+      structuredLog(
+        'grafana/frontend.features.dashboard-scene.panel-edit.PanelDataPane.PanelDataQueriesTab',
+        'error',
+        err
+      );
     }
   }
 

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/PanelDataPaneNext.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/PanelDataPaneNext.tsx
@@ -9,7 +9,7 @@ import {
   getNextRefId,
   type ScopedVars,
 } from '@grafana/data';
-import { config, isExpressionReference, reportInteraction } from '@grafana/runtime';
+import { logStructured as structuredLog, config, isExpressionReference, reportInteraction } from '@grafana/runtime';
 import { getDataSourceInstance, getDataSourceInstanceSettings } from '@grafana/runtime/unstable';
 import {
   SceneDataTransformer,
@@ -228,7 +228,12 @@ export class PanelDataPaneNext extends SceneObjectBase<PanelDataPaneNextState> {
       this.setState({ datasource, dsSettings, dsError: undefined });
       storeLastUsedDataSourceInLocalStorage(getDataSourceRef(dsSettings) || { default: true });
     } catch (err) {
-      console.error('Failed to load datasource:', err);
+      structuredLog(
+        'grafana/frontend.features.dashboard-scene.panel-edit.PanelEditNext.PanelDataPaneNext',
+        'error',
+        'Failed to load datasource:',
+        err
+      );
 
       // Fallback to default datasource (parity with PanelDataQueriesTab)
       try {
@@ -242,7 +247,12 @@ export class PanelDataPaneNext extends SceneObjectBase<PanelDataPaneNextState> {
           // resolveDatasourceRef() handles the stale-ref case on the next activation.
         }
       } catch (fallbackErr) {
-        console.error('Failed to load default datasource:', fallbackErr);
+        structuredLog(
+          'grafana/frontend.features.dashboard-scene.panel-edit.PanelEditNext.PanelDataPaneNext',
+          'error',
+          'Failed to load default datasource:',
+          fallbackErr
+        );
         this.setState({
           datasource: undefined,
           dsSettings: undefined,

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Header/PluginActions.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Header/PluginActions.tsx
@@ -5,7 +5,7 @@ import {
   PluginExtensionPoints,
   type PluginExtensionQueryEditorRowAdaptiveTelemetryV1Context,
 } from '@grafana/data';
-import { renderLimitedComponents, usePluginComponents } from '@grafana/runtime';
+import { logStructured as structuredLog, renderLimitedComponents, usePluginComponents } from '@grafana/runtime';
 import { type DataQuery } from '@grafana/schema';
 import { Stack } from '@grafana/ui';
 import { type QueryActionComponent, RowActionComponents } from 'app/features/query/components/QueryActionComponent';
@@ -94,7 +94,12 @@ function useAdaptiveTelemetryComponents(query: DataQuery | null) {
       pluginId: /grafana-adaptive.*/,
     });
   } catch (error) {
-    console.error('Failed to render adaptive telemetry components:', error);
+    structuredLog(
+      'grafana/frontend.features.dashboard-scene.panel-edit.PanelEditNext.QueryEditor.Header.PluginActions',
+      'error',
+      'Failed to render adaptive telemetry components:',
+      error
+    );
     return null;
   }
 }

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/localStorageWithTTL.ts
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/localStorageWithTTL.ts
@@ -1,3 +1,5 @@
+import { logStructured as structuredLog } from '@grafana/runtime';
+
 import { store } from '@grafana/data';
 
 interface StoredValueWithTTL<T> {
@@ -20,7 +22,12 @@ export const setLocalStorageWithTTL = <T>(key: string, value: T) => {
   try {
     store.setObject(key, item);
   } catch (error) {
-    console.error('Failed to persist value with TTL', error);
+    structuredLog(
+      'grafana/frontend.features.dashboard-scene.panel-edit.PanelEditNext.localStorageWithTTL',
+      'error',
+      'Failed to persist value with TTL',
+      error
+    );
   }
 };
 

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/localStorageWithTTL.ts
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/localStorageWithTTL.ts
@@ -1,6 +1,5 @@
-import { logStructured as structuredLog } from '@grafana/runtime';
-
 import { store } from '@grafana/data';
+import { logStructured as structuredLog } from '@grafana/runtime';
 
 interface StoredValueWithTTL<T> {
   value: T;

--- a/public/app/features/dashboard-scene/scene/DashboardLayoutOrchestrator.tsx
+++ b/public/app/features/dashboard-scene/scene/DashboardLayoutOrchestrator.tsx
@@ -242,7 +242,6 @@ export class DashboardLayoutOrchestrator extends SceneObjectBase<DashboardLayout
             }
           } else {
             const warningMessage = 'No grid item to drag';
-            console.warn(warningMessage);
             logWarning(warningMessage);
           }
         });

--- a/public/app/features/dashboard-scene/scene/DashboardMacro.ts
+++ b/public/app/features/dashboard-scene/scene/DashboardMacro.ts
@@ -1,3 +1,5 @@
+import { logStructured as structuredLog } from '@grafana/runtime';
+
 import { type FormatVariable, type SceneObject, sceneUtils } from '@grafana/scenes';
 
 import { getDashboardSceneFor } from '../utils/utils';
@@ -39,7 +41,12 @@ export function registerDashboardMacro() {
 
     return () => unregister();
   } catch (e) {
-    console.error('Error registering dashboard macro', e);
+    structuredLog(
+      'grafana/frontend.features.dashboard-scene.scene.DashboardMacro',
+      'error',
+      'Error registering dashboard macro',
+      e
+    );
     return () => {};
   }
 }

--- a/public/app/features/dashboard-scene/scene/DashboardMacro.ts
+++ b/public/app/features/dashboard-scene/scene/DashboardMacro.ts
@@ -1,5 +1,4 @@
 import { logStructured as structuredLog } from '@grafana/runtime';
-
 import { type FormatVariable, type SceneObject, sceneUtils } from '@grafana/scenes';
 
 import { getDashboardSceneFor } from '../utils/utils';

--- a/public/app/features/dashboard-scene/scene/DashboardMutationClientSetter.ts
+++ b/public/app/features/dashboard-scene/scene/DashboardMutationClientSetter.ts
@@ -1,3 +1,5 @@
+import { logStructured as structuredLog } from '@grafana/runtime';
+
 /**
  * Bridge between DashboardScene and the mutation-api module.
  *
@@ -19,7 +21,9 @@ export function provideMutationClientFactory(create: CreateMutationClient): void
 
 export function createMutationClient(scene: unknown): () => void {
   if (!_create) {
-    console.warn(
+    structuredLog(
+      'grafana/frontend.features.dashboard-scene.scene.DashboardMutationClientSetter',
+      'warn',
       'createMutationClient called before provideMutationClientFactory. Mutation API will not be available.'
     );
     return () => {};

--- a/public/app/features/dashboard-scene/scene/DashboardScene.tsx
+++ b/public/app/features/dashboard-scene/scene/DashboardScene.tsx
@@ -13,7 +13,14 @@ import {
   store,
 } from '@grafana/data';
 import { t } from '@grafana/i18n';
-import { config, getDataSourceSrv, locationService, RefreshEvent, reportInteraction } from '@grafana/runtime';
+import {
+  logStructured as structuredLog,
+  config,
+  getDataSourceSrv,
+  locationService,
+  RefreshEvent,
+  reportInteraction,
+} from '@grafana/runtime';
 import { FlagKeys, getFeatureFlagClient, getPanelPluginMeta } from '@grafana/runtime/internal';
 import {
   type CancelActivationHandler,
@@ -310,7 +317,7 @@ export class DashboardScene extends SceneObjectBase<DashboardSceneState> impleme
         try {
           return createSceneVariableFromVariableModelV2(v);
         } catch (err) {
-          console.error(err);
+          structuredLog('grafana/frontend.features.dashboard-scene.scene.DashboardScene', 'error', err);
           return null;
         }
       })
@@ -338,7 +345,7 @@ export class DashboardScene extends SceneObjectBase<DashboardSceneState> impleme
         try {
           return createSceneVariableFromVariableModelV2(v);
         } catch (err) {
-          console.error(err);
+          structuredLog('grafana/frontend.features.dashboard-scene.scene.DashboardScene', 'error', err);
           return null;
         }
       })
@@ -503,7 +510,11 @@ export class DashboardScene extends SceneObjectBase<DashboardSceneState> impleme
 
   public exitEditMode({ skipConfirm, restoreInitialState }: { skipConfirm: boolean; restoreInitialState?: boolean }) {
     if (!this.canDiscard()) {
-      console.error('Trying to discard back to a state that does not exist, initialState undefined');
+      structuredLog(
+        'grafana/frontend.features.dashboard-scene.scene.DashboardScene',
+        'error',
+        'Trying to discard back to a state that does not exist, initialState undefined'
+      );
       return;
     }
 
@@ -618,7 +629,11 @@ export class DashboardScene extends SceneObjectBase<DashboardSceneState> impleme
    */
   public discardChangesAndKeepEditing() {
     if (!this.canDiscard()) {
-      console.error('Trying to discard back to a state that does not exist, initialState undefined');
+      structuredLog(
+        'grafana/frontend.features.dashboard-scene.scene.DashboardScene',
+        'error',
+        'Trying to discard back to a state that does not exist, initialState undefined'
+      );
       return;
     }
 
@@ -879,7 +894,11 @@ export class DashboardScene extends SceneObjectBase<DashboardSceneState> impleme
         clearClipboard();
         store.set(LS_PANEL_COPY_KEY, JSON.stringify({ elements, gridItem: gridItemKind }));
       } else {
-        console.error('Trying to copy a panel that is not DashboardGridItem child');
+        structuredLog(
+          'grafana/frontend.features.dashboard-scene.scene.DashboardScene',
+          'error',
+          'Trying to copy a panel that is not DashboardGridItem child'
+        );
         throw new Error('Trying to copy a panel that is not DashboardGridItem child');
       }
       return;
@@ -892,7 +911,11 @@ export class DashboardScene extends SceneObjectBase<DashboardSceneState> impleme
     let gridItem = vizPanel.parent;
 
     if (!(gridItem instanceof DashboardGridItem)) {
-      console.error('Trying to copy a panel that is not DashboardGridItem child');
+      structuredLog(
+        'grafana/frontend.features.dashboard-scene.scene.DashboardScene',
+        'error',
+        'Trying to copy a panel that is not DashboardGridItem child'
+      );
       throw new Error('Trying to copy a panel that is not DashboardGridItem child');
     }
 
@@ -1047,7 +1070,12 @@ export class DashboardScene extends SceneObjectBase<DashboardSceneState> impleme
 
       appEvents.emit('alert-success', ['Panel styles applied.']);
     } catch (e) {
-      console.error('Error pasting panel styles:', e);
+      structuredLog(
+        'grafana/frontend.features.dashboard-scene.scene.DashboardScene',
+        'error',
+        'Error pasting panel styles:',
+        e
+      );
       appEvents.emit('alert-error', ['Error pasting panel styles.']);
       DashboardInteractions.panelStylesMenuClicked(
         'paste',
@@ -1133,7 +1161,11 @@ export class DashboardScene extends SceneObjectBase<DashboardSceneState> impleme
       return;
     }
 
-    console.error('Trying to unlink a lib panel in a layout that is not DashboardGridItem or AutoGridItem');
+    structuredLog(
+      'grafana/frontend.features.dashboard-scene.scene.DashboardScene',
+      'error',
+      'Trying to unlink a lib panel in a layout that is not DashboardGridItem or AutoGridItem'
+    );
   }
 
   public showModal(modal: SceneObject) {

--- a/public/app/features/dashboard-scene/scene/DashboardSceneUrlSync.ts
+++ b/public/app/features/dashboard-scene/scene/DashboardSceneUrlSync.ts
@@ -1,5 +1,4 @@
 import { logStructured as structuredLog } from '@grafana/runtime';
-
 import { type SceneObjectUrlSyncHandler, type SceneObjectUrlValues, type VizPanel } from '@grafana/scenes';
 
 import { buildPanelEditScene } from '../panel-edit/PanelEditor';

--- a/public/app/features/dashboard-scene/scene/DashboardSceneUrlSync.ts
+++ b/public/app/features/dashboard-scene/scene/DashboardSceneUrlSync.ts
@@ -1,3 +1,5 @@
+import { logStructured as structuredLog } from '@grafana/runtime';
+
 import { type SceneObjectUrlSyncHandler, type SceneObjectUrlValues, type VizPanel } from '@grafana/scenes';
 
 import { buildPanelEditScene } from '../panel-edit/PanelEditor';
@@ -71,7 +73,11 @@ export class DashboardSceneUrlSync implements SceneObjectUrlSyncHandler {
       const panel = findEditPanel(this._scene, values.editPanel);
 
       if (!panel) {
-        console.warn(`Panel ${values.editPanel} not found`);
+        structuredLog(
+          'grafana/frontend.features.dashboard-scene.scene.DashboardSceneUrlSync',
+          'warn',
+          `Panel ${values.editPanel} not found`
+        );
         return;
       }
 

--- a/public/app/features/dashboard-scene/scene/GoToSnapshotOriginButton.tsx
+++ b/public/app/features/dashboard-scene/scene/GoToSnapshotOriginButton.tsx
@@ -2,7 +2,7 @@ import { css } from '@emotion/css';
 
 import { textUtil } from '@grafana/data';
 import { t } from '@grafana/i18n';
-import { config, locationService } from '@grafana/runtime';
+import { logStructured as structuredLog, config, locationService } from '@grafana/runtime';
 import { ConfirmModal, ToolbarButton } from '@grafana/ui';
 
 import { appEvents } from '../../../core/app_events';
@@ -59,6 +59,11 @@ export const onOpenSnapshotOriginalDashboard = (originalUrl: string) => {
       locationService.push(sanitizedRelativeURL);
     }
   } catch (err) {
-    console.error('Failed to open original dashboard', err);
+    structuredLog(
+      'grafana/frontend.features.dashboard-scene.scene.GoToSnapshotOriginButton',
+      'error',
+      'Failed to open original dashboard',
+      err
+    );
   }
 };

--- a/public/app/features/dashboard-scene/scene/export/exporters.ts
+++ b/public/app/features/dashboard-scene/scene/export/exporters.ts
@@ -1,7 +1,7 @@
 import { defaults, each, sortBy } from 'lodash';
 
 import { type DataSourceRef, type VariableOption, VariableRefresh } from '@grafana/data';
-import { getDataSourceSrv } from '@grafana/runtime';
+import { logStructured as structuredLog, getDataSourceSrv } from '@grafana/runtime';
 import { getPanelPluginMeta } from '@grafana/runtime/internal';
 import { type Panel } from '@grafana/schema';
 import {
@@ -357,7 +357,7 @@ export async function makeExportableV1(dashboard: DashboardModel) {
 
     return newObj;
   } catch (err) {
-    console.error('Export failed:', err);
+    structuredLog('grafana/frontend.features.dashboard-scene.scene.export.exporters', 'error', 'Export failed:', err);
     return {
       error: err,
     };
@@ -379,7 +379,12 @@ async function convertLibraryPanelToInlinePanel(libraryPanelElement: LibraryPane
     inlinePanel.spec.id = id;
     return inlinePanel;
   } catch (error) {
-    console.error(`Failed to load library panel ${libraryPanel.uid}:`, error);
+    structuredLog(
+      'grafana/frontend.features.dashboard-scene.scene.export.exporters',
+      'error',
+      `Failed to load library panel ${libraryPanel.uid}:`,
+      error
+    );
 
     const errorMessage = error instanceof Error ? error.message : 'Unknown error';
     dispatch(
@@ -600,7 +605,7 @@ export async function makeExportableV2(dashboard: DashboardV2Spec, isSharingExte
 
     return dashboard;
   } catch (err) {
-    console.error('Export failed:', err);
+    structuredLog('grafana/frontend.features.dashboard-scene.scene.export.exporters', 'error', 'Export failed:', err);
     return {
       error: err,
     };

--- a/public/app/features/dashboard-scene/scene/layout-auto-grid/AutoGridItem.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-auto-grid/AutoGridItem.tsx
@@ -1,8 +1,7 @@
-import { logStructured as structuredLog } from '@grafana/runtime';
-
 import { isEqual } from 'lodash';
 import React from 'react';
 
+import { logStructured as structuredLog } from '@grafana/runtime';
 import {
   CustomVariable,
   MultiValueVariable,

--- a/public/app/features/dashboard-scene/scene/layout-auto-grid/AutoGridItem.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-auto-grid/AutoGridItem.tsx
@@ -1,3 +1,5 @@
+import { logStructured as structuredLog } from '@grafana/runtime';
+
 import { isEqual } from 'lodash';
 import React from 'react';
 
@@ -91,7 +93,11 @@ export class AutoGridItem extends SceneObjectBase<AutoGridItemState> implements 
       });
 
     if (!(variable instanceof MultiValueVariable)) {
-      console.error('DashboardGridItem: Variable is not a MultiValueVariable');
+      structuredLog(
+        'grafana/frontend.features.dashboard-scene.scene.layout-auto-grid.AutoGridItem',
+        'error',
+        'DashboardGridItem: Variable is not a MultiValueVariable'
+      );
       return;
     }
 

--- a/public/app/features/dashboard-scene/scene/layout-auto-grid/AutoGridLayoutManager.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-auto-grid/AutoGridLayoutManager.tsx
@@ -1,6 +1,6 @@
 import { AppEvents } from '@grafana/data';
 import { t } from '@grafana/i18n';
-import { config, getAppEvents } from '@grafana/runtime';
+import { logStructured as structuredLog, config, getAppEvents } from '@grafana/runtime';
 import {
   type SceneComponentProps,
   type SceneObject,
@@ -253,7 +253,11 @@ export class AutoGridLayoutManager
   public duplicatePanel(panel: VizPanel) {
     const gridItem = panel.parent;
     if (!(gridItem instanceof AutoGridItem)) {
-      console.error('Trying to duplicate a panel that is not inside a DashboardGridItem');
+      structuredLog(
+        'grafana/frontend.features.dashboard-scene.scene.layout-auto-grid.AutoGridLayoutManager',
+        'error',
+        'Trying to duplicate a panel that is not inside a DashboardGridItem'
+      );
       return;
     }
 

--- a/public/app/features/dashboard-scene/scene/layout-default/DashboardGridItem.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-default/DashboardGridItem.tsx
@@ -1,3 +1,5 @@
+import { logStructured as structuredLog } from '@grafana/runtime';
+
 import { isEqual } from 'lodash';
 import React from 'react';
 import { type Unsubscribable } from 'rxjs';
@@ -150,7 +152,11 @@ export class DashboardGridItem
       });
 
     if (!(variable instanceof MultiValueVariable)) {
-      console.error('DashboardGridItem: Variable is not a MultiValueVariable');
+      structuredLog(
+        'grafana/frontend.features.dashboard-scene.scene.layout-default.DashboardGridItem',
+        'error',
+        'DashboardGridItem: Variable is not a MultiValueVariable'
+      );
       return;
     }
 

--- a/public/app/features/dashboard-scene/scene/layout-default/DashboardGridItem.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-default/DashboardGridItem.tsx
@@ -1,9 +1,8 @@
-import { logStructured as structuredLog } from '@grafana/runtime';
-
 import { isEqual } from 'lodash';
 import React from 'react';
 import { type Unsubscribable } from 'rxjs';
 
+import { logStructured as structuredLog } from '@grafana/runtime';
 import {
   type VizPanel,
   SceneObjectBase,

--- a/public/app/features/dashboard-scene/scene/layout-default/DefaultGridLayoutManager.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-default/DefaultGridLayoutManager.tsx
@@ -3,7 +3,7 @@ import { css, cx } from '@emotion/css';
 import { AppEvents, type GrafanaTheme2 } from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';
 import { t } from '@grafana/i18n';
-import { config, getAppEvents } from '@grafana/runtime';
+import { logStructured as structuredLog, config, getAppEvents } from '@grafana/runtime';
 import {
   type SceneObjectState,
   SceneGridLayout,
@@ -264,7 +264,11 @@ export class DefaultGridLayoutManager
   public duplicatePanel(vizPanel: VizPanel) {
     const gridItem = vizPanel.parent;
     if (!(gridItem instanceof DashboardGridItem)) {
-      console.error('Trying to duplicate a panel that is not inside a DashboardGridItem');
+      structuredLog(
+        'grafana/frontend.features.dashboard-scene.scene.layout-default.DefaultGridLayoutManager',
+        'error',
+        'Trying to duplicate a panel that is not inside a DashboardGridItem'
+      );
       return;
     }
 

--- a/public/app/features/dashboard-scene/scene/layout-default/RowRepeaterBehavior.ts
+++ b/public/app/features/dashboard-scene/scene/layout-default/RowRepeaterBehavior.ts
@@ -1,7 +1,6 @@
-import { logStructured as structuredLog } from '@grafana/runtime';
-
 import { isEqual } from 'lodash';
 
+import { logStructured as structuredLog } from '@grafana/runtime';
 import {
   MultiValueVariable,
   sceneGraph,

--- a/public/app/features/dashboard-scene/scene/layout-default/RowRepeaterBehavior.ts
+++ b/public/app/features/dashboard-scene/scene/layout-default/RowRepeaterBehavior.ts
@@ -1,3 +1,5 @@
+import { logStructured as structuredLog } from '@grafana/runtime';
+
 import { isEqual } from 'lodash';
 
 import {
@@ -97,12 +99,20 @@ export class RowRepeaterBehavior extends SceneObjectBase<RowRepeaterBehaviorStat
     const variable = sceneGraph.lookupVariable(this.state.variableName, this.parent?.parent!);
 
     if (!variable) {
-      console.error('RepeatedRowBehavior: Variable not found');
+      structuredLog(
+        'grafana/frontend.features.dashboard-scene.scene.layout-default.RowRepeaterBehavior',
+        'error',
+        'RepeatedRowBehavior: Variable not found'
+      );
       return;
     }
 
     if (!(variable instanceof MultiValueVariable)) {
-      console.error('RepeatedRowBehavior: Variable is not a MultiValueVariable');
+      structuredLog(
+        'grafana/frontend.features.dashboard-scene.scene.layout-default.RowRepeaterBehavior',
+        'error',
+        'RepeatedRowBehavior: Variable is not a MultiValueVariable'
+      );
       return;
     }
 

--- a/public/app/features/dashboard-scene/scene/layout-rows/RowItem.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-rows/RowItem.tsx
@@ -251,7 +251,6 @@ export class RowItem
         layout.setState({ children: newChildren });
       } else {
         const warningMessage = 'Grid item has unexpected parent type';
-        console.warn(warningMessage);
         logWarning(warningMessage);
       }
     }
@@ -266,7 +265,6 @@ export class RowItem
       layout.addGridItem(gridItem);
     } else {
       const warningMessage = 'Layout manager does not support addGridItem';
-      console.warn(warningMessage);
       logWarning(warningMessage);
     }
     this.setIsDropTarget(false);

--- a/public/app/features/dashboard-scene/scene/layout-tabs/TabItem.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-tabs/TabItem.tsx
@@ -259,7 +259,6 @@ export class TabItem
         layout.setState({ children: newChildren });
       } else {
         const warningMessage = 'Grid item has unexpected parent type';
-        console.warn(warningMessage);
         logWarning(warningMessage);
       }
     }
@@ -281,13 +280,11 @@ export class TabItem
           rowLayout.addGridItem(gridItem);
         } else {
           const warningMessage = 'First row layout does not support addGridItem';
-          console.warn(warningMessage);
           logWarning(warningMessage);
         }
       }
     } else {
       const warningMessage = 'Layout manager does not support addGridItem';
-      console.warn(warningMessage);
       logWarning(warningMessage);
     }
     this.setIsDropTarget(false);

--- a/public/app/features/dashboard-scene/serialization/DashboardSceneSerializer.ts
+++ b/public/app/features/dashboard-scene/serialization/DashboardSceneSerializer.ts
@@ -368,7 +368,6 @@ export class V2DashboardSerializer
           }
         } else {
           const warningMsg = 'Dashboard serializer: Undefined variable found in dashboard save model, ignoring it';
-          console.warn(warningMsg);
           logWarning(warningMsg);
         }
       }

--- a/public/app/features/dashboard-scene/serialization/angularMigration.ts
+++ b/public/app/features/dashboard-scene/serialization/angularMigration.ts
@@ -1,3 +1,5 @@
+import { logStructured as structuredLog } from '@grafana/runtime';
+
 import { defaults, cloneDeep } from 'lodash';
 
 import { type PanelModel as PanelModelFromData, type PanelPlugin } from '@grafana/data';
@@ -42,7 +44,9 @@ export function getAngularPanelMigrationHandler(oldModel: PanelModel) {
       const targetClone = cloneDeep(oldModel.targets);
       Object.defineProperty(panel, 'targets', {
         get: function () {
-          console.warn(
+          structuredLog(
+            'grafana/frontend.features.dashboard-scene.serialization.angularMigration',
+            'warn',
             'Accessing the targets property when migrating a panel plugin is deprecated. Changes to this property will be ignored.'
           );
           return targetClone;
@@ -108,7 +112,9 @@ export function getV2AngularMigrationHandler(migrationData: AngularMigrationData
     const targetClone = cloneDeep(panel.targets);
     Object.defineProperty(panel, 'targets', {
       get: function () {
-        console.warn(
+        structuredLog(
+          'grafana/frontend.features.dashboard-scene.serialization.angularMigration',
+          'warn',
           'Accessing the targets property when migrating a panel plugin is deprecated. Changes to this property will be ignored.'
         );
         return targetClone;

--- a/public/app/features/dashboard-scene/serialization/angularMigration.ts
+++ b/public/app/features/dashboard-scene/serialization/angularMigration.ts
@@ -1,8 +1,7 @@
-import { logStructured as structuredLog } from '@grafana/runtime';
-
 import { defaults, cloneDeep } from 'lodash';
 
 import { type PanelModel as PanelModelFromData, type PanelPlugin } from '@grafana/data';
+import { logStructured as structuredLog } from '@grafana/runtime';
 import { autoMigrateAngular, type PanelModel } from 'app/features/dashboard/state/PanelModel';
 
 /**

--- a/public/app/features/dashboard-scene/serialization/layoutSerializers/utils.ts
+++ b/public/app/features/dashboard-scene/serialization/layoutSerializers/utils.ts
@@ -1,5 +1,5 @@
 import { getNextRefId } from '@grafana/data';
-import { config } from '@grafana/runtime';
+import { logStructured as structuredLog, config } from '@grafana/runtime';
 import { getPanelPluginMetasMapSync, type PanelPluginMetas } from '@grafana/runtime/internal';
 import {
   type SceneDataProvider,
@@ -382,7 +382,9 @@ export function getDataSourceForQuery(querySpecDS: DataSourceRef | undefined | n
     // In the datasource list from bootData "id" is the type and the uid could be uid or the name
     // in cases like grafana, dashboard or mixed datasource
 
-    console.warn(
+    structuredLog(
+      'grafana/frontend.features.dashboard-scene.serialization.layoutSerializers.utils',
+      'warn',
       `Could not find datasource for query kind ${queryKind}, defaulting to ${dsList[defaultDatasource].meta.id}`
     );
     return {

--- a/public/app/features/dashboard-scene/serialization/transformSaveModelSchemaV2ToScene.ts
+++ b/public/app/features/dashboard-scene/serialization/transformSaveModelSchemaV2ToScene.ts
@@ -1,6 +1,6 @@
 import { uniqueId } from 'lodash';
 
-import { config, getDataSourceSrv } from '@grafana/runtime';
+import { logStructured as structuredLog, config, getDataSourceSrv } from '@grafana/runtime';
 import {
   AdHocFiltersVariable,
   type AdHocFilterWithLabels,
@@ -322,7 +322,11 @@ function createVariablesForDashboard(dashboard: DashboardV2Spec, defaultVariable
       try {
         return createSceneVariableFromVariableModel(v);
       } catch (err) {
-        console.error(err);
+        structuredLog(
+          'grafana/frontend.features.dashboard-scene.serialization.transformSaveModelSchemaV2ToScene',
+          'error',
+          err
+        );
         return null;
       }
     })
@@ -338,7 +342,11 @@ function createVariablesForDashboard(dashboard: DashboardV2Spec, defaultVariable
       try {
         return createSceneVariableFromVariableModel(v);
       } catch (err) {
-        console.error(err);
+        structuredLog(
+          'grafana/frontend.features.dashboard-scene.serialization.transformSaveModelSchemaV2ToScene',
+          'error',
+          err
+        );
         return null;
       }
     })
@@ -634,7 +642,11 @@ function createVariablesForSnapshot(dashboard: DashboardV2Spec): SceneVariableSe
         // for other variable types we are using the SnapshotVariable
         return createSnapshotVariable(v);
       } catch (err) {
-        console.error(err);
+        structuredLog(
+          'grafana/frontend.features.dashboard-scene.serialization.transformSaveModelSchemaV2ToScene',
+          'error',
+          err
+        );
         return null;
       }
     })

--- a/public/app/features/dashboard-scene/serialization/transformSceneToSaveModelSchemaV2.ts
+++ b/public/app/features/dashboard-scene/serialization/transformSceneToSaveModelSchemaV2.ts
@@ -1,7 +1,7 @@
 import { omit } from 'lodash';
 
 import { type AnnotationQuery, getDataSourceRef, isEmptyObject, type TimeRange } from '@grafana/data';
-import { config, getDataSourceSrv } from '@grafana/runtime';
+import { logStructured as structuredLog, config, getDataSourceSrv } from '@grafana/runtime';
 import { ExpressionDatasourceRef } from '@grafana/runtime/internal';
 import {
   behaviors,
@@ -179,7 +179,12 @@ export function transformSceneToSaveModelSchemaV2(scene: DashboardScene, isSnaps
     // should never reach this point, validation should throw an error
     throw new Error('Error we could transform the dashboard to schema v2: ' + dashboardSchemaV2);
   } catch (reason) {
-    console.error('Error transforming dashboard to schema v2: ' + reason, dashboardSchemaV2);
+    structuredLog(
+      'grafana/frontend.features.dashboard-scene.serialization.transformSceneToSaveModelSchemaV2',
+      'error',
+      'Error transforming dashboard to schema v2: ' + reason,
+      dashboardSchemaV2
+    );
     throw new Error('Error transforming dashboard to schema v2: ' + reason);
   }
 }
@@ -687,7 +692,9 @@ function getAnnotations(state: DashboardSceneState, dsReferencesMapping?: DSRefe
       // for layers created for v2 schema. See transform transformSaveModelSchemaV2ToScene.ts.
       // In this case we will resolve default data source
       layerDs = getDefaultDataSourceRef();
-      console.error(
+      structuredLog(
+        'grafana/frontend.features.dashboard-scene.serialization.transformSceneToSaveModelSchemaV2',
+        'error',
         'Misconfigured AnnotationsDataLayer: Data source is required for annotations. Resolving default data source',
         layer,
         layerDs

--- a/public/app/features/dashboard-scene/serialization/transformToV1TypesUtils.ts
+++ b/public/app/features/dashboard-scene/serialization/transformToV1TypesUtils.ts
@@ -1,3 +1,5 @@
+import { logStructured as structuredLog } from '@grafana/runtime';
+
 import { type FieldConfigSource as FieldConfigSourceV1, SpecialValueMatch as SpecialValueMatchV1 } from '@grafana/data';
 import {
   VariableHide as VariableHideV1,
@@ -98,7 +100,11 @@ function transformSpecialValueMatchToV1(match: SpecialValueMatch): SpecialValueM
     case 'empty':
       return SpecialValueMatchV1.Empty;
     default:
-      console.warn(`Skipping special value mapping with unknown match type: "${match}"`);
+      structuredLog(
+        'grafana/frontend.features.dashboard-scene.serialization.transformToV1TypesUtils',
+        'warn',
+        `Skipping special value mapping with unknown match type: "${match}"`
+      );
       return undefined;
   }
 }

--- a/public/app/features/dashboard-scene/serialization/transformToV1TypesUtils.ts
+++ b/public/app/features/dashboard-scene/serialization/transformToV1TypesUtils.ts
@@ -1,6 +1,5 @@
-import { logStructured as structuredLog } from '@grafana/runtime';
-
 import { type FieldConfigSource as FieldConfigSourceV1, SpecialValueMatch as SpecialValueMatchV1 } from '@grafana/data';
+import { logStructured as structuredLog } from '@grafana/runtime';
 import {
   VariableHide as VariableHideV1,
   VariableRefresh as VariableRefreshV1,

--- a/public/app/features/dashboard-scene/settings/AnnotationsEditView.test.tsx
+++ b/public/app/features/dashboard-scene/settings/AnnotationsEditView.test.tsx
@@ -11,6 +11,7 @@ import {
   LoadingState,
   type PanelData,
 } from '@grafana/data';
+import { logStructured } from '@grafana/runtime';
 import { SceneTimeRange, type dataLayers } from '@grafana/scenes';
 import { type DataSourceRef } from '@grafana/schema';
 
@@ -61,6 +62,7 @@ const grafanaDsInstanceSettings = {
 
 jest.mock('@grafana/runtime', () => ({
   ...jest.requireActual('@grafana/runtime'),
+  logStructured: jest.fn(),
   getDataSourceSrv: () => {
     return {
       //return default datasource when no ref is provided
@@ -100,7 +102,6 @@ describe('AnnotationsEditView', () => {
     beforeEach(async () => {
       const result = await buildTestScene();
       annotationsView = result.annotationsView;
-      jest.spyOn(console, 'error').mockImplementation();
     });
 
     it('should return the correct urlKey', () => {
@@ -110,7 +111,11 @@ describe('AnnotationsEditView', () => {
     it('should return undefined when datasource does not support annotations', () => {
       const ds = annotationsView.getDataSourceRefForAnnotation();
       expect(ds).toBe(undefined);
-      expect(console.error).toHaveBeenCalledWith('Default datasource does not support annotations');
+      expect(logStructured).toHaveBeenCalledWith(
+        'grafana/frontend.features.dashboard-scene.settings.AnnotationsEditView',
+        'error',
+        'Default datasource does not support annotations'
+      );
     });
 
     it('should add a new annotation and group it with the other annotations', () => {

--- a/public/app/features/dashboard-scene/settings/AnnotationsEditView.tsx
+++ b/public/app/features/dashboard-scene/settings/AnnotationsEditView.tsx
@@ -6,7 +6,7 @@ import {
   PageLayoutType,
 } from '@grafana/data';
 import { t, Trans } from '@grafana/i18n';
-import { config, getDataSourceSrv, locationService } from '@grafana/runtime';
+import { logStructured as structuredLog, config, getDataSourceSrv, locationService } from '@grafana/runtime';
 import { useFlagGrafanaDashboardSettingsRedesign } from '@grafana/runtime/internal';
 import { type SceneComponentProps, SceneObjectBase, type VizPanel, dataLayers } from '@grafana/scenes';
 import { Alert, Button } from '@grafana/ui';
@@ -73,7 +73,11 @@ export class AnnotationsEditView extends SceneObjectBase<AnnotationsEditViewStat
     const defaultInstanceDS = getDataSourceSrv().getInstanceSettings(null);
     // check for an annotation flag in the plugin json to see if it supports annotations
     if (!defaultInstanceDS || !defaultInstanceDS.meta.annotations) {
-      console.error('Default datasource does not support annotations');
+      structuredLog(
+        'grafana/frontend.features.dashboard-scene.settings.AnnotationsEditView',
+        'error',
+        'Default datasource does not support annotations'
+      );
       return undefined;
     }
     return getDataSourceRef(defaultInstanceDS);

--- a/public/app/features/dashboard-scene/settings/GeneralSettingsEditView.tsx
+++ b/public/app/features/dashboard-scene/settings/GeneralSettingsEditView.tsx
@@ -2,7 +2,7 @@ import { type ChangeEvent } from 'react';
 
 import { PageLayoutType } from '@grafana/data';
 import { Trans, t } from '@grafana/i18n';
-import { config } from '@grafana/runtime';
+import { logStructured as structuredLog, config } from '@grafana/runtime';
 import { type SceneComponentProps, SceneObjectBase, behaviors, sceneGraph } from '@grafana/scenes';
 import { type TimeZone } from '@grafana/schema';
 import {
@@ -159,7 +159,7 @@ export class GeneralSettingsEditView
       const liveNow = this.getLiveNowTimer();
       enable ? liveNow.enable() : liveNow.disable();
     } catch (err) {
-      console.error(err);
+      structuredLog('grafana/frontend.features.dashboard-scene.settings.GeneralSettingsEditView', 'error', err);
     }
   };
 

--- a/public/app/features/dashboard-scene/settings/VariablesEditView.tsx
+++ b/public/app/features/dashboard-scene/settings/VariablesEditView.tsx
@@ -2,7 +2,7 @@ import { useMemo } from 'react';
 
 import { type NavModel, type NavModelItem, PageLayoutType, generateUUID } from '@grafana/data';
 import { t, Trans } from '@grafana/i18n';
-import { config, locationService } from '@grafana/runtime';
+import { logStructured as structuredLog, config, locationService } from '@grafana/runtime';
 import { useFlagGrafanaDashboardSettingsRedesign } from '@grafana/runtime/internal';
 import {
   type SceneComponentProps,
@@ -78,7 +78,11 @@ export class VariablesEditView extends SceneObjectBase<VariablesEditViewState> i
 
     if (!variable) {
       // Handle the case where the variable is not found
-      console.error('Variable not found');
+      structuredLog(
+        'grafana/frontend.features.dashboard-scene.settings.VariablesEditView',
+        'error',
+        'Variable not found'
+      );
       return;
     }
 
@@ -94,7 +98,11 @@ export class VariablesEditView extends SceneObjectBase<VariablesEditViewState> i
     const { variables } = this.getVariableSet().state;
     if (variableIndex === -1) {
       // Handle the case where the variable is not found
-      console.error('Variable not found');
+      structuredLog(
+        'grafana/frontend.features.dashboard-scene.settings.VariablesEditView',
+        'error',
+        'Variable not found'
+      );
       return;
     }
 
@@ -120,7 +128,11 @@ export class VariablesEditView extends SceneObjectBase<VariablesEditViewState> i
     const variables = this.getVariableSet().state.variables;
 
     if (variableIndex === -1) {
-      console.error('Variable not found');
+      structuredLog(
+        'grafana/frontend.features.dashboard-scene.settings.VariablesEditView',
+        'error',
+        'Variable not found'
+      );
       return;
     }
 
@@ -153,7 +165,7 @@ export class VariablesEditView extends SceneObjectBase<VariablesEditViewState> i
     }
     // check the index are within the variables array
     if (fromIndex < 0 || fromIndex >= variables.length || toIndex < 0 || toIndex >= variables.length) {
-      console.error('Invalid index');
+      structuredLog('grafana/frontend.features.dashboard-scene.settings.VariablesEditView', 'error', 'Invalid index');
       return;
     }
     const updatedVariables = [...variables];
@@ -167,7 +179,11 @@ export class VariablesEditView extends SceneObjectBase<VariablesEditViewState> i
   public onEdit = (identifier: string) => {
     const variableIndex = this.getVariableIndex(identifier);
     if (variableIndex === -1) {
-      console.error('Variable not found');
+      structuredLog(
+        'grafana/frontend.features.dashboard-scene.settings.VariablesEditView',
+        'error',
+        'Variable not found'
+      );
       return;
     }
     this.setState({ editIndex: variableIndex });
@@ -191,7 +207,11 @@ export class VariablesEditView extends SceneObjectBase<VariablesEditViewState> i
 
     if (!variable) {
       // Handle the case where the variable is not found
-      console.error('Variable not found');
+      structuredLog(
+        'grafana/frontend.features.dashboard-scene.settings.VariablesEditView',
+        'error',
+        'Variable not found'
+      );
       return;
     }
 

--- a/public/app/features/dashboard-scene/settings/VersionsEditView.tsx
+++ b/public/app/features/dashboard-scene/settings/VersionsEditView.tsx
@@ -1,11 +1,10 @@
-import { logStructured as structuredLog } from '@grafana/runtime';
-
 import { skipToken } from '@reduxjs/toolkit/query/react';
 import * as React from 'react';
 import { useMemo } from 'react';
 
 import { PageLayoutType, dateTimeFormat, dateTimeFormatTimeAgo } from '@grafana/data';
 import { Trans } from '@grafana/i18n';
+import { logStructured as structuredLog } from '@grafana/runtime';
 import { type SceneComponentProps, SceneObjectBase, sceneGraph } from '@grafana/scenes';
 import { Alert, Spinner, Stack } from '@grafana/ui';
 import { useGetDisplayMappingQuery } from 'app/api/clients/iam/v0alpha1';

--- a/public/app/features/dashboard-scene/settings/VersionsEditView.tsx
+++ b/public/app/features/dashboard-scene/settings/VersionsEditView.tsx
@@ -1,3 +1,5 @@
+import { logStructured as structuredLog } from '@grafana/runtime';
+
 import { skipToken } from '@reduxjs/toolkit/query/react';
 import * as React from 'react';
 import { useMemo } from 'react';
@@ -133,7 +135,7 @@ export class VersionsEditView extends SceneObjectBase<VersionsEditViewState> imp
         // Update the continueToken for the next request, if available
         this._continueToken = result.metadata.continue ?? '';
       })
-      .catch((err) => console.log(err))
+      .catch((err) => structuredLog('grafana/frontend.features.dashboard-scene.settings.VersionsEditView', 'info', err))
       .finally(() => this.setState({ isAppending: false }));
   };
 

--- a/public/app/features/dashboard-scene/settings/annotations/AnnotationQueryOptions.tsx
+++ b/public/app/features/dashboard-scene/settings/annotations/AnnotationQueryOptions.tsx
@@ -3,7 +3,7 @@ import { useAsync } from 'react-use';
 
 import { AppEvents, type DataSourceInstanceSettings, getDataSourceRef } from '@grafana/data';
 import { t, Trans } from '@grafana/i18n';
-import { getAppEvents, getDataSourceSrv } from '@grafana/runtime';
+import { logStructured as structuredLog, getAppEvents, getDataSourceSrv } from '@grafana/runtime';
 import { type DataQuery } from '@grafana/schema';
 import { Box, Button, ButtonGroup, Field, Modal, Stack } from '@grafana/ui';
 import StandardAnnotationQueryEditor from 'app/features/annotations/components/StandardAnnotationQueryEditor';
@@ -79,7 +79,12 @@ function QueryLibraryButton({ layer, onQuerySelected }: { layer: AnnotationLayer
           layer.setState({ query: updatedQuery });
           layer.runLayer();
         } catch (error) {
-          console.error('Failed to replace annotation query!', error);
+          structuredLog(
+            'grafana/frontend.features.dashboard-scene.settings.annotations.AnnotationQueryOptions',
+            'error',
+            'Failed to replace annotation query!',
+            error
+          );
           getAppEvents().publish({
             type: AppEvents.alertError.name,
             payload: ['Failed to create annotation query!', error instanceof Error ? error.message : error],

--- a/public/app/features/dashboard-scene/settings/variables/editors/AdHocFiltersVariableEditor.tsx
+++ b/public/app/features/dashboard-scene/settings/variables/editors/AdHocFiltersVariableEditor.tsx
@@ -9,7 +9,7 @@ import {
   getDataSourceRef,
 } from '@grafana/data';
 import { t } from '@grafana/i18n';
-import { config, getDataSourceSrv, reportInteraction } from '@grafana/runtime';
+import { logStructured as structuredLog, config, getDataSourceSrv, reportInteraction } from '@grafana/runtime';
 import { AdHocFiltersVariable, type AdHocFilterWithLabels, type SceneVariable } from '@grafana/scenes';
 import { OptionsPaneItemDescriptor } from 'app/features/dashboard/components/PanelEditor/OptionsPaneItemDescriptor';
 
@@ -173,7 +173,11 @@ export function AdHocFiltersVariableEditor(props: AdHocFiltersVariableEditorProp
 
 export function getAdHocFilterOptions(variable: SceneVariable): OptionsPaneItemDescriptor[] {
   if (!(variable instanceof AdHocFiltersVariable)) {
-    console.warn('getAdHocFilterOptions: variable is not an AdHocFiltersVariable');
+    structuredLog(
+      'grafana/frontend.features.dashboard-scene.settings.variables.editors.AdHocFiltersVariableEditor',
+      'warn',
+      'getAdHocFilterOptions: variable is not an AdHocFiltersVariable'
+    );
     return [];
   }
 

--- a/public/app/features/dashboard-scene/settings/variables/editors/ConstantVariableEditor.tsx
+++ b/public/app/features/dashboard-scene/settings/variables/editors/ConstantVariableEditor.tsx
@@ -1,3 +1,5 @@
+import { logStructured as structuredLog } from '@grafana/runtime';
+
 import { type FormEvent } from 'react';
 import { lastValueFrom } from 'rxjs';
 
@@ -24,7 +26,11 @@ export function ConstantVariableEditor({ variable }: ConstantVariableEditorProps
 
 export function getConstantVariableOptions(variable: SceneVariable): OptionsPaneItemDescriptor[] {
   if (!(variable instanceof ConstantVariable)) {
-    console.warn('getConstantVariableOptions: variable is not a ConstantVariable');
+    structuredLog(
+      'grafana/frontend.features.dashboard-scene.settings.variables.editors.ConstantVariableEditor',
+      'warn',
+      'getConstantVariableOptions: variable is not a ConstantVariable'
+    );
     return [];
   }
 

--- a/public/app/features/dashboard-scene/settings/variables/editors/ConstantVariableEditor.tsx
+++ b/public/app/features/dashboard-scene/settings/variables/editors/ConstantVariableEditor.tsx
@@ -1,9 +1,8 @@
-import { logStructured as structuredLog } from '@grafana/runtime';
-
 import { type FormEvent } from 'react';
 import { lastValueFrom } from 'rxjs';
 
 import { t } from '@grafana/i18n';
+import { logStructured as structuredLog } from '@grafana/runtime';
 import { ConstantVariable, type SceneVariable } from '@grafana/scenes';
 import { Input } from '@grafana/ui';
 import { OptionsPaneItemDescriptor } from 'app/features/dashboard/components/PanelEditor/OptionsPaneItemDescriptor';

--- a/public/app/features/dashboard-scene/settings/variables/editors/GroupByVariableEditor.tsx
+++ b/public/app/features/dashboard-scene/settings/variables/editors/GroupByVariableEditor.tsx
@@ -8,7 +8,7 @@ import {
   type SelectableValue,
   getDataSourceRef,
 } from '@grafana/data';
-import { getDataSourceSrv } from '@grafana/runtime';
+import { logStructured as structuredLog, getDataSourceSrv } from '@grafana/runtime';
 import { GroupByVariable, type SceneVariable } from '@grafana/scenes';
 import { OptionsPaneItemDescriptor } from 'app/features/dashboard/components/PanelEditor/OptionsPaneItemDescriptor';
 
@@ -106,7 +106,11 @@ export function GroupByVariableEditor(props: GroupByVariableEditorProps) {
 
 export function getGroupByVariableOptions(variable: SceneVariable): OptionsPaneItemDescriptor[] {
   if (!(variable instanceof GroupByVariable)) {
-    console.warn('getAdHocFilterOptions: variable is not an AdHocFiltersVariable');
+    structuredLog(
+      'grafana/frontend.features.dashboard-scene.settings.variables.editors.GroupByVariableEditor',
+      'warn',
+      'getAdHocFilterOptions: variable is not an AdHocFiltersVariable'
+    );
     return [];
   }
 

--- a/public/app/features/dashboard-scene/settings/variables/editors/IntervalVariableEditor.tsx
+++ b/public/app/features/dashboard-scene/settings/variables/editors/IntervalVariableEditor.tsx
@@ -1,9 +1,8 @@
-import { logStructured as structuredLog } from '@grafana/runtime';
-
 import { noop } from 'lodash';
 import { type ChangeEvent, type FormEvent } from 'react';
 
 import { type SelectableValue } from '@grafana/data';
+import { logStructured as structuredLog } from '@grafana/runtime';
 import { IntervalVariable, type SceneVariable } from '@grafana/scenes';
 import { OptionsPaneItemDescriptor } from 'app/features/dashboard/components/PanelEditor/OptionsPaneItemDescriptor';
 import {

--- a/public/app/features/dashboard-scene/settings/variables/editors/IntervalVariableEditor.tsx
+++ b/public/app/features/dashboard-scene/settings/variables/editors/IntervalVariableEditor.tsx
@@ -1,3 +1,5 @@
+import { logStructured as structuredLog } from '@grafana/runtime';
+
 import { noop } from 'lodash';
 import { type ChangeEvent, type FormEvent } from 'react';
 
@@ -65,7 +67,11 @@ export function IntervalVariableEditor({ variable, onRunQuery, inline }: Interva
 
 export function getIntervalVariableOptions(variable: SceneVariable): OptionsPaneItemDescriptor[] {
   if (!(variable instanceof IntervalVariable)) {
-    console.warn('getIntervalVariableOptions: variable is not an IntervalVariable');
+    structuredLog(
+      'grafana/frontend.features.dashboard-scene.settings.variables.editors.IntervalVariableEditor',
+      'warn',
+      'getIntervalVariableOptions: variable is not an IntervalVariable'
+    );
     return [];
   }
 

--- a/public/app/features/dashboard-scene/settings/variables/editors/QueryVariableEditor/getQueryVariableOptions.tsx
+++ b/public/app/features/dashboard-scene/settings/variables/editors/QueryVariableEditor/getQueryVariableOptions.tsx
@@ -1,5 +1,4 @@
 import { logStructured as structuredLog } from '@grafana/runtime';
-
 import { QueryVariable, type SceneVariable } from '@grafana/scenes';
 
 import { OptionsPaneItemDescriptor } from '../../../../../dashboard/components/PanelEditor/OptionsPaneItemDescriptor';

--- a/public/app/features/dashboard-scene/settings/variables/editors/QueryVariableEditor/getQueryVariableOptions.tsx
+++ b/public/app/features/dashboard-scene/settings/variables/editors/QueryVariableEditor/getQueryVariableOptions.tsx
@@ -1,3 +1,5 @@
+import { logStructured as structuredLog } from '@grafana/runtime';
+
 import { QueryVariable, type SceneVariable } from '@grafana/scenes';
 
 import { OptionsPaneItemDescriptor } from '../../../../../dashboard/components/PanelEditor/OptionsPaneItemDescriptor';
@@ -6,7 +8,11 @@ import { PaneItem } from './PaneItem';
 
 export function getQueryVariableOptions(variable: SceneVariable): OptionsPaneItemDescriptor[] {
   if (!(variable instanceof QueryVariable)) {
-    console.warn('getQueryVariableOptions: variable is not a QueryVariable');
+    structuredLog(
+      'grafana/frontend.features.dashboard-scene.settings.variables.editors.QueryVariableEditor.getQueryVariableOptions',
+      'warn',
+      'getQueryVariableOptions: variable is not a QueryVariable'
+    );
     return [];
   }
 

--- a/public/app/features/dashboard-scene/settings/variables/editors/SwitchVariableEditor.tsx
+++ b/public/app/features/dashboard-scene/settings/variables/editors/SwitchVariableEditor.tsx
@@ -1,5 +1,4 @@
 import { logStructured as structuredLog } from '@grafana/runtime';
-
 import { type SceneVariable, SwitchVariable } from '@grafana/scenes';
 import { OptionsPaneItemDescriptor } from 'app/features/dashboard/components/PanelEditor/OptionsPaneItemDescriptor';
 

--- a/public/app/features/dashboard-scene/settings/variables/editors/SwitchVariableEditor.tsx
+++ b/public/app/features/dashboard-scene/settings/variables/editors/SwitchVariableEditor.tsx
@@ -1,3 +1,5 @@
+import { logStructured as structuredLog } from '@grafana/runtime';
+
 import { type SceneVariable, SwitchVariable } from '@grafana/scenes';
 import { OptionsPaneItemDescriptor } from 'app/features/dashboard/components/PanelEditor/OptionsPaneItemDescriptor';
 
@@ -44,7 +46,11 @@ export function SwitchVariableEditor({ variable, inline = false }: SwitchVariabl
 
 export function getSwitchVariableOptions(variable: SceneVariable): OptionsPaneItemDescriptor[] {
   if (!(variable instanceof SwitchVariable)) {
-    console.warn('getSwitchVariableOptions: variable is not a SwitchVariable');
+    structuredLog(
+      'grafana/frontend.features.dashboard-scene.settings.variables.editors.SwitchVariableEditor',
+      'warn',
+      'getSwitchVariableOptions: variable is not a SwitchVariable'
+    );
     return [];
   }
 

--- a/public/app/features/dashboard-scene/settings/variables/editors/TextBoxVariableEditor.tsx
+++ b/public/app/features/dashboard-scene/settings/variables/editors/TextBoxVariableEditor.tsx
@@ -1,3 +1,5 @@
+import { logStructured as structuredLog } from '@grafana/runtime';
+
 import { noop } from 'lodash';
 import { type FormEvent } from 'react';
 
@@ -25,7 +27,11 @@ export function TextBoxVariableEditor({ variable, inline }: TextBoxVariableEdito
 
 export function getTextBoxVariableOptions(variable: SceneVariable): OptionsPaneItemDescriptor[] {
   if (!(variable instanceof TextBoxVariable)) {
-    console.warn('getTextBoxVariableOptions: variable is not a TextBoxVariable');
+    structuredLog(
+      'grafana/frontend.features.dashboard-scene.settings.variables.editors.TextBoxVariableEditor',
+      'warn',
+      'getTextBoxVariableOptions: variable is not a TextBoxVariable'
+    );
     return [];
   }
 

--- a/public/app/features/dashboard-scene/settings/variables/editors/TextBoxVariableEditor.tsx
+++ b/public/app/features/dashboard-scene/settings/variables/editors/TextBoxVariableEditor.tsx
@@ -1,9 +1,8 @@
-import { logStructured as structuredLog } from '@grafana/runtime';
-
 import { noop } from 'lodash';
 import { type FormEvent } from 'react';
 
 import { t } from '@grafana/i18n';
+import { logStructured as structuredLog } from '@grafana/runtime';
 import { type SceneVariable, TextBoxVariable } from '@grafana/scenes';
 import { OptionsPaneItemDescriptor } from 'app/features/dashboard/components/PanelEditor/OptionsPaneItemDescriptor';
 

--- a/public/app/features/dashboard-scene/sharing/DownloadDiagnostics.tsx
+++ b/public/app/features/dashboard-scene/sharing/DownloadDiagnostics.tsx
@@ -195,7 +195,6 @@ function DownloadDiagnosticsRenderer({ model }: SceneComponentProps<DownloadDiag
       dashboardModel = dashboard?.getSaveModel();
       panelModel = dashboard ? findPanelSaveModel(dashboardModel, panel, dashboard) : undefined;
     } catch (error) {
-      console.warn(SAVE_MODEL_FAILURE_MESSAGE, error);
       logError(error instanceof Error ? error : new Error(SAVE_MODEL_FAILURE_MESSAGE), {
         panelKey: panel.state.key ?? '',
         dashboardUid: dashboard?.state.uid ?? '',
@@ -219,7 +218,6 @@ function DownloadDiagnosticsRenderer({ model }: SceneComponentProps<DownloadDiag
       JSON.stringify(captured);
       panelData = captured;
     } catch (error) {
-      console.warn(PANEL_DATA_FAILURE_MESSAGE, error);
       logError(error instanceof Error ? error : new Error(PANEL_DATA_FAILURE_MESSAGE), {
         panelKey: panel.state.key ?? '',
       });

--- a/public/app/features/dashboard-scene/sharing/ExportButton/ExportAsImage.tsx
+++ b/public/app/features/dashboard-scene/sharing/ExportButton/ExportAsImage.tsx
@@ -5,7 +5,7 @@ import { useAsyncFn } from 'react-use';
 
 import { type GrafanaTheme2 } from '@grafana/data';
 import { Trans, t } from '@grafana/i18n';
-import { config } from '@grafana/runtime';
+import { logStructured as structuredLog, config } from '@grafana/runtime';
 import { type SceneComponentProps, SceneObjectBase } from '@grafana/scenes';
 import { Alert, Button, TextLink, useStyles2 } from '@grafana/ui';
 import { DashboardInteractions } from 'app/features/dashboard-scene/utils/interactions';
@@ -48,7 +48,12 @@ function ExportAsImageRenderer({ model }: SceneComponentProps<ExportAsImage>) {
 
       return result.blob;
     } catch (error) {
-      console.error('Error exporting image:', error);
+      structuredLog(
+        'grafana/frontend.features.dashboard-scene.sharing.ExportButton.ExportAsImage',
+        'error',
+        'Error exporting image:',
+        error
+      );
       DashboardInteractions.generateDashboardImageClicked({
         scale: config.rendererDefaultImageScale || 1,
         shareResource: 'dashboard',

--- a/public/app/features/dashboard-scene/sidebar/DashboardSidebar.tsx
+++ b/public/app/features/dashboard-scene/sidebar/DashboardSidebar.tsx
@@ -1,7 +1,6 @@
-import { logStructured as structuredLog } from '@grafana/runtime';
-
 import { isEqual } from 'lodash';
 
+import { logStructured as structuredLog } from '@grafana/runtime';
 import {
   NewSceneObjectAddedEvent,
   type SceneObject,

--- a/public/app/features/dashboard-scene/sidebar/DashboardSidebar.tsx
+++ b/public/app/features/dashboard-scene/sidebar/DashboardSidebar.tsx
@@ -1,3 +1,5 @@
+import { logStructured as structuredLog } from '@grafana/runtime';
+
 import { isEqual } from 'lodash';
 
 import {
@@ -232,7 +234,12 @@ export class DashboardSidebar extends SceneObjectBase<DashboardSidebarState> imp
   private selectElement(element: ElementSelectionContextItem, options: ElementSelectionOnSelectOptions) {
     let obj = sceneGraph.findByKey(this, element.id);
     if (!obj) {
-      console.warn('Cannot find element by key="%s"!', element.id);
+      structuredLog(
+        'grafana/frontend.features.dashboard-scene.sidebar.DashboardSidebar',
+        'warn',
+        'Cannot find element by key="%s"!',
+        element.id
+      );
       return;
     }
 
@@ -240,7 +247,12 @@ export class DashboardSidebar extends SceneObjectBase<DashboardSidebarState> imp
     if (sourceKey) {
       obj = sceneGraph.findByKey(this, sourceKey);
       if (!obj) {
-        console.warn('Cannot find element by source key="%s"!', sourceKey);
+        structuredLog(
+          'grafana/frontend.features.dashboard-scene.sidebar.DashboardSidebar',
+          'warn',
+          'Cannot find element by source key="%s"!',
+          sourceKey
+        );
         return;
       }
     }

--- a/public/app/features/dashboard-scene/utils/DashboardModelCompatibilityWrapper.ts
+++ b/public/app/features/dashboard-scene/utils/DashboardModelCompatibilityWrapper.ts
@@ -7,7 +7,7 @@ import {
   type DateTimeInput,
   EventBusSrv,
 } from '@grafana/data';
-import { TimeRangeUpdatedEvent } from '@grafana/runtime';
+import { logStructured as structuredLog, TimeRangeUpdatedEvent } from '@grafana/runtime';
 import { behaviors, sceneGraph, type SceneObject, VizPanel } from '@grafana/scenes';
 
 import { DashboardDataLayerSet } from '../scene/DashboardDataLayerSet';
@@ -157,7 +157,12 @@ export class DashboardModelCompatibilityWrapper {
   public removePanel(panel: PanelModelCompatibilityWrapper) {
     const vizPanel = findVizPanelByKey(this._scene, getVizPanelKeyForPanelId(panel.id));
     if (!vizPanel) {
-      console.error('Trying to remove a panel that was not found in scene', panel);
+      structuredLog(
+        'grafana/frontend.features.dashboard-scene.utils.DashboardModelCompatibilityWrapper',
+        'error',
+        'Trying to remove a panel that was not found in scene',
+        panel
+      );
       return;
     }
 

--- a/public/app/features/dashboard-scene/utils/PanelModelCompatibilityWrapper.ts
+++ b/public/app/features/dashboard-scene/utils/PanelModelCompatibilityWrapper.ts
@@ -1,6 +1,5 @@
-import { logStructured as structuredLog } from '@grafana/runtime';
-
 import { type PanelModel } from '@grafana/data';
+import { logStructured as structuredLog } from '@grafana/runtime';
 import { SceneDataTransformer, type VizPanel } from '@grafana/scenes';
 import { type DataSourceRef, type DataTransformerConfig } from '@grafana/schema';
 

--- a/public/app/features/dashboard-scene/utils/PanelModelCompatibilityWrapper.ts
+++ b/public/app/features/dashboard-scene/utils/PanelModelCompatibilityWrapper.ts
@@ -1,3 +1,5 @@
+import { logStructured as structuredLog } from '@grafana/runtime';
+
 import { type PanelModel } from '@grafana/data';
 import { SceneDataTransformer, type VizPanel } from '@grafana/scenes';
 import { type DataSourceRef, type DataTransformerConfig } from '@grafana/schema';
@@ -11,7 +13,12 @@ export class PanelModelCompatibilityWrapper implements PanelModel {
     const id = getPanelIdForVizPanel(this._vizPanel);
 
     if (isNaN(id)) {
-      console.error('VizPanel key could not be translated to a legacy numeric panel id', this._vizPanel);
+      structuredLog(
+        'grafana/frontend.features.dashboard-scene.utils.PanelModelCompatibilityWrapper',
+        'error',
+        'VizPanel key could not be translated to a legacy numeric panel id',
+        this._vizPanel
+      );
       return 0;
     }
 

--- a/public/app/features/dashboard-scene/utils/dashboardControls.ts
+++ b/public/app/features/dashboard-scene/utils/dashboardControls.ts
@@ -1,7 +1,7 @@
 import { filter, Observable, scan, share, type Subscriber } from 'rxjs';
 
 import { type DataSourceApi } from '@grafana/data';
-import { getDataSourceSrv } from '@grafana/runtime';
+import { logStructured as structuredLog, getDataSourceSrv } from '@grafana/runtime';
 import { type SceneVariable } from '@grafana/scenes';
 import { type DashboardLink, type DataSourceRef } from '@grafana/schema';
 import { type VariableKind } from '@grafana/schema/apis/dashboard.grafana.app/v2';
@@ -68,7 +68,13 @@ async function loadControlsFromRef(ref: DataSourceRef, subscriber: Subscriber<De
   try {
     ds = await getDataSourceSrv().get(ref);
   } catch (e) {
-    console.warn('Failed to load datasource', ref, e);
+    structuredLog(
+      'grafana/frontend.features.dashboard-scene.utils.dashboardControls',
+      'warn',
+      'Failed to load datasource',
+      ref,
+      e
+    );
     return;
   }
 
@@ -98,7 +104,13 @@ async function emitDefaultVariables(ds: DataSourceApi, subscriber: Subscriber<De
       subscriber.next({ type: 'variables', data });
     }
   } catch (e) {
-    console.warn('Failed to load default variables from datasource', ds.type, e);
+    structuredLog(
+      'grafana/frontend.features.dashboard-scene.utils.dashboardControls',
+      'warn',
+      'Failed to load default variables from datasource',
+      ds.type,
+      e
+    );
   }
 }
 
@@ -120,7 +132,13 @@ async function emitDefaultLinks(ds: DataSourceApi, subscriber: Subscriber<Defaul
       });
     }
   } catch (e) {
-    console.warn('Failed to load default links from datasource', ds.type, e);
+    structuredLog(
+      'grafana/frontend.features.dashboard-scene.utils.dashboardControls',
+      'warn',
+      'Failed to load default links from datasource',
+      ds.type,
+      e
+    );
   }
 }
 

--- a/public/app/features/dashboard-scene/utils/predefinedVariables.ts
+++ b/public/app/features/dashboard-scene/utils/predefinedVariables.ts
@@ -1,5 +1,5 @@
 import { BASE_URL } from '@grafana/api-clients/rtkq/dashboard/v2beta1';
-import { getBackendSrv } from '@grafana/runtime';
+import { logStructured as structuredLog, getBackendSrv } from '@grafana/runtime';
 import { FlagKeys, getFeatureFlagClient } from '@grafana/runtime/internal';
 import { type ControlSourceRef, type VariableKind } from '@grafana/schema/apis/dashboard.grafana.app/v2';
 import { type Variable, type VariableList } from 'app/api/clients/dashboard/v2beta1';
@@ -99,7 +99,12 @@ export async function fetchPredefinedVariables(folderUid?: string): Promise<Vari
     cache.set(cacheKey, { ts: Date.now(), variables });
     return variables;
   } catch (err) {
-    console.warn('Failed to load predefined dashboard variables', err);
+    structuredLog(
+      'grafana/frontend.features.dashboard-scene.utils.predefinedVariables',
+      'warn',
+      'Failed to load predefined dashboard variables',
+      err
+    );
     return null;
   }
 }

--- a/public/app/features/dashboard-scene/utils/variables.ts
+++ b/public/app/features/dashboard-scene/utils/variables.ts
@@ -1,5 +1,5 @@
 import { type AdHocVariableFilter, type TypedVariableModel } from '@grafana/data';
-import { config, getDataSourceSrv } from '@grafana/runtime';
+import { logStructured as structuredLog, config, getDataSourceSrv } from '@grafana/runtime';
 import {
   AdHocFiltersVariable,
   ConstantVariable,
@@ -80,7 +80,7 @@ export function createVariablesForDashboard(oldModel: DashboardModel, defaultVar
       try {
         return createSceneVariableFromVariableModel(v);
       } catch (err) {
-        console.error(err);
+        structuredLog('grafana/frontend.features.dashboard-scene.utils.variables', 'error', err);
         return null;
       }
     })
@@ -93,7 +93,7 @@ export function createVariablesForDashboard(oldModel: DashboardModel, defaultVar
       try {
         return createSceneVariableFromVariableModelV2(v);
       } catch (err) {
-        console.error(err);
+        structuredLog('grafana/frontend.features.dashboard-scene.utils.variables', 'error', err);
         return null;
       }
     })
@@ -139,7 +139,7 @@ export function createVariablesForSnapshot(oldModel: DashboardModel) {
         // for other variable types we are using the SnapshotVariable
         return createSnapshotVariable(v);
       } catch (err) {
-        console.error(err);
+        structuredLog('grafana/frontend.features.dashboard-scene.utils.variables', 'error', err);
         return null;
       }
     })

--- a/public/app/features/dashboard/api/ResponseTransformers.ts
+++ b/public/app/features/dashboard/api/ResponseTransformers.ts
@@ -1,5 +1,5 @@
 import { type MetricFindValue, type TypedVariableModel, type AnnotationQuery } from '@grafana/data';
-import { config } from '@grafana/runtime';
+import { logStructured as structuredLog, config } from '@grafana/runtime';
 import {
   type DataQuery,
   type DataSourceRef,
@@ -728,7 +728,9 @@ function getVariables(vars: TypedVariableModel[]): DashboardV2Spec['variables'] 
         let query = v.query || {};
 
         if (typeof query === 'string') {
-          console.warn(
+          structuredLog(
+            'grafana/frontend.features.dashboard.api.ResponseTransformers',
+            'warn',
             'Query variable query is a string which is deprecated in the schema v2. It should extend DataQuery'
           );
           query = {
@@ -941,7 +943,11 @@ function getVariables(vars: TypedVariableModel[]): DashboardV2Spec['variables'] 
         break;
       default:
         // do not throw error, just log it
-        console.error(`Variable transformation not implemented: ${v.type}`);
+        structuredLog(
+          'grafana/frontend.features.dashboard.api.ResponseTransformers',
+          'error',
+          `Variable transformation not implemented: ${v.type}`
+        );
     }
   }
   return variables;
@@ -1154,7 +1160,11 @@ function getVariablesV1(vars: DashboardV2Spec['variables']): VariableModel[] {
         break;
       default:
         // do not throw error, just log it
-        console.error(`Variable transformation not implemented: ${v}`);
+        structuredLog(
+          'grafana/frontend.features.dashboard.api.ResponseTransformers',
+          'error',
+          `Variable transformation not implemented: ${v}`
+        );
     }
   }
   return variables;
@@ -1410,7 +1420,11 @@ function transformSpecialValueMatchToV1(match: SpecialValueMatch): SpecialValueM
     case 'empty':
       return SpecialValueMatchV1.Empty;
     default:
-      console.warn(`Skipping special value mapping with unknown match type: "${match}"`);
+      structuredLog(
+        'grafana/frontend.features.dashboard.api.ResponseTransformers',
+        'warn',
+        `Skipping special value mapping with unknown match type: "${match}"`
+      );
       return undefined;
   }
 }

--- a/public/app/features/dashboard/components/DashExportModal/DashboardExporter.ts
+++ b/public/app/features/dashboard/components/DashExportModal/DashboardExporter.ts
@@ -1,7 +1,7 @@
 import { defaults, each, sortBy } from 'lodash';
 
 import { type DataSourceRef, type VariableOption, VariableRefresh } from '@grafana/data';
-import { getDataSourceSrv } from '@grafana/runtime';
+import { logStructured as structuredLog, getDataSourceSrv } from '@grafana/runtime';
 import { getPanelPluginMeta } from '@grafana/runtime/internal';
 import config from 'app/core/config';
 import { type PanelModel } from 'app/features/dashboard/state/PanelModel';
@@ -318,7 +318,12 @@ export class DashboardExporter {
 
       return newObj;
     } catch (err) {
-      console.error('Export failed:', err);
+      structuredLog(
+        'grafana/frontend.features.dashboard.components.DashExportModal.DashboardExporter',
+        'error',
+        'Export failed:',
+        err
+      );
       return {
         error: err,
       };

--- a/public/app/features/dashboard/components/GenAI/hooks.ts
+++ b/public/app/features/dashboard/components/GenAI/hooks.ts
@@ -69,7 +69,6 @@ export function useLLMStream(options: Options = defaultOptions): UseLLMStreamRes
         'Failed to generate content using LLM',
         'Please try again or if the problem persists, contact your organization admin.'
       );
-      console.error(e);
       getLogger('features.dashboards.genai').logError(e, {
         messages: JSON.stringify(messages),
         model,

--- a/public/app/features/dashboard/components/HelpWizard/SupportSnapshotService.ts
+++ b/public/app/features/dashboard/components/HelpWizard/SupportSnapshotService.ts
@@ -1,3 +1,5 @@
+import { logStructured as structuredLog } from '@grafana/runtime';
+
 import saveAs from 'file-saver';
 
 import { dateTimeFormat, formattedValueToString, getValueFormat, type SelectableValue } from '@grafana/data';
@@ -88,7 +90,12 @@ export class SupportSnapshotService extends StateManagerBase<SupportSnapshotStat
       const dash = createDashboardSceneFromDashboardModel(oldModel, snapshot);
       scene = dash.state.body; // skip the wrappers
     } catch (ex) {
-      console.log('Error creating scene:', ex);
+      structuredLog(
+        'grafana/frontend.features.dashboard.components.HelpWizard.SupportSnapshotService',
+        'info',
+        'Error creating scene:',
+        ex
+      );
     }
 
     this.setState({ snapshot, snapshotText, markdownText, snapshotSize, snapshotUpdate: snapshotUpdate + 1, scene });

--- a/public/app/features/dashboard/components/HelpWizard/SupportSnapshotService.ts
+++ b/public/app/features/dashboard/components/HelpWizard/SupportSnapshotService.ts
@@ -1,9 +1,8 @@
-import { logStructured as structuredLog } from '@grafana/runtime';
-
 import saveAs from 'file-saver';
 
 import { dateTimeFormat, formattedValueToString, getValueFormat, type SelectableValue } from '@grafana/data';
 import { t } from '@grafana/i18n';
+import { logStructured as structuredLog } from '@grafana/runtime';
 import { type SceneObject } from '@grafana/scenes';
 import { StateManagerBase } from 'app/core/services/StateManagerBase';
 import { type Randomize } from 'app/features/dashboard-scene/inspect/HelpWizard/randomizer';

--- a/public/app/features/dashboard/dashgrid/DashboardLibrary/DashboardCard.tsx
+++ b/public/app/features/dashboard/dashgrid/DashboardLibrary/DashboardCard.tsx
@@ -8,7 +8,7 @@ import Skeleton from 'react-loading-skeleton';
 import { createAssistantContextItem, useAssistant } from '@grafana/assistant';
 import { type GrafanaTheme2 } from '@grafana/data';
 import { t, Trans } from '@grafana/i18n';
-import { config } from '@grafana/runtime';
+import { logStructured as structuredLog, config } from '@grafana/runtime';
 import {
   Badge,
   Box,
@@ -234,7 +234,14 @@ function DashboardCardComponent({
               kind === 'suggested_dashboard' ? styles.thumbnailCoverImage : styles.thumbnailContainImage
             )}
             onError={(e) => {
-              console.error('Failed to load image for:', title, 'URL:', imageUrl);
+              structuredLog(
+                'grafana/frontend.features.dashboard.dashgrid.DashboardLibrary.DashboardCard',
+                'error',
+                'Failed to load image for:',
+                title,
+                'URL:',
+                imageUrl
+              );
               e.currentTarget.style.display = 'none';
             }}
           />

--- a/public/app/features/dashboard/dashgrid/DashboardLibrary/GrafanaTemplatesTab.tsx
+++ b/public/app/features/dashboard/dashgrid/DashboardLibrary/GrafanaTemplatesTab.tsx
@@ -3,7 +3,7 @@ import { useAsync } from 'react-use';
 
 import { type DataSourceInstanceListItem } from '@grafana/data';
 import { t } from '@grafana/i18n';
-import { getBackendSrv, locationService } from '@grafana/runtime';
+import { logStructured as structuredLog, getBackendSrv, locationService } from '@grafana/runtime';
 import {
   useFlagAnalyticsFramework,
   useFlagAssistantFrontendToolsDashboardTemplates,
@@ -60,7 +60,12 @@ export const GrafanaTemplatesTab = ({
 
       return response.items;
     } catch (error) {
-      console.error('Error loading template dashboards ', error);
+      structuredLog(
+        'grafana/frontend.features.dashboard.dashgrid.DashboardLibrary.GrafanaTemplatesTab',
+        'error',
+        'Error loading template dashboards ',
+        error
+      );
       return [];
     }
   }, []);

--- a/public/app/features/dashboard/dashgrid/DashboardLibrary/SuggestedDashboardsList/SuggestedDashboardsList.tsx
+++ b/public/app/features/dashboard/dashgrid/DashboardLibrary/SuggestedDashboardsList/SuggestedDashboardsList.tsx
@@ -5,7 +5,7 @@ import { useAsyncFn, useDebounce } from 'react-use';
 
 import { type GrafanaTheme2 } from '@grafana/data';
 import { t } from '@grafana/i18n';
-import { config, isFetchError, locationService } from '@grafana/runtime';
+import { logStructured as structuredLog, config, isFetchError, locationService } from '@grafana/runtime';
 import { getDataSourceInstanceSettings } from '@grafana/runtime/unstable';
 import { FilterInput, Grid, Pagination, Stack, useStyles2 } from '@grafana/ui';
 import { type PluginDashboard } from 'app/types/plugins';
@@ -253,7 +253,12 @@ export const SuggestedDashboardsList = ({
           });
         }
       } catch (err) {
-        console.error('Error loading community dashboards', err);
+        structuredLog(
+          'grafana/frontend.features.dashboard.dashgrid.DashboardLibrary.SuggestedDashboardsList.SuggestedDashboardsList',
+          'error',
+          'Error loading community dashboards',
+          err
+        );
       } finally {
         setIsCommunityLoading(false);
       }
@@ -424,7 +429,12 @@ export const SuggestedDashboardsList = ({
         sourceEntryPoint,
       });
     } catch (err) {
-      console.error('Error checking dashboard compatibility:', err);
+      structuredLog(
+        'grafana/frontend.features.dashboard.dashgrid.DashboardLibrary.SuggestedDashboardsList.SuggestedDashboardsList',
+        'error',
+        'Error checking dashboard compatibility:',
+        err
+      );
 
       const errorMessage = isFetchError(err) ? err.data?.message : 'Failed to check compatibility';
       const errorCode = isFetchError(err) ? err.data?.code : undefined;

--- a/public/app/features/dashboard/dashgrid/DashboardLibrary/api/compatibilityApi.ts
+++ b/public/app/features/dashboard/dashgrid/DashboardLibrary/api/compatibilityApi.ts
@@ -1,5 +1,5 @@
 import { getAPINamespace } from '@grafana/api-clients';
-import { getBackendSrv } from '@grafana/runtime';
+import { logStructured as structuredLog, getBackendSrv } from '@grafana/runtime';
 import { type DashboardJson } from 'app/features/manage-dashboards/types';
 
 /**
@@ -138,7 +138,12 @@ export async function checkDashboardCompatibility(
     return response;
   } catch (error) {
     // Log error for debugging
-    console.error('Dashboard compatibility check failed:', error);
+    structuredLog(
+      'grafana/frontend.features.dashboard.dashgrid.DashboardLibrary.api.compatibilityApi',
+      'error',
+      'Dashboard compatibility check failed:',
+      error
+    );
 
     // Re-throw original error for caller to handle
     throw error;

--- a/public/app/features/dashboard/dashgrid/DashboardLibrary/api/dashboardLibraryApi.ts
+++ b/public/app/features/dashboard/dashgrid/DashboardLibrary/api/dashboardLibraryApi.ts
@@ -1,4 +1,4 @@
-import { getBackendSrv, logInfo, logWarning } from '@grafana/runtime';
+import { logStructured as structuredLog, getBackendSrv, logInfo, logWarning } from '@grafana/runtime';
 import { type DashboardJson } from 'app/features/manage-dashboards/types';
 import { type PluginDashboard } from 'app/types/plugins';
 
@@ -102,7 +102,12 @@ export async function fetchCommunityDashboards(
   }
 
   // Fallback for unexpected response format
-  console.warn('Unexpected API response format from Grafana.com:', result);
+  structuredLog(
+    'grafana/frontend.features.dashboard.dashgrid.DashboardLibrary.api.dashboardLibraryApi',
+    'warn',
+    'Unexpected API response format from Grafana.com:',
+    result
+  );
   return {
     page: params.page,
     pages: 1,
@@ -127,7 +132,12 @@ export async function fetchProvisionedDashboards(datasourceType: string): Promis
     });
     return Array.isArray(dashboards) ? dashboards.filter((dashboard) => !dashboard.removed) : [];
   } catch (error) {
-    console.error('Error loading provisioned dashboards', error);
+    structuredLog(
+      'grafana/frontend.features.dashboard.dashgrid.DashboardLibrary.api.dashboardLibraryApi',
+      'error',
+      'Error loading provisioned dashboards',
+      error
+    );
     return [];
   }
 }
@@ -143,10 +153,6 @@ const filterNonSafeDashboards = (dashboards: GnetDashboard[], dataSourceType?: s
 
     if (unsafePanelTypes.length > 0) {
       unsafeDashboardsCount++;
-
-      console.warn(
-        `Community dashboard ${item.id} ${item.name} filtered out due to panel types ${item.panelTypeSlugs?.join(', ')} that can embed JavaScript`
-      );
 
       logWarning('Community dashboard filtered out due to unsafe panel types', {
         dashboardId: item.id.toString(),

--- a/public/app/features/dashboard/dashgrid/DashboardLibrary/utils/communityDashboardHelpers.ts
+++ b/public/app/features/dashboard/dashgrid/DashboardLibrary/utils/communityDashboardHelpers.ts
@@ -1,6 +1,6 @@
 import { type PanelModel } from '@grafana/data';
 import { t } from '@grafana/i18n';
-import { locationService } from '@grafana/runtime';
+import { logStructured as structuredLog, locationService } from '@grafana/runtime';
 import { createErrorNotification } from 'app/core/copy/appNotification';
 import { notifyApp } from 'app/core/reducers/appNotification';
 import { interpolateV1Dashboard } from 'app/features/manage-dashboards/import/utils/inputs';
@@ -165,7 +165,12 @@ function canPanelContainJS(panel: PanelModel): boolean {
   try {
     panelJson = JSON.stringify(panelWithoutSanitizedFields);
   } catch (e) {
-    console.warn('Failed to stringify panel', e);
+    structuredLog(
+      'grafana/frontend.features.dashboard.dashgrid.DashboardLibrary.utils.communityDashboardHelpers',
+      'warn',
+      'Failed to stringify panel',
+      e
+    );
     return true;
   }
 
@@ -196,7 +201,11 @@ function canPanelContainJS(panel: PanelModel): boolean {
 
   const hasSuspiciousValue = valuePatterns.some((pattern) => {
     if (pattern.test(panelJson)) {
-      console.warn('Panel contains JavaScript code in value');
+      structuredLog(
+        'grafana/frontend.features.dashboard.dashgrid.DashboardLibrary.utils.communityDashboardHelpers',
+        'warn',
+        'Panel contains JavaScript code in value'
+      );
       return true;
     }
     return false;
@@ -204,7 +213,11 @@ function canPanelContainJS(panel: PanelModel): boolean {
 
   const hasSuspiciousKey = keyPatterns.some((pattern) => {
     if (pattern.test(panelJson)) {
-      console.warn('Panel contains JavaScript code in key');
+      structuredLog(
+        'grafana/frontend.features.dashboard.dashgrid.DashboardLibrary.utils.communityDashboardHelpers',
+        'warn',
+        'Panel contains JavaScript code in key'
+      );
       return true;
     }
     return false;
@@ -320,7 +333,12 @@ export async function onUseCommunityDashboard({
       }
     }
   } catch (err) {
-    console.error('Error loading community dashboard:', err);
+    structuredLog(
+      'grafana/frontend.features.dashboard.dashgrid.DashboardLibrary.utils.communityDashboardHelpers',
+      'error',
+      'Error loading community dashboard:',
+      err
+    );
     dispatch(
       notifyApp(
         createErrorNotification(t('dashboard-library.community-error-title', 'Error loading community dashboard'))

--- a/public/app/features/dashboard/services/DashboardAnalyticsAggregator.ts
+++ b/public/app/features/dashboard/services/DashboardAnalyticsAggregator.ts
@@ -1,4 +1,4 @@
-import { logMeasurement, reportInteraction } from '@grafana/runtime';
+import { logStructured as structuredLog, logMeasurement, reportInteraction } from '@grafana/runtime';
 import { type performanceUtils } from '@grafana/scenes';
 
 import { consumeDashboardFetchTiming, FETCH_ATTRIBUTION_MAX_LEAD_MS } from './DashboardFetchTiming';
@@ -109,7 +109,12 @@ export class DashboardAnalyticsAggregator implements performanceUtils.ScenePerfo
     // Aggregate panel metrics without verbose logging (handled by ScenePerformanceLogger)
     const panel = this.panelMetrics.get(data.panelKey);
     if (!panel) {
-      console.warn('Panel not found for operation completion:', data.panelKey);
+      structuredLog(
+        'grafana/frontend.features.dashboard.services.DashboardAnalyticsAggregator',
+        'warn',
+        'Panel not found for operation completion:',
+        data.panelKey
+      );
       return;
     }
 

--- a/public/app/features/dashboard/services/DashboardLoaderSrv.ts
+++ b/public/app/features/dashboard/services/DashboardLoaderSrv.ts
@@ -1,5 +1,5 @@
 import { AppEvents, dateMath, type UrlQueryMap, type UrlQueryValue } from '@grafana/data';
-import { config, getBackendSrv, isFetchError, locationService } from '@grafana/runtime';
+import { logStructured as structuredLog, config, getBackendSrv, isFetchError, locationService } from '@grafana/runtime';
 import { type Spec as DashboardV2Spec } from '@grafana/schema/apis/dashboard.grafana.app/v2';
 import { backendSrv } from 'app/core/services/backend_srv';
 import impressionSrv from 'app/core/services/impression_srv';
@@ -74,7 +74,11 @@ abstract class DashboardLoaderSrvBase<T> implements DashboardLoaderSrvLike<T> {
           };
         },
         (err) => {
-          console.error('Script dashboard error ' + err);
+          structuredLog(
+            'grafana/frontend.features.dashboard.services.DashboardLoaderSrv',
+            'error',
+            'Script dashboard error ' + err
+          );
           appEvents.emit(AppEvents.alertError, [
             'Script Error',
             'Please make sure it exists and returns a valid dashboard',
@@ -176,7 +180,12 @@ export class DashboardLoaderSrv extends DashboardLoaderSrvBase<DashboardDTO> {
           return await api.getDashboardDTO(uid, params);
         } catch (e) {
           if (isFetchError(e) && !(e instanceof DashboardVersionError)) {
-            console.error('Failed to load dashboard', e);
+            structuredLog(
+              'grafana/frontend.features.dashboard.services.DashboardLoaderSrv',
+              'error',
+              'Failed to load dashboard',
+              e
+            );
             e.isHandled = true;
             if (e.status === 404) {
               appEvents.emit(AppEvents.alertError, ['Dashboard not found']);
@@ -241,7 +250,12 @@ export class DashboardLoaderSrvV2 extends DashboardLoaderSrvBase<DashboardWithAc
           return await api.getDashboardDTO(uid, params);
         } catch (e) {
           if (isFetchError(e) && !(e instanceof DashboardVersionError)) {
-            console.error('Failed to load dashboard', e);
+            structuredLog(
+              'grafana/frontend.features.dashboard.services.DashboardLoaderSrv',
+              'error',
+              'Failed to load dashboard',
+              e
+            );
             e.isHandled = true;
             if (e.status === 404) {
               appEvents.emit(AppEvents.alertError, ['Dashboard not found']);

--- a/public/app/features/dashboard/state/DashboardModel.ts
+++ b/public/app/features/dashboard/state/DashboardModel.ts
@@ -17,7 +17,7 @@ import {
   type UrlQueryValue,
 } from '@grafana/data';
 import { type PromQuery } from '@grafana/prometheus';
-import { RefreshEvent, TimeRangeUpdatedEvent } from '@grafana/runtime';
+import { logStructured as structuredLog, RefreshEvent, TimeRangeUpdatedEvent } from '@grafana/runtime';
 import { type Dashboard, type DashboardLink, type VariableModel } from '@grafana/schema';
 import { DEFAULT_ANNOTATION_COLOR } from '@grafana/ui';
 import { GRID_CELL_HEIGHT, GRID_CELL_VMARGIN, GRID_COLUMN_COUNT, REPEAT_DIR_VERTICAL } from 'app/core/constants';
@@ -1054,13 +1054,21 @@ export class DashboardModel implements TimeModel {
 
   /** @deprecated */
   on<T>(event: AppEvent<T>, callback: (payload?: T) => void) {
-    console.log('DashboardModel.on is deprecated use events.subscribe');
+    structuredLog(
+      'grafana/frontend.features.dashboard.state.DashboardModel',
+      'info',
+      'DashboardModel.on is deprecated use events.subscribe'
+    );
     this.events.on(event, callback);
   }
 
   /** @deprecated */
   off<T>(event: AppEvent<T>, callback: (payload?: T) => void) {
-    console.log('DashboardModel.off is deprecated');
+    structuredLog(
+      'grafana/frontend.features.dashboard.state.DashboardModel',
+      'info',
+      'DashboardModel.off is deprecated'
+    );
     this.events.off(event, callback);
   }
 

--- a/public/app/features/datasources/components/EditDataSource.tsx
+++ b/public/app/features/datasources/components/EditDataSource.tsx
@@ -11,7 +11,7 @@ import {
   type PluginExtensionDataSourceConfigContext,
   DataSourceUpdatedSuccessfully,
 } from '@grafana/data';
-import { usePluginComponents, type UsePluginComponentsResult } from '@grafana/runtime';
+import { logStructured as structuredLog, usePluginComponents, type UsePluginComponentsResult } from '@grafana/runtime';
 import { useDataSourceInstanceSettings } from '@grafana/runtime/unstable';
 import { appEvents } from 'app/core/app_events';
 import PageLoader from 'app/core/components/PageLoader/PageLoader';
@@ -196,7 +196,12 @@ export function EditDataSourceView({
         return;
       }
       retryAdvisorCheck(dataSource.uid).catch((error) => {
-        console.warn('Error retrying datasource advisor check', error);
+        structuredLog(
+          'grafana/frontend.features.datasources.components.EditDataSource',
+          'warn',
+          'Error retrying datasource advisor check',
+          error
+        );
       });
       onTest();
     },

--- a/public/app/features/dimensions/editors/FileUploader.tsx
+++ b/public/app/features/dimensions/editors/FileUploader.tsx
@@ -1,3 +1,5 @@
+import { logStructured as structuredLog } from '@grafana/runtime';
+
 import { css } from '@emotion/css';
 import { type Dispatch, type SetStateAction, useState } from 'react';
 
@@ -47,7 +49,9 @@ export const FileUploader = ({ mediaType, setFormData, setUpload, error }: Props
   const onFileRemove = (file: DropzoneFile) => {
     fetch(`/api/storage/delete/upload/${file.file.name}`, {
       method: 'DELETE',
-    }).catch((error) => console.error('cannot delete file', error));
+    }).catch((error) =>
+      structuredLog('grafana/frontend.features.dimensions.editors.FileUploader', 'error', 'cannot delete file', error)
+    );
   };
 
   const acceptableFiles =

--- a/public/app/features/dimensions/editors/FileUploader.tsx
+++ b/public/app/features/dimensions/editors/FileUploader.tsx
@@ -1,10 +1,9 @@
-import { logStructured as structuredLog } from '@grafana/runtime';
-
 import { css } from '@emotion/css';
 import { type Dispatch, type SetStateAction, useState } from 'react';
 
 import { type GrafanaTheme2 } from '@grafana/data';
 import { Trans, t } from '@grafana/i18n';
+import { logStructured as structuredLog } from '@grafana/runtime';
 import { FileDropzone, useStyles2, Button, type DropzoneFile, Field } from '@grafana/ui';
 import { SanitizedSVG } from 'app/core/components/SVG/SanitizedSVG';
 

--- a/public/app/features/dimensions/editors/ResourcePickerPopover.tsx
+++ b/public/app/features/dimensions/editors/ResourcePickerPopover.tsx
@@ -6,7 +6,7 @@ import { useRef, useState } from 'react';
 
 import { type GrafanaTheme2 } from '@grafana/data';
 import { Trans } from '@grafana/i18n';
-import { config, getBackendSrv } from '@grafana/runtime';
+import { logStructured as structuredLog, config, getBackendSrv } from '@grafana/runtime';
 import { Button, useStyles2, getPortalContainer } from '@grafana/ui';
 
 import { type MediaType, PickerTabType, type ResourceFolderName } from '../types';
@@ -140,7 +140,13 @@ export const ResourcePickerPopover = (props: Props) => {
                           .then(() => onChange(`${config.appUrl}api/storage/read/${data.path}`))
                           .then(() => hidePopper?.());
                       })
-                      .catch((err) => console.error(err));
+                      .catch((err) =>
+                        structuredLog(
+                          'grafana/frontend.features.dimensions.editors.ResourcePickerPopover',
+                          'error',
+                          err
+                        )
+                      );
                   } else {
                     onChange(newValue);
                     hidePopper?.();

--- a/public/app/features/explore/Logs/LogsMetaRow.tsx
+++ b/public/app/features/explore/Logs/LogsMetaRow.tsx
@@ -1,3 +1,5 @@
+import { logStructured as structuredLog } from '@grafana/runtime';
+
 import { css } from '@emotion/css';
 import { memo } from 'react';
 
@@ -119,6 +121,10 @@ function renderMetaItem(value: string | number | Labels, kind: LogsMetaKind, log
   if (kind === LogsMetaKind.Error) {
     return <span className="logs-meta-item__error">{value.toString()}</span>;
   }
-  console.error(`Meta type ${typeof value} ${value} not recognized.`);
+  structuredLog(
+    'grafana/frontend.features.explore.Logs.LogsMetaRow',
+    'error',
+    `Meta type ${typeof value} ${value} not recognized.`
+  );
   return <></>;
 }

--- a/public/app/features/explore/Logs/LogsMetaRow.tsx
+++ b/public/app/features/explore/Logs/LogsMetaRow.tsx
@@ -1,10 +1,9 @@
-import { logStructured as structuredLog } from '@grafana/runtime';
-
 import { css } from '@emotion/css';
 import { memo } from 'react';
 
 import { LogsDedupStrategy, type LogsMetaItem, LogsMetaKind, type Labels, store, shallowCompare } from '@grafana/data';
 import { t } from '@grafana/i18n';
+import { logStructured as structuredLog } from '@grafana/runtime';
 import { Button, useStyles2 } from '@grafana/ui';
 
 import { LogLabels, LogLabelsList, type Props as LogLabelsProps } from '../../logs/components/LogLabels';

--- a/public/app/features/explore/Logs/LogsTableWrap.tsx
+++ b/public/app/features/explore/Logs/LogsTableWrap.tsx
@@ -16,7 +16,7 @@ import {
   type TimeRange,
 } from '@grafana/data';
 import { t } from '@grafana/i18n';
-import { reportInteraction } from '@grafana/runtime';
+import { logStructured as structuredLog, reportInteraction } from '@grafana/runtime';
 import { getDragStyles, InlineField, Select, useStyles2 } from '@grafana/ui';
 import { FIELD_SELECTOR_MIN_WIDTH } from 'app/features/logs/components/fieldSelector/FieldSelector';
 import { LogsTableFieldSelector } from 'app/features/logs/components/fieldSelector/LogsTableFieldSelector';
@@ -385,7 +385,12 @@ export function LogsTableWrap(props: Props) {
   // Toggle a column on or off when the user interacts with an element in the multi-select sidebar
   const toggleColumn = (columnName: FieldName) => {
     if (!columnsWithMeta || !(columnName in columnsWithMeta)) {
-      console.warn('failed to get column', columnsWithMeta);
+      structuredLog(
+        'grafana/frontend.features.explore.Logs.LogsTableWrap',
+        'warn',
+        'failed to get column',
+        columnsWithMeta
+      );
       return;
     }
 

--- a/public/app/features/explore/Logs/utils/table/logsTable.ts
+++ b/public/app/features/explore/Logs/utils/table/logsTable.ts
@@ -1,3 +1,5 @@
+import { logStructured as structuredLog } from '@grafana/runtime';
+
 import { type DataFrame, FieldType, getFieldDisplayName, LogsSortOrder } from '@grafana/data';
 import { type TableSortByFieldState } from '@grafana/schema/dist/esm/common/common.gen';
 import { LOGS_DATAPLANE_TIMESTAMP_NAME } from 'app/features/logs/logsFrame';
@@ -34,7 +36,12 @@ export const getDefaultTableSortBy = (
         return parsed;
       }
     } catch (e) {
-      console.error('failed to parse table sort from local storage!', e);
+      structuredLog(
+        'grafana/frontend.features.explore.Logs.utils.table.logsTable',
+        'error',
+        'failed to parse table sort from local storage!',
+        e
+      );
     }
   }
 

--- a/public/app/features/explore/Logs/utils/table/logsTable.ts
+++ b/public/app/features/explore/Logs/utils/table/logsTable.ts
@@ -1,6 +1,5 @@
-import { logStructured as structuredLog } from '@grafana/runtime';
-
 import { type DataFrame, FieldType, getFieldDisplayName, LogsSortOrder } from '@grafana/data';
+import { logStructured as structuredLog } from '@grafana/runtime';
 import { type TableSortByFieldState } from '@grafana/schema/dist/esm/common/common.gen';
 import { LOGS_DATAPLANE_TIMESTAMP_NAME } from 'app/features/logs/logsFrame';
 

--- a/public/app/features/explore/PrometheusListView/utils/getRawPrometheusListItemsFromDataFrame.ts
+++ b/public/app/features/explore/PrometheusListView/utils/getRawPrometheusListItemsFromDataFrame.ts
@@ -1,3 +1,5 @@
+import { logStructured as structuredLog } from '@grafana/runtime';
+
 import { type DataFrame, formattedValueToString } from '@grafana/data';
 
 import { type instantQueryRawVirtualizedListData } from '../RawListContainer';
@@ -51,7 +53,11 @@ export const getRawPrometheusListItemsFromDataFrame = (dataFrame: DataFrame): in
             }
           }
         } else {
-          console.warn('Field display method is missing!');
+          structuredLog(
+            'grafana/frontend.features.explore.PrometheusListView.utils.getRawPrometheusListItemsFromDataFrame',
+            'warn',
+            'Field display method is missing!'
+          );
         }
       }
     }

--- a/public/app/features/explore/PrometheusListView/utils/getRawPrometheusListItemsFromDataFrame.ts
+++ b/public/app/features/explore/PrometheusListView/utils/getRawPrometheusListItemsFromDataFrame.ts
@@ -1,6 +1,5 @@
-import { logStructured as structuredLog } from '@grafana/runtime';
-
 import { type DataFrame, formattedValueToString } from '@grafana/data';
+import { logStructured as structuredLog } from '@grafana/runtime';
 
 import { type instantQueryRawVirtualizedListData } from '../RawListContainer';
 

--- a/public/app/features/explore/QueryLibrary/OpenQueryLibraryExposedComponent.tsx
+++ b/public/app/features/explore/QueryLibrary/OpenQueryLibraryExposedComponent.tsx
@@ -1,7 +1,7 @@
 import { useCallback } from 'react';
 
 import { t } from '@grafana/i18n';
-import { reportInteraction } from '@grafana/runtime';
+import { logStructured as structuredLog, reportInteraction } from '@grafana/runtime';
 import { type DataQuery } from '@grafana/schema';
 import { ToolbarButton } from '@grafana/ui';
 
@@ -81,7 +81,9 @@ export const OpenQueryLibraryExposedComponent = ({
   }, [context, datasourceFilters, onSelectQuery, openDrawer, query]);
 
   if (!queryLibraryEnabled) {
-    console.warn(
+    structuredLog(
+      'grafana/frontend.features.explore.QueryLibrary.OpenQueryLibraryExposedComponent',
+      'warn',
       '[OpenQueryLibraryExposedComponent]: Attempted to use unsupported exposed component. Query library is not enabled.'
     );
     return null;

--- a/public/app/features/explore/TraceView/components/CriticalPath/index.tsx
+++ b/public/app/features/explore/TraceView/components/CriticalPath/index.tsx
@@ -1,3 +1,5 @@
+import { logStructured as structuredLog } from '@grafana/runtime';
+
 // Copyright (c) 2023 The Jaeger Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -104,7 +106,12 @@ function criticalPathForTrace(trace: Trace) {
       criticalPath = computeCriticalPath(sanitizedSpanMap, rootSpanId, criticalPath);
     } catch (error) {
       /* eslint-disable no-console */
-      console.log('error while computing critical path for a trace', error);
+      structuredLog(
+        'grafana/frontend.features.explore.TraceView.components.CriticalPath.index',
+        'info',
+        'error while computing critical path for a trace',
+        error
+      );
     }
   }
   return criticalPath;

--- a/public/app/features/explore/TraceView/components/CriticalPath/index.tsx
+++ b/public/app/features/explore/TraceView/components/CriticalPath/index.tsx
@@ -1,3 +1,5 @@
+import memoizeOne from 'memoize-one';
+
 import { logStructured as structuredLog } from '@grafana/runtime';
 
 // Copyright (c) 2023 The Jaeger Authors
@@ -13,8 +15,6 @@ import { logStructured as structuredLog } from '@grafana/runtime';
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-
-import memoizeOne from 'memoize-one';
 
 import { type TraceSpan, type CriticalPathSection, type Trace } from '../types/trace';
 

--- a/public/app/features/explore/TraceView/components/ScrollManager.tsx
+++ b/public/app/features/explore/TraceView/components/ScrollManager.tsx
@@ -1,3 +1,5 @@
+import { logStructured as structuredLog } from '@grafana/runtime';
+
 // Copyright (c) 2017 Uber Technologies, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -106,7 +108,11 @@ export default class ScrollManager {
     const position = xrs.getRowPosition(rowIndex);
     if (!position) {
       // eslint-disable-next-line no-console
-      console.warn('Invalid row index');
+      structuredLog(
+        'grafana/frontend.features.explore.TraceView.components.ScrollManager',
+        'warn',
+        'Invalid row index'
+      );
       return;
     }
     let { y } = position;

--- a/public/app/features/explore/TraceView/components/TraceTimelineViewer/ListView/index.tsx
+++ b/public/app/features/explore/TraceView/components/TraceTimelineViewer/ListView/index.tsx
@@ -1,3 +1,5 @@
+import { logStructured as structuredLog } from '@grafana/runtime';
+
 // Copyright (c) 2017 Uber Technologies, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -388,7 +390,11 @@ export default class ListView extends React.Component<TListViewProps> {
         const itemKey = node.getAttribute('data-item-key');
         if (!itemKey) {
           // eslint-disable-next-line no-console
-          console.warn('itemKey not found');
+          structuredLog(
+            'grafana/frontend.features.explore.TraceView.components.TraceTimelineViewer.ListView.index',
+            'warn',
+            'itemKey not found'
+          );
           continue;
         }
         // measure the first child, if it's available, otherwise the node itself

--- a/public/app/features/explore/TraceView/components/TraceTimelineViewer/ListView/index.tsx
+++ b/public/app/features/explore/TraceView/components/TraceTimelineViewer/ListView/index.tsx
@@ -1,3 +1,5 @@
+import * as React from 'react';
+
 import { logStructured as structuredLog } from '@grafana/runtime';
 
 // Copyright (c) 2017 Uber Technologies, Inc.
@@ -13,8 +15,6 @@ import { logStructured as structuredLog } from '@grafana/runtime';
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-
-import * as React from 'react';
 
 import type TNil from '../../types/TNil';
 

--- a/public/app/features/explore/TraceView/components/model/link-patterns.tsx
+++ b/public/app/features/explore/TraceView/components/model/link-patterns.tsx
@@ -1,3 +1,5 @@
+import { logStructured as structuredLog } from '@grafana/runtime';
+
 // Copyright (c) 2017 The Jaeger Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -110,7 +112,12 @@ export function processLinkPattern(pattern: any): ProcessedLinkPattern | null {
     };
   } catch (error) {
     // eslint-disable-next-line no-console
-    console.error(`Ignoring invalid link pattern: ${error}`, pattern);
+    structuredLog(
+      'grafana/frontend.features.explore.TraceView.components.model.link-patterns',
+      'error',
+      `Ignoring invalid link pattern: ${error}`,
+      pattern
+    );
     return null;
   }
 }

--- a/public/app/features/explore/TraceView/components/model/link-patterns.tsx
+++ b/public/app/features/explore/TraceView/components/model/link-patterns.tsx
@@ -1,3 +1,5 @@
+import { uniq as _uniq } from 'lodash';
+
 import { logStructured as structuredLog } from '@grafana/runtime';
 
 // Copyright (c) 2017 The Jaeger Authors.
@@ -13,8 +15,6 @@ import { logStructured as structuredLog } from '@grafana/runtime';
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-
-import { uniq as _uniq } from 'lodash';
 
 import { type Trace } from '../types/trace';
 

--- a/public/app/features/explore/TraceView/components/model/transform-trace-data.tsx
+++ b/public/app/features/explore/TraceView/components/model/transform-trace-data.tsx
@@ -1,5 +1,3 @@
-import { logStructured as structuredLog } from '@grafana/runtime';
-
 // Copyright (c) 2017 Uber Technologies, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -18,6 +16,7 @@ import { isEqual as _isEqual } from 'lodash';
 
 // @ts-ignore
 import { type TraceKeyValuePair } from '@grafana/data';
+import { logStructured as structuredLog } from '@grafana/runtime';
 
 import { AGGREGATION_PREFIX } from '../constants/aggregation';
 import { getTraceSpanIdsAsTree } from '../selectors/trace';

--- a/public/app/features/explore/TraceView/components/model/transform-trace-data.tsx
+++ b/public/app/features/explore/TraceView/components/model/transform-trace-data.tsx
@@ -1,3 +1,5 @@
+import { logStructured as structuredLog } from '@grafana/runtime';
+
 // Copyright (c) 2017 Uber Technologies, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -188,10 +190,20 @@ export default function transformTraceData(data: TraceResponse | undefined): Tra
     const idCount = spanIdCounts.get(spanID);
     if (idCount != null) {
       // eslint-disable-next-line no-console
-      console.warn(`Dupe spanID, ${idCount + 1} x ${spanID}`, span, spanMap.get(spanID));
+      structuredLog(
+        'grafana/frontend.features.explore.TraceView.components.model.transform-trace-data',
+        'warn',
+        `Dupe spanID, ${idCount + 1} x ${spanID}`,
+        span,
+        spanMap.get(spanID)
+      );
       if (_isEqual(span, spanMap.get(spanID))) {
         // eslint-disable-next-line no-console
-        console.warn('\t two spans with same ID have `isEqual(...) === true`');
+        structuredLog(
+          'grafana/frontend.features.explore.TraceView.components.model.transform-trace-data',
+          'warn',
+          '\t two spans with same ID have `isEqual(...) === true`'
+        );
       }
       spanIdCounts.set(spanID, idCount + 1);
       spanID = `${spanID}_${idCount}`;

--- a/public/app/features/explore/TraceView/createSpanLink.tsx
+++ b/public/app/features/explore/TraceView/createSpanLink.tsx
@@ -21,7 +21,7 @@ import {
   type TraceToLogsTag,
 } from '@grafana/o11y-ds-frontend';
 import { type PromQuery } from '@grafana/prometheus';
-import { getTemplateSrv } from '@grafana/runtime';
+import { logStructured as structuredLog, getTemplateSrv } from '@grafana/runtime';
 import { type DataQuery } from '@grafana/schema';
 import { Icon } from '@grafana/ui';
 import { getDatasourceSrv } from 'app/features/plugins/datasource_srv';
@@ -123,7 +123,7 @@ export function createSpanLinkFactory({
         spanLinks.push.apply(spanLinks, newSpanLinks);
       } catch (error) {
         // It's fairly easy to crash here for example if data source defines wrong interpolation in the data link
-        console.error(error);
+        structuredLog('grafana/frontend.features.explore.TraceView.createSpanLink', 'error', error);
         return spanLinks;
       }
     }

--- a/public/app/features/explore/hooks/useExplorePageContext.ts
+++ b/public/app/features/explore/hooks/useExplorePageContext.ts
@@ -1,3 +1,5 @@
+import { logStructured as structuredLog } from '@grafana/runtime';
+
 import { useEffect, useState } from 'react';
 
 import { createAssistantContextItem, type ChatContextItem, useProvidePageContext } from '@grafana/assistant';
@@ -118,7 +120,7 @@ function getDisplayText(query: DataQuery, ds?: DataSourceApi): string | undefine
   try {
     return ds?.getQueryDisplayText?.(query);
   } catch (error) {
-    console.error(error);
+    structuredLog('grafana/frontend.features.explore.hooks.useExplorePageContext', 'error', error);
     return undefined;
   }
 }

--- a/public/app/features/explore/hooks/useExplorePageContext.ts
+++ b/public/app/features/explore/hooks/useExplorePageContext.ts
@@ -1,9 +1,8 @@
-import { logStructured as structuredLog } from '@grafana/runtime';
-
 import { useEffect, useState } from 'react';
 
 import { createAssistantContextItem, type ChatContextItem, useProvidePageContext } from '@grafana/assistant';
 import { type DataSourceApi } from '@grafana/data';
+import { logStructured as structuredLog } from '@grafana/runtime';
 import { getDataSourceInstanceSettings } from '@grafana/runtime/unstable';
 import { type DataQuery } from '@grafana/schema';
 import { type ExploreItemState } from 'app/types/explore';

--- a/public/app/features/explore/state/correlations.ts
+++ b/public/app/features/explore/state/correlations.ts
@@ -5,7 +5,7 @@ import {
   generatedAPI as correlationsAPIv0alpha1,
 } from '@grafana/api-clients/rtkq/correlations/v0alpha1';
 import { type DataLinkTransformationConfig } from '@grafana/data';
-import { type CorrelationData, reportInteraction, config } from '@grafana/runtime';
+import { logStructured as structuredLog, type CorrelationData, reportInteraction, config } from '@grafana/runtime';
 import { getDataSourceInstance } from '@grafana/runtime/unstable';
 import { createErrorNotification } from 'app/core/copy/appNotification';
 import { notifyApp } from 'app/core/reducers/appNotification';
@@ -117,7 +117,7 @@ export function saveCurrentCorrelation(
           dispatch(
             notifyApp(createErrorNotification('Error creating correlation', getMessageFromError(response.error)))
           );
-          console.error(response.error);
+          structuredLog('grafana/frontend.features.explore.state.correlations', 'error', response.error);
         }
       } else {
         const correlation: CreateCorrelationParams = {
@@ -145,7 +145,7 @@ export function saveCurrentCorrelation(
           })
           .catch((err) => {
             dispatch(notifyApp(createErrorNotification('Error creating correlation', err)));
-            console.error(err);
+            structuredLog('grafana/frontend.features.explore.state.correlations', 'error', err);
           });
       }
     }

--- a/public/app/features/explore/state/query.ts
+++ b/public/app/features/explore/state/query.ts
@@ -20,7 +20,7 @@ import {
   type SupplementaryQueryType,
 } from '@grafana/data';
 import { combinePanelData } from '@grafana/o11y-ds-frontend';
-import { config } from '@grafana/runtime';
+import { logStructured as structuredLog, config } from '@grafana/runtime';
 import { getDataSourceInstance } from '@grafana/runtime/unstable';
 import { type DataQuery } from '@grafana/schema';
 import { notifyApp } from 'app/core/reducers/appNotification';
@@ -675,7 +675,7 @@ export const runQueries = createAsyncThunk<void, RunQueriesOptions>(
         error(error) {
           dispatch(notifyApp(createErrorNotification('Query processing error', error)));
           dispatch(changeLoadingStateAction({ exploreId, loadingState: LoadingState.Error }));
-          console.error(error);
+          structuredLog('grafana/frontend.features.explore.state.query', 'error', error);
         },
         complete() {
           // In case we don't get any response at all but the observable completed, make sure we stop loading state.
@@ -797,7 +797,7 @@ export const runLoadMoreLogsQueries = createAsyncThunk<void, RunLoadMoreLogsQuer
       error(error) {
         dispatch(notifyApp(createErrorNotification('Query processing error', error)));
         dispatch(changeLoadingStateAction({ exploreId, loadingState: LoadingState.Error }));
-        console.error(error);
+        structuredLog('grafana/frontend.features.explore.state.query', 'error', error);
       },
       complete() {
         dispatch(changeLoadingStateAction({ exploreId, loadingState: LoadingState.Done }));

--- a/public/app/features/explore/state/utils.ts
+++ b/public/app/features/explore/state/utils.ts
@@ -1,3 +1,5 @@
+import { logStructured as structuredLog } from '@grafana/runtime';
+
 import { uniq } from 'lodash';
 
 import {
@@ -117,7 +119,7 @@ export async function loadAndInitDatasource(
       instance.init();
     } catch (err) {
       // TODO: should probably be handled better
-      console.error(err);
+      structuredLog('grafana/frontend.features.explore.state.utils', 'error', err);
     }
   }
 

--- a/public/app/features/explore/state/utils.ts
+++ b/public/app/features/explore/state/utils.ts
@@ -1,5 +1,3 @@
-import { logStructured as structuredLog } from '@grafana/runtime';
-
 import { uniq } from 'lodash';
 
 import {
@@ -23,6 +21,7 @@ import {
   type URLRange,
   type URLRangeValue,
 } from '@grafana/data';
+import { logStructured as structuredLog } from '@grafana/runtime';
 import { getDataSourceInstance } from '@grafana/runtime/unstable';
 import { type DataQuery, type DataSourceJsonData, type DataSourceRef, type TimeZone } from '@grafana/schema';
 import { getLocalRichHistoryStorage } from 'app/core/history/richHistoryStorageProvider';

--- a/public/app/features/expressions/components/QueryToolbox.tsx
+++ b/public/app/features/expressions/components/QueryToolbox.tsx
@@ -1,3 +1,5 @@
+import { logStructured as structuredLog } from '@grafana/runtime';
+
 import { css } from '@emotion/css';
 import { useCallback, useEffect, useRef, useState, type JSX } from 'react';
 
@@ -39,7 +41,7 @@ export const QueryToolbox = ({ onFormatCode, onExpand, isExpanded, query }: Quer
       await navigator.clipboard.writeText(query.expression ?? '');
       setShowCopySuccess(true);
     } catch (e) {
-      console.error(e);
+      structuredLog('grafana/frontend.features.expressions.components.QueryToolbox', 'error', e);
     }
   }, [query.expression]);
 

--- a/public/app/features/expressions/components/QueryToolbox.tsx
+++ b/public/app/features/expressions/components/QueryToolbox.tsx
@@ -1,10 +1,9 @@
-import { logStructured as structuredLog } from '@grafana/runtime';
-
 import { css } from '@emotion/css';
 import { useCallback, useEffect, useRef, useState, type JSX } from 'react';
 
 import { type GrafanaTheme2 } from '@grafana/data';
 import { t } from '@grafana/i18n';
+import { logStructured as structuredLog } from '@grafana/runtime';
 import { IconButton, useStyles2, Stack, InlineToast, Tooltip, Icon } from '@grafana/ui';
 
 import { type SqlExpressionQuery } from '../types';

--- a/public/app/features/expressions/components/SqlExpressions/hooks/useFunctionSignatures.ts
+++ b/public/app/features/expressions/components/SqlExpressions/hooks/useFunctionSignatures.ts
@@ -1,3 +1,5 @@
+import { logStructured as structuredLog } from '@grafana/runtime';
+
 import { useEffect, useState } from 'react';
 
 import { type SqlFunctionSignature } from '../SqlEditor/signatureHelp';
@@ -23,7 +25,12 @@ export function useFunctionSignatures(enabled: boolean): SqlFunctionSignature[] 
         }
       })
       .catch((error) => {
-        console.warn('Failed to load SQL function signatures for signature help', error);
+        structuredLog(
+          'grafana/frontend.features.expressions.components.SqlExpressions.hooks.useFunctionSignatures',
+          'warn',
+          'Failed to load SQL function signatures for signature help',
+          error
+        );
       });
 
     return () => {

--- a/public/app/features/expressions/components/SqlExpressions/hooks/useFunctionSignatures.ts
+++ b/public/app/features/expressions/components/SqlExpressions/hooks/useFunctionSignatures.ts
@@ -1,6 +1,6 @@
-import { logStructured as structuredLog } from '@grafana/runtime';
-
 import { useEffect, useState } from 'react';
+
+import { logStructured as structuredLog } from '@grafana/runtime';
 
 import { type SqlFunctionSignature } from '../SqlEditor/signatureHelp';
 

--- a/public/app/features/geo/gazetteer/gazetteer.ts
+++ b/public/app/features/geo/gazetteer/gazetteer.ts
@@ -1,3 +1,5 @@
+import { logStructured as structuredLog } from '@grafana/runtime';
+
 import { getCenter } from 'ol/extent';
 import { type Geometry, Point } from 'ol/geom';
 
@@ -227,7 +229,13 @@ export async function getGazetteer(path?: string): Promise<Gazetteer> {
       const data = await response.json();
       lookup = loadGazetteer(path, data);
     } catch (err) {
-      console.warn('Error loading placename lookup', path, err);
+      structuredLog(
+        'grafana/frontend.features.geo.gazetteer.gazetteer',
+        'warn',
+        'Error loading placename lookup',
+        path,
+        err
+      );
       lookup = {
         path,
         error: 'Error loading URL',

--- a/public/app/features/geo/gazetteer/gazetteer.ts
+++ b/public/app/features/geo/gazetteer/gazetteer.ts
@@ -1,9 +1,8 @@
-import { logStructured as structuredLog } from '@grafana/runtime';
-
 import { getCenter } from 'ol/extent';
 import { type Geometry, Point } from 'ol/geom';
 
 import { type DataFrame, type Field, FieldType, type KeyValue, toDataFrame } from '@grafana/data';
+import { logStructured as structuredLog } from '@grafana/runtime';
 
 import { frameFromGeoJSON } from '../format/geojson';
 import { pointFieldFromLonLat, pointFieldFromGeohash } from '../format/utils';

--- a/public/app/features/inspector/InspectJSONTab.tsx
+++ b/public/app/features/inspector/InspectJSONTab.tsx
@@ -7,7 +7,7 @@ import { firstValueFrom } from 'rxjs';
 import { AppEvents, type PanelData, type SelectableValue, LoadingState } from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';
 import { Trans, t } from '@grafana/i18n';
-import { locationService } from '@grafana/runtime';
+import { logStructured as structuredLog, locationService } from '@grafana/runtime';
 import { Button, CodeEditor, Field, Select, useStyles2 } from '@grafana/ui';
 import { appEvents } from 'app/core/app_events';
 import { type DashboardModel } from 'app/features/dashboard/state/DashboardModel';
@@ -104,7 +104,7 @@ export function InspectJSONTab({ panel, dashboard, data, onClose }: Props) {
           appEvents.emit(AppEvents.alertSuccess, ['Panel model updated']);
         }
       } catch (err) {
-        console.error('Error applying updates', err);
+        structuredLog('grafana/frontend.features.inspector.InspectJSONTab', 'error', 'Error applying updates', err);
         appEvents.emit(AppEvents.alertError, ['Invalid JSON text']);
       }
 

--- a/public/app/features/library-panels/components/LibraryPanelsView/actions.ts
+++ b/public/app/features/library-panels/components/LibraryPanelsView/actions.ts
@@ -1,3 +1,5 @@
+import { logStructured as structuredLog } from '@grafana/runtime';
+
 import { type Action } from '@reduxjs/toolkit';
 import { type Dispatch } from 'react';
 import { from, merge, of, Subscription, timer } from 'rxjs';
@@ -54,7 +56,12 @@ export function searchForLibraryPanels(args: SearchArgs): SearchDispatchResult {
         }
 
         // For real errors, log and show error to user
-        console.error('Error fetching library panels:', err);
+        structuredLog(
+          'grafana/frontend.features.library-panels.components.LibraryPanelsView.actions',
+          'error',
+          'Error fetching library panels:',
+          err
+        );
 
         // Update state to show empty results
         return of(searchCompleted({ ...initialLibraryPanelsViewState, page: args.page, perPage: args.perPage }));
@@ -78,7 +85,7 @@ export function deleteLibraryPanel(uid: string, args: SearchArgs) {
       await apiDeleteLibraryPanel(uid);
       searchForLibraryPanels(args)(dispatch);
     } catch (e) {
-      console.error(e);
+      structuredLog('grafana/frontend.features.library-panels.components.LibraryPanelsView.actions', 'error', e);
     }
   };
 }

--- a/public/app/features/library-panels/components/LibraryPanelsView/actions.ts
+++ b/public/app/features/library-panels/components/LibraryPanelsView/actions.ts
@@ -1,9 +1,9 @@
-import { logStructured as structuredLog } from '@grafana/runtime';
-
 import { type Action } from '@reduxjs/toolkit';
 import { type Dispatch } from 'react';
 import { from, merge, of, Subscription, timer } from 'rxjs';
 import { catchError, finalize, mapTo, mergeMap, share, takeUntil } from 'rxjs/operators';
+
+import { logStructured as structuredLog } from '@grafana/runtime';
 
 import { deleteLibraryPanel as apiDeleteLibraryPanel, getLibraryPanels } from '../../state/api';
 

--- a/public/app/features/live/centrifuge/LiveDataStream.ts
+++ b/public/app/features/live/centrifuge/LiveDataStream.ts
@@ -14,6 +14,7 @@ import {
 } from '@grafana/data';
 import { getStreamingFrameOptions } from '@grafana/data/internal';
 import {
+  logStructured as structuredLog,
   type LiveDataStreamOptions,
   StreamingFrameAction,
   type StreamingFrameOptions,
@@ -154,7 +155,13 @@ export class LiveDataStream<T = unknown> {
   };
 
   private onError = (err: unknown) => {
-    console.log('LiveQuery [error]', { err }, this.deps.channelId);
+    structuredLog(
+      'grafana/frontend.features.live.centrifuge.LiveDataStream',
+      'info',
+      'LiveQuery [error]',
+      { err },
+      this.deps.channelId
+    );
     this.stream.next({
       type: InternalStreamMessageType.Error,
       error: toDataQueryError(err),
@@ -163,7 +170,12 @@ export class LiveDataStream<T = unknown> {
   };
 
   private onComplete = () => {
-    console.log('LiveQuery [complete]', this.deps.channelId);
+    structuredLog(
+      'grafana/frontend.features.live.centrifuge.LiveDataStream',
+      'info',
+      'LiveQuery [complete]',
+      this.deps.channelId
+    );
     this.shutdown();
   };
 
@@ -280,7 +292,11 @@ export class LiveDataStream<T = unknown> {
       }
 
       if (!messages.length) {
-        console.warn(`expected to find at least one non error message ${messages.map(({ type }) => type)}`);
+        structuredLog(
+          'grafana/frontend.features.live.centrifuge.LiveDataStream',
+          'warn',
+          `expected to find at least one non error message ${messages.map(({ type }) => type)}`
+        );
         // send empty frame
         return {
           key: subKey,
@@ -358,7 +374,11 @@ export class LiveDataStream<T = unknown> {
 
         const newValueSameSchemaMessages = filterMessages(messages, InternalStreamMessageType.NewValuesSameSchema);
         if (newValueSameSchemaMessages.length !== messages.length) {
-          console.warn(`unsupported message type ${messages.map(({ type }) => type)}`);
+          structuredLog(
+            'grafana/frontend.features.live.centrifuge.LiveDataStream',
+            'warn',
+            `unsupported message type ${messages.map(({ type }) => type)}`
+          );
         }
 
         return getNewValuesSameSchemaResponseData(newValueSameSchemaMessages);

--- a/public/app/features/live/centrifuge/channel.ts
+++ b/public/app/features/live/centrifuge/channel.ts
@@ -1,3 +1,5 @@
+import { logStructured as structuredLog } from '@grafana/runtime';
+
 import {
   type Subscription,
   type JoinContext,
@@ -81,7 +83,7 @@ export class CentrifugeLiveChannel<T = any> {
           this.sendStatus();
         }
       } catch (err) {
-        console.log('publish error', this.addr, err);
+        structuredLog('grafana/frontend.features.live.centrifuge.channel', 'info', 'publish error', this.addr, err);
         this.currentStatus.error = err;
         this.currentStatus.timestamp = Date.now();
         this.sendStatus();

--- a/public/app/features/live/centrifuge/channel.ts
+++ b/public/app/features/live/centrifuge/channel.ts
@@ -1,5 +1,3 @@
-import { logStructured as structuredLog } from '@grafana/runtime';
-
 import {
   type Subscription,
   type JoinContext,
@@ -21,6 +19,7 @@ import {
   type DataFrameJSON,
   isValidLiveChannelAddress,
 } from '@grafana/data';
+import { logStructured as structuredLog } from '@grafana/runtime';
 
 /**
  * Internal class that maps Centrifuge support to GrafanaLive

--- a/public/app/features/live/centrifuge/service.ts
+++ b/public/app/features/live/centrifuge/service.ts
@@ -18,6 +18,7 @@ import {
   toLiveChannelId,
 } from '@grafana/data';
 import {
+  logStructured as structuredLog,
   type FetchResponse,
   type GrafanaLiveSrv,
   type LiveDataStreamOptions,
@@ -126,7 +127,12 @@ export class CentrifugeService implements CentrifugeSrv {
   };
 
   private onServerSideMessage = (context: ServerPublicationContext) => {
-    console.log('Publication from server-side channel', context);
+    structuredLog(
+      'grafana/frontend.features.live.centrifuge.service',
+      'info',
+      'Publication from server-side channel',
+      context
+    );
   };
 
   private onError = (context: ErrorContext) => {

--- a/public/app/features/live/dashboard/dashboardWatcher.ts
+++ b/public/app/features/live/dashboard/dashboardWatcher.ts
@@ -10,7 +10,7 @@ import {
   LiveChannelScope,
   generateUUID,
 } from '@grafana/data';
-import { getGrafanaLiveSrv, locationService } from '@grafana/runtime';
+import { logStructured as structuredLog, getGrafanaLiveSrv, locationService } from '@grafana/runtime';
 import { appEvents } from 'app/core/app_events';
 import { contextSrv } from 'app/core/services/context_srv';
 
@@ -137,7 +137,13 @@ class DashboardWatcher {
 
             const dash = getDashboardSrv().getCurrent();
             if (dash?.uid !== event.message.uid) {
-              console.log('dashboard event for different dashboard?', event, dash);
+              structuredLog(
+                'grafana/frontend.features.live.dashboard.dashboardWatcher',
+                'info',
+                'dashboard event for different dashboard?',
+                event,
+                dash
+              );
               return;
             }
 

--- a/public/app/features/live/live.test.ts
+++ b/public/app/features/live/live.test.ts
@@ -1,11 +1,16 @@
 import { Subject } from 'rxjs';
 
 import { type DataQueryResponse, FieldType, LiveChannelScope, StreamingDataFrame } from '@grafana/data';
-import { type BackendSrv } from '@grafana/runtime';
+import { type BackendSrv, logStructured } from '@grafana/runtime';
 
 import { type CentrifugeSrv, type StreamingDataQueryResponse } from './centrifuge/service';
 import { StreamingResponseDataType } from './data/utils';
 import { GrafanaLiveService } from './live';
+
+jest.mock('@grafana/runtime', () => ({
+  ...jest.requireActual('@grafana/runtime'),
+  logStructured: jest.fn(),
+}));
 
 describe('GrafanaLiveService', () => {
   const mockGetDataStream = jest.fn();
@@ -142,6 +147,10 @@ describe('GrafanaLiveService', () => {
     const frame: StreamingDataFrame = response?.data[0];
     expect(frame).toBeInstanceOf(StreamingDataFrame);
     expect(frame.fields).toEqual([]);
-    expect(console.warn).toHaveBeenCalled();
+    expect(logStructured).toHaveBeenCalledWith(
+      'grafana/frontend.features.live.live',
+      'warn',
+      expect.stringContaining('expected first packet to contain a full frame')
+    );
   });
 });

--- a/public/app/features/live/live.ts
+++ b/public/app/features/live/live.ts
@@ -1,7 +1,7 @@
 import { map } from 'rxjs';
 
 import { toLiveChannelId, StreamingDataFrame } from '@grafana/data';
-import { type BackendSrv, type GrafanaLiveSrv } from '@grafana/runtime';
+import { logStructured as structuredLog, type BackendSrv, type GrafanaLiveSrv } from '@grafana/runtime';
 
 import { type CentrifugeSrv, type StreamingDataQueryResponse } from './centrifuge/service';
 import { isStreamingResponseData, StreamingResponseDataType } from './data/utils';
@@ -30,7 +30,11 @@ export class GrafanaLiveService implements GrafanaLiveSrv {
     const updateBuffer = (next: StreamingDataQueryResponse): void => {
       const data = next.data[0];
       if (!buffer && !isStreamingResponseData(data, StreamingResponseDataType.FullFrame)) {
-        console.warn(`expected first packet to contain a full frame, received ${data?.type}`);
+        structuredLog(
+          'grafana/frontend.features.live.live',
+          'warn',
+          `expected first packet to contain a full frame, received ${data?.type}`
+        );
         return;
       }
 

--- a/public/app/features/logs/components/fieldSelector/LogListFieldSelector.tsx
+++ b/public/app/features/logs/components/fieldSelector/LogListFieldSelector.tsx
@@ -4,7 +4,7 @@ import { useCallback, useLayoutEffect, useMemo, useState } from 'react';
 
 import { type DataFrame, store } from '@grafana/data';
 import { t } from '@grafana/i18n';
-import { reportInteraction } from '@grafana/runtime';
+import { logStructured as structuredLog, reportInteraction } from '@grafana/runtime';
 import { getDragStyles, IconButton, useStyles2 } from '@grafana/ui';
 
 import { useLogListContext } from '../panel/LogListContext';
@@ -116,7 +116,9 @@ export const LogListFieldSelector = ({ containerElement, dataFrames, logs }: Log
   const fields = useMemo(() => getFieldsWithStats(dataFrames), [dataFrames]);
 
   if (!onClickShowField || !onClickHideField || !setDisplayedFields) {
-    console.warn(
+    structuredLog(
+      'grafana/frontend.features.logs.components.fieldSelector.LogListFieldSelector',
+      'warn',
       'LogListFieldSelector: Missing required props: onClickShowField, onClickHideField, setDisplayedFields'
     );
     return null;

--- a/public/app/features/logs/components/panel/grammar.ts
+++ b/public/app/features/logs/components/panel/grammar.ts
@@ -1,3 +1,5 @@
+import { logStructured as structuredLog } from '@grafana/runtime';
+
 import { type Grammar } from 'prismjs';
 
 import { escapeRegex, parseFlags } from '@grafana/data';
@@ -64,7 +66,12 @@ export const generateTextMatchGrammar = (highlightWords: string[] | undefined = 
       try {
         return new RegExp(`(?:${cleaned})`, flags);
       } catch (e) {
-        console.error(`generateTextMatchGrammar: cannot generate regular expression from /${cleaned}/${flags}`, e);
+        structuredLog(
+          'grafana/frontend.features.logs.components.panel.grammar',
+          'error',
+          `generateTextMatchGrammar: cannot generate regular expression from /${cleaned}/${flags}`,
+          e
+        );
       }
       return undefined;
     })
@@ -74,7 +81,12 @@ export const generateTextMatchGrammar = (highlightWords: string[] | undefined = 
     try {
       expressions.push(new RegExp(escapeRegex(search), 'gi'));
     } catch (e) {
-      console.error(`generateTextMatchGrammar: cannot generate regular expression from /${search}/gi`, e);
+      structuredLog(
+        'grafana/frontend.features.logs.components.panel.grammar',
+        'error',
+        `generateTextMatchGrammar: cannot generate regular expression from /${search}/gi`,
+        e
+      );
     }
   }
   if (!expressions.length) {

--- a/public/app/features/logs/components/panel/grammar.ts
+++ b/public/app/features/logs/components/panel/grammar.ts
@@ -1,8 +1,7 @@
-import { logStructured as structuredLog } from '@grafana/runtime';
-
 import { type Grammar } from 'prismjs';
 
 import { escapeRegex, parseFlags } from '@grafana/data';
+import { logStructured as structuredLog } from '@grafana/runtime';
 
 import { type LogListModel } from './processing';
 

--- a/public/app/features/logs/components/panel/panelState/getLogsPanelState.ts
+++ b/public/app/features/logs/components/panel/panelState/getLogsPanelState.ts
@@ -1,3 +1,5 @@
+import { logStructured as structuredLog } from '@grafana/runtime';
+
 import { urlUtil } from '@grafana/data';
 
 interface LogsPermalinkUrlState {
@@ -18,7 +20,12 @@ export function getLogsPanelState(): LogsPermalinkUrlState | undefined {
     try {
       return JSON.parse(panelStateEncoded[0]);
     } catch (e) {
-      console.error('error parsing logsPanelState', e);
+      structuredLog(
+        'grafana/frontend.features.logs.components.panel.panelState.getLogsPanelState',
+        'error',
+        'error parsing logsPanelState',
+        e
+      );
     }
   }
 

--- a/public/app/features/logs/components/panel/panelState/getLogsPanelState.ts
+++ b/public/app/features/logs/components/panel/panelState/getLogsPanelState.ts
@@ -1,6 +1,5 @@
-import { logStructured as structuredLog } from '@grafana/runtime';
-
 import { urlUtil } from '@grafana/data';
+import { logStructured as structuredLog } from '@grafana/runtime';
 
 interface LogsPermalinkUrlState {
   logs?: {

--- a/public/app/features/logs/components/panel/virtualization.ts
+++ b/public/app/features/logs/components/panel/virtualization.ts
@@ -1,3 +1,5 @@
+import { logStructured as structuredLog } from '@grafana/runtime';
+
 import ansicolor from 'ansicolor';
 
 import { BusEventWithPayload, type GrafanaTheme2 } from '@grafana/data';
@@ -73,7 +75,11 @@ export class LogLineVirtualization {
     const domCharWidth = this.measureTextWidthWithDOM('e');
     const diff = domCharWidth - canvasCharWidth;
     if (diff >= 0.1) {
-      console.warn('Virtualized log list: falling back to DOM for measurement');
+      structuredLog(
+        'grafana/frontend.features.logs.components.panel.virtualization',
+        'warn',
+        'Virtualized log list: falling back to DOM for measurement'
+      );
       this.measurementMode = 'dom';
     }
   };

--- a/public/app/features/logs/components/panel/virtualization.ts
+++ b/public/app/features/logs/components/panel/virtualization.ts
@@ -1,8 +1,7 @@
-import { logStructured as structuredLog } from '@grafana/runtime';
-
 import ansicolor from 'ansicolor';
 
 import { BusEventWithPayload, type GrafanaTheme2 } from '@grafana/data';
+import { logStructured as structuredLog } from '@grafana/runtime';
 
 import { type LogLineTimestampResolution } from './LogLine';
 import { type LogListFontSize } from './LogList';

--- a/public/app/features/logs/utils.ts
+++ b/public/app/features/logs/utils.ts
@@ -1,3 +1,5 @@
+import { logStructured as structuredLog } from '@grafana/runtime';
+
 import saveAs from 'file-saver';
 import { countBy, chain } from 'lodash';
 import { type MouseEvent } from 'react';
@@ -400,10 +402,10 @@ export function getLogLevelInfo(dataFrame: DataFrame, allDataFrames: DataFrame[]
   const valueField = fieldCache.getFirstFieldOfType(FieldType.number);
 
   if (!timeField) {
-    console.error('Time field missing in data frame');
+    structuredLog('grafana/frontend.features.logs.utils', 'error', 'Time field missing in data frame');
   }
   if (!valueField) {
-    console.error('Value field missing in data frame');
+    structuredLog('grafana/frontend.features.logs.utils', 'error', 'Value field missing in data frame');
   }
 
   const level = valueField ? getFieldDisplayName(valueField, dataFrame, allDataFrames) : 'logs';

--- a/public/app/features/logs/utils.ts
+++ b/public/app/features/logs/utils.ts
@@ -1,5 +1,3 @@
-import { logStructured as structuredLog } from '@grafana/runtime';
-
 import saveAs from 'file-saver';
 import { countBy, chain } from 'lodash';
 import { type MouseEvent } from 'react';
@@ -34,6 +32,7 @@ import {
   store,
 } from '@grafana/data';
 import { t } from '@grafana/i18n';
+import { logStructured as structuredLog } from '@grafana/runtime';
 import { FlagKeys, getFeatureFlagClient } from '@grafana/runtime/internal';
 import { getConfig } from 'app/core/config';
 

--- a/public/app/features/loki-helpers/mergeResponses.ts
+++ b/public/app/features/loki-helpers/mergeResponses.ts
@@ -1,3 +1,5 @@
+import { logStructured as structuredLog } from '@grafana/runtime';
+
 import {
   closestIdx,
   type DataFrame,
@@ -100,7 +102,11 @@ function mergeFrames(dest: DataFrame, source: DataFrame) {
   const sourceIdField = source.fields.find((field) => field.type === FieldType.string && field.name === 'id');
 
   if (!destTimeField || !sourceTimeField) {
-    console.error(new Error(`Time fields not found in the data frames`));
+    structuredLog(
+      'grafana/frontend.features.loki-helpers.mergeResponses',
+      'error',
+      new Error(`Time fields not found in the data frames`)
+    );
     return;
   }
 

--- a/public/app/features/loki-helpers/mergeResponses.ts
+++ b/public/app/features/loki-helpers/mergeResponses.ts
@@ -1,5 +1,3 @@
-import { logStructured as structuredLog } from '@grafana/runtime';
-
 import {
   closestIdx,
   type DataFrame,
@@ -13,6 +11,7 @@ import {
   type QueryResultMetaStat,
   shallowCompare,
 } from '@grafana/data';
+import { logStructured as structuredLog } from '@grafana/runtime';
 
 function getFrameKey(frame: DataFrame): string | undefined {
   // Metric range query data

--- a/public/app/features/panel-screenshot/PanelScreenshotServiceImpl.ts
+++ b/public/app/features/panel-screenshot/PanelScreenshotServiceImpl.ts
@@ -1,5 +1,10 @@
 import { type PanelPlugin, type PanelScreenshotContext } from '@grafana/data';
-import { type PanelScreenshotOptions, type PanelScreenshotService, reportInteraction } from '@grafana/runtime';
+import {
+  logStructured as structuredLog,
+  type PanelScreenshotOptions,
+  type PanelScreenshotService,
+  reportInteraction,
+} from '@grafana/runtime';
 import { isSceneObject } from '@grafana/scenes';
 
 import { syncGetPanelPlugin } from '../plugins/importPanelPlugin';
@@ -115,7 +120,9 @@ function warnOnMimeMismatch(blob: Blob, format: Format, panelType: string): void
   if (!actual || actual === expected) {
     return;
   }
-  console.warn(
+  structuredLog(
+    'grafana/frontend.features.panel-screenshot.PanelScreenshotServiceImpl',
+    'warn',
     `[panel-screenshot] plugin "${panelType}" returned ${actual} but ${expected} was requested. ` +
       'Update onScreenshot to honour the requested format, or return null to defer to the default renderer.'
   );

--- a/public/app/features/panel/panellinks/linkSuppliers.ts
+++ b/public/app/features/panel/panellinks/linkSuppliers.ts
@@ -1,5 +1,3 @@
-import { logStructured as structuredLog } from '@grafana/runtime';
-
 import {
   type DataLink,
   type DisplayValue,
@@ -14,6 +12,7 @@ import {
   type ScopedVars,
 } from '@grafana/data';
 import { t } from '@grafana/i18n';
+import { logStructured as structuredLog } from '@grafana/runtime';
 import { type VizPanel } from '@grafana/scenes';
 import { dashboardSceneGraph } from 'app/features/dashboard-scene/utils/dashboardSceneGraph';
 

--- a/public/app/features/panel/panellinks/linkSuppliers.ts
+++ b/public/app/features/panel/panellinks/linkSuppliers.ts
@@ -1,3 +1,5 @@
+import { logStructured as structuredLog } from '@grafana/runtime';
+
 import {
   type DataLink,
   type DisplayValue,
@@ -123,7 +125,7 @@ export const getFieldLinksSupplier = (value: FieldDisplay): LinkModelSupplier<Fi
           };
         }
       } else {
-        console.log('VALUE', value);
+        structuredLog('grafana/frontend.features.panel.panellinks.linkSuppliers', 'info', 'VALUE', value);
       }
 
       const replace: InterpolateFunction = (value: string, vars: ScopedVars | undefined, fmt?: string | Function) => {

--- a/public/app/features/panel/suggestions/getAllSuggestions.ts
+++ b/public/app/features/panel/suggestions/getAllSuggestions.ts
@@ -1,5 +1,3 @@
-import { logStructured as structuredLog } from '@grafana/runtime';
-
 import {
   AppEvents,
   type DataFrame,
@@ -11,6 +9,7 @@ import {
   VisualizationSuggestionScore,
 } from '@grafana/data';
 import { t } from '@grafana/i18n';
+import { logStructured as structuredLog } from '@grafana/runtime';
 import { getListedPanelPluginMetas, getPanelPluginMeta } from '@grafana/runtime/internal';
 import { appEvents } from 'app/core/app_events';
 import { isBuiltinPluginPath } from 'app/features/plugins/built_in_plugins';

--- a/public/app/features/panel/suggestions/getAllSuggestions.ts
+++ b/public/app/features/panel/suggestions/getAllSuggestions.ts
@@ -1,3 +1,5 @@
+import { logStructured as structuredLog } from '@grafana/runtime';
+
 import {
   AppEvents,
   type DataFrame,
@@ -51,7 +53,12 @@ export async function loadPlugins(pluginIds: string[]): Promise<PluginLoadResult
       plugins.push(settled.value);
     } else {
       const pluginId = pluginIds[i];
-      console.error(`Failed to load ${pluginId} for visualization suggestions:`, settled.reason);
+      structuredLog(
+        'grafana/frontend.features.panel.suggestions.getAllSuggestions',
+        'error',
+        `Failed to load ${pluginId} for visualization suggestions:`,
+        settled.reason
+      );
 
       if (await isBuiltInPlugin(pluginId)) {
         hasErrors = true;
@@ -156,7 +163,12 @@ export async function getAllSuggestions(series?: DataFrame[]): Promise<Suggestio
         list.push(...suggestions);
       }
     } catch (e) {
-      console.warn(`error when loading suggestions from plugin "${plugin.meta.id}"`, e);
+      structuredLog(
+        'grafana/frontend.features.panel.suggestions.getAllSuggestions',
+        'warn',
+        `error when loading suggestions from plugin "${plugin.meta.id}"`,
+        e
+      );
       pluginSuggestionsError = true;
     }
   }

--- a/public/app/features/plugins/admin/api.ts
+++ b/public/app/features/plugins/admin/api.ts
@@ -1,5 +1,5 @@
 import { type PluginError, renderMarkdown } from '@grafana/data';
-import { getBackendSrv, isFetchError } from '@grafana/runtime';
+import { logStructured as structuredLog, getBackendSrv, isFetchError } from '@grafana/runtime';
 import { installPluginMeta, logPluginMetaError, uninstallPluginMeta } from '@grafana/runtime/internal';
 import { accessControlQueryParam } from 'app/core/utils/accessControl';
 import { isVersionGtOrEq } from 'app/core/utils/version';
@@ -92,7 +92,11 @@ export async function getRemotePlugins(): Promise<RemotePlugin[]> {
     if (isFetchError(error)) {
       // It can happen that GCOM is not available, in that case we show a limited set of information to the user.
       error.isHandled = true;
-      console.error('Failed to fetch plugins from catalog (default https://grafana.com/api/plugins)');
+      structuredLog(
+        'grafana/frontend.features.plugins.admin.api',
+        'error',
+        'Failed to fetch plugins from catalog (default https://grafana.com/api/plugins)'
+      );
       return [];
     }
 
@@ -272,9 +276,17 @@ export async function getPluginEntitlement(id: string): Promise<boolean> {
       if (error.status === 401 || error.status === 403 || error.status === 404) {
         return false;
       }
-      console.warn(`Failed to fetch entitlement for plugin "${id}" (status ${error.status})`);
+      structuredLog(
+        'grafana/frontend.features.plugins.admin.api',
+        'warn',
+        `Failed to fetch entitlement for plugin "${id}" (status ${error.status})`
+      );
     } else {
-      console.warn(`Failed to fetch entitlement for plugin "${id}": unexpected error`);
+      structuredLog(
+        'grafana/frontend.features.plugins.admin.api',
+        'warn',
+        `Failed to fetch entitlement for plugin "${id}": unexpected error`
+      );
     }
     return false;
   }

--- a/public/app/features/plugins/admin/components/GetStartedWithPlugin/GetStartedWithApp.tsx
+++ b/public/app/features/plugins/admin/components/GetStartedWithPlugin/GetStartedWithApp.tsx
@@ -1,3 +1,5 @@
+import { logStructured as structuredLog } from '@grafana/runtime';
+
 import * as React from 'react';
 
 import { type PluginMeta } from '@grafana/data';
@@ -67,6 +69,11 @@ const updatePluginSettingsAndReload = async (id: string, data: Partial<PluginMet
     // Reloading the page as the plugin meta changes made here wouldn't be propagated throughout the app.
     window.location.reload();
   } catch (e) {
-    console.error('Error while updating the plugin', e);
+    structuredLog(
+      'grafana/frontend.features.plugins.admin.components.GetStartedWithPlugin.GetStartedWithApp',
+      'error',
+      'Error while updating the plugin',
+      e
+    );
   }
 };

--- a/public/app/features/plugins/admin/components/GetStartedWithPlugin/GetStartedWithApp.tsx
+++ b/public/app/features/plugins/admin/components/GetStartedWithPlugin/GetStartedWithApp.tsx
@@ -1,9 +1,8 @@
-import { logStructured as structuredLog } from '@grafana/runtime';
-
 import * as React from 'react';
 
 import { type PluginMeta } from '@grafana/data';
 import { Trans } from '@grafana/i18n';
+import { logStructured as structuredLog } from '@grafana/runtime';
 import { updateAppPluginSettings } from '@grafana/runtime/unstable';
 import { Button } from '@grafana/ui';
 import { contextSrv } from 'app/core/services/context_srv';

--- a/public/app/features/plugins/admin/pages/Browse.tsx
+++ b/public/app/features/plugins/admin/pages/Browse.tsx
@@ -4,7 +4,7 @@ import { useLocation } from 'react-router-dom-v5-compat';
 
 import { type SelectableValue, type GrafanaTheme2, type PluginType } from '@grafana/data';
 import { Trans, t } from '@grafana/i18n';
-import { locationSearchToObject } from '@grafana/runtime';
+import { logStructured as structuredLog, locationSearchToObject } from '@grafana/runtime';
 import { Select, RadioButtonGroup, useStyles2, Tooltip, Field, TextLink } from '@grafana/ui';
 import { Page } from 'app/core/components/Page/Page';
 import { getNavModel } from 'app/core/selectors/navModel';
@@ -72,7 +72,7 @@ export default function Browse() {
 
   // How should we handle errors?
   if (error) {
-    console.error(error.message);
+    structuredLog('grafana/frontend.features.plugins.admin.pages.Browse', 'error', error.message);
     return null;
   }
 

--- a/public/app/features/plugins/admin/state/actions.ts
+++ b/public/app/features/plugins/admin/state/actions.ts
@@ -2,7 +2,7 @@ import { createAction, createAsyncThunk, type Update } from '@reduxjs/toolkit';
 import { from, forkJoin, timeout, lastValueFrom, catchError, of } from 'rxjs';
 
 import { type PanelPlugin, type PluginError } from '@grafana/data';
-import { config, getBackendSrv, isFetchError } from '@grafana/runtime';
+import { logStructured as structuredLog, config, getBackendSrv, isFetchError } from '@grafana/runtime';
 import { refetchPanelPluginMetas } from '@grafana/runtime/internal';
 import { importPanelPlugin } from 'app/features/plugins/importPanelPlugin';
 import { type StoreState, type ThunkResult } from 'app/types/store';
@@ -46,7 +46,7 @@ export const fetchAll = createAsyncThunk(`${STATE_PREFIX}/fetchAll`, async (_, t
     const remote$ = from(getRemotePlugins()).pipe(
       catchError((err) => {
         thunkApi.dispatch({ type: `${STATE_PREFIX}/fetchRemote/rejected` });
-        console.error(err);
+        structuredLog('grafana/frontend.features.plugins.admin.state.actions', 'error', err);
         return of([]);
       })
     );
@@ -121,7 +121,7 @@ export const fetchAll = createAsyncThunk(`${STATE_PREFIX}/fetchAll`, async (_, t
           }
         },
         (error) => {
-          console.log(error);
+          structuredLog('grafana/frontend.features.plugins.admin.state.actions', 'info', error);
           thunkApi.dispatch({ type: `${STATE_PREFIX}/fetchLocal/rejected` });
           thunkApi.dispatch({ type: `${STATE_PREFIX}/fetchRemote/rejected` });
           return thunkApi.rejectWithValue('Unknown error.');
@@ -219,7 +219,7 @@ export const install = createAsyncThunk<
 
     return { id, changes };
   } catch (e) {
-    console.error(e);
+    structuredLog('grafana/frontend.features.plugins.admin.state.actions', 'error', e);
     if (isFetchError(e)) {
       // add id to identify errors in multiple requests
       e.data.id = id;
@@ -246,7 +246,7 @@ export const uninstall = createAsyncThunk<Update<CatalogPlugin, string>, string>
         changes: { isInstalled: false, installedVersion: undefined, isFullyInstalled: false },
       };
     } catch (e) {
-      console.error(e);
+      structuredLog('grafana/frontend.features.plugins.admin.state.actions', 'error', e);
 
       return thunkApi.rejectWithValue('Unknown error.');
     }

--- a/public/app/features/plugins/components/AppRootPage.tsx
+++ b/public/app/features/plugins/components/AppRootPage.tsx
@@ -274,7 +274,6 @@ async function loadAppPlugin(pluginId: string, dispatch: React.Dispatch<AnyActio
     );
     const error = err instanceof Error ? err : new Error(getMessageFromError(err));
     getLogger('features.plugins').logError(error);
-    console.error(error);
   }
 }
 

--- a/public/app/features/plugins/components/PluginErrorBoundary.tsx
+++ b/public/app/features/plugins/components/PluginErrorBoundary.tsx
@@ -1,3 +1,5 @@
+import { logStructured as structuredLog } from '@grafana/runtime';
+
 import * as React from 'react';
 
 import { PluginContext } from '@grafana/data';
@@ -32,7 +34,13 @@ export class PluginErrorBoundary extends React.Component<PluginErrorBoundaryProp
     if (this.props.onError) {
       this.props.onError(error, info);
     } else {
-      console.error(`Plugin "${this.context?.meta.id}" failed to load:`, error, info);
+      structuredLog(
+        'grafana/frontend.features.plugins.components.PluginErrorBoundary',
+        'error',
+        `Plugin "${this.context?.meta.id}" failed to load:`,
+        error,
+        info
+      );
     }
 
     this.setState({ error, errorInfo: info });

--- a/public/app/features/plugins/components/PluginErrorBoundary.tsx
+++ b/public/app/features/plugins/components/PluginErrorBoundary.tsx
@@ -1,8 +1,7 @@
-import { logStructured as structuredLog } from '@grafana/runtime';
-
 import * as React from 'react';
 
 import { PluginContext } from '@grafana/data';
+import { logStructured as structuredLog } from '@grafana/runtime';
 
 interface PluginErrorBoundaryProps {
   children: React.ReactNode;

--- a/public/app/features/plugins/components/restrictedGrafanaApis/dashboardMutation/dashboardMutationApi.ts
+++ b/public/app/features/plugins/components/restrictedGrafanaApis/dashboardMutation/dashboardMutationApi.ts
@@ -1,5 +1,3 @@
-import { logStructured as structuredLog } from '@grafana/runtime';
-
 /**
  * Dashboard Mutation API -- Restricted API wrapper with built-in store.
  *
@@ -13,6 +11,7 @@ import { logStructured as structuredLog } from '@grafana/runtime';
  */
 
 import type { DashboardMutationAPI } from '@grafana/data';
+import { logStructured as structuredLog } from '@grafana/runtime';
 import { ALL_COMMANDS } from 'app/features/dashboard-scene/mutation-api';
 import { DashboardMutationClient } from 'app/features/dashboard-scene/mutation-api/DashboardMutationClient';
 import type { MutationClient, MutationRequest } from 'app/features/dashboard-scene/mutation-api/types';

--- a/public/app/features/plugins/components/restrictedGrafanaApis/dashboardMutation/dashboardMutationApi.ts
+++ b/public/app/features/plugins/components/restrictedGrafanaApis/dashboardMutation/dashboardMutationApi.ts
@@ -1,3 +1,5 @@
+import { logStructured as structuredLog } from '@grafana/runtime';
+
 /**
  * Dashboard Mutation API -- Restricted API wrapper with built-in store.
  *
@@ -26,7 +28,12 @@ provideMutationClientFactory((sceneObject) => {
   try {
     _client = new DashboardMutationClient(scene);
   } catch (error) {
-    console.error('Failed to register Dashboard Mutation API:', error);
+    structuredLog(
+      'grafana/frontend.features.plugins.components.restrictedGrafanaApis.dashboardMutation.dashboardMutationApi',
+      'error',
+      'Failed to register Dashboard Mutation API:',
+      error
+    );
   }
 
   return () => {

--- a/public/app/features/plugins/extensions/logs/LogViewFilters.tsx
+++ b/public/app/features/plugins/extensions/logs/LogViewFilters.tsx
@@ -1,3 +1,5 @@
+import { logStructured as structuredLog } from '@grafana/runtime';
+
 import { isEmpty } from 'lodash';
 import { type ReactElement, useId, useMemo } from 'react';
 
@@ -96,7 +98,11 @@ function useLogFilters(
 
   return useMemo(() => {
     if (data && data?.series.length > 1) {
-      console.warn('LogViewFilter does not support multiple series in query result.');
+      structuredLog(
+        'grafana/frontend.features.plugins.extensions.logs.LogViewFilters',
+        'warn',
+        'LogViewFilter does not support multiple series in query result.'
+      );
     }
 
     const frame = data?.series[0];

--- a/public/app/features/plugins/extensions/logs/LogViewFilters.tsx
+++ b/public/app/features/plugins/extensions/logs/LogViewFilters.tsx
@@ -1,10 +1,9 @@
-import { logStructured as structuredLog } from '@grafana/runtime';
-
 import { isEmpty } from 'lodash';
 import { type ReactElement, useId, useMemo } from 'react';
 
 import { type DataFrame, type SelectableValue } from '@grafana/data';
 import { t } from '@grafana/i18n';
+import { logStructured as structuredLog } from '@grafana/runtime';
 import { type SceneDataProvider } from '@grafana/scenes';
 import { InlineField, InlineFieldRow, MultiSelect } from '@grafana/ui';
 

--- a/public/app/features/plugins/extensions/logs/log.ts
+++ b/public/app/features/plugins/extensions/logs/log.ts
@@ -3,7 +3,6 @@ import { nanoid } from 'nanoid';
 import { type Observable, ReplaySubject } from 'rxjs';
 
 import { type Labels, LogLevel } from '@grafana/data';
-import { config } from '@grafana/runtime';
 import { getLogger } from '@grafana/runtime/unstable';
 
 export type ExtensionsLogItem = {
@@ -41,15 +40,11 @@ export class ExtensionsLog {
 
   warning(message: string, labels?: Labels): void {
     getLogger('ui-extension-logs').logWarning(message, { ...this.baseLabels, ...labels });
-    config.buildInfo.env === 'development' && console.warn(message, { ...this.baseLabels, ...labels });
     this.log(LogLevel.warning, message, labels);
   }
 
   error(message: string, labels?: Labels): void {
-    // TODO: If Faro has console instrumentation, then the following will track the same error message twice
-    // (first: `monitoringLogger.logError()`, second: `console.error()` which gets picked up by Faro)
     getLogger('ui-extension-logs').logError(new Error(message), { ...this.baseLabels, ...labels });
-    console.error(message, { ...this.baseLabels, ...labels });
     this.log(LogLevel.error, message, labels);
   }
 

--- a/public/app/features/plugins/extensions/utils.test.tsx
+++ b/public/app/features/plugins/extensions/utils.test.tsx
@@ -2,7 +2,7 @@ import { render, screen, waitFor } from '@testing-library/react';
 import { type Unsubscribable } from 'rxjs';
 
 import { dateTime, usePluginContext, PluginLoadingStrategy, type PluginMeta } from '@grafana/data';
-import { config, type AppPluginConfig } from '@grafana/runtime';
+import { config, logStructured, type AppPluginConfig } from '@grafana/runtime';
 import { setAppPluginMetas } from '@grafana/runtime/internal';
 import { appEvents } from 'app/core/app_events';
 import { ShowModalReactEvent } from 'app/types/events';
@@ -27,6 +27,10 @@ import {
 jest.mock('@grafana/runtime/unstable', () => ({
   ...jest.requireActual('@grafana/runtime/unstable'),
   getPluginSettings: () => Promise.resolve({ info: { version: '1.0.0' }, id: 'test-plugin' }),
+}));
+jest.mock('@grafana/runtime', () => ({
+  ...jest.requireActual('@grafana/runtime'),
+  logStructured: jest.fn(),
 }));
 
 describe('Plugin Extensions / Utils', () => {
@@ -226,9 +230,7 @@ describe('Plugin Extensions / Utils', () => {
   });
 
   describe('handleErrorsInFn()', () => {
-    test('should catch errors thrown by the provided function and print them as console warnings', () => {
-      global.console.warn = jest.fn();
-
+    test('should catch and log errors thrown by the provided function', () => {
       expect(() => {
         const fn = handleErrorsInFn((foo: string) => {
           throw new Error('Error: ' + foo);
@@ -236,8 +238,11 @@ describe('Plugin Extensions / Utils', () => {
 
         fn('TEST');
 
-        // Logs the errors
-        expect(console.warn).toHaveBeenCalledWith('Error: TEST');
+        expect(logStructured).toHaveBeenCalledWith(
+          'grafana/frontend.features.plugins.extensions.utils',
+          'warn',
+          'Error: TEST'
+        );
       }).not.toThrow();
     });
   });

--- a/public/app/features/plugins/extensions/utils.tsx
+++ b/public/app/features/plugins/extensions/utils.tsx
@@ -16,7 +16,7 @@ import {
   type PluginMeta,
   urlUtil,
 } from '@grafana/data';
-import { reportInteraction, config } from '@grafana/runtime';
+import { logStructured as structuredLog, reportInteraction, config } from '@grafana/runtime';
 import { getAppPluginMetas } from '@grafana/runtime/internal';
 import { getPluginSettings } from '@grafana/runtime/unstable';
 import { Modal } from '@grafana/ui';
@@ -50,7 +50,11 @@ export function handleErrorsInFn(fn: Function, errorMessagePrefix = '') {
       return fn(...args);
     } catch (e) {
       if (e instanceof Error) {
-        console.warn(`${errorMessagePrefix}${e.message}`);
+        structuredLog(
+          'grafana/frontend.features.plugins.extensions.utils',
+          'warn',
+          `${errorMessagePrefix}${e.message}`
+        );
       }
     }
   };

--- a/public/app/features/plugins/importer/addTranslationsToI18n.ts
+++ b/public/app/features/plugins/importer/addTranslationsToI18n.ts
@@ -1,7 +1,6 @@
-import { logStructured as structuredLog } from '@grafana/runtime';
-
 import { DEFAULT_LANGUAGE } from '@grafana/i18n';
 import { addResourceBundle } from '@grafana/i18n/internal';
+import { logStructured as structuredLog } from '@grafana/runtime';
 
 import { SystemJS } from '../loader/systemjs';
 import { resolveModulePath } from '../loader/utils';

--- a/public/app/features/plugins/importer/addTranslationsToI18n.ts
+++ b/public/app/features/plugins/importer/addTranslationsToI18n.ts
@@ -1,3 +1,5 @@
+import { logStructured as structuredLog } from '@grafana/runtime';
+
 import { DEFAULT_LANGUAGE } from '@grafana/i18n';
 import { addResourceBundle } from '@grafana/i18n/internal';
 
@@ -26,29 +28,44 @@ export async function addTranslationsToI18n({
   const path = resolvedPath ?? fallbackPath;
 
   if (!path) {
-    console.warn(`Could not find any translation for plugin ${pluginId}`, { resolvedLanguage, fallbackLanguage });
+    structuredLog(
+      'grafana/frontend.features.plugins.importer.addTranslationsToI18n',
+      'warn',
+      `Could not find any translation for plugin ${pluginId}`,
+      { resolvedLanguage, fallbackLanguage }
+    );
     return;
   }
 
   try {
     const module = await SystemJS.import(resolveModulePath(path));
     if (!module.default) {
-      console.warn(`Could not find default export for plugin ${pluginId}`, {
-        resolvedLanguage,
-        fallbackLanguage,
-        path,
-      });
+      structuredLog(
+        'grafana/frontend.features.plugins.importer.addTranslationsToI18n',
+        'warn',
+        `Could not find default export for plugin ${pluginId}`,
+        {
+          resolvedLanguage,
+          fallbackLanguage,
+          path,
+        }
+      );
       return;
     }
 
     const language = resolvedPath ? resolvedLanguage : fallbackLanguage;
     addResourceBundle(language, pluginId, module.default);
   } catch (error) {
-    console.warn(`Could not load translation for plugin ${pluginId}`, {
-      resolvedLanguage,
-      fallbackLanguage,
-      error,
-      path,
-    });
+    structuredLog(
+      'grafana/frontend.features.plugins.importer.addTranslationsToI18n',
+      'warn',
+      `Could not load translation for plugin ${pluginId}`,
+      {
+        resolvedLanguage,
+        fallbackLanguage,
+        error,
+        path,
+      }
+    );
   }
 }

--- a/public/app/features/plugins/importer/importPluginModule.ts
+++ b/public/app/features/plugins/importer/importPluginModule.ts
@@ -78,7 +78,6 @@ export async function importPluginModule({
       errorMessage = `Could not load plugin. Updating the "${pluginName}" plugin to the latest version may fix the problem.`;
     }
     let error = new Error(errorMessage, { cause: e });
-    console.error(error);
     getLogger('features.plugins').logError(error, {
       path,
       pluginId,

--- a/public/app/features/plugins/importer/pluginImporter.ts
+++ b/public/app/features/plugins/importer/pluginImporter.ts
@@ -12,7 +12,7 @@ import {
   type PluginMeta,
   throwIfAngular,
 } from '@grafana/data';
-import { config } from '@grafana/runtime';
+import { logStructured as structuredLog, config } from '@grafana/runtime';
 import { getLogger } from '@grafana/runtime/unstable';
 import { type GenericDataSourcePlugin } from 'app/features/datasources/types';
 import { getPanelPluginLoadError } from 'app/features/panel/components/PanelPluginError';
@@ -56,7 +56,12 @@ const panelPluginPostImport: PostImportStrategy<PanelPlugin, PanelPluginMeta> = 
     throw new Error('missing export: plugin');
   } catch (error) {
     // TODO, maybe a different error plugin
-    console.warn('Error loading panel plugin: ' + meta.id, error);
+    structuredLog(
+      'grafana/frontend.features.plugins.importer.pluginImporter',
+      'warn',
+      'Error loading panel plugin: ' + meta.id,
+      error
+    );
     return getPanelPluginLoadError(meta, error);
   }
 };

--- a/public/app/features/plugins/loader/systemjsHooks.ts
+++ b/public/app/features/plugins/loader/systemjsHooks.ts
@@ -1,5 +1,5 @@
 import { PluginLoadingStrategy } from '@grafana/data';
-import { config } from '@grafana/runtime';
+import { logStructured as structuredLog, config } from '@grafana/runtime';
 
 import { transformPluginSourceForCDN } from '../cdn/utils';
 
@@ -102,7 +102,11 @@ export function decorateSystemJSResolve(
       const url = originalResolve.apply(this, [resolvedUrl, parentUrl]);
       return resolvePluginUrlWithCache(url);
     }
-    console.warn(`SystemJS: failed to resolve '${id}'`);
+    structuredLog(
+      'grafana/frontend.features.plugins.loader.systemjsHooks',
+      'warn',
+      `SystemJS: failed to resolve '${id}'`
+    );
     return id;
   }
 }

--- a/public/app/features/plugins/loader/utils.ts
+++ b/public/app/features/plugins/loader/utils.ts
@@ -1,4 +1,4 @@
-import { config } from '@grafana/runtime';
+import { logStructured as structuredLog, config } from '@grafana/runtime';
 
 import { sandboxPluginDependencies } from '../sandbox/pluginDependencies';
 
@@ -29,7 +29,7 @@ function addPreload(id: string, preload: (() => Promise<System.Module>) | System
   try {
     resolvedId = SystemJS.resolve(id);
   } catch (e) {
-    console.log(e);
+    structuredLog('grafana/frontend.features.plugins.loader.utils', 'info', e);
   }
 
   if (resolvedId && SystemJS.has(resolvedId)) {

--- a/public/app/features/plugins/pluginPreloader.ts
+++ b/public/app/features/plugins/pluginPreloader.ts
@@ -1,3 +1,5 @@
+import { logStructured as structuredLog } from '@grafana/runtime';
+
 import type { AppPluginConfig } from '@grafana/data';
 import { getPluginSettings } from '@grafana/runtime/unstable';
 import { contextSrv } from 'app/core/services/context_srv';
@@ -33,6 +35,11 @@ async function preload(config: AppPluginConfig): Promise<void> {
       return;
     }
 
-    console.error(`[Plugins] Failed to preload plugin: ${config.path} (version: ${config.version})`, error);
+    structuredLog(
+      'grafana/frontend.features.plugins.pluginPreloader',
+      'error',
+      `[Plugins] Failed to preload plugin: ${config.path} (version: ${config.version})`,
+      error
+    );
   }
 }

--- a/public/app/features/plugins/pluginPreloader.ts
+++ b/public/app/features/plugins/pluginPreloader.ts
@@ -1,6 +1,5 @@
-import { logStructured as structuredLog } from '@grafana/runtime';
-
 import type { AppPluginConfig } from '@grafana/data';
+import { logStructured as structuredLog } from '@grafana/runtime';
 import { getPluginSettings } from '@grafana/runtime/unstable';
 import { contextSrv } from 'app/core/services/context_srv';
 

--- a/public/app/features/plugins/sandbox/distortions.ts
+++ b/public/app/features/plugins/sandbox/distortions.ts
@@ -1,9 +1,8 @@
-import { logStructured as structuredLog } from '@grafana/runtime';
-
 import { type ProxyTarget } from '@locker/near-membrane-shared';
 import DOMPurify from 'dompurify';
 import { cloneDeep, isFunction } from 'lodash';
 
+import { logStructured as structuredLog } from '@grafana/runtime';
 import { type Monaco } from '@grafana/ui';
 
 import { loadScriptIntoSandbox } from './codeLoader';

--- a/public/app/features/plugins/sandbox/distortions.ts
+++ b/public/app/features/plugins/sandbox/distortions.ts
@@ -1,3 +1,5 @@
+import { logStructured as structuredLog } from '@grafana/runtime';
+
 import { type ProxyTarget } from '@locker/near-membrane-shared';
 import DOMPurify from 'dompurify';
 import { cloneDeep, isFunction } from 'lodash';
@@ -140,7 +142,7 @@ function distortConsole(distortions: DistortionMap) {
       const pluginId = meta.id;
 
       function sandboxLog(...args: unknown[]) {
-        console.log(`[plugin ${pluginId}]`, ...args);
+        structuredLog('grafana/frontend.features.plugins.sandbox.distortions', 'info', `[plugin ${pluginId}]`, ...args);
       }
       return {
         log: sandboxLog,
@@ -170,7 +172,7 @@ function distortAlert(distortions: DistortionMap) {
     });
 
     return function (...args: unknown[]) {
-      console.log(`[plugin ${pluginId}]`, ...args);
+      structuredLog('grafana/frontend.features.plugins.sandbox.distortions', 'info', `[plugin ${pluginId}]`, ...args);
     };
   }
   const descriptor = Object.getOwnPropertyDescriptor(window, 'alert');

--- a/public/app/features/plugins/sandbox/sandboxPluginLoader.ts
+++ b/public/app/features/plugins/sandbox/sandboxPluginLoader.ts
@@ -2,7 +2,7 @@ import createVirtualEnvironment from '@locker/near-membrane-dom';
 import { type ProxyTarget } from '@locker/near-membrane-shared';
 
 import { type BootData } from '@grafana/data';
-import { config } from '@grafana/runtime';
+import { logStructured as structuredLog, config } from '@grafana/runtime';
 import { defaultTrustedTypesPolicy } from 'app/core/trustedTypePolicies';
 
 import { getPluginCode, getPluginLoadData, patchSandboxEnvironmentPrototype } from './codeLoader';
@@ -139,7 +139,9 @@ async function doImportPluginModuleInSandbox(meta: SandboxPluginMeta): Promise<S
               `Error in ${meta.id}: Plugins should not use window.grafanaBootData. Use "config" from "@grafana/runtime" instead.`
             );
           } else {
-            console.error(
+            structuredLog(
+              'grafana/frontend.features.plugins.sandbox.sandboxPluginLoader',
+              'error',
               `${meta.id.toUpperCase()}: Plugins should not use window.grafanaBootData. Use "config" from "@grafana/runtime" instead.`
             );
           }

--- a/public/app/features/profile/api.ts
+++ b/public/app/features/profile/api.ts
@@ -1,4 +1,4 @@
-import { getBackendSrv } from '@grafana/runtime';
+import { logStructured as structuredLog, getBackendSrv } from '@grafana/runtime';
 import { type Team } from 'app/types/teams';
 import { type UserDTO, type UserOrg, type UserSession } from 'app/types/user';
 
@@ -8,7 +8,7 @@ async function changePassword(payload: ChangePasswordFields): Promise<void> {
   try {
     await getBackendSrv().put('/api/user/password', payload);
   } catch (err) {
-    console.error(err);
+    structuredLog('grafana/frontend.features.profile.api', 'error', err);
   }
 }
 
@@ -42,7 +42,7 @@ async function updateUserProfile(payload: ProfileUpdateFields): Promise<void> {
   try {
     await getBackendSrv().put('/api/user', payload);
   } catch (err) {
-    console.error(err);
+    structuredLog('grafana/frontend.features.profile.api', 'error', err);
   }
 }
 

--- a/public/app/features/provisioning/components/Shared/SaveProvisionedResourceDrawer.tsx
+++ b/public/app/features/provisioning/components/Shared/SaveProvisionedResourceDrawer.tsx
@@ -3,7 +3,7 @@ import { useMemo, useState } from 'react';
 import { FormProvider, useForm } from 'react-hook-form';
 
 import { t } from '@grafana/i18n';
-import { reportInteraction } from '@grafana/runtime';
+import { logStructured as structuredLog, reportInteraction } from '@grafana/runtime';
 import { Button, Drawer, Stack, Text } from '@grafana/ui';
 import { type RepositoryView, useDeleteRepositoryFilesWithPathMutation } from 'app/api/clients/provisioning/v0alpha1';
 import {
@@ -292,7 +292,9 @@ export function SaveProvisionedResourceDrawer(props: SaveProvisionedResourceDraw
     // new kind wired into a page before its registry entry exists. Warn in dev so it's a visible signal
     // rather than a silent no-op where the user clicks save/delete and nothing happens.
     if (process.env.NODE_ENV !== 'production') {
-      console.warn(
+      structuredLog(
+        'grafana/frontend.features.provisioning.components.Shared.SaveProvisionedResourceDrawer',
+        'warn',
         `SaveProvisionedResourceDrawer: no registered provisioning kind for "${props.resource.apiVersion}"/"${props.resource.kind}"; the drawer will not render.`
       );
     }

--- a/public/app/features/query/components/QueryGroup.tsx
+++ b/public/app/features/query/components/QueryGroup.tsx
@@ -15,7 +15,7 @@ import {
 } from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';
 import { Trans, t } from '@grafana/i18n';
-import { getDataSourceSrv, locationService } from '@grafana/runtime';
+import { logStructured as structuredLog, getDataSourceSrv, locationService } from '@grafana/runtime';
 import { type DataQuery } from '@grafana/schema';
 import { Button, InlineFormLabel, Modal, ScrollContainer, Stack, stylesFactory } from '@grafana/ui';
 import { PluginHelp } from 'app/core/components/PluginHelp/PluginHelp';
@@ -123,7 +123,12 @@ export class QueryGroup extends PureComponent<Props, State> {
         defaultDataSource,
       });
     } catch (error) {
-      console.error('failed to load data source', error);
+      structuredLog(
+        'grafana/frontend.features.query.components.QueryGroup',
+        'error',
+        'failed to load data source',
+        error
+      );
     }
   }
 

--- a/public/app/features/query/state/DashboardQueryRunner/LegacyAnnotationQueryRunner.ts
+++ b/public/app/features/query/state/DashboardQueryRunner/LegacyAnnotationQueryRunner.ts
@@ -1,9 +1,8 @@
-import { logStructured as structuredLog } from '@grafana/runtime';
-
 import { from, type Observable, of } from 'rxjs';
 import { catchError } from 'rxjs/operators';
 
 import { type AnnotationEvent, type DataSourceApi } from '@grafana/data';
+import { logStructured as structuredLog } from '@grafana/runtime';
 import { shouldUseLegacyRunner } from 'app/features/annotations/standardAnnotationSupport';
 
 import { type AnnotationQueryRunner, type AnnotationQueryRunnerOptions } from './types';

--- a/public/app/features/query/state/DashboardQueryRunner/LegacyAnnotationQueryRunner.ts
+++ b/public/app/features/query/state/DashboardQueryRunner/LegacyAnnotationQueryRunner.ts
@@ -1,3 +1,5 @@
+import { logStructured as structuredLog } from '@grafana/runtime';
+
 import { from, type Observable, of } from 'rxjs';
 import { catchError } from 'rxjs/operators';
 
@@ -26,13 +28,21 @@ export class LegacyAnnotationQueryRunner implements AnnotationQueryRunner {
     }
 
     if (datasource?.annotationQuery === undefined) {
-      console.warn('datasource does not have an annotation query');
+      structuredLog(
+        'grafana/frontend.features.query.state.DashboardQueryRunner.LegacyAnnotationQueryRunner',
+        'warn',
+        'datasource does not have an annotation query'
+      );
       return of([]);
     }
 
     const annotationQuery = datasource.annotationQuery({ range, rangeRaw: range.raw, annotation, dashboard });
     if (annotationQuery === undefined) {
-      console.warn('datasource does not have an annotation query');
+      structuredLog(
+        'grafana/frontend.features.query.state.DashboardQueryRunner.LegacyAnnotationQueryRunner',
+        'warn',
+        'datasource does not have an annotation query'
+      );
       return of([]);
     }
 

--- a/public/app/features/query/state/DashboardQueryRunner/utils.ts
+++ b/public/app/features/query/state/DashboardQueryRunner/utils.ts
@@ -2,7 +2,7 @@ import { cloneDeep } from 'lodash';
 import { type Observable, of } from 'rxjs';
 
 import { type AnnotationEvent, type AnnotationQuery, type DataSourceApi } from '@grafana/data';
-import { config, toDataQueryError } from '@grafana/runtime';
+import { logStructured as structuredLog, config, toDataQueryError } from '@grafana/runtime';
 import { dispatch } from 'app/store/store';
 
 import { createErrorNotification } from '../../../../core/copy/appNotification';
@@ -38,7 +38,12 @@ export function handleDashboardQueryRunnerWorkerError(err: any): Observable<Dash
 
 function notifyWithError(title: string, err: any) {
   const error = toDataQueryError(err);
-  console.error('handleAnnotationQueryRunnerError', error);
+  structuredLog(
+    'grafana/frontend.features.query.state.DashboardQueryRunner.utils',
+    'error',
+    'handleAnnotationQueryRunnerError',
+    error
+  );
   const notification = createErrorNotification(title, error.message);
   dispatch(notifyApp(notification));
 }

--- a/public/app/features/query/state/PanelQueryRunner.ts
+++ b/public/app/features/query/state/PanelQueryRunner.ts
@@ -30,7 +30,7 @@ import {
   type StreamingDataFrame,
   DataTopic,
 } from '@grafana/data';
-import { toDataQueryError } from '@grafana/runtime';
+import { logStructured as structuredLog, toDataQueryError } from '@grafana/runtime';
 import { ExpressionDatasourceRef } from '@grafana/runtime/internal';
 import { isStreamingDataFrame } from 'app/features/live/data/utils';
 import { getDatasourceSrv } from 'app/features/plugins/datasource_srv';
@@ -257,7 +257,12 @@ export class PanelQueryRunner {
         return { ...data, series, annotations };
       }),
       catchError((err) => {
-        console.warn('Error running transformation:', err);
+        structuredLog(
+          'grafana/frontend.features.query.state.PanelQueryRunner',
+          'warn',
+          'Error running transformation:',
+          err
+        );
         return of({
           ...data,
           state: LoadingState.Error,

--- a/public/app/features/query/state/QueryRunner.ts
+++ b/public/app/features/query/state/QueryRunner.ts
@@ -15,7 +15,7 @@ import {
   type DataSourceRef,
   preProcessPanelData,
 } from '@grafana/data';
-import { getTemplateSrv } from '@grafana/runtime';
+import { logStructured as structuredLog, getTemplateSrv } from '@grafana/runtime';
 import { getDatasourceSrv } from 'app/features/plugins/datasource_srv';
 
 import { getNextRequestId } from './PanelQueryRunner';
@@ -113,7 +113,8 @@ export class QueryRunner implements QueryRunnerSrv {
             },
           });
         },
-        error: (error) => console.error('PanelQueryRunner Error', error),
+        error: (error) =>
+          structuredLog('grafana/frontend.features.query.state.QueryRunner', 'error', 'PanelQueryRunner Error', error),
       });
   }
 

--- a/public/app/features/query/state/runRequest.ts
+++ b/public/app/features/query/state/runRequest.ts
@@ -18,7 +18,14 @@ import {
   type PanelData,
   type TimeRange,
 } from '@grafana/data';
-import { config, isMigrationHandler, migrateRequest, toDataQueryError, isExpressionReference } from '@grafana/runtime';
+import {
+  logStructured as structuredLog,
+  config,
+  isMigrationHandler,
+  migrateRequest,
+  toDataQueryError,
+  isExpressionReference,
+} from '@grafana/runtime';
 import { backendSrv } from 'app/core/services/backend_srv';
 import { queryIsEmpty } from 'app/core/utils/query';
 import { dataSource as expressionDatasource } from 'app/features/expressions/ExpressionDatasource';
@@ -161,7 +168,7 @@ export function runRequest(
     }),
     // handle errors
     catchError((err) => {
-      console.error('runRequest.catchError', err);
+      structuredLog('grafana/frontend.features.query.state.runRequest', 'error', 'runRequest.catchError', err);
       return of({
         ...state.panelData,
         state: LoadingState.Error,

--- a/public/app/features/scopes/ScopesApiClient.ts
+++ b/public/app/features/scopes/ScopesApiClient.ts
@@ -1,6 +1,5 @@
-import { logStructured as structuredLog } from '@grafana/runtime';
-
 import { type Scope, type ScopeDashboardBinding, type ScopeNode } from '@grafana/data';
+import { logStructured as structuredLog } from '@grafana/runtime';
 import { FlagKeys, getFeatureFlagClient } from '@grafana/runtime/internal';
 import { scopeAPIv0alpha1 } from 'app/api/clients/scope/v0alpha1';
 import type { FindDefaultScope } from 'app/api/clients/scope/v0alpha1/endpoints.gen';

--- a/public/app/features/scopes/ScopesApiClient.ts
+++ b/public/app/features/scopes/ScopesApiClient.ts
@@ -1,3 +1,5 @@
+import { logStructured as structuredLog } from '@grafana/runtime';
+
 import { type Scope, type ScopeDashboardBinding, type ScopeNode } from '@grafana/data';
 import { FlagKeys, getFeatureFlagClient } from '@grafana/runtime/internal';
 import { scopeAPIv0alpha1 } from 'app/api/clients/scope/v0alpha1';
@@ -35,7 +37,13 @@ export class ScopesApiClient {
       // Check if the data is actually an error response (Kubernetes Status object)
       if (this.isStatusError(result.data)) {
         const errorMessage = getMessageFromError(result.data);
-        console.error(`Failed to fetch %s:`, context, errorMessage);
+        structuredLog(
+          'grafana/frontend.features.scopes.ScopesApiClient',
+          'error',
+          `Failed to fetch %s:`,
+          context,
+          errorMessage
+        );
         return undefined;
       }
       return result.data;
@@ -43,7 +51,13 @@ export class ScopesApiClient {
 
     if ('error' in result) {
       const errorMessage = getMessageFromError(result.error);
-      console.error(`Failed to fetch %s:`, context, errorMessage);
+      structuredLog(
+        'grafana/frontend.features.scopes.ScopesApiClient',
+        'error',
+        `Failed to fetch %s:`,
+        context,
+        errorMessage
+      );
     }
 
     return undefined;
@@ -55,7 +69,13 @@ export class ScopesApiClient {
       return this.extractDataOrHandleError(result, `scope: ${name}`);
     } catch (err) {
       const errorMessage = getMessageFromError(err);
-      console.error('Failed to fetch scope:', name, errorMessage);
+      structuredLog(
+        'grafana/frontend.features.scopes.ScopesApiClient',
+        'error',
+        'Failed to fetch scope:',
+        name,
+        errorMessage
+      );
       return undefined;
     } finally {
       // Unsubscribe for extra safety, even though with subscribe: false and awaiting,
@@ -75,7 +95,9 @@ export class ScopesApiClient {
 
       if (successfulScopes.length < scopesIds.length) {
         const failedCount = scopesIds.length - successfulScopes.length;
-        console.warn(
+        structuredLog(
+          'grafana/frontend.features.scopes.ScopesApiClient',
+          'warn',
           'Failed to fetch',
           failedCount,
           'of',
@@ -88,7 +110,13 @@ export class ScopesApiClient {
       return successfulScopes;
     } catch (err) {
       const errorMessage = getMessageFromError(err);
-      console.error('Failed to fetch multiple scopes:', scopesIds, errorMessage);
+      structuredLog(
+        'grafana/frontend.features.scopes.ScopesApiClient',
+        'error',
+        'Failed to fetch multiple scopes:',
+        scopesIds,
+        errorMessage
+      );
       return [];
     }
   }
@@ -111,13 +139,25 @@ export class ScopesApiClient {
 
       if ('error' in result) {
         const errorMessage = getMessageFromError(result.error);
-        console.error('Failed to fetch multiple scope nodes:', names, errorMessage);
+        structuredLog(
+          'grafana/frontend.features.scopes.ScopesApiClient',
+          'error',
+          'Failed to fetch multiple scope nodes:',
+          names,
+          errorMessage
+        );
       }
 
       return [];
     } catch (err) {
       const errorMessage = getMessageFromError(err);
-      console.error('Failed to fetch multiple scope nodes:', names, errorMessage);
+      structuredLog(
+        'grafana/frontend.features.scopes.ScopesApiClient',
+        'error',
+        'Failed to fetch multiple scope nodes:',
+        names,
+        errorMessage
+      );
       return [];
     } finally {
       // Unsubscribe for extra safety, even though with subscribe: false and awaiting,
@@ -171,7 +211,13 @@ export class ScopesApiClient {
         }
         contextParts.push('limit=' + limit);
         const context = contextParts.join(', ');
-        console.error('Failed to fetch scope nodes:', context, errorMessage);
+        structuredLog(
+          'grafana/frontend.features.scopes.ScopesApiClient',
+          'error',
+          'Failed to fetch scope nodes:',
+          context,
+          errorMessage
+        );
       }
 
       return [];
@@ -186,7 +232,13 @@ export class ScopesApiClient {
       }
       contextParts.push('limit=' + limit);
       const context = contextParts.join(', ');
-      console.error('Failed to fetch scope nodes:', context, errorMessage);
+      structuredLog(
+        'grafana/frontend.features.scopes.ScopesApiClient',
+        'error',
+        'Failed to fetch scope nodes:',
+        context,
+        errorMessage
+      );
       return [];
     } finally {
       // Unsubscribe for extra safety, even though with subscribe: false and awaiting,
@@ -214,13 +266,25 @@ export class ScopesApiClient {
 
       if ('error' in result) {
         const errorMessage = getMessageFromError(result.error);
-        console.error('Failed to fetch dashboards for scopes:', scopeNames, errorMessage);
+        structuredLog(
+          'grafana/frontend.features.scopes.ScopesApiClient',
+          'error',
+          'Failed to fetch dashboards for scopes:',
+          scopeNames,
+          errorMessage
+        );
       }
 
       return [];
     } catch (err) {
       const errorMessage = getMessageFromError(err);
-      console.error('Failed to fetch dashboards for scopes:', scopeNames, errorMessage);
+      structuredLog(
+        'grafana/frontend.features.scopes.ScopesApiClient',
+        'error',
+        'Failed to fetch dashboards for scopes:',
+        scopeNames,
+        errorMessage
+      );
       return [];
     } finally {
       // Unsubscribe for extra safety, even though with subscribe: false and awaiting,
@@ -253,13 +317,25 @@ export class ScopesApiClient {
 
       if ('error' in result) {
         const errorMessage = getMessageFromError(result.error);
-        console.error('Failed to fetch scope navigations for scopes:', scopeNames, errorMessage);
+        structuredLog(
+          'grafana/frontend.features.scopes.ScopesApiClient',
+          'error',
+          'Failed to fetch scope navigations for scopes:',
+          scopeNames,
+          errorMessage
+        );
       }
 
       return [];
     } catch (err) {
       const errorMessage = getMessageFromError(err);
-      console.error('Failed to fetch scope navigations for scopes:', scopeNames, errorMessage);
+      structuredLog(
+        'grafana/frontend.features.scopes.ScopesApiClient',
+        'error',
+        'Failed to fetch scope navigations for scopes:',
+        scopeNames,
+        errorMessage
+      );
       return [];
     } finally {
       // Unsubscribe for extra safety, even though with subscribe: false and awaiting,
@@ -312,7 +388,12 @@ export class ScopesApiClient {
       return name;
     } catch (err) {
       const errorMessage = getMessageFromError(err);
-      console.error('Failed to fetch default scope:', errorMessage);
+      structuredLog(
+        'grafana/frontend.features.scopes.ScopesApiClient',
+        'error',
+        'Failed to fetch default scope:',
+        errorMessage
+      );
       return undefined;
     } finally {
       subscription.unsubscribe();
@@ -328,7 +409,13 @@ export class ScopesApiClient {
       return this.extractDataOrHandleError(result, `scope node: ${scopeNodeId}`);
     } catch (err) {
       const errorMessage = getMessageFromError(err);
-      console.error('Failed to fetch scope node:', scopeNodeId, errorMessage);
+      structuredLog(
+        'grafana/frontend.features.scopes.ScopesApiClient',
+        'error',
+        'Failed to fetch scope node:',
+        scopeNodeId,
+        errorMessage
+      );
       return undefined;
     } finally {
       // Unsubscribe for extra safety, even though with subscribe: false and awaiting,

--- a/public/app/features/scopes/ScopesService.ts
+++ b/public/app/features/scopes/ScopesService.ts
@@ -2,7 +2,12 @@ import { isEqual } from 'lodash';
 import { BehaviorSubject, type Observable, combineLatest, type Subscription } from 'rxjs';
 import { map, distinctUntilChanged } from 'rxjs/operators';
 
-import { type LocationService, type ScopesContextValue, type ScopesContextValueState } from '@grafana/runtime';
+import {
+  logStructured as structuredLog,
+  type LocationService,
+  type ScopesContextValue,
+  type ScopesContextValueState,
+} from '@grafana/runtime';
 
 import { type ScopesApiClient } from './ScopesApiClient';
 import { type ScopesDashboardsService } from './dashboards/ScopesDashboardsService';
@@ -102,7 +107,12 @@ export class ScopesService implements ScopesContextValue {
           const tree = this.selectorService.state.tree;
           if (derivedNodeId && tree) {
             this.selectorService.resolvePathToRoot(derivedNodeId, tree, firstApplied.scopeId).catch((error) => {
-              console.error('Failed to pre-load node path from defaultPath', error);
+              structuredLog(
+                'grafana/frontend.features.scopes.ScopesService',
+                'error',
+                'Failed to pre-load node path from defaultPath',
+                error
+              );
             });
           }
         }
@@ -112,7 +122,7 @@ export class ScopesService implements ScopesContextValue {
     // Preload scope node (which loads parent too)
     if (scopeNodeId) {
       this.selectorService.resolvePathToRoot(scopeNodeId, this.selectorService.state.tree!).catch((error) => {
-        console.error('Failed to pre-load node path', error);
+        structuredLog('grafana/frontend.features.scopes.ScopesService', 'error', 'Failed to pre-load node path', error);
       });
     }
 
@@ -294,7 +304,12 @@ export class ScopesService implements ScopesContextValue {
               // calls elsewhere in this file so a rejection from either
               // fetchDefaultScope or the changeScopes chain above is logged
               // instead of surfacing as an unhandled rejection.
-              console.error('Failed to apply default scope:', err);
+              structuredLog(
+                'grafana/frontend.features.scopes.ScopesService',
+                'error',
+                'Failed to apply default scope:',
+                err
+              );
             });
         }
         // Defer the URL write when scope metadata has not loaded yet.

--- a/public/app/features/scopes/selector/ScopesSelectorService.ts
+++ b/public/app/features/scopes/selector/ScopesSelectorService.ts
@@ -1,5 +1,5 @@
 import { type ScopeNode, store as storeImpl } from '@grafana/data';
-import { config, locationService } from '@grafana/runtime';
+import { logStructured as structuredLog, config, locationService } from '@grafana/runtime';
 import { type performanceUtils } from '@grafana/scenes';
 import { getDashboardSceneProfiler } from 'app/features/dashboard/services/DashboardProfiler';
 import { isRenderTarget } from 'app/features/dashboard/services/isRenderTarget';
@@ -99,7 +99,12 @@ export class ScopesSelectorService extends ScopesServiceBase<ScopesSelectorServi
       }
       return node;
     } catch (error) {
-      console.error('Failed to load node', error);
+      structuredLog(
+        'grafana/frontend.features.scopes.selector.ScopesSelectorService',
+        'error',
+        'Failed to load node',
+        error
+      );
       return undefined;
     }
   };
@@ -107,7 +112,12 @@ export class ScopesSelectorService extends ScopesServiceBase<ScopesSelectorServi
   private getNodePath = async (scopeNodeId: string, visited: Set<string> = new Set()): Promise<ScopeNode[]> => {
     // Protect against circular references
     if (visited.has(scopeNodeId)) {
-      console.error('Circular reference detected in node path', scopeNodeId);
+      structuredLog(
+        'grafana/frontend.features.scopes.selector.ScopesSelectorService',
+        'error',
+        'Circular reference detected in node path',
+        scopeNodeId
+      );
       return [];
     }
 
@@ -440,7 +450,12 @@ export class ScopesSelectorService extends ScopesServiceBase<ScopesSelectorServi
 
     // Validate API response is an array
     if (!Array.isArray(fetchedScopes)) {
-      console.error('Expected fetchedScopes to be an array, got:', typeof fetchedScopes);
+      structuredLog(
+        'grafana/frontend.features.scopes.selector.ScopesSelectorService',
+        'error',
+        'Expected fetchedScopes to be an array, got:',
+        typeof fetchedScopes
+      );
       this.updateState({ scopes: newScopesState, loading: false });
       return;
     }
@@ -603,7 +618,12 @@ export class ScopesSelectorService extends ScopesServiceBase<ScopesSelectorServi
           newTree = expandNodes(newTree, parentPath);
         }
       } catch (error) {
-        console.error('Failed to expand to selected scope', error);
+        structuredLog(
+          'grafana/frontend.features.scopes.selector.ScopesSelectorService',
+          'error',
+          'Failed to expand to selected scope',
+          error
+        );
       }
     }
 

--- a/public/app/features/scopes/selector/scopesTreeUtils.ts
+++ b/public/app/features/scopes/selector/scopesTreeUtils.ts
@@ -1,3 +1,5 @@
+import { logStructured as structuredLog } from '@grafana/runtime';
+
 import { type ScopeNode } from '@grafana/data';
 
 import { type NodesMap, type TreeNode } from './types';
@@ -125,7 +127,11 @@ export const insertPathNodesIntoTree = (tree: TreeNode, path: ScopeNode[]) => {
     newTree = modifyTreeNodeAtPath(newTree, pathSlice, (treeNode) => {
       treeNode.children = { ...treeNode.children };
       if (!childNodeName) {
-        console.warn('Failed to insert full path into tree. Did not find child to' + stringPath[index]);
+        structuredLog(
+          'grafana/frontend.features.scopes.selector.scopesTreeUtils',
+          'warn',
+          'Failed to insert full path into tree. Did not find child to' + stringPath[index]
+        );
         treeNode.childrenLoaded = treeNode.childrenLoaded ?? false;
         return;
       }

--- a/public/app/features/scopes/selector/scopesTreeUtils.ts
+++ b/public/app/features/scopes/selector/scopesTreeUtils.ts
@@ -1,6 +1,5 @@
-import { logStructured as structuredLog } from '@grafana/runtime';
-
 import { type ScopeNode } from '@grafana/data';
+import { logStructured as structuredLog } from '@grafana/runtime';
 
 import { type NodesMap, type TreeNode } from './types';
 

--- a/public/app/features/scopes/selector/useScopeNode.ts
+++ b/public/app/features/scopes/selector/useScopeNode.ts
@@ -1,3 +1,5 @@
+import { logStructured as structuredLog } from '@grafana/runtime';
+
 import { useEffect, useState } from 'react';
 
 import { type ScopeNode } from '@grafana/data';
@@ -21,7 +23,7 @@ export function useScopeNode(scopeNodeId?: string) {
         const node = await scopesSelectorService.getScopeNode(scopeNodeId);
         setNode(node);
       } catch (error) {
-        console.error('Failed to load node', error);
+        structuredLog('grafana/frontend.features.scopes.selector.useScopeNode', 'error', 'Failed to load node', error);
       } finally {
         setIsLoading(false);
       }

--- a/public/app/features/scopes/selector/useScopeNode.ts
+++ b/public/app/features/scopes/selector/useScopeNode.ts
@@ -1,8 +1,7 @@
-import { logStructured as structuredLog } from '@grafana/runtime';
-
 import { useEffect, useState } from 'react';
 
 import { type ScopeNode } from '@grafana/data';
+import { logStructured as structuredLog } from '@grafana/runtime';
 
 import { useScopesServices } from '../ScopesContextProvider';
 

--- a/public/app/features/search/service/deletedDashboardsCache.ts
+++ b/public/app/features/search/service/deletedDashboardsCache.ts
@@ -1,5 +1,4 @@
 import { logStructured as structuredLog } from '@grafana/runtime';
-
 import { iamAPIv0alpha1, type DisplayList } from 'app/api/clients/iam/v0alpha1';
 import {
   AnnoKeyFolder,

--- a/public/app/features/search/service/deletedDashboardsCache.ts
+++ b/public/app/features/search/service/deletedDashboardsCache.ts
@@ -1,3 +1,5 @@
+import { logStructured as structuredLog } from '@grafana/runtime';
+
 import { iamAPIv0alpha1, type DisplayList } from 'app/api/clients/iam/v0alpha1';
 import {
   AnnoKeyFolder,
@@ -123,7 +125,12 @@ class DeletedDashboardsCache {
         rows: Array.from(deduped.values()),
       };
     } catch (error) {
-      console.error('Failed to fetch deleted dashboards:', error);
+      structuredLog(
+        'grafana/frontend.features.search.service.deletedDashboardsCache',
+        'error',
+        'Failed to fetch deleted dashboards:',
+        error
+      );
       return EMPTY_TABLE_RESPONSE;
     }
   }
@@ -220,7 +227,12 @@ export async function resolveDeletedByDisplayMap(
   } catch (error) {
     // `Promise.allSettled` cannot reject; this catches synchronous throws from `dispatch()`
     // itself. Mark every UID unknown so callers render placeholders, not raw UIDs.
-    console.error('Failed to resolve deleted dashboard user displays:', getMessageFromError(error));
+    structuredLog(
+      'grafana/frontend.features.search.service.deletedDashboardsCache',
+      'error',
+      'Failed to resolve deleted dashboard user displays:',
+      getMessageFromError(error)
+    );
     for (const uid of toFetch) {
       result.set(uid, DELETED_BY_UNKNOWN);
     }
@@ -233,12 +245,22 @@ function extractDisplayData(
   settled: PromiseSettledResult<{ data?: DisplayList; error?: unknown }>
 ): DisplayList | undefined {
   if (settled.status === 'rejected') {
-    console.error('Failed to resolve deleted dashboard user displays:', getMessageFromError(settled.reason));
+    structuredLog(
+      'grafana/frontend.features.search.service.deletedDashboardsCache',
+      'error',
+      'Failed to resolve deleted dashboard user displays:',
+      getMessageFromError(settled.reason)
+    );
     return undefined;
   }
   // RTK Query query thunks resolve (do not reject) on request errors — surface them explicitly.
   if (settled.value.error) {
-    console.error('Failed to resolve deleted dashboard user displays:', getMessageFromError(settled.value.error));
+    structuredLog(
+      'grafana/frontend.features.search.service.deletedDashboardsCache',
+      'error',
+      'Failed to resolve deleted dashboard user displays:',
+      getMessageFromError(settled.value.error)
+    );
     return undefined;
   }
   return settled.value.data;

--- a/public/app/features/search/service/unified.ts
+++ b/public/app/features/search/service/unified.ts
@@ -14,7 +14,7 @@ import {
   type SelectableValue,
 } from '@grafana/data';
 import { t } from '@grafana/i18n';
-import { config, getBackendSrv } from '@grafana/runtime';
+import { logStructured as structuredLog, config, getBackendSrv } from '@grafana/runtime';
 import { generatedAPI, type ListStarsApiResponse } from 'app/api/clients/collections/v1alpha1';
 import { getAPIBaseURL } from 'app/api/utils';
 import { type TermCount } from 'app/core/components/TagFilter/TagFilter';
@@ -204,7 +204,7 @@ export class UnifiedSearcher implements GrafanaSearcher {
         const resp = await this.fetchResponse(nextPageUrl);
         const frame = toDashboardResults(resp, query.sort ?? '');
         if (!frame) {
-          console.log('no results', frame);
+          structuredLog('grafana/frontend.features.search.service.unified', 'info', 'no results', frame);
           return;
         }
 

--- a/public/app/features/search/service/utils.ts
+++ b/public/app/features/search/service/utils.ts
@@ -1,3 +1,5 @@
+import { logStructured as structuredLog } from '@grafana/runtime';
+
 import { type ManagedBy } from '@grafana/api-clients/rtkq/dashboard/v0alpha1';
 import { type DataFrame, type DataFrameView, type IconName, fuzzySearch } from '@grafana/data';
 import { type DashboardViewItemWithUIItems } from 'app/features/browse-dashboards/types';
@@ -67,7 +69,7 @@ async function getCurrentFolderUID(): Promise<string | undefined> {
     }
     return Promise.resolve(dash?.meta?.folderUid);
   } catch (e) {
-    console.error(e);
+    structuredLog('grafana/frontend.features.search.service.utils', 'error', e);
   }
   return undefined;
 }

--- a/public/app/features/search/service/utils.ts
+++ b/public/app/features/search/service/utils.ts
@@ -1,7 +1,6 @@
-import { logStructured as structuredLog } from '@grafana/runtime';
-
 import { type ManagedBy } from '@grafana/api-clients/rtkq/dashboard/v0alpha1';
 import { type DataFrame, type DataFrameView, type IconName, fuzzySearch } from '@grafana/data';
+import { logStructured as structuredLog } from '@grafana/runtime';
 import { type DashboardViewItemWithUIItems } from 'app/features/browse-dashboards/types';
 import {
   isSharedWithMe,

--- a/public/app/features/serviceaccounts/ServiceAccountCreatePage.tsx
+++ b/public/app/features/serviceaccounts/ServiceAccountCreatePage.tsx
@@ -3,7 +3,7 @@ import { FormProvider, useForm } from 'react-hook-form';
 
 import { OrgRole } from '@grafana/data';
 import { Trans, t } from '@grafana/i18n';
-import { config, getBackendSrv, locationService } from '@grafana/runtime';
+import { logStructured as structuredLog, config, getBackendSrv, locationService } from '@grafana/runtime';
 import { Button, Input, Field, FieldSet } from '@grafana/ui';
 import { Form } from 'app/core/components/Form/Form';
 import { Page } from 'app/core/components/Page/Page';
@@ -68,7 +68,12 @@ export const ServiceAccountCreatePage = ({}: Props): JSX.Element => {
           setRoleOptions(options);
         }
       } catch (e) {
-        console.error('Error loading options', e); // TODO: handle error
+        structuredLog(
+          'grafana/frontend.features.serviceaccounts.ServiceAccountCreatePage',
+          'error',
+          'Error loading options',
+          e
+        ); // TODO: handle error
       }
     }
     if (contextSrv.licensedAccessControlEnabled()) {
@@ -101,7 +106,7 @@ export const ServiceAccountCreatePage = ({}: Props): JSX.Element => {
           await updateUserRoles(pendingRoles, newAccount.id, newAccount.orgId);
         }
       } catch (e) {
-        console.error(e); // TODO: handle error
+        structuredLog('grafana/frontend.features.serviceaccounts.ServiceAccountCreatePage', 'error', e); // TODO: handle error
       }
       locationService.push(`/org/serviceaccounts/${response.uid}`);
     },

--- a/public/app/features/serviceaccounts/components/ServiceAccountProfile.tsx
+++ b/public/app/features/serviceaccounts/components/ServiceAccountProfile.tsx
@@ -1,3 +1,5 @@
+import { logStructured as structuredLog } from '@grafana/runtime';
+
 import { css } from '@emotion/css';
 import { useEffect, useState, type JSX } from 'react';
 
@@ -39,7 +41,11 @@ export function ServiceAccountProfile({ serviceAccount, timeZone, onChange }: Pr
           setRoleOptions(options);
         }
       } catch (e) {
-        console.error('Error loading options for service account');
+        structuredLog(
+          'grafana/frontend.features.serviceaccounts.components.ServiceAccountProfile',
+          'error',
+          'Error loading options for service account'
+        );
       }
     }
     if (contextSrv.licensedAccessControlEnabled()) {

--- a/public/app/features/serviceaccounts/components/ServiceAccountProfile.tsx
+++ b/public/app/features/serviceaccounts/components/ServiceAccountProfile.tsx
@@ -1,10 +1,9 @@
-import { logStructured as structuredLog } from '@grafana/runtime';
-
 import { css } from '@emotion/css';
 import { useEffect, useState, type JSX } from 'react';
 
 import { type GrafanaTheme2, type OrgRole, type TimeZone, dateTimeFormat } from '@grafana/data';
 import { Trans, t } from '@grafana/i18n';
+import { logStructured as structuredLog } from '@grafana/runtime';
 import { Label, TextLink, useStyles2 } from '@grafana/ui';
 import { fetchRoleOptions } from 'app/core/components/RolePicker/api';
 import { contextSrv } from 'app/core/services/context_srv';

--- a/public/app/features/serviceaccounts/state/actions.ts
+++ b/public/app/features/serviceaccounts/state/actions.ts
@@ -1,6 +1,6 @@
 import { debounce } from 'lodash';
 
-import { getBackendSrv } from '@grafana/runtime';
+import { logStructured as structuredLog, getBackendSrv } from '@grafana/runtime';
 import { fetchRoleOptions } from 'app/core/components/RolePicker/api';
 import { contextSrv } from 'app/core/services/context_srv';
 import { AccessControlAction } from 'app/types/accessControl';
@@ -31,7 +31,7 @@ export function fetchACOptions(): ThunkResult<void> {
         dispatch(acOptionsLoaded(options));
       }
     } catch (error) {
-      console.error(error);
+      structuredLog('grafana/frontend.features.serviceaccounts.state.actions', 'error', error);
     }
   };
 }
@@ -76,7 +76,7 @@ export function fetchServiceAccounts(
         dispatch(serviceAccountsFetched(result));
       }
     } catch (error) {
-      console.error(error);
+      structuredLog('grafana/frontend.features.serviceaccounts.state.actions', 'error', error);
     } finally {
       dispatch(serviceAccountsFetchEnd());
     }

--- a/public/app/features/serviceaccounts/state/actionsServiceAccountPage.ts
+++ b/public/app/features/serviceaccounts/state/actionsServiceAccountPage.ts
@@ -1,4 +1,4 @@
-import { getBackendSrv, locationService } from '@grafana/runtime';
+import { logStructured as structuredLog, getBackendSrv, locationService } from '@grafana/runtime';
 import { accessControlQueryParam } from 'app/core/utils/accessControl';
 import { type ServiceAccountDTO } from 'app/types/serviceaccount';
 import { type ThunkResult } from 'app/types/store';
@@ -21,7 +21,7 @@ export function loadServiceAccount(saUid: string): ThunkResult<void> {
       const response = await getBackendSrv().get(`${BASE_URL}/${saUid}`, accessControlQueryParam());
       dispatch(serviceAccountLoaded(response));
     } catch (error) {
-      console.error(error);
+      structuredLog('grafana/frontend.features.serviceaccounts.state.actionsServiceAccountPage', 'error', error);
     } finally {
       dispatch(serviceAccountFetchEnd());
     }
@@ -69,7 +69,7 @@ export function loadServiceAccountTokens(saUid: string): ThunkResult<void> {
       const response = await getBackendSrv().get(`${BASE_URL}/${saUid}/tokens`);
       dispatch(serviceAccountTokensLoaded(response));
     } catch (error) {
-      console.error(error);
+      structuredLog('grafana/frontend.features.serviceaccounts.state.actionsServiceAccountPage', 'error', error);
     }
   };
 }

--- a/public/app/features/stars/hooks.ts
+++ b/public/app/features/stars/hooks.ts
@@ -9,7 +9,7 @@ import {
 import { API_GROUP as DASHBOARD_API_GROUP } from '@grafana/api-clients/rtkq/dashboard/v0alpha1';
 import { API_GROUP as FOLDER_API_GROUP } from '@grafana/api-clients/rtkq/folder/v1beta1';
 import { type IconName, locationUtil } from '@grafana/data';
-import { config } from '@grafana/runtime';
+import { logStructured as structuredLog, config } from '@grafana/runtime';
 import { useAddStarMutation, useRemoveStarMutation, useListStarsQuery } from 'app/api/clients/collections/v1alpha1';
 import { setStarred, setStarredItems, type StarredNavItem } from 'app/core/reducers/navBarTree';
 import { contextSrv } from 'app/core/services/context_srv';
@@ -238,7 +238,7 @@ export const useSyncStarredItemsInNav = () => {
         setSearchFailed(false);
       })
       .catch((err) => {
-        console.error('Failed to sync starred items to nav', err);
+        structuredLog('grafana/frontend.features.stars.hooks', 'error', 'Failed to sync starred items to nav', err);
         // Resolve the loading state rather than showing it forever
         setHasSynced(true);
         setSearchFailed(true);

--- a/public/app/features/teams/TeamList.tsx
+++ b/public/app/features/teams/TeamList.tsx
@@ -5,7 +5,7 @@ import { type SortingRule } from 'react-table';
 
 import { type DashboardHit } from '@grafana/api-clients/rtkq/dashboard/v0alpha1';
 import { Trans, t } from '@grafana/i18n';
-import { reportInteraction } from '@grafana/runtime';
+import { logStructured as structuredLog, reportInteraction } from '@grafana/runtime';
 import {
   Avatar,
   type CellProps,
@@ -234,7 +234,7 @@ const TeamList = () => {
                   'Failed to check if the team owns folders. Please try again.'
                 )
               );
-              console.error(error);
+              structuredLog('grafana/frontend.features.teams.TeamList', 'error', error);
               return;
             }
 

--- a/public/app/features/templating/formatVariableValue.ts
+++ b/public/app/features/templating/formatVariableValue.ts
@@ -1,5 +1,4 @@
 import { logStructured as structuredLog } from '@grafana/runtime';
-
 import { formatRegistry } from '@grafana/scenes';
 import { VariableFormatID } from '@grafana/schema';
 

--- a/public/app/features/templating/formatVariableValue.ts
+++ b/public/app/features/templating/formatVariableValue.ts
@@ -1,3 +1,5 @@
+import { logStructured as structuredLog } from '@grafana/runtime';
+
 import { formatRegistry } from '@grafana/scenes';
 import { VariableFormatID } from '@grafana/schema';
 
@@ -42,7 +44,11 @@ export function formatVariableValue(value: any, format?: any, variable?: any, te
   let formatItem = formatRegistry.getIfExists(format);
 
   if (!formatItem) {
-    console.error(`Variable format ${format} not found. Using glob format as fallback.`);
+    structuredLog(
+      'grafana/frontend.features.templating.formatVariableValue',
+      'error',
+      `Variable format ${format} not found. Using glob format as fallback.`
+    );
     formatItem = formatRegistry.get(VariableFormatID.Glob);
   }
 

--- a/public/app/features/theme-playground/ThemePlayground.tsx
+++ b/public/app/features/theme-playground/ThemePlayground.tsx
@@ -21,7 +21,7 @@ import victorian from '@grafana/data/themes/definitions/victorian.json';
 import zen from '@grafana/data/themes/definitions/zen.json';
 import themeJsonSchema from '@grafana/data/themes/schema.generated.json';
 import { t } from '@grafana/i18n';
-import { useChromeHeaderHeight } from '@grafana/runtime';
+import { logStructured as structuredLog, useChromeHeaderHeight } from '@grafana/runtime';
 import { useFlagGrafanaVisualDesignRefresh } from '@grafana/runtime/internal';
 import { CodeEditor, Combobox, Field, Stack, useStyles2 } from '@grafana/ui';
 import { ThemeDemo } from '@grafana/ui/internal';
@@ -74,7 +74,11 @@ const experimentalDefinitions: Record<string, unknown> = {
 for (const [name, json] of Object.entries(experimentalDefinitions)) {
   const result = NewThemeOptionsSchema.safeParse(json);
   if (!result.success) {
-    console.error(`Invalid theme definition for theme ${name}: ${result.error.message}`);
+    structuredLog(
+      'grafana/frontend.features.theme-playground.ThemePlayground',
+      'error',
+      `Invalid theme definition for theme ${name}: ${result.error.message}`
+    );
   } else {
     themeMap[result.data.id] = result.data;
   }

--- a/public/app/features/transformers/editors/FilterByNameTransformerEditor.tsx
+++ b/public/app/features/transformers/editors/FilterByNameTransformerEditor.tsx
@@ -9,7 +9,7 @@ import {
 } from '@grafana/data';
 import { type FilterFieldsByNameTransformerOptions } from '@grafana/data/internal';
 import { t } from '@grafana/i18n';
-import { getTemplateSrv } from '@grafana/runtime';
+import { logStructured as structuredLog, getTemplateSrv } from '@grafana/runtime';
 import { Input, FilterPill, InlineFieldRow, InlineField, InlineSwitch, Select } from '@grafana/ui';
 
 interface FilterByNameTransformerEditorProps extends TransformerUIProps<FilterFieldsByNameTransformerOptions> {}
@@ -94,7 +94,7 @@ export class FilterByNameTransformerEditor extends React.PureComponent<
           }
         }
       } catch (error) {
-        console.error(error);
+        structuredLog('grafana/frontend.features.transformers.editors.FilterByNameTransformerEditor', 'error', error);
       }
     }
 

--- a/public/app/features/transformers/extractFields/fieldExtractors.ts
+++ b/public/app/features/transformers/extractFields/fieldExtractors.ts
@@ -1,6 +1,5 @@
-import { logStructured as structuredLog } from '@grafana/runtime';
-
 import { escapeStringForRegex, Registry, type RegistryItem, stringStartsAsRegEx, stringToJsRegex } from '@grafana/data';
+import { logStructured as structuredLog } from '@grafana/runtime';
 
 import { type ExtractFieldsOptions, FieldExtractorID } from './types';
 

--- a/public/app/features/transformers/extractFields/fieldExtractors.ts
+++ b/public/app/features/transformers/extractFields/fieldExtractors.ts
@@ -1,3 +1,5 @@
+import { logStructured as structuredLog } from '@grafana/runtime';
+
 import { escapeStringForRegex, Registry, type RegistryItem, stringStartsAsRegEx, stringToJsRegex } from '@grafana/data';
 
 import { type ExtractFieldsOptions, FieldExtractorID } from './types';
@@ -29,7 +31,7 @@ const extRegExp: FieldExtractor = {
         regex = stringToJsRegex(options.regExp!);
       } catch (error) {
         if (error instanceof Error) {
-          console.warn(error.message);
+          structuredLog('grafana/frontend.features.transformers.extractFields.fieldExtractors', 'warn', error.message);
         }
       }
     }

--- a/public/app/features/variables/pickers/OptionsPicker/OptionsPicker.tsx
+++ b/public/app/features/variables/pickers/OptionsPicker/OptionsPicker.tsx
@@ -1,5 +1,3 @@
-import { logStructured as structuredLog } from '@grafana/runtime';
-
 import { css } from '@emotion/css';
 import { type ComponentType, memo } from 'react';
 import { connect, type ConnectedProps } from 'react-redux';
@@ -12,6 +10,7 @@ import {
   type VariableWithOptions,
 } from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';
+import { logStructured as structuredLog } from '@grafana/runtime';
 import { ClickOutsideWrapper } from '@grafana/ui';
 import { type StoreState, type ThunkDispatch } from 'app/types/store';
 

--- a/public/app/features/variables/pickers/OptionsPicker/OptionsPicker.tsx
+++ b/public/app/features/variables/pickers/OptionsPicker/OptionsPicker.tsx
@@ -1,3 +1,5 @@
+import { logStructured as structuredLog } from '@grafana/runtime';
+
 import { css } from '@emotion/css';
 import { type ComponentType, memo } from 'react';
 import { connect, type ConnectedProps } from 'react-redux';
@@ -59,7 +61,11 @@ export const optionPickerFactory = <Model extends VariableWithOptions | Variable
   const mapStateToProps = (state: StoreState, ownProps: OwnProps) => {
     const { rootStateKey } = ownProps.variable;
     if (!rootStateKey) {
-      console.error('OptionPickerFactory: variable has no rootStateKey');
+      structuredLog(
+        'grafana/frontend.features.variables.pickers.OptionsPicker.OptionsPicker',
+        'error',
+        'OptionPickerFactory: variable has no rootStateKey'
+      );
       return {
         picker: initialOptionPickerState,
       };
@@ -94,7 +100,11 @@ export const optionPickerFactory = <Model extends VariableWithOptions | Variable
 
     function onHideOptions() {
       if (!variable.rootStateKey) {
-        console.error('Variable has no rootStateKey');
+        structuredLog(
+          'grafana/frontend.features.variables.pickers.OptionsPicker.OptionsPicker',
+          'error',
+          'Variable has no rootStateKey'
+        );
         return;
       }
       commitChangesToVariable(variable.rootStateKey, onVariableChange);
@@ -124,7 +134,11 @@ export const optionPickerFactory = <Model extends VariableWithOptions | Variable
 
     function onNavigate(key: NavigationKey, clearOthers: boolean) {
       if (!variable.rootStateKey) {
-        console.error('Variable has no rootStateKey');
+        structuredLog(
+          'grafana/frontend.features.variables.pickers.OptionsPicker.OptionsPicker',
+          'error',
+          'Variable has no rootStateKey'
+        );
         return;
       }
       navigateOptions(variable.rootStateKey, key, clearOthers);

--- a/public/app/features/variables/pickers/OptionsPicker/actions.ts
+++ b/public/app/features/variables/pickers/OptionsPicker/actions.ts
@@ -1,3 +1,5 @@
+import { logStructured as structuredLog } from '@grafana/runtime';
+
 import { debounce, trim } from 'lodash';
 
 import { isEmptyObject, containsSearchFilter, type VariableWithOptions, type VariableOption } from '@grafana/data';
@@ -180,7 +182,7 @@ const searchForOptions = async (
 
     dispatch(toKeyedAction(key, updateOptionsFromSearch(updated.options)));
   } catch (error) {
-    console.error(error);
+    structuredLog('grafana/frontend.features.variables.pickers.OptionsPicker.actions', 'error', error);
   }
 };
 

--- a/public/app/features/variables/pickers/OptionsPicker/actions.ts
+++ b/public/app/features/variables/pickers/OptionsPicker/actions.ts
@@ -1,8 +1,7 @@
-import { logStructured as structuredLog } from '@grafana/runtime';
-
 import { debounce, trim } from 'lodash';
 
 import { isEmptyObject, containsSearchFilter, type VariableWithOptions, type VariableOption } from '@grafana/data';
+import { logStructured as structuredLog } from '@grafana/runtime';
 import { type StoreState, type ThunkDispatch, type ThunkResult } from 'app/types/store';
 
 import { variableAdapters } from '../../adapters';

--- a/public/app/features/variables/query/operators.ts
+++ b/public/app/features/variables/query/operators.ts
@@ -1,3 +1,5 @@
+import { logStructured as structuredLog } from '@grafana/runtime';
+
 import { from, of, type OperatorFunction } from 'rxjs';
 import { map, mergeMap } from 'rxjs/operators';
 
@@ -110,7 +112,11 @@ export function updateOptionsState(args: {
       map((results) => {
         const { variable, dispatch, getTemplatedRegexFunc } = args;
         if (!variable.rootStateKey) {
-          console.error('updateOptionsState: variable.rootStateKey is not defined');
+          structuredLog(
+            'grafana/frontend.features.variables.query.operators',
+            'error',
+            'updateOptionsState: variable.rootStateKey is not defined'
+          );
           return;
         }
         const templatedRegex = getTemplatedRegexFunc(variable);

--- a/public/app/features/variables/query/operators.ts
+++ b/public/app/features/variables/query/operators.ts
@@ -1,5 +1,3 @@
-import { logStructured as structuredLog } from '@grafana/runtime';
-
 import { from, of, type OperatorFunction } from 'rxjs';
 import { map, mergeMap } from 'rxjs/operators';
 
@@ -12,6 +10,7 @@ import {
   type PanelData,
   type QueryVariableModel,
 } from '@grafana/data';
+import { logStructured as structuredLog } from '@grafana/runtime';
 import { type ThunkDispatch } from 'app/types/store';
 
 import { validateVariableSelectionState } from '../state/actions';

--- a/public/app/features/variables/state/actions.ts
+++ b/public/app/features/variables/state/actions.ts
@@ -20,7 +20,7 @@ import {
   VariableRefresh,
   type VariableWithOptions,
 } from '@grafana/data';
-import { locationService, logWarning } from '@grafana/runtime';
+import { logStructured as structuredLog, locationService, logWarning } from '@grafana/runtime';
 import { notifyApp } from 'app/core/reducers/appNotification';
 import { contextSrv } from 'app/core/services/context_srv';
 import { getTimeSrv } from 'app/features/dashboard/services/TimeSrv';
@@ -661,7 +661,7 @@ export const onTimeRangeUpdated =
       await Promise.all(promises);
       dependencies.events.publish(new VariablesTimeRangeProcessDone({ variableIds }));
     } catch (error) {
-      console.error(error);
+      structuredLog('grafana/frontend.features.variables.state.actions', 'error', error);
       dispatch(notifyApp(createVariableErrorNotification('Template variable service failed', error)));
     }
   };
@@ -815,7 +815,7 @@ export const initVariablesTransaction =
       dispatch(toKeyedAction(uid, variablesCompleteTransaction({ uid })));
     } catch (err) {
       dispatch(notifyApp(createVariableErrorNotification('Templating init failed', err)));
-      console.error(err);
+      structuredLog('grafana/frontend.features.variables.state.actions', 'error', err);
     }
   };
 
@@ -885,7 +885,7 @@ export const updateOptions =
       dispatch(toKeyedAction(rootStateKey, variableStateFailed(toVariablePayload(identifier, { error }))));
 
       if (!rethrow) {
-        console.error(error);
+        structuredLog('grafana/frontend.features.variables.state.actions', 'error', error);
         dispatch(notifyApp(createVariableErrorNotification('Error updating options:', error, identifier)));
       }
 
@@ -965,7 +965,7 @@ export function upgradeLegacyQueries(
       );
     } catch (err) {
       dispatch(notifyApp(createVariableErrorNotification('Failed to upgrade legacy queries', err)));
-      console.error(err);
+      structuredLog('grafana/frontend.features.variables.state.actions', 'error', err);
     }
   };
 }

--- a/public/app/features/variables/switch/SwitchVariablePicker.tsx
+++ b/public/app/features/variables/switch/SwitchVariablePicker.tsx
@@ -1,3 +1,5 @@
+import { logStructured as structuredLog } from '@grafana/runtime';
+
 import { type ChangeEvent, type ReactElement, useCallback } from 'react';
 
 import { type SwitchVariableModel } from '@grafana/data';
@@ -12,7 +14,11 @@ export function SwitchVariablePicker({ variable, onVariableChange }: Props): Rea
   const updateVariable = useCallback(
     (event: ChangeEvent<HTMLInputElement>) => {
       if (!variable.rootStateKey) {
-        console.error('Cannot update variable without rootStateKey');
+        structuredLog(
+          'grafana/frontend.features.variables.switch.SwitchVariablePicker',
+          'error',
+          'Cannot update variable without rootStateKey'
+        );
         return;
       }
 

--- a/public/app/features/variables/switch/SwitchVariablePicker.tsx
+++ b/public/app/features/variables/switch/SwitchVariablePicker.tsx
@@ -1,8 +1,7 @@
-import { logStructured as structuredLog } from '@grafana/runtime';
-
 import { type ChangeEvent, type ReactElement, useCallback } from 'react';
 
 import { type SwitchVariableModel } from '@grafana/data';
+import { logStructured as structuredLog } from '@grafana/runtime';
 import { Switch } from '@grafana/ui';
 
 import { variableAdapters } from '../adapters';

--- a/public/app/features/variables/textbox/TextBoxVariablePicker.tsx
+++ b/public/app/features/variables/textbox/TextBoxVariablePicker.tsx
@@ -1,3 +1,5 @@
+import { logStructured as structuredLog } from '@grafana/runtime';
+
 import {
   type ChangeEvent,
   type FocusEvent,
@@ -31,7 +33,11 @@ export function TextBoxVariablePicker({ variable, onVariableChange, readOnly }: 
 
   const updateVariable = useCallback(() => {
     if (!variable.rootStateKey) {
-      console.error('Cannot update variable without rootStateKey');
+      structuredLog(
+        'grafana/frontend.features.variables.textbox.TextBoxVariablePicker',
+        'error',
+        'Cannot update variable without rootStateKey'
+      );
       return;
     }
 

--- a/public/app/features/variables/textbox/TextBoxVariablePicker.tsx
+++ b/public/app/features/variables/textbox/TextBoxVariablePicker.tsx
@@ -1,5 +1,3 @@
-import { logStructured as structuredLog } from '@grafana/runtime';
-
 import {
   type ChangeEvent,
   type FocusEvent,
@@ -12,6 +10,7 @@ import {
 
 import { type TextBoxVariableModel, isEmptyObject } from '@grafana/data';
 import { t } from '@grafana/i18n';
+import { logStructured as structuredLog } from '@grafana/runtime';
 import { Input } from '@grafana/ui';
 import { useDispatch } from 'app/types/store';
 

--- a/public/app/index.ts
+++ b/public/app/index.ts
@@ -1,3 +1,5 @@
+import { logStructured as structuredLog } from '@grafana/runtime';
+
 // The new index.html fetches window.grafanaBootData asynchronously.
 // Since much of Grafana depends on it in includes side effects at import time,
 // we delay loading the rest of the app using import() until the boot data is ready.
@@ -47,7 +49,7 @@ bootstrapWindowData().catch((error) => {
   const isRedirect = error && error.redirect && typeof error.redirect === 'string';
   // If a redirect was thrown, just ignore this. The index.html will handle the redirect
   if (!isRedirect) {
-    console.error('Error bootstrapping Grafana', error);
+    structuredLog('grafana/frontend.index', 'error', 'Error bootstrapping Grafana', error);
     window.__grafana_load_failed(error);
   }
 });

--- a/public/app/index.ts
+++ b/public/app/index.ts
@@ -1,10 +1,9 @@
+import type { Preferences } from '@grafana/api-clients/rtkq/preferences/v1';
 import { logStructured as structuredLog } from '@grafana/runtime';
 
 // The new index.html fetches window.grafanaBootData asynchronously.
 // Since much of Grafana depends on it in includes side effects at import time,
 // we delay loading the rest of the app using import() until the boot data is ready.
-
-import type { Preferences } from '@grafana/api-clients/rtkq/preferences/v1';
 
 import { initPreferences } from './initPreferences';
 import { patchFetchForLegacyAPIMode } from './legacyAPIHandling';

--- a/public/app/initPreferences.ts
+++ b/public/app/initPreferences.ts
@@ -1,6 +1,5 @@
-import { logStructured as structuredLog } from '@grafana/runtime';
-
 import type { Preferences } from '@grafana/api-clients/rtkq/preferences/v1';
+import { logStructured as structuredLog } from '@grafana/runtime';
 
 export const initPreferences = async (): Promise<Preferences | undefined> => {
   const preferences = await fetchMergedPreferences();

--- a/public/app/initPreferences.ts
+++ b/public/app/initPreferences.ts
@@ -1,3 +1,5 @@
+import { logStructured as structuredLog } from '@grafana/runtime';
+
 import type { Preferences } from '@grafana/api-clients/rtkq/preferences/v1';
 
 export const initPreferences = async (): Promise<Preferences | undefined> => {
@@ -51,7 +53,7 @@ export async function fetchMergedPreferences(): Promise<Preferences | undefined>
     }
     return await resp.json();
   } catch (err) {
-    console.warn('Failed to fetch merged preferences', err);
+    structuredLog('grafana/frontend.initPreferences', 'warn', 'Failed to fetch merged preferences', err);
     return undefined;
   }
 }

--- a/public/app/legacyAPIHandling.ts
+++ b/public/app/legacyAPIHandling.ts
@@ -1,3 +1,5 @@
+import { logStructured as structuredLog } from '@grafana/runtime';
+
 // Controlled by the `grafana.frontendLegacyAPIHandling` feature flag, monkey-patches
 // fetch to log or block calls to legacy /api/ endpoints
 export function patchFetchForLegacyAPIMode() {
@@ -21,7 +23,7 @@ export function patchFetchForLegacyAPIMode() {
       return Promise.reject(new Error(`Request to legacy api ${url.pathname} blocked`));
     }
 
-    console.warn(`Request made to legacy api ${url.pathname}`);
+    structuredLog('grafana/frontend.legacyAPIHandling', 'warn', `Request made to legacy api ${url.pathname}`);
     return originalFetch(input, init);
   };
 }

--- a/public/app/plugins/datasource/azuremonitor/azure_monitor/azure_monitor_datasource.ts
+++ b/public/app/plugins/datasource/azuremonitor/azure_monitor/azure_monitor_datasource.ts
@@ -3,6 +3,7 @@ import { find } from 'lodash';
 import { type AzureCredentials } from '@grafana/azure-sdk';
 import { type ScopedVars } from '@grafana/data';
 import {
+  logStructured as structuredLog,
   config,
   DataSourceWithBackend,
   getTemplateSrv,
@@ -267,7 +268,11 @@ export default class AzureMonitorDatasource extends DataSourceWithBackend<
         return result;
       })
       .catch((reason) => {
-        console.error(`Failed to get metric namespaces: ${reason}`);
+        structuredLog(
+          'grafana/frontend.plugins.datasource.azuremonitor.azure_monitor.azure_monitor_datasource',
+          'error',
+          `Failed to get metric namespaces: ${reason}`
+        );
         return [];
       });
   }

--- a/public/app/plugins/datasource/azuremonitor/components/LogsQueryEditor/LogsQueryEditor.tsx
+++ b/public/app/plugins/datasource/azuremonitor/components/LogsQueryEditor/LogsQueryEditor.tsx
@@ -3,7 +3,7 @@ import { useEffect, useState } from 'react';
 import { type PanelData, type TimeRange } from '@grafana/data';
 import { Trans } from '@grafana/i18n';
 import { EditorFieldGroup, EditorRow, EditorRows } from '@grafana/plugin-ui';
-import { config, getTemplateSrv } from '@grafana/runtime';
+import { logStructured as structuredLog, config, getTemplateSrv } from '@grafana/runtime';
 import { Alert, LinkButton, Space, Text, TextLink } from '@grafana/ui';
 
 import { LogsEditorMode, ResultFormat } from '../../dataquery.gen';
@@ -193,11 +193,21 @@ const LogsQueryEditor = ({
           setDataIngestedWarning(null);
         }
       } catch (err) {
-        console.error(err);
+        structuredLog(
+          'grafana/frontend.plugins.datasource.azuremonitor.components.LogsQueryEditor.LogsQueryEditor',
+          'error',
+          err
+        );
       }
     };
 
-    getBasicLogsUsage(query).catch((err) => console.error(err));
+    getBasicLogsUsage(query).catch((err) =>
+      structuredLog(
+        'grafana/frontend.plugins.datasource.azuremonitor.components.LogsQueryEditor.LogsQueryEditor',
+        'error',
+        err
+      )
+    );
   }, [datasource.azureLogAnalyticsDatasource, query, showBasicLogsToggle, from, to]);
   let portalLinkButton = null;
 

--- a/public/app/plugins/datasource/azuremonitor/components/LogsQueryEditor/QueryField.tsx
+++ b/public/app/plugins/datasource/azuremonitor/components/LogsQueryEditor/QueryField.tsx
@@ -1,8 +1,7 @@
-import { logStructured as structuredLog } from '@grafana/runtime';
-
 import { type EngineSchema, getKustoWorker } from '@kusto/monaco-kusto';
 import { useCallback, useEffect, useState } from 'react';
 
+import { logStructured as structuredLog } from '@grafana/runtime';
 import { CodeEditor, type Monaco, type MonacoEditor } from '@grafana/ui';
 
 import { type AzureQueryEditorFieldProps } from '../../types/types';

--- a/public/app/plugins/datasource/azuremonitor/components/LogsQueryEditor/QueryField.tsx
+++ b/public/app/plugins/datasource/azuremonitor/components/LogsQueryEditor/QueryField.tsx
@@ -1,3 +1,5 @@
+import { logStructured as structuredLog } from '@grafana/runtime';
+
 import { type EngineSchema, getKustoWorker } from '@kusto/monaco-kusto';
 import { useCallback, useEffect, useState } from 'react';
 
@@ -29,11 +31,21 @@ const QueryField = ({ query, onQueryChange, schema }: AzureQueryEditorFieldProps
           await kustoMode.setSchema(schema);
         }
       } catch (err) {
-        console.error(err);
+        structuredLog(
+          'grafana/frontend.plugins.datasource.azuremonitor.components.LogsQueryEditor.QueryField',
+          'error',
+          err
+        );
       }
     };
 
-    setupEditor(monaco, schema).catch((err) => console.error(err));
+    setupEditor(monaco, schema).catch((err) =>
+      structuredLog(
+        'grafana/frontend.plugins.datasource.azuremonitor.components.LogsQueryEditor.QueryField',
+        'error',
+        err
+      )
+    );
   }, [schema, monaco]);
 
   const handleEditorMount = useCallback((editor: MonacoEditor, monaco: Monaco) => {

--- a/public/app/plugins/datasource/azuremonitor/credentials.ts
+++ b/public/app/plugins/datasource/azuremonitor/credentials.ts
@@ -6,7 +6,7 @@ import {
   resolveLegacyCloudName,
   updateDatasourceCredentials,
 } from '@grafana/azure-sdk';
-import { config } from '@grafana/runtime';
+import { logStructured as structuredLog, config } from '@grafana/runtime';
 
 import { type AzureMonitorDataSourceInstanceSettings, type AzureMonitorDataSourceSettings } from './types/types';
 
@@ -57,7 +57,12 @@ function getLegacyCredentials(
     return { authType: options.jsonData.azureAuthType };
   } catch (e) {
     if (e instanceof Error) {
-      console.error('Unable to restore legacy credentials: %s', e.message);
+      structuredLog(
+        'grafana/frontend.plugins.datasource.azuremonitor.credentials',
+        'error',
+        'Unable to restore legacy credentials: %s',
+        e.message
+      );
     }
     return undefined;
   }

--- a/public/app/plugins/datasource/azuremonitor/resourcePicker/resourcePickerData.ts
+++ b/public/app/plugins/datasource/azuremonitor/resourcePicker/resourcePickerData.ts
@@ -1,7 +1,7 @@
 import { uniq } from 'lodash';
 
 import { AzureCloud, getDefaultAzureCloud } from '@grafana/azure-sdk';
-import { DataSourceWithBackend, reportInteraction } from '@grafana/runtime';
+import { logStructured as structuredLog, DataSourceWithBackend, reportInteraction } from '@grafana/runtime';
 
 import { logsResourceTypes } from '../azureMetadata/logsResourceTypes';
 import { resourceTypeDisplayNames, resourceTypes } from '../azureMetadata/resourceTypes';
@@ -355,7 +355,12 @@ export default class ResourcePickerData extends DataSourceWithBackend<
           }
         }
       } catch (e) {
-        console.warn(`Failed to fetch metric namespaces for region ${region}, falling back to predefined list:`, e);
+        structuredLog(
+          'grafana/frontend.plugins.datasource.azuremonitor.resourcePicker.resourcePickerData',
+          'warn',
+          `Failed to fetch metric namespaces for region ${region}, falling back to predefined list:`,
+          e
+        );
       }
     };
 

--- a/public/app/plugins/datasource/cloudwatch/components/shared/LogGroups/LogGroupsField.tsx
+++ b/public/app/plugins/datasource/cloudwatch/components/shared/LogGroups/LogGroupsField.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react';
 
 import { EditorField, EditorRow } from '@grafana/plugin-ui';
-import { config } from '@grafana/runtime';
+import { logStructured as structuredLog, config } from '@grafana/runtime';
 import { Box, Stack } from '@grafana/ui';
 
 import { type LogGroup, type LogGroupClass, LogsQueryLanguage, type LogsQueryScope } from '../../../dataquery.gen';
@@ -92,7 +92,11 @@ export const LogGroupsField = ({
           onChange([...logGroups, ...variables.map((v) => ({ name: v, arn: v }))]);
         })
         .catch((err) => {
-          console.error(err);
+          structuredLog(
+            'grafana/frontend.plugins.datasource.cloudwatch.components.shared.LogGroups.LogGroupsField',
+            'error',
+            err
+          );
         });
     }
   }, [datasource, legacyLogGroupNames, logGroups, onChange, region, loadingLogGroupsStarted]);

--- a/public/app/plugins/datasource/cloudwatch/tracking.ts
+++ b/public/app/plugins/datasource/cloudwatch/tracking.ts
@@ -1,5 +1,5 @@
 import { type DashboardLoadedEvent } from '@grafana/data';
-import { config, reportInteraction } from '@grafana/runtime';
+import { logStructured as structuredLog, config, reportInteraction } from '@grafana/runtime';
 
 import {
   type CloudWatchLogsQuery,
@@ -146,7 +146,12 @@ export const onDashboardLoadedHandler = ({
 
     reportInteraction('grafana_ds_cloudwatch_dashboard_loaded', e);
   } catch (error) {
-    console.error('error in cloudwatch tracking handler', error);
+    structuredLog(
+      'grafana/frontend.plugins.datasource.cloudwatch.tracking',
+      'error',
+      'error in cloudwatch tracking handler',
+      error
+    );
   }
 };
 

--- a/public/app/plugins/datasource/cloudwatch/utils/datalinks.ts
+++ b/public/app/plugins/datasource/cloudwatch/utils/datalinks.ts
@@ -7,7 +7,7 @@ import {
   type ScopedVars,
   type TimeRange,
 } from '@grafana/data';
-import { config, getDataSourceSrv } from '@grafana/runtime';
+import { logStructured as structuredLog, config, getDataSourceSrv } from '@grafana/runtime';
 
 import { type AwsUrl, encodeUrl } from '../aws_url';
 import { type CloudWatchLogsQuery } from '../dataquery.gen';
@@ -67,7 +67,12 @@ async function createInternalXrayLink(datasourceUid: string, region: string): Pr
   try {
     ds = await getDataSourceSrv().get(datasourceUid);
   } catch (e) {
-    console.error('Could not load linked xray data source, it was probably deleted after it was linked', e);
+    structuredLog(
+      'grafana/frontend.plugins.datasource.cloudwatch.utils.datalinks',
+      'error',
+      'Could not load linked xray data source, it was probably deleted after it was linked',
+      e
+    );
     return undefined;
   }
 

--- a/public/app/plugins/datasource/cloudwatch/variables.ts
+++ b/public/app/plugins/datasource/cloudwatch/variables.ts
@@ -1,5 +1,3 @@
-import { logStructured as structuredLog } from '@grafana/runtime';
-
 import { from, type Observable } from 'rxjs';
 import { map } from 'rxjs/operators';
 
@@ -10,6 +8,7 @@ import {
   type MetricFindValue,
   type SelectableValue,
 } from '@grafana/data';
+import { logStructured as structuredLog } from '@grafana/runtime';
 
 import { VariableQueryEditor } from './components/VariableQueryEditor/VariableQueryEditor';
 import { ALL_ACCOUNTS_OPTION } from './components/shared/Account';

--- a/public/app/plugins/datasource/cloudwatch/variables.ts
+++ b/public/app/plugins/datasource/cloudwatch/variables.ts
@@ -1,3 +1,5 @@
+import { logStructured as structuredLog } from '@grafana/runtime';
+
 import { from, type Observable } from 'rxjs';
 import { map } from 'rxjs/operators';
 
@@ -57,7 +59,12 @@ export class CloudWatchVariableSupport extends CustomVariableSupport<CloudWatchD
           return this.handleAccountsQuery(query);
       }
     } catch (error) {
-      console.error(`Could not run CloudWatchMetricFindQuery ${query}`, error);
+      structuredLog(
+        'grafana/frontend.plugins.datasource.cloudwatch.variables',
+        'error',
+        `Could not run CloudWatchMetricFindQuery ${query}`,
+        error
+      );
       return [];
     }
   }

--- a/public/app/plugins/datasource/dashboard/datasource.ts
+++ b/public/app/plugins/datasource/dashboard/datasource.ts
@@ -1,5 +1,3 @@
-import { logStructured as structuredLog } from '@grafana/runtime';
-
 import { type Observable, debounce, debounceTime, defer, filter, finalize, first, interval, map, of } from 'rxjs';
 
 import {
@@ -23,6 +21,7 @@ import {
   type DataSourceGetDrilldownsApplicabilityOptions,
   type DrilldownsApplicability,
 } from '@grafana/data';
+import { logStructured as structuredLog } from '@grafana/runtime';
 import {
   isSceneObject,
   sceneGraph,

--- a/public/app/plugins/datasource/dashboard/datasource.ts
+++ b/public/app/plugins/datasource/dashboard/datasource.ts
@@ -1,3 +1,5 @@
+import { logStructured as structuredLog } from '@grafana/runtime';
+
 import { type Observable, debounce, debounceTime, defer, filter, finalize, first, interval, map, of } from 'rxjs';
 
 import {
@@ -313,7 +315,13 @@ export class DashboardDatasource extends DataSourceApi<DashboardQuery> {
         options: { value: filter.value },
       });
     } catch (error) {
-      console.warn('Failed to create value matcher for filter:', filter, error);
+      structuredLog(
+        'grafana/frontend.plugins.datasource.dashboard.datasource',
+        'warn',
+        'Failed to create value matcher for filter:',
+        filter,
+        error
+      );
       return null;
     }
   }

--- a/public/app/plugins/datasource/grafana-testdata-datasource/components/RawFrameEditor.tsx
+++ b/public/app/plugins/datasource/grafana-testdata-datasource/components/RawFrameEditor.tsx
@@ -2,7 +2,7 @@ import { isArray } from 'lodash';
 import { useState } from 'react';
 
 import { dataFrameToJSON, toDataFrame, toDataFrameDTO } from '@grafana/data';
-import { toDataQueryResponse } from '@grafana/runtime';
+import { logStructured as structuredLog, toDataQueryResponse } from '@grafana/runtime';
 import { Alert, CodeEditor } from '@grafana/ui';
 
 import { type EditorProps } from '../QueryEditor';
@@ -35,8 +35,18 @@ export const RawFrameEditor = ({ onChange, query }: EditorProps) => {
       }
 
       if (data) {
-        console.log('Original', json);
-        console.log('Save', data);
+        structuredLog(
+          'grafana/frontend.plugins.datasource.grafana-testdata-datasource.components.RawFrameEditor',
+          'info',
+          'Original',
+          json
+        );
+        structuredLog(
+          'grafana/frontend.plugins.datasource.grafana-testdata-datasource.components.RawFrameEditor',
+          'info',
+          'Save',
+          data
+        );
         setError(undefined);
         setWarning('Converted to direct frame result');
         onChange({ ...query, rawFrameContent: JSON.stringify(data, null, 2) });
@@ -45,7 +55,12 @@ export const RawFrameEditor = ({ onChange, query }: EditorProps) => {
 
       setError('Unable to read dataframes in text');
     } catch (e) {
-      console.log('Error parsing json', e);
+      structuredLog(
+        'grafana/frontend.plugins.datasource.grafana-testdata-datasource.components.RawFrameEditor',
+        'info',
+        'Error parsing json',
+        e
+      );
       setError('Enter JSON array of data frames (or raw query results body)');
       setWarning(undefined);
     }

--- a/public/app/plugins/datasource/grafana-testdata-datasource/runStreams.ts
+++ b/public/app/plugins/datasource/grafana-testdata-datasource/runStreams.ts
@@ -18,7 +18,7 @@ import {
   createTheme,
   generateUUID,
 } from '@grafana/data';
-import { getBackendSrv } from '@grafana/runtime';
+import { logStructured as structuredLog, getBackendSrv } from '@grafana/runtime';
 
 import { getRandomLine } from './LogIpsum';
 import { type TestDataDataQuery, type StreamingQuery } from './dataquery';
@@ -125,7 +125,11 @@ function runSignalStream(
     setTimeout(pushNextEvent, 5);
 
     return () => {
-      console.log('unsubscribing to stream ' + streamId);
+      structuredLog(
+        'grafana/frontend.plugins.datasource.grafana-testdata-datasource.runStreams',
+        'info',
+        'unsubscribing to stream ' + streamId
+      );
       clearTimeout(timeoutId);
     };
   });
@@ -171,7 +175,11 @@ function runLogsStream(
     setTimeout(pushNextEvent, 5);
 
     return () => {
-      console.log('unsubscribing to stream ' + streamId);
+      structuredLog(
+        'grafana/frontend.plugins.datasource.grafana-testdata-datasource.runStreams',
+        'info',
+        'unsubscribing to stream ' + streamId
+      );
       clearTimeout(timeoutId);
     };
   });
@@ -219,7 +227,12 @@ function runWatchStream(
       .subscribe({
         next: (chunk) => {
           if (!chunk.data || !chunk.ok) {
-            console.info('chunk missing data', chunk);
+            structuredLog(
+              'grafana/frontend.plugins.datasource.grafana-testdata-datasource.runStreams',
+              'info',
+              'chunk missing data',
+              chunk
+            );
             return;
           }
           decoder
@@ -240,21 +253,43 @@ function runWatchStream(
                     state: LoadingState.Streaming,
                   });
                 } catch (err) {
-                  console.warn('error parsing line', line, err);
+                  structuredLog(
+                    'grafana/frontend.plugins.datasource.grafana-testdata-datasource.runStreams',
+                    'warn',
+                    'error parsing line',
+                    line,
+                    err
+                  );
                 }
               }
             });
         },
         error: (err) => {
-          console.warn('error in stream', streamId, err);
+          structuredLog(
+            'grafana/frontend.plugins.datasource.grafana-testdata-datasource.runStreams',
+            'warn',
+            'error in stream',
+            streamId,
+            err
+          );
         },
         complete: () => {
-          console.info('complete stream', streamId);
+          structuredLog(
+            'grafana/frontend.plugins.datasource.grafana-testdata-datasource.runStreams',
+            'info',
+            'complete stream',
+            streamId
+          );
         },
       });
 
     return () => {
-      console.log('unsubscribing to stream', streamId);
+      structuredLog(
+        'grafana/frontend.plugins.datasource.grafana-testdata-datasource.runStreams',
+        'info',
+        'unsubscribing to stream',
+        streamId
+      );
       sub.unsubscribe();
     };
   });
@@ -314,7 +349,11 @@ function runFetchStream(
       });
 
       if (value.done) {
-        console.log('Finished stream');
+        structuredLog(
+          'grafana/frontend.plugins.datasource.grafana-testdata-datasource.runStreams',
+          'info',
+          'Finished stream'
+        );
         subscriber.complete(); // necessary?
         return;
       }
@@ -335,7 +374,11 @@ function runFetchStream(
 
     return () => {
       // Cancel fetch?
-      console.log('unsubscribing to stream ' + streamId);
+      structuredLog(
+        'grafana/frontend.plugins.datasource.grafana-testdata-datasource.runStreams',
+        'info',
+        'unsubscribing to stream ' + streamId
+      );
     };
   });
 }
@@ -368,7 +411,11 @@ function runTracesStream(
     setTimeout(pushNextEvent, 5);
 
     return () => {
-      console.log('unsubscribing to stream ' + streamId);
+      structuredLog(
+        'grafana/frontend.plugins.datasource.grafana-testdata-datasource.runStreams',
+        'info',
+        'unsubscribing to stream ' + streamId
+      );
       clearTimeout(timeoutId);
     };
   });

--- a/public/app/plugins/datasource/grafana/components/QueryEditor.tsx
+++ b/public/app/plugins/datasource/grafana/components/QueryEditor.tsx
@@ -8,7 +8,7 @@ import {
   type DataQueryRequest,
   type Field,
 } from '@grafana/data';
-import { config, getDataSourceSrv } from '@grafana/runtime';
+import { logStructured as structuredLog, config, getDataSourceSrv } from '@grafana/runtime';
 import { InlineField, Select, Alert, Input, InlineFieldRow, Stack, InlineLabel } from '@grafana/ui';
 import { getManagedChannelInfo } from 'app/features/live/info';
 
@@ -143,7 +143,7 @@ export const QueryEditor = memo(function QueryEditor(props: Props) {
         try {
           buffer = rangeUtil.intervalToSeconds(txt) * 1000;
         } catch (err) {
-          console.warn('ERROR', err);
+          structuredLog('grafana/frontend.plugins.datasource.grafana.components.QueryEditor', 'warn', 'ERROR', err);
         }
       }
       onChange({

--- a/public/app/plugins/datasource/graphite/datasource.test.ts
+++ b/public/app/plugins/datasource/graphite/datasource.test.ts
@@ -22,6 +22,7 @@ import {
   config,
   type FetchResponse,
   getTemplateSrv,
+  logStructured,
   type TemplateSrv,
   type VariableInterpolation,
 } from '@grafana/runtime';
@@ -40,6 +41,7 @@ jest.mock('@grafana/runtime', () => ({
   getBackendSrv: () => ({
     fetch: fetchMock,
   }),
+  logStructured: jest.fn(),
   getTemplateSrv: () => {
     return {
       replace: (s: string) => s,
@@ -483,7 +485,11 @@ describe('graphiteDatasource', () => {
         results = data;
       });
       expect(results).toEqual([]);
-      expect(console.error).toHaveBeenCalledWith(expect.stringMatching(/Unable to get annotations/));
+      expect(logStructured).toHaveBeenCalledWith(
+        'grafana/frontend.plugins.datasource.graphite.datasource',
+        'error',
+        expect.stringMatching(/Unable to get annotations/)
+      );
     });
   });
 
@@ -597,7 +603,11 @@ describe('graphiteDatasource', () => {
         results = data;
       });
       expect(results).toEqual([]);
-      expect(console.error).toHaveBeenCalledWith(expect.stringMatching(/Unable to get annotations/));
+      expect(logStructured).toHaveBeenCalledWith(
+        'grafana/frontend.plugins.datasource.graphite.datasource',
+        'error',
+        expect.stringMatching(/Unable to get annotations/)
+      );
     });
   });
 

--- a/public/app/plugins/datasource/graphite/datasource.ts
+++ b/public/app/plugins/datasource/graphite/datasource.ts
@@ -24,6 +24,7 @@ import {
   toDataFrame,
 } from '@grafana/data';
 import {
+  logStructured as structuredLog,
   type BackendSrvRequest,
   config,
   DataSourceWithBackend,
@@ -583,7 +584,11 @@ export class GraphiteDatasource
       return this.events({ range: range, tags: tags }).then((results) => {
         const list = [];
         if (!isArray(results.data)) {
-          console.error(`Unable to get annotations.`);
+          structuredLog(
+            'grafana/frontend.plugins.datasource.graphite.datasource',
+            'error',
+            `Unable to get annotations.`
+          );
           return [];
         }
         for (let i = 0; i < results.data.length; i++) {
@@ -1075,7 +1080,12 @@ export class GraphiteDatasource
         this.funcDefs = gfunc.parseFuncDefs(functions);
         return this.funcDefs;
       } catch (error) {
-        console.error('Fetching graphite functions error', error);
+        structuredLog(
+          'grafana/frontend.plugins.datasource.graphite.datasource',
+          'error',
+          'Fetching graphite functions error',
+          error
+        );
         this.funcDefs = gfunc.getFuncDefs(this.graphiteVersion);
         return this.funcDefs;
       }
@@ -1094,7 +1104,12 @@ export class GraphiteDatasource
           return this.funcDefs;
         }),
         catchError((error) => {
-          console.error('Fetching graphite functions error', error);
+          structuredLog(
+            'grafana/frontend.plugins.datasource.graphite.datasource',
+            'error',
+            'Fetching graphite functions error',
+            error
+          );
           this.funcDefs = gfunc.getFuncDefs(this.graphiteVersion);
           return of(this.funcDefs);
         })

--- a/public/app/plugins/datasource/graphite/graphite_query.ts
+++ b/public/app/plugins/datasource/graphite/graphite_query.ts
@@ -1,7 +1,7 @@
 import { compact, each, findIndex, flatten, get, join, keyBy, last, map, reduce, without } from 'lodash';
 
 import { type ScopedVars } from '@grafana/data';
-import { type TemplateSrv } from '@grafana/runtime';
+import { logStructured as structuredLog, type TemplateSrv } from '@grafana/runtime';
 
 import { type GraphiteDatasource } from './datasource';
 import { type FuncInstance } from './gfunc';
@@ -94,7 +94,12 @@ export default class GraphiteQuery {
       }
     } catch (err) {
       if (err instanceof Error) {
-        console.error('error parsing target:', err.message);
+        structuredLog(
+          'grafana/frontend.plugins.datasource.graphite.graphite_query',
+          'error',
+          'error parsing target:',
+          err.message
+        );
         this.error = err.message;
       }
       this.target.textEditor = true;

--- a/public/app/plugins/panel/canvas/components/connections/Connections.tsx
+++ b/public/app/plugins/panel/canvas/components/connections/Connections.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { BehaviorSubject } from 'rxjs';
 
-import { config } from '@grafana/runtime';
+import { logStructured as structuredLog, config } from '@grafana/runtime';
 import { type CanvasConnection, type ConnectionCoordinates, ConnectionPath } from 'app/features/canvas/element';
 import { type ElementState } from 'app/features/canvas/runtime/element';
 import { type Scene } from 'app/features/canvas/runtime/scene';
@@ -135,7 +135,7 @@ export class Connections {
     let element: ElementState | undefined = this.findElementTarget(event.target);
 
     if (!element) {
-      console.log('no element');
+      structuredLog('grafana/frontend.plugins.panel.canvas.components.connections.Connections', 'info', 'no element');
       return;
     }
 
@@ -144,7 +144,11 @@ export class Connections {
     } else {
       this.connectionSource = element;
       if (!this.connectionSource) {
-        console.log('no connection source');
+        structuredLog(
+          'grafana/frontend.plugins.panel.canvas.components.connections.Connections',
+          'info',
+          'no connection source'
+        );
         return;
       }
     }

--- a/public/app/plugins/panel/canvas/components/connections/Connections2.tsx
+++ b/public/app/plugins/panel/canvas/components/connections/Connections2.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { BehaviorSubject } from 'rxjs';
 
-import { config } from '@grafana/runtime';
+import { logStructured as structuredLog, config } from '@grafana/runtime';
 import { type CanvasConnection, type ConnectionCoordinates, ConnectionPath } from 'app/features/canvas/element';
 import { type ElementState } from 'app/features/canvas/runtime/element';
 import { type Scene } from 'app/features/canvas/runtime/scene';
@@ -128,7 +128,7 @@ export class Connections2 {
     let element: ElementState | undefined = this.findElementTarget(event.target);
 
     if (!element) {
-      console.log('no element');
+      structuredLog('grafana/frontend.plugins.panel.canvas.components.connections.Connections2', 'info', 'no element');
       return;
     }
 
@@ -137,7 +137,11 @@ export class Connections2 {
     } else {
       this.connectionSource = element;
       if (!this.connectionSource) {
-        console.log('no connection source');
+        structuredLog(
+          'grafana/frontend.plugins.panel.canvas.components.connections.Connections2',
+          'info',
+          'no connection source'
+        );
         return;
       }
     }

--- a/public/app/plugins/panel/canvas/editor/element/elementEditor.tsx
+++ b/public/app/plugins/panel/canvas/editor/element/elementEditor.tsx
@@ -1,9 +1,8 @@
-import { logStructured as structuredLog } from '@grafana/runtime';
-
 import { get as lodashGet } from 'lodash';
 
 import { type NestedPanelOptions, type NestedValueAccess } from '@grafana/data';
 import { t } from '@grafana/i18n';
+import { logStructured as structuredLog } from '@grafana/runtime';
 import { type CanvasElementOptions } from 'app/features/canvas/element';
 import {
   canvasElementRegistry,

--- a/public/app/plugins/panel/canvas/editor/element/elementEditor.tsx
+++ b/public/app/plugins/panel/canvas/editor/element/elementEditor.tsx
@@ -1,3 +1,5 @@
+import { logStructured as structuredLog } from '@grafana/runtime';
+
 import { get as lodashGet } from 'lodash';
 
 import { type NestedPanelOptions, type NestedValueAccess } from '@grafana/data';
@@ -45,7 +47,12 @@ export function getElementEditor(opts: CanvasEditorOptions): NestedPanelOptions<
         if (path === 'type' && value) {
           const layer = canvasElementRegistry.getIfExists(value);
           if (!layer) {
-            console.warn('layer does not exist', value);
+            structuredLog(
+              'grafana/frontend.plugins.panel.canvas.editor.element.elementEditor',
+              'warn',
+              'layer does not exist',
+              value
+            );
             return;
           }
           options = {

--- a/public/app/plugins/panel/canvas/editor/element/utils.ts
+++ b/public/app/plugins/panel/canvas/editor/element/utils.ts
@@ -1,5 +1,10 @@
 import { AppEvents, textUtil } from '@grafana/data';
-import { type BackendSrvRequest, getBackendSrv, getTemplateSrv } from '@grafana/runtime';
+import {
+  logStructured as structuredLog,
+  type BackendSrvRequest,
+  getBackendSrv,
+  getTemplateSrv,
+} from '@grafana/runtime';
 import { appEvents } from 'app/core/app_events';
 import { createAbsoluteUrl, type RelativeUrl } from 'app/features/alerting/unified/utils/url';
 import { getDashboardSrv } from 'app/features/dashboard/services/DashboardSrv';
@@ -23,7 +28,7 @@ export const callApi = (api: APIEditorConfig, updateLoadingStateCallback?: IsLoa
     .subscribe({
       error: (error) => {
         appEvents.emit(AppEvents.alertError, ['An error has occurred. Check console output for more details.']);
-        console.error('API call error: ', error);
+        structuredLog('grafana/frontend.plugins.panel.canvas.editor.element.utils', 'error', 'API call error: ', error);
         updateLoadingStateCallback && updateLoadingStateCallback(false);
       },
       complete: () => {

--- a/public/app/plugins/panel/canvas/editor/layer/TreeNavigationEditor.tsx
+++ b/public/app/plugins/panel/canvas/editor/layer/TreeNavigationEditor.tsx
@@ -5,7 +5,7 @@ import { type Key, useEffect, useMemo, useState } from 'react';
 
 import { type GrafanaTheme2, type StandardEditorProps } from '@grafana/data';
 import { Trans, t } from '@grafana/i18n';
-import { config } from '@grafana/runtime';
+import { logStructured as structuredLog, config } from '@grafana/runtime';
 import { Button, Icon, Stack, useStyles2, useTheme2 } from '@grafana/ui';
 import { AddLayerButton } from 'app/core/components/Layers/AddLayerButton';
 import { type ElementState } from 'app/features/canvas/runtime/element';
@@ -130,7 +130,7 @@ export const TreeNavigationEditor = ({ item }: StandardEditorProps<unknown, Tree
     if (layer.scene) {
       frameSelection(layer.scene);
     } else {
-      console.warn('no scene!');
+      structuredLog('grafana/frontend.plugins.panel.canvas.editor.layer.TreeNavigationEditor', 'warn', 'no scene!');
     }
   };
 

--- a/public/app/plugins/panel/canvas/editor/layer/layerEditor.tsx
+++ b/public/app/plugins/panel/canvas/editor/layer/layerEditor.tsx
@@ -1,3 +1,5 @@
+import { logStructured as structuredLog } from '@grafana/runtime';
+
 import { get as lodashGet } from 'lodash';
 
 import { type NestedPanelOptions, type NestedValueAccess } from '@grafana/data';
@@ -53,7 +55,11 @@ export function getLayerEditor(opts: InstanceState): NestedPanelOptions<LayerEdi
       },
       onChange: (path, value) => {
         if (path === 'type' && value) {
-          console.warn('unable to change layer type');
+          structuredLog(
+            'grafana/frontend.plugins.panel.canvas.editor.layer.layerEditor',
+            'warn',
+            'unable to change layer type'
+          );
           return;
         }
         const c = setOptionImmutably(options, path, value);

--- a/public/app/plugins/panel/canvas/editor/layer/layerEditor.tsx
+++ b/public/app/plugins/panel/canvas/editor/layer/layerEditor.tsx
@@ -1,9 +1,8 @@
-import { logStructured as structuredLog } from '@grafana/runtime';
-
 import { get as lodashGet } from 'lodash';
 
 import { type NestedPanelOptions, type NestedValueAccess } from '@grafana/data';
 import { t } from '@grafana/i18n';
+import { logStructured as structuredLog } from '@grafana/runtime';
 import { type ElementState } from 'app/features/canvas/runtime/element';
 import { FrameState } from 'app/features/canvas/runtime/frame';
 import { type Scene } from 'app/features/canvas/runtime/scene';

--- a/public/app/plugins/panel/dashlist/migrations.ts
+++ b/public/app/plugins/panel/dashlist/migrations.ts
@@ -1,5 +1,5 @@
 import { type PanelModel } from '@grafana/data';
-import { getBackendSrv } from '@grafana/runtime';
+import { logStructured as structuredLog, getBackendSrv } from '@grafana/runtime';
 import { type FolderDTO } from 'app/types/folders';
 
 import { type Options } from './panelcfg.gen';
@@ -67,7 +67,12 @@ export async function dashlistMigrationHandler(panel: PanelModel<Options> & Angu
       newOptions.folderUID = folderUID;
       delete newOptions.folderId;
     } catch (err) {
-      console.warn('Dashlist: Error migrating folder ID to UID', err);
+      structuredLog(
+        'grafana/frontend.plugins.panel.dashlist.migrations',
+        'warn',
+        'Dashlist: Error migrating folder ID to UID',
+        err
+      );
     }
   }
 

--- a/public/app/plugins/panel/geomap/GeomapPanel.tsx
+++ b/public/app/plugins/panel/geomap/GeomapPanel.tsx
@@ -17,7 +17,7 @@ import { Subscription } from 'rxjs';
 
 import { DataHoverEvent, type PanelData, type PanelProps } from '@grafana/data';
 import { t } from '@grafana/i18n';
-import { config, locationService } from '@grafana/runtime';
+import { logStructured as structuredLog, config, locationService } from '@grafana/runtime';
 import { type PanelContext, PanelContextRoot } from '@grafana/ui';
 import { appEvents } from 'app/core/app_events';
 import { VariablesChanged } from 'app/features/variables/types';
@@ -327,7 +327,7 @@ export class GeomapPanel extends Component<Props, State> {
         layers.push(await initLayer(this, map, lyr, false));
       }
     } catch (ex) {
-      console.error('error loading layers', ex);
+      structuredLog('grafana/frontend.plugins.panel.geomap.GeomapPanel', 'error', 'error loading layers', ex);
     }
 
     for (const lyr of layers) {

--- a/public/app/plugins/panel/geomap/layers/basemaps/maplibre.ts
+++ b/public/app/plugins/panel/geomap/layers/basemaps/maplibre.ts
@@ -1,9 +1,8 @@
-import { logStructured as structuredLog } from '@grafana/runtime';
-
 import LayerGroup from 'ol/layer/Group';
 import { apply } from 'ol-mapbox-style';
 
 import { type MapLayerRegistryItem } from '@grafana/data';
+import { logStructured as structuredLog } from '@grafana/runtime';
 
 // MapLibre Style Specification constants
 const LAYER_TYPE_BACKGROUND = 'background';

--- a/public/app/plugins/panel/geomap/layers/basemaps/maplibre.ts
+++ b/public/app/plugins/panel/geomap/layers/basemaps/maplibre.ts
@@ -1,3 +1,5 @@
+import { logStructured as structuredLog } from '@grafana/runtime';
+
 import LayerGroup from 'ol/layer/Group';
 import { apply } from 'ol-mapbox-style';
 
@@ -61,7 +63,11 @@ const maplibreLayer: MapLayerRegistryItem<Partial<MaplibreConfig>> = {
         try {
           const res = await fetch(cfg.url);
           if (!res.ok) {
-            console.warn(`Failed to load MapLibre style from ${cfg.url}: ${res.status} ${res.statusText}`);
+            structuredLog(
+              'grafana/frontend.plugins.panel.geomap.layers.basemaps.maplibre',
+              'warn',
+              `Failed to load MapLibre style from ${cfg.url}: ${res.status} ${res.statusText}`
+            );
             // Try fallback approach
             await tryFallbackApply();
             return;
@@ -82,7 +88,12 @@ const maplibreLayer: MapLayerRegistryItem<Partial<MaplibreConfig>> = {
           await apply(layer, style, { styleUrl: cfg.url, accessToken: cfg.accessToken });
           applyNoRepeat();
         } catch (error) {
-          console.warn('Failed to parse or apply MapLibre style JSON:', error);
+          structuredLog(
+            'grafana/frontend.plugins.panel.geomap.layers.basemaps.maplibre',
+            'warn',
+            'Failed to parse or apply MapLibre style JSON:',
+            error
+          );
           // Try fallback approach
           await tryFallbackApply();
         }
@@ -93,7 +104,12 @@ const maplibreLayer: MapLayerRegistryItem<Partial<MaplibreConfig>> = {
           await apply(layer, cfg.url, { accessToken: cfg.accessToken });
           applyNoRepeat();
         } catch (fallbackError) {
-          console.warn('Failed to load MapLibre style from both JSON and direct URL approaches:', fallbackError);
+          structuredLog(
+            'grafana/frontend.plugins.panel.geomap.layers.basemaps.maplibre',
+            'warn',
+            'Failed to load MapLibre style from both JSON and direct URL approaches:',
+            fallbackError
+          );
         }
       };
 

--- a/public/app/plugins/panel/geomap/style/markers.ts
+++ b/public/app/plugins/panel/geomap/style/markers.ts
@@ -3,7 +3,7 @@ import type { FlatStyle } from 'ol/style/flat';
 import tinycolor from 'tinycolor2';
 
 import { Registry, type RegistryItem, textUtil } from '@grafana/data';
-import { config } from '@grafana/runtime';
+import { logStructured as structuredLog, config } from '@grafana/runtime';
 import { getPublicOrAbsoluteUrl } from 'app/features/dimensions/resource';
 
 import { defaultStyleConfig, DEFAULT_SIZE, type StyleConfigValues, type StyleMaker } from './types';
@@ -297,7 +297,7 @@ async function prepareSVG(url: string, size?: number, backgroundOpacity?: number
       return `data:image/svg+xml,${svgURI}`;
     })
     .catch((error) => {
-      console.error(error); // eslint-disable-line no-console
+      structuredLog('grafana/frontend.plugins.panel.geomap.style.markers', 'error', error); // eslint-disable-line no-console
       return '';
     });
 }

--- a/public/app/plugins/panel/geomap/style/utils.ts
+++ b/public/app/plugins/panel/geomap/style/utils.ts
@@ -1,4 +1,4 @@
-import { config } from '@grafana/runtime';
+import { logStructured as structuredLog, config } from '@grafana/runtime';
 import { TextDimensionMode } from '@grafana/schema';
 
 import { getMarkerMaker } from './markers';
@@ -106,7 +106,11 @@ export function getRGBValues(colorString: string): ColorValue | null {
 
   // Handle other color formats if needed
   else {
-    console.warn(`Unsupported color format: ${colorString}`);
+    structuredLog(
+      'grafana/frontend.plugins.panel.geomap.style.utils',
+      'warn',
+      `Unsupported color format: ${colorString}`
+    );
   }
   return null;
 }
@@ -142,10 +146,18 @@ function getRGBFromRGBString(rgbString: string): ColorValue | null {
         a: parseFloat(matches[3]), // Using parseFloat for alpha as it can be decimal (0-1)
       };
     } else {
-      console.warn(`Unsupported color format: ${rgbString}`);
+      structuredLog(
+        'grafana/frontend.plugins.panel.geomap.style.utils',
+        'warn',
+        `Unsupported color format: ${rgbString}`
+      );
     }
   } else {
-    console.warn(`Unsupported color format: ${rgbString}`);
+    structuredLog(
+      'grafana/frontend.plugins.panel.geomap.style.utils',
+      'warn',
+      `Unsupported color format: ${rgbString}`
+    );
   }
   return null;
 }

--- a/public/app/plugins/panel/geomap/utils/layers.ts
+++ b/public/app/plugins/panel/geomap/utils/layers.ts
@@ -4,7 +4,7 @@ import LayerGroup from 'ol/layer/Group';
 import WebGLPointsLayer from 'ol/layer/WebGLPoints';
 
 import { getFrameMatchers, type MapLayerHandler, type MapLayerOptions, type PanelData, textUtil } from '@grafana/data';
-import { config } from '@grafana/runtime';
+import { logStructured as structuredLog, config } from '@grafana/runtime';
 
 import { type GeomapPanel } from '../GeomapPanel';
 import { MARKERS_LAYER_ID } from '../layers/data/markersLayer';
@@ -90,7 +90,7 @@ async function updateLayer(panel: GeomapPanel, uid: string, newOptions: MapLayer
     // initialize with new data
     applyLayerFilter(info.handler, newOptions, panel.props.data);
   } catch (err) {
-    console.warn('ERROR', err); // eslint-disable-line no-console
+    structuredLog('grafana/frontend.plugins.panel.geomap.utils.layers', 'warn', 'ERROR', err); // eslint-disable-line no-console
     return false;
   }
 

--- a/public/app/plugins/panel/heatmap/HeatmapPanel.tsx
+++ b/public/app/plugins/panel/heatmap/HeatmapPanel.tsx
@@ -2,7 +2,7 @@ import { css } from '@emotion/css';
 import { useMemo, useRef, useState } from 'react';
 
 import { DashboardCursorSync, type PanelProps, type TimeRange } from '@grafana/data';
-import { PanelDataErrorView } from '@grafana/runtime';
+import { logStructured as structuredLog, PanelDataErrorView } from '@grafana/runtime';
 import { type LegendPlacement, type ScaleDistributionConfig } from '@grafana/schema';
 import {
   EventBusPlugin,
@@ -54,7 +54,7 @@ export const HeatmapPanel = (props: HeatmapPanelProps) => {
         timeRange,
       });
     } catch (ex) {
-      console.error(ex);
+      structuredLog('grafana/frontend.plugins.panel.heatmap.HeatmapPanel', 'error', ex);
       return { warning: `${ex}` };
     }
   }, [data.series, data.annotations, options, palette, theme, replaceVariables, timeRange]);

--- a/public/app/plugins/panel/live/LivePanel.tsx
+++ b/public/app/plugins/panel/live/LivePanel.tsx
@@ -19,7 +19,7 @@ import {
   StreamingDataFrame,
 } from '@grafana/data';
 import { Trans, t } from '@grafana/i18n';
-import { config, getGrafanaLiveSrv } from '@grafana/runtime';
+import { logStructured as structuredLog, config, getGrafanaLiveSrv } from '@grafana/runtime';
 import { Alert, stylesFactory, JSONFormatter, CustomScrollbar } from '@grafana/ui';
 
 import { TablePanel } from '../table/TablePanel';
@@ -72,7 +72,7 @@ export class LivePanel extends PureComponent<Props, State> {
       } else if (isLiveChannelMessageEvent(event)) {
         this.setState({ message: event.message, changed: Date.now() });
       } else {
-        console.log('ignore', event);
+        structuredLog('grafana/frontend.plugins.panel.live.LivePanel', 'info', 'ignore', event);
       }
     },
   };
@@ -87,7 +87,7 @@ export class LivePanel extends PureComponent<Props, State> {
   async loadChannel() {
     const addr = this.props.options?.channel;
     if (!isValidLiveChannelAddress(addr)) {
-      console.log('INVALID', addr);
+      structuredLog('grafana/frontend.plugins.panel.live.LivePanel', 'info', 'INVALID', addr);
       this.unsubscribe();
       this.setState({
         addr: undefined,
@@ -96,13 +96,13 @@ export class LivePanel extends PureComponent<Props, State> {
     }
 
     if (isEqual(addr, this.state.addr)) {
-      console.log('Same channel', this.state.addr);
+      structuredLog('grafana/frontend.plugins.panel.live.LivePanel', 'info', 'Same channel', this.state.addr);
       return;
     }
 
     const live = getGrafanaLiveSrv();
     if (!live) {
-      console.log('INVALID', addr);
+      structuredLog('grafana/frontend.plugins.panel.live.LivePanel', 'info', 'INVALID', addr);
       this.unsubscribe();
       this.setState({
         addr: undefined,
@@ -111,7 +111,7 @@ export class LivePanel extends PureComponent<Props, State> {
     }
     this.unsubscribe();
 
-    console.log('LOAD', addr);
+    structuredLog('grafana/frontend.plugins.panel.live.LivePanel', 'info', 'LOAD', addr);
 
     // Subscribe to new events
     try {

--- a/public/app/plugins/panel/live/LivePublish.tsx
+++ b/public/app/plugins/panel/live/LivePublish.tsx
@@ -2,7 +2,7 @@ import { useMemo } from 'react';
 
 import { type LiveChannelAddress, isValidLiveChannelAddress } from '@grafana/data';
 import { Trans } from '@grafana/i18n';
-import { getBackendSrv, getGrafanaLiveSrv } from '@grafana/runtime';
+import { logStructured as structuredLog, getBackendSrv, getGrafanaLiveSrv } from '@grafana/runtime';
 import { CodeEditor, Button } from '@grafana/ui';
 
 import { MessagePublishMode } from './types';
@@ -46,7 +46,12 @@ export function LivePublish({ height, mode, body, addr, onSave }: Props) {
     }
 
     const rsp = await getGrafanaLiveSrv().publish(addr, body);
-    console.log('onPublishClicked (response from publish)', rsp);
+    structuredLog(
+      'grafana/frontend.plugins.panel.live.LivePublish',
+      'info',
+      'onPublishClicked (response from publish)',
+      rsp
+    );
   };
 
   return (

--- a/public/app/plugins/panel/logs/LogsPanel.tsx
+++ b/public/app/plugins/panel/logs/LogsPanel.tsx
@@ -30,7 +30,7 @@ import {
   transformDataFrame,
   store,
 } from '@grafana/data';
-import { getAppEvents } from '@grafana/runtime';
+import { logStructured as structuredLog, getAppEvents } from '@grafana/runtime';
 import { usePanelContext, useStyles2 } from '@grafana/ui';
 import { getDashboardSrv } from 'app/features/dashboard/services/DashboardSrv';
 import { getFieldLinksForExplore } from 'app/features/explore/utils/links';
@@ -417,7 +417,7 @@ export const LogsPanel = ({ data, timeZone, fieldConfig, options, onOptionsChang
         }
       } catch (e) {
         errored = true;
-        console.error(e);
+        structuredLog('grafana/frontend.plugins.panel.logs.LogsPanel', 'error', e);
       } finally {
         setLoadMoreState(errored ? LoadingState.Error : LoadingState.Done);
         loadingRef.current = false;
@@ -615,7 +615,11 @@ async function requestMoreLogs(
   for (const uid in targetGroups) {
     const dataSource = dataSourcesMap.get(panelData.request.targets[0].refId);
     if (!dataSource) {
-      console.warn(`Could not resolve data source for target ${panelData.request.targets[0].refId}`);
+      structuredLog(
+        'grafana/frontend.plugins.panel.logs.LogsPanel',
+        'warn',
+        `Could not resolve data source for target ${panelData.request.targets[0].refId}`
+      );
       continue;
     }
     dataRequests.push(

--- a/public/app/plugins/panel/logstable/LogDetailsContext.tsx
+++ b/public/app/plugins/panel/logstable/LogDetailsContext.tsx
@@ -1,7 +1,6 @@
-import { logStructured as structuredLog } from '@grafana/runtime';
-
 import { createContext, type ReactNode, useCallback, useContext, useEffect, useState } from 'react';
 
+import { logStructured as structuredLog } from '@grafana/runtime';
 import { type LogListModel } from 'app/features/logs/components/panel/processing';
 
 export interface LogDetailsContextData {

--- a/public/app/plugins/panel/logstable/LogDetailsContext.tsx
+++ b/public/app/plugins/panel/logstable/LogDetailsContext.tsx
@@ -1,3 +1,5 @@
+import { logStructured as structuredLog } from '@grafana/runtime';
+
 import { createContext, type ReactNode, useCallback, useContext, useEffect, useState } from 'react';
 
 import { type LogListModel } from 'app/features/logs/components/panel/processing';
@@ -82,7 +84,11 @@ export const LogDetailsContextProvider = ({ children, enableLogDetails, logs }: 
       }
       const log = typeof logRef === 'number' ? logs.at(logRef) : logRef;
       if (!log) {
-        console.error(`LogDetailsContext: undefined log with reference ${logRef}`);
+        structuredLog(
+          'grafana/frontend.plugins.panel.logstable.LogDetailsContext',
+          'error',
+          `LogDetailsContext: undefined log with reference ${logRef}`
+        );
         return;
       }
       const found = showDetails.find((stateLog) => stateLog.uid === log.uid);

--- a/public/app/plugins/panel/logstable/fieldSelector/buildColumnsWithMeta.ts
+++ b/public/app/plugins/panel/logstable/fieldSelector/buildColumnsWithMeta.ts
@@ -1,6 +1,5 @@
-import { logStructured as structuredLog } from '@grafana/runtime';
-
 import { type DataFrame, type FieldWithIndex } from '@grafana/data';
+import { logStructured as structuredLog } from '@grafana/runtime';
 import { type FieldNameMeta, type FieldNameMetaStore } from 'app/features/explore/Logs/LogsTableWrap';
 import { LOG_LINE_BODY_FIELD_NAME } from 'app/features/logs/components/fieldSelector/logFields';
 

--- a/public/app/plugins/panel/logstable/fieldSelector/buildColumnsWithMeta.ts
+++ b/public/app/plugins/panel/logstable/fieldSelector/buildColumnsWithMeta.ts
@@ -1,3 +1,5 @@
+import { logStructured as structuredLog } from '@grafana/runtime';
+
 import { type DataFrame, type FieldWithIndex } from '@grafana/data';
 import { type FieldNameMeta, type FieldNameMetaStore } from 'app/features/explore/Logs/LogsTableWrap';
 import { LOG_LINE_BODY_FIELD_NAME } from 'app/features/logs/components/fieldSelector/logFields';
@@ -104,7 +106,12 @@ export const buildColumnsWithMeta = (
       pendingLabelState[logsFrameFields.bodyField.name].active = true;
       pendingLabelState[logsFrameFields.bodyField.name].index = idx;
     } else {
-      console.error(`Unknown field ${fieldName}`, { pendingLabelState, displayedFields });
+      structuredLog(
+        'grafana/frontend.plugins.panel.logstable.fieldSelector.buildColumnsWithMeta',
+        'error',
+        `Unknown field ${fieldName}`,
+        { pendingLabelState, displayedFields }
+      );
     }
   });
 

--- a/public/app/plugins/panel/logstable/hooks/useExtractFields.ts
+++ b/public/app/plugins/panel/logstable/hooks/useExtractFields.ts
@@ -12,7 +12,7 @@ import {
   transformDataFrame,
   useDataLinksContext,
 } from '@grafana/data';
-import { getTemplateSrv } from '@grafana/runtime';
+import { logStructured as structuredLog, getTemplateSrv } from '@grafana/runtime';
 import { useTheme2 } from '@grafana/ui';
 
 import { getLogsTableFieldConfigRegistry } from '../logsTableFieldConfig';
@@ -61,7 +61,12 @@ export function useExtractFields({ rawTableFrame, fieldConfig, timeZone, replace
         }
       })
       .catch((err) => {
-        console.error('LogsTable: Extract fields transform error', err);
+        structuredLog(
+          'grafana/frontend.plugins.panel.logstable.hooks.useExtractFields',
+          'error',
+          'LogsTable: Extract fields transform error',
+          err
+        );
       });
   }, [dataLinkPostProcessor, fieldConfig, isMounted, loadingState, rawTableFrame, replaceVariables, theme, timeZone]);
 

--- a/public/app/plugins/panel/logstable/hooks/useOrganizeFields.tsx
+++ b/public/app/plugins/panel/logstable/hooks/useOrganizeFields.tsx
@@ -1,3 +1,5 @@
+import { logStructured as structuredLog } from '@grafana/runtime';
+
 import { merge } from 'lodash';
 import { useEffect, useState } from 'react';
 import useMountedState from 'react-use/lib/useMountedState';
@@ -68,7 +70,12 @@ export function useOrganizeFields({
         }
       })
       .catch((err) => {
-        console.error('LogsTable: Organize fields transform error', err);
+        structuredLog(
+          'grafana/frontend.plugins.panel.logstable.hooks.useOrganizeFields',
+          'error',
+          'LogsTable: Organize fields transform error',
+          err
+        );
       });
   }, [
     bodyFieldName,

--- a/public/app/plugins/panel/logstable/hooks/useOrganizeFields.tsx
+++ b/public/app/plugins/panel/logstable/hooks/useOrganizeFields.tsx
@@ -1,11 +1,10 @@
-import { logStructured as structuredLog } from '@grafana/runtime';
-
 import { merge } from 'lodash';
 import { useEffect, useState } from 'react';
 import useMountedState from 'react-use/lib/useMountedState';
 import { lastValueFrom } from 'rxjs';
 
 import { type DataFrame, type FieldConfigSource, transformDataFrame } from '@grafana/data';
+import { logStructured as structuredLog } from '@grafana/runtime';
 import { type CustomCellRendererProps, TableCellDisplayMode } from '@grafana/ui';
 import { type LogsFrame } from 'app/features/logs/logsFrame';
 

--- a/public/app/plugins/panel/logstable/rows/LogsTableRowActionButtons.tsx
+++ b/public/app/plugins/panel/logstable/rows/LogsTableRowActionButtons.tsx
@@ -1,10 +1,9 @@
-import { logStructured as structuredLog } from '@grafana/runtime';
-
 import { css } from '@emotion/css';
 import { useCallback } from 'react';
 
 import { type GrafanaTheme2 } from '@grafana/data';
 import { t } from '@grafana/i18n';
+import { logStructured as structuredLog } from '@grafana/runtime';
 import { ClipboardButton, type CustomCellRendererProps, IconButton, useTheme2 } from '@grafana/ui';
 import { type LogsFrame } from 'app/features/logs/logsFrame';
 

--- a/public/app/plugins/panel/logstable/rows/LogsTableRowActionButtons.tsx
+++ b/public/app/plugins/panel/logstable/rows/LogsTableRowActionButtons.tsx
@@ -1,3 +1,5 @@
+import { logStructured as structuredLog } from '@grafana/runtime';
+
 import { css } from '@emotion/css';
 import { useCallback } from 'react';
 
@@ -64,7 +66,11 @@ export function LogsTableRowActionButtons(props: Props) {
                 if (logId) {
                   return buildLinkToLog(logId) ?? '';
                 } else {
-                  console.error('failed to copy log line link!');
+                  structuredLog(
+                    'grafana/frontend.plugins.panel.logstable.rows.LogsTableRowActionButtons',
+                    'error',
+                    'failed to copy log line link!'
+                  );
                 }
                 return '';
               }}

--- a/public/app/plugins/panel/news/utils.ts
+++ b/public/app/plugins/panel/news/utils.ts
@@ -1,6 +1,5 @@
-import { logStructured as structuredLog } from '@grafana/runtime';
-
 import { FieldType, type DataFrame, dateTime } from '@grafana/data';
+import { logStructured as structuredLog } from '@grafana/runtime';
 
 import { type Feed } from './types';
 

--- a/public/app/plugins/panel/news/utils.ts
+++ b/public/app/plugins/panel/news/utils.ts
@@ -1,3 +1,5 @@
+import { logStructured as structuredLog } from '@grafana/runtime';
+
 import { FieldType, type DataFrame, dateTime } from '@grafana/data';
 
 import { type Feed } from './types';
@@ -23,7 +25,7 @@ export function feedToDataFrame(feed: Feed): DataFrame {
         content.push(body);
       }
     } catch (err) {
-      console.warn('Error reading news item:', err, item);
+      structuredLog('grafana/frontend.plugins.panel.news.utils', 'warn', 'Error reading news item:', err, item);
     }
   }
 

--- a/public/app/plugins/panel/table/migrations.ts
+++ b/public/app/plugins/panel/table/migrations.ts
@@ -1,5 +1,3 @@
-import { logStructured as structuredLog } from '@grafana/runtime';
-
 import { omitBy, isNil, isNumber, defaultTo, groupBy, omit } from 'lodash';
 
 import {
@@ -14,6 +12,7 @@ import {
   ByNamesMatcherMode,
 } from '@grafana/data';
 import { type ReduceTransformerOptions } from '@grafana/data/internal';
+import { logStructured as structuredLog } from '@grafana/runtime';
 
 import { type Options } from './panelcfg.gen';
 

--- a/public/app/plugins/panel/table/migrations.ts
+++ b/public/app/plugins/panel/table/migrations.ts
@@ -1,3 +1,5 @@
+import { logStructured as structuredLog } from '@grafana/runtime';
+
 import { omitBy, isNil, isNumber, defaultTo, groupBy, omit } from 'lodash';
 
 import {
@@ -23,7 +25,7 @@ import { type Options } from './panelcfg.gen';
 export const tableMigrationHandler = (panel: PanelModel<Options>): Partial<Options> => {
   // Table was saved as an angular table, lets just swap to the 'table-old' panel
   if (!panel.pluginVersion && 'columns' in panel) {
-    console.log('Was angular table', panel);
+    structuredLog('grafana/frontend.plugins.panel.table.migrations', 'info', 'Was angular table', panel);
   }
 
   // ensure overrides array exists before applying rest of overrides

--- a/public/app/plugins/panel/timeseries/NullsThresholdInput.tsx
+++ b/public/app/plugins/panel/timeseries/NullsThresholdInput.tsx
@@ -1,9 +1,8 @@
-import { logStructured as structuredLog } from '@grafana/runtime';
-
 import * as React from 'react';
 
 import { rangeUtil } from '@grafana/data';
 import { t } from '@grafana/i18n';
+import { logStructured as structuredLog } from '@grafana/runtime';
 import { Input } from '@grafana/ui';
 
 export enum InputPrefix {

--- a/public/app/plugins/panel/timeseries/NullsThresholdInput.tsx
+++ b/public/app/plugins/panel/timeseries/NullsThresholdInput.tsx
@@ -1,3 +1,5 @@
+import { logStructured as structuredLog } from '@grafana/runtime';
+
 import * as React from 'react';
 
 import { rangeUtil } from '@grafana/data';
@@ -31,7 +33,7 @@ export const NullsThresholdInput = ({ value, onChange, inputPrefix, isTime }: Pr
           val = Number(txt);
         }
       } catch (err) {
-        console.warn('ERROR', err);
+        structuredLog('grafana/frontend.plugins.panel.timeseries.NullsThresholdInput', 'warn', 'ERROR', err);
       }
     }
     onChange(val);

--- a/public/app/plugins/panel/timeseries/migrations.ts
+++ b/public/app/plugins/panel/timeseries/migrations.ts
@@ -1,3 +1,5 @@
+import { logStructured as structuredLog } from '@grafana/runtime';
+
 import { omitBy, pickBy, isNil, isNumber, isString } from 'lodash';
 
 import {
@@ -283,7 +285,14 @@ function graphToTimeseriesOptions(angular: any): {
             });
             break;
           default:
-            console.log('Ignore override migration:', seriesOverride.alias, p, v);
+            structuredLog(
+              'grafana/frontend.plugins.panel.timeseries.migrations',
+              'info',
+              'Ignore override migration:',
+              seriesOverride.alias,
+              p,
+              v
+            );
         }
       }
       if (dashOverride) {

--- a/public/app/plugins/panel/timeseries/migrations.ts
+++ b/public/app/plugins/panel/timeseries/migrations.ts
@@ -1,5 +1,3 @@
-import { logStructured as structuredLog } from '@grafana/runtime';
-
 import { omitBy, pickBy, isNil, isNumber, isString } from 'lodash';
 
 import {
@@ -18,6 +16,7 @@ import {
   type Threshold,
   ThresholdsMode,
 } from '@grafana/data';
+import { logStructured as structuredLog } from '@grafana/runtime';
 import {
   LegendDisplayMode,
   TooltipDisplayMode,

--- a/public/app/plugins/panel/timeseries/plugins/AnnotationsPlugin.tsx
+++ b/public/app/plugins/panel/timeseries/plugins/AnnotationsPlugin.tsx
@@ -1,5 +1,3 @@
-import { logStructured as structuredLog } from '@grafana/runtime';
-
 import * as React from 'react';
 import { useCallback, useEffect, useLayoutEffect, useReducer, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
@@ -7,6 +5,7 @@ import tinycolor from 'tinycolor2';
 import uPlot from 'uplot';
 
 import { colorManipulator, type DataFrame, type InterpolateFunction } from '@grafana/data';
+import { logStructured as structuredLog } from '@grafana/runtime';
 import { type TimeZone, type VizAnnotations } from '@grafana/schema';
 import {
   DEFAULT_ANNOTATION_COLOR,

--- a/public/app/plugins/panel/timeseries/plugins/AnnotationsPlugin.tsx
+++ b/public/app/plugins/panel/timeseries/plugins/AnnotationsPlugin.tsx
@@ -1,3 +1,5 @@
+import { logStructured as structuredLog } from '@grafana/runtime';
+
 import * as React from 'react';
 import { useCallback, useEffect, useLayoutEffect, useReducer, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
@@ -200,7 +202,12 @@ export const AnnotationsPlugin = ({
                   try {
                     ctx.fillStyle = colorManipulator.alpha(color, regionOpacity ?? 0.1);
                   } catch (e) {
-                    console.error(`Invalid color: ${color}.`, e);
+                    structuredLog(
+                      'grafana/frontend.plugins.panel.timeseries.plugins.AnnotationsPlugin',
+                      'error',
+                      `Invalid color: ${color}.`,
+                      e
+                    );
                     ctx.fillStyle = colorManipulator.alpha(DEFAULT_ANNOTATION_COLOR_HEX8, regionOpacity ?? 0.1);
                   }
 

--- a/public/app/plugins/panel/timeseries/plugins/annotations/useAnnotationClustering.tsx
+++ b/public/app/plugins/panel/timeseries/plugins/annotations/useAnnotationClustering.tsx
@@ -1,3 +1,5 @@
+import { logStructured as structuredLog } from '@grafana/runtime';
+
 import { useMemo } from 'react';
 import uPlot from 'uplot';
 
@@ -120,7 +122,11 @@ export const useAnnotationClustering = ({ annotations, clusteringMode, plotWidth
       }
     } else if (clusteringMode === ClusteringMode.Hover) {
       // Have the tooltip be clustered, but not the annotations: https://github.com/grafana/grafana/issues/119436
-      console.warn('Hover mode not implemented');
+      structuredLog(
+        'grafana/frontend.plugins.panel.timeseries.plugins.annotations.useAnnotationClustering',
+        'warn',
+        'Hover mode not implemented'
+      );
     }
 
     // Sort clustered frames

--- a/public/app/plugins/panel/timeseries/plugins/annotations/useAnnotationClustering.tsx
+++ b/public/app/plugins/panel/timeseries/plugins/annotations/useAnnotationClustering.tsx
@@ -1,10 +1,9 @@
-import { logStructured as structuredLog } from '@grafana/runtime';
-
 import { useMemo } from 'react';
 import uPlot from 'uplot';
 
 import { type DataFrame, FieldType } from '@grafana/data';
 import { maybeSortFrame } from '@grafana/data/internal';
+import { logStructured as structuredLog } from '@grafana/runtime';
 import { type TimeRange2 } from '@grafana/ui/internal';
 
 import { DEFAULT_CLUSTERING_ANNOTATION_SPACING } from './constants';


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
**What is this feature?**

Migrates 400 active Grafana frontend runtime `console.*` calls across 250 files to a Faro-backed structured logging helper. The helper preserves errors and stacks, serializes additional arguments into context, and records a static source for each call site. Intentional console sinks for opt-in debugging, profiling, and Echo console reporting remain explicitly exempt.

Adds scoped ESLint enforcement and updates affected unit-test assertions.

**Why do we need this feature?**

Raw browser console calls are difficult to query and correlate in production. Structured events provide consistent source, severity, error, and argument context while preventing future regressions.

**Who is this feature for?**

Grafana developers and operators diagnosing frontend behavior.

**Which issue(s) does this PR fix?**:

N/A

**Special notes for your reviewer:**

This is a broad mechanical frontend migration. Validation includes targeted Jest suites, the decoupled Graphite workspace suite, ESLint across every migrated file, and frontend typechecking.

Please check that:
- [ ] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle. (Not applicable.)
- [x] The docs are updated, and if this is a notable improvement, it's added to What's New. (No user-facing documentation change.)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5bdcdefd-17a1-43bb-b025-20cbd67598de?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5bdcdefd-17a1-43bb-b025-20cbd67598de&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

