### PR TITLE
API: dual-path leftovers for org users, library connections, signed-in user, live

### DIFF
--- a/apps/live/kinds/manifest.cue
+++ b/apps/live/kinds/manifest.cue
@@ -30,6 +30,36 @@ manifest: {
 							}
 						}
 					}
+					"/ws": {
+						"GET": {
+							name: "getWs"
+							response: {
+								status: string
+							}
+						}
+					}
+					"/list": {
+						"GET": {
+							name: "getList"
+							response: {
+								channels: [...]
+							}
+						}
+					}
+					"/push/{streamId}": {
+						"GET": {
+							name: "getPush"
+							response: {
+								status: string
+							}
+						}
+						"POST": {
+							name: "createPush"
+							response: {
+								status: string
+							}
+						}
+					}
 				}
 			}
 		}

--- a/apps/live/pkg/apis/live/v1alpha1/client_gen.go
+++ b/apps/live/pkg/apis/live/v1alpha1/client_gen.go
@@ -30,6 +30,69 @@ func NewCustomRouteClientFromGenerator(generator resource.ClientGenerator, defau
 	return NewCustomRouteClient(client), nil
 }
 
+type GetListRequest struct {
+	Headers http.Header
+}
+
+func (c *CustomRouteClient) GetList(ctx context.Context, namespace string, request GetListRequest) (*GetListResponse, error) {
+	resp, err := c.NamespacedRequest(ctx, namespace, resource.CustomRouteRequestOptions{
+		Path:    "/list",
+		Verb:    "GET",
+		Headers: request.Headers,
+	})
+	if err != nil {
+		return nil, err
+	}
+	cast := GetListResponse{}
+	err = json.Unmarshal(resp, &cast)
+	if err != nil {
+		return nil, fmt.Errorf("unable to unmarshal response bytes into GetListResponse: %w", err)
+	}
+	return &cast, nil
+}
+
+type GetPushRequest struct {
+	Headers http.Header
+}
+
+func (c *CustomRouteClient) GetPush(ctx context.Context, namespace string, request GetPushRequest) (*GetPushResponse, error) {
+	resp, err := c.NamespacedRequest(ctx, namespace, resource.CustomRouteRequestOptions{
+		Path:    "/push/{streamId}",
+		Verb:    "GET",
+		Headers: request.Headers,
+	})
+	if err != nil {
+		return nil, err
+	}
+	cast := GetPushResponse{}
+	err = json.Unmarshal(resp, &cast)
+	if err != nil {
+		return nil, fmt.Errorf("unable to unmarshal response bytes into GetPushResponse: %w", err)
+	}
+	return &cast, nil
+}
+
+type CreatePushRequest struct {
+	Headers http.Header
+}
+
+func (c *CustomRouteClient) CreatePush(ctx context.Context, namespace string, request CreatePushRequest) (*CreatePushResponse, error) {
+	resp, err := c.NamespacedRequest(ctx, namespace, resource.CustomRouteRequestOptions{
+		Path:    "/push/{streamId}",
+		Verb:    "POST",
+		Headers: request.Headers,
+	})
+	if err != nil {
+		return nil, err
+	}
+	cast := CreatePushResponse{}
+	err = json.Unmarshal(resp, &cast)
+	if err != nil {
+		return nil, fmt.Errorf("unable to unmarshal response bytes into CreatePushResponse: %w", err)
+	}
+	return &cast, nil
+}
+
 type GetSomethingRequest struct {
 	Params  GetSomethingRequestParams
 	Headers http.Header
@@ -50,6 +113,27 @@ func (c *CustomRouteClient) GetSomething(ctx context.Context, namespace string, 
 	err = json.Unmarshal(resp, &cast)
 	if err != nil {
 		return nil, fmt.Errorf("unable to unmarshal response bytes into GetSomethingResponse: %w", err)
+	}
+	return &cast, nil
+}
+
+type GetWsRequest struct {
+	Headers http.Header
+}
+
+func (c *CustomRouteClient) GetWs(ctx context.Context, namespace string, request GetWsRequest) (*GetWsResponse, error) {
+	resp, err := c.NamespacedRequest(ctx, namespace, resource.CustomRouteRequestOptions{
+		Path:    "/ws",
+		Verb:    "GET",
+		Headers: request.Headers,
+	})
+	if err != nil {
+		return nil, err
+	}
+	cast := GetWsResponse{}
+	err = json.Unmarshal(resp, &cast)
+	if err != nil {
+		return nil, fmt.Errorf("unable to unmarshal response bytes into GetWsResponse: %w", err)
 	}
 	return &cast, nil
 }

--- a/apps/live/pkg/apis/live/v1alpha1/createpush_response_body_types_gen.go
+++ b/apps/live/pkg/apis/live/v1alpha1/createpush_response_body_types_gen.go
@@ -1,0 +1,18 @@
+// Code generated - EDITING IS FUTILE. DO NOT EDIT.
+
+package v1alpha1
+
+// +k8s:openapi-gen=true
+type CreatePushBody struct {
+	Status string `json:"status"`
+}
+
+// NewCreatePushBody creates a new CreatePushBody object.
+func NewCreatePushBody() *CreatePushBody {
+	return &CreatePushBody{}
+}
+
+// OpenAPIModelName returns the OpenAPI model name for CreatePushBody.
+func (CreatePushBody) OpenAPIModelName() string {
+	return "com.github.grafana.grafana.apps.live.pkg.apis.live.v1alpha1.CreatePushBody"
+}

--- a/apps/live/pkg/apis/live/v1alpha1/createpush_response_object_types_gen.go
+++ b/apps/live/pkg/apis/live/v1alpha1/createpush_response_object_types_gen.go
@@ -1,0 +1,41 @@
+// Code generated - EDITING IS FUTILE. DO NOT EDIT.
+
+package v1alpha1
+
+import (
+	"github.com/grafana/grafana-app-sdk/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+// +k8s:openapi-gen=true
+type CreatePushResponse struct {
+	metav1.TypeMeta `json:",inline"`
+	CreatePushBody  `json:",inline"`
+}
+
+func NewCreatePushResponse() *CreatePushResponse {
+	return &CreatePushResponse{}
+}
+
+func (t *CreatePushBody) DeepCopyInto(dst *CreatePushBody) {
+	_ = resource.CopyObjectInto(dst, t)
+}
+
+func (o *CreatePushResponse) DeepCopyObject() runtime.Object {
+	dst := NewCreatePushResponse()
+	o.DeepCopyInto(dst)
+	return dst
+}
+
+func (o *CreatePushResponse) DeepCopyInto(dst *CreatePushResponse) {
+	dst.TypeMeta.APIVersion = o.TypeMeta.APIVersion
+	dst.TypeMeta.Kind = o.TypeMeta.Kind
+	o.CreatePushBody.DeepCopyInto(&dst.CreatePushBody)
+}
+
+func (CreatePushResponse) OpenAPIModelName() string {
+	return "com.github.grafana.grafana.apps.live.pkg.apis.live.v1alpha1.CreatePushResponse"
+}
+
+var _ runtime.Object = NewCreatePushResponse()

--- a/apps/live/pkg/apis/live/v1alpha1/getlist_response_body_types_gen.go
+++ b/apps/live/pkg/apis/live/v1alpha1/getlist_response_body_types_gen.go
@@ -1,0 +1,20 @@
+// Code generated - EDITING IS FUTILE. DO NOT EDIT.
+
+package v1alpha1
+
+// +k8s:openapi-gen=true
+type GetListBody struct {
+	Channels []interface{} `json:"channels"`
+}
+
+// NewGetListBody creates a new GetListBody object.
+func NewGetListBody() *GetListBody {
+	return &GetListBody{
+		Channels: []interface{}{},
+	}
+}
+
+// OpenAPIModelName returns the OpenAPI model name for GetListBody.
+func (GetListBody) OpenAPIModelName() string {
+	return "com.github.grafana.grafana.apps.live.pkg.apis.live.v1alpha1.GetListBody"
+}

--- a/apps/live/pkg/apis/live/v1alpha1/getlist_response_object_types_gen.go
+++ b/apps/live/pkg/apis/live/v1alpha1/getlist_response_object_types_gen.go
@@ -1,0 +1,41 @@
+// Code generated - EDITING IS FUTILE. DO NOT EDIT.
+
+package v1alpha1
+
+import (
+	"github.com/grafana/grafana-app-sdk/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+// +k8s:openapi-gen=true
+type GetListResponse struct {
+	metav1.TypeMeta `json:",inline"`
+	GetListBody     `json:",inline"`
+}
+
+func NewGetListResponse() *GetListResponse {
+	return &GetListResponse{}
+}
+
+func (t *GetListBody) DeepCopyInto(dst *GetListBody) {
+	_ = resource.CopyObjectInto(dst, t)
+}
+
+func (o *GetListResponse) DeepCopyObject() runtime.Object {
+	dst := NewGetListResponse()
+	o.DeepCopyInto(dst)
+	return dst
+}
+
+func (o *GetListResponse) DeepCopyInto(dst *GetListResponse) {
+	dst.TypeMeta.APIVersion = o.TypeMeta.APIVersion
+	dst.TypeMeta.Kind = o.TypeMeta.Kind
+	o.GetListBody.DeepCopyInto(&dst.GetListBody)
+}
+
+func (GetListResponse) OpenAPIModelName() string {
+	return "com.github.grafana.grafana.apps.live.pkg.apis.live.v1alpha1.GetListResponse"
+}
+
+var _ runtime.Object = NewGetListResponse()

--- a/apps/live/pkg/apis/live/v1alpha1/getpush_response_body_types_gen.go
+++ b/apps/live/pkg/apis/live/v1alpha1/getpush_response_body_types_gen.go
@@ -1,0 +1,18 @@
+// Code generated - EDITING IS FUTILE. DO NOT EDIT.
+
+package v1alpha1
+
+// +k8s:openapi-gen=true
+type GetPushBody struct {
+	Status string `json:"status"`
+}
+
+// NewGetPushBody creates a new GetPushBody object.
+func NewGetPushBody() *GetPushBody {
+	return &GetPushBody{}
+}
+
+// OpenAPIModelName returns the OpenAPI model name for GetPushBody.
+func (GetPushBody) OpenAPIModelName() string {
+	return "com.github.grafana.grafana.apps.live.pkg.apis.live.v1alpha1.GetPushBody"
+}

--- a/apps/live/pkg/apis/live/v1alpha1/getpush_response_object_types_gen.go
+++ b/apps/live/pkg/apis/live/v1alpha1/getpush_response_object_types_gen.go
@@ -1,0 +1,41 @@
+// Code generated - EDITING IS FUTILE. DO NOT EDIT.
+
+package v1alpha1
+
+import (
+	"github.com/grafana/grafana-app-sdk/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+// +k8s:openapi-gen=true
+type GetPushResponse struct {
+	metav1.TypeMeta `json:",inline"`
+	GetPushBody     `json:",inline"`
+}
+
+func NewGetPushResponse() *GetPushResponse {
+	return &GetPushResponse{}
+}
+
+func (t *GetPushBody) DeepCopyInto(dst *GetPushBody) {
+	_ = resource.CopyObjectInto(dst, t)
+}
+
+func (o *GetPushResponse) DeepCopyObject() runtime.Object {
+	dst := NewGetPushResponse()
+	o.DeepCopyInto(dst)
+	return dst
+}
+
+func (o *GetPushResponse) DeepCopyInto(dst *GetPushResponse) {
+	dst.TypeMeta.APIVersion = o.TypeMeta.APIVersion
+	dst.TypeMeta.Kind = o.TypeMeta.Kind
+	o.GetPushBody.DeepCopyInto(&dst.GetPushBody)
+}
+
+func (GetPushResponse) OpenAPIModelName() string {
+	return "com.github.grafana.grafana.apps.live.pkg.apis.live.v1alpha1.GetPushResponse"
+}
+
+var _ runtime.Object = NewGetPushResponse()

--- a/apps/live/pkg/apis/live/v1alpha1/getsomething_request_params_object_gen.go
+++ b/apps/live/pkg/apis/live/v1alpha1/getsomething_request_params_object_gen.go
@@ -3,35 +3,36 @@
 package v1alpha1
 
 import (
-	"github.com/grafana/grafana-app-sdk/resource"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+    "github.com/grafana/grafana-app-sdk/resource"
+    metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
 type GetSomethingRequestParamsObject struct {
-	metav1.TypeMeta           `json:",inline"`
-	GetSomethingRequestParams `json:",inline"`
+    metav1.TypeMeta `json:",inline"`
+    GetSomethingRequestParams `json:",inline"`
 }
 
 func NewGetSomethingRequestParamsObject() *GetSomethingRequestParamsObject {
-	return &GetSomethingRequestParamsObject{}
+    return &GetSomethingRequestParamsObject{}
 }
 
 func (o *GetSomethingRequestParamsObject) DeepCopyObject() runtime.Object {
-	dst := NewGetSomethingRequestParamsObject()
-	o.DeepCopyInto(dst)
-	return dst
+    dst := NewGetSomethingRequestParamsObject()
+    o.DeepCopyInto(dst)
+    return dst
 }
 
 func (o *GetSomethingRequestParamsObject) DeepCopyInto(dst *GetSomethingRequestParamsObject) {
-	dst.TypeMeta.APIVersion = o.TypeMeta.APIVersion
-	dst.TypeMeta.Kind = o.TypeMeta.Kind
-	dstGetSomethingRequestParams := GetSomethingRequestParams{}
-	_ = resource.CopyObjectInto(&dstGetSomethingRequestParams, &o.GetSomethingRequestParams)
+    dst.TypeMeta.APIVersion = o.TypeMeta.APIVersion
+    dst.TypeMeta.Kind = o.TypeMeta.Kind
+    dstGetSomethingRequestParams := GetSomethingRequestParams{}
+    _ = resource.CopyObjectInto(&dstGetSomethingRequestParams, &o.GetSomethingRequestParams)
 }
 
+
 func (GetSomethingRequestParamsObject) OpenAPIModelName() string {
-	return "com.github.grafana.grafana.apps.live.pkg.apis.live.v1alpha1.GetSomethingRequestParamsObject"
+    return "com.github.grafana.grafana.apps.live.pkg.apis.live.v1alpha1.GetSomethingRequestParamsObject"
 }
 
 var _ runtime.Object = NewGetSomethingRequestParamsObject()

--- a/apps/live/pkg/apis/live/v1alpha1/getws_response_body_types_gen.go
+++ b/apps/live/pkg/apis/live/v1alpha1/getws_response_body_types_gen.go
@@ -1,0 +1,18 @@
+// Code generated - EDITING IS FUTILE. DO NOT EDIT.
+
+package v1alpha1
+
+// +k8s:openapi-gen=true
+type GetWsBody struct {
+	Status string `json:"status"`
+}
+
+// NewGetWsBody creates a new GetWsBody object.
+func NewGetWsBody() *GetWsBody {
+	return &GetWsBody{}
+}
+
+// OpenAPIModelName returns the OpenAPI model name for GetWsBody.
+func (GetWsBody) OpenAPIModelName() string {
+	return "com.github.grafana.grafana.apps.live.pkg.apis.live.v1alpha1.GetWsBody"
+}

--- a/apps/live/pkg/apis/live/v1alpha1/getws_response_object_types_gen.go
+++ b/apps/live/pkg/apis/live/v1alpha1/getws_response_object_types_gen.go
@@ -1,0 +1,41 @@
+// Code generated - EDITING IS FUTILE. DO NOT EDIT.
+
+package v1alpha1
+
+import (
+	"github.com/grafana/grafana-app-sdk/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+// +k8s:openapi-gen=true
+type GetWsResponse struct {
+	metav1.TypeMeta `json:",inline"`
+	GetWsBody       `json:",inline"`
+}
+
+func NewGetWsResponse() *GetWsResponse {
+	return &GetWsResponse{}
+}
+
+func (t *GetWsBody) DeepCopyInto(dst *GetWsBody) {
+	_ = resource.CopyObjectInto(dst, t)
+}
+
+func (o *GetWsResponse) DeepCopyObject() runtime.Object {
+	dst := NewGetWsResponse()
+	o.DeepCopyInto(dst)
+	return dst
+}
+
+func (o *GetWsResponse) DeepCopyInto(dst *GetWsResponse) {
+	dst.TypeMeta.APIVersion = o.TypeMeta.APIVersion
+	dst.TypeMeta.Kind = o.TypeMeta.Kind
+	o.GetWsBody.DeepCopyInto(&dst.GetWsBody)
+}
+
+func (GetWsResponse) OpenAPIModelName() string {
+	return "com.github.grafana.grafana.apps.live.pkg.apis.live.v1alpha1.GetWsResponse"
+}
+
+var _ runtime.Object = NewGetWsResponse()

--- a/apps/live/pkg/apis/manifestdata/live_manifest.go
+++ b/apps/live/pkg/apis/manifestdata/live_manifest.go
@@ -45,6 +45,165 @@ var appManifestData = app.ManifestData{
 			},
 			Routes: app.ManifestVersionRoutes{
 				Namespaced: map[string]spec3.PathProps{
+					"/list": {
+						Get: &spec3.Operation{
+							OperationProps: spec3.OperationProps{
+
+								OperationId: "getList",
+
+								Responses: &spec3.Responses{
+									ResponsesProps: spec3.ResponsesProps{
+										Default: &spec3.Response{
+											ResponseProps: spec3.ResponseProps{
+												Description: "Default OK response",
+												Content: map[string]*spec3.MediaType{
+													"application/json": {
+														MediaTypeProps: spec3.MediaTypeProps{
+															Schema: &spec.Schema{
+																SchemaProps: spec.SchemaProps{
+																	Type: []string{"object"},
+																	Properties: map[string]spec.Schema{
+																		"apiVersion": {
+																			SchemaProps: spec.SchemaProps{
+																				Type:        []string{"string"},
+																				Description: "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+																			},
+																		},
+																		"channels": {
+																			SchemaProps: spec.SchemaProps{
+																				Type: []string{"array"},
+																				Items: &spec.SchemaOrArray{
+																					Schema: &spec.Schema{
+																						SchemaProps: spec.SchemaProps{
+																							Type: []string{"object"},
+																							AdditionalProperties: &spec.SchemaOrBool{
+																								Schema: &spec.Schema{
+																									SchemaProps: spec.SchemaProps{},
+																								},
+																							},
+																						}},
+																				},
+																			},
+																		},
+																		"kind": {
+																			SchemaProps: spec.SchemaProps{
+																				Type:        []string{"string"},
+																				Description: "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+																			},
+																		},
+																	},
+																	Required: []string{
+																		"channels",
+																		"apiVersion",
+																		"kind",
+																	},
+																}},
+														}},
+												},
+											},
+										},
+									}},
+							},
+						},
+					},
+					"/push/{streamId}": {
+						Get: &spec3.Operation{
+							OperationProps: spec3.OperationProps{
+
+								OperationId: "getPush",
+
+								Responses: &spec3.Responses{
+									ResponsesProps: spec3.ResponsesProps{
+										Default: &spec3.Response{
+											ResponseProps: spec3.ResponseProps{
+												Description: "Default OK response",
+												Content: map[string]*spec3.MediaType{
+													"application/json": {
+														MediaTypeProps: spec3.MediaTypeProps{
+															Schema: &spec.Schema{
+																SchemaProps: spec.SchemaProps{
+																	Type: []string{"object"},
+																	Properties: map[string]spec.Schema{
+																		"apiVersion": {
+																			SchemaProps: spec.SchemaProps{
+																				Type:        []string{"string"},
+																				Description: "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+																			},
+																		},
+																		"kind": {
+																			SchemaProps: spec.SchemaProps{
+																				Type:        []string{"string"},
+																				Description: "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+																			},
+																		},
+																		"status": {
+																			SchemaProps: spec.SchemaProps{
+																				Type: []string{"string"},
+																			},
+																		},
+																	},
+																	Required: []string{
+																		"status",
+																		"apiVersion",
+																		"kind",
+																	},
+																}},
+														}},
+												},
+											},
+										},
+									}},
+							},
+						},
+						Post: &spec3.Operation{
+							OperationProps: spec3.OperationProps{
+
+								OperationId: "createPush",
+
+								Responses: &spec3.Responses{
+									ResponsesProps: spec3.ResponsesProps{
+										Default: &spec3.Response{
+											ResponseProps: spec3.ResponseProps{
+												Description: "Default OK response",
+												Content: map[string]*spec3.MediaType{
+													"application/json": {
+														MediaTypeProps: spec3.MediaTypeProps{
+															Schema: &spec.Schema{
+																SchemaProps: spec.SchemaProps{
+																	Type: []string{"object"},
+																	Properties: map[string]spec.Schema{
+																		"apiVersion": {
+																			SchemaProps: spec.SchemaProps{
+																				Type:        []string{"string"},
+																				Description: "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+																			},
+																		},
+																		"kind": {
+																			SchemaProps: spec.SchemaProps{
+																				Type:        []string{"string"},
+																				Description: "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+																			},
+																		},
+																		"status": {
+																			SchemaProps: spec.SchemaProps{
+																				Type: []string{"string"},
+																			},
+																		},
+																	},
+																	Required: []string{
+																		"status",
+																		"apiVersion",
+																		"kind",
+																	},
+																}},
+														}},
+												},
+											},
+										},
+									}},
+							},
+						},
+					},
 					"/something": {
 						Get: &spec3.Operation{
 							OperationProps: spec3.OperationProps{
@@ -116,6 +275,56 @@ var appManifestData = app.ManifestData{
 							},
 						},
 					},
+					"/ws": {
+						Get: &spec3.Operation{
+							OperationProps: spec3.OperationProps{
+
+								OperationId: "getWs",
+
+								Responses: &spec3.Responses{
+									ResponsesProps: spec3.ResponsesProps{
+										Default: &spec3.Response{
+											ResponseProps: spec3.ResponseProps{
+												Description: "Default OK response",
+												Content: map[string]*spec3.MediaType{
+													"application/json": {
+														MediaTypeProps: spec3.MediaTypeProps{
+															Schema: &spec.Schema{
+																SchemaProps: spec.SchemaProps{
+																	Type: []string{"object"},
+																	Properties: map[string]spec.Schema{
+																		"apiVersion": {
+																			SchemaProps: spec.SchemaProps{
+																				Type:        []string{"string"},
+																				Description: "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+																			},
+																		},
+																		"kind": {
+																			SchemaProps: spec.SchemaProps{
+																				Type:        []string{"string"},
+																				Description: "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+																			},
+																		},
+																		"status": {
+																			SchemaProps: spec.SchemaProps{
+																				Type: []string{"string"},
+																			},
+																		},
+																	},
+																	Required: []string{
+																		"status",
+																		"apiVersion",
+																		"kind",
+																	},
+																}},
+														}},
+												},
+											},
+										},
+									}},
+							},
+						},
+					},
 				},
 				Cluster: map[string]spec3.PathProps{},
 				Schemas: map[string]spec.Schema{},
@@ -144,7 +353,11 @@ func ManifestGoTypeAssociator(kind, version string) (goType resource.Kind, exist
 }
 
 var customRouteToGoResponseType = map[string]any{
-	"v1alpha1||<namespace>/something|GET": v1alpha1.GetSomethingResponse{},
+	"v1alpha1||<namespace>/list|GET":             v1alpha1.GetListResponse{},
+	"v1alpha1||<namespace>/push/{streamId}|GET":  v1alpha1.GetPushResponse{},
+	"v1alpha1||<namespace>/push/{streamId}|POST": v1alpha1.CreatePushResponse{},
+	"v1alpha1||<namespace>/something|GET":        v1alpha1.GetSomethingResponse{},
+	"v1alpha1||<namespace>/ws|GET":               v1alpha1.GetWsResponse{},
 }
 
 // ManifestCustomRouteResponsesAssociator returns the associated response go type for a given kind, version, custom route path, and method, if one exists.

--- a/apps/live/pkg/app/app.go
+++ b/apps/live/pkg/app/app.go
@@ -1,58 +1,66 @@
 package app
 
 import (
-	"k8s.io/apimachinery/pkg/runtime/schema"
+	"context"
 
 	"github.com/grafana/grafana-app-sdk/app"
 	"github.com/grafana/grafana-app-sdk/resource"
 	"github.com/grafana/grafana-app-sdk/simple"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
 	liveV1 "github.com/grafana/grafana/apps/live/pkg/apis/live/v1alpha1"
 )
 
+type liveRouteHandler func(ctx context.Context, writer app.CustomRouteResponseWriter, request *app.CustomRouteRequest) error
+
+// LiveConfig holds optional custom-route handlers injected by the registry layer.
+// Channel CRUD is always available when the live app is installed; transport
+// routes (ws/list/push) are only wired when handlers are provided.
 type LiveConfig struct {
 	Enable bool
+
+	WebSocketHandler liveRouteHandler
+	ListHandler      liveRouteHandler
+	PushGetHandler   liveRouteHandler
+	PushPostHandler  liveRouteHandler
 }
 
 func New(cfg app.Config) (app.App, error) {
-	// APIPath needs to be set to `/apis`, as it defaults to empty
 	cfg.KubeConfig.APIPath = "/apis"
-	// // We create a client to work with our Example kind in our reconciler
-	// client, err := k8s.NewClientRegistry(cfg.KubeConfig, k8s.DefaultClientConfig()).ClientFor(liveV1.ChannelKind())
-	// if err != nil {
-	// 	return nil, fmt.Errorf("unable to create example client: %w", err)
-	// }
-	// exampleConfig, ok := cfg.SpecificConfig.(*LiveConfig)
-	// if ok {
-	// 	fmt.Printf("CONFIG: %+v. // %v\n", exampleConfig, client)
-	// }
 
-	// This is the configuration for our App.
+	routes := simple.AppVersionRouteHandlers{
+		{
+			Namespaced: true,
+			Path:       "something",
+			Method:     "GET",
+		}: GetSomethingHandler,
+	}
+
+	if liveConfig, ok := cfg.SpecificConfig.(*LiveConfig); ok && liveConfig != nil {
+		if liveConfig.WebSocketHandler != nil {
+			routes[simple.AppVersionRoute{Namespaced: true, Path: "ws", Method: "GET"}] = simple.AppCustomRouteHandler(liveConfig.WebSocketHandler)
+		}
+		if liveConfig.ListHandler != nil {
+			routes[simple.AppVersionRoute{Namespaced: true, Path: "list", Method: "GET"}] = simple.AppCustomRouteHandler(liveConfig.ListHandler)
+		}
+		if liveConfig.PushGetHandler != nil {
+			routes[simple.AppVersionRoute{Namespaced: true, Path: "push/{streamId}", Method: "GET"}] = simple.AppCustomRouteHandler(liveConfig.PushGetHandler)
+		}
+		if liveConfig.PushPostHandler != nil {
+			routes[simple.AppVersionRoute{Namespaced: true, Path: "push/{streamId}", Method: "POST"}] = simple.AppCustomRouteHandler(liveConfig.PushPostHandler)
+		}
+	}
+
 	simpleConfig := simple.AppConfig{
 		Name:       "live",
 		KubeConfig: cfg.KubeConfig,
-		// ManagedKinds is the list of all kinds our app manages (the kinds owned by our app).
-		// Here, a Kind is defined as a distinct Group, Version, and Kind combination,
-		// so for each version of our Example kind, we need to add it to this list.
-		// Each kind can also have admission control attached to it--different versions can have different admission control attached.
-		// Handlers for custom routes defined in the manifest for the kind go here--this is where they actuall get routed,
-		// they are only defined in the manifest.
-		// Reconcilers and/or Watchers are also attached here, though they should only be attached to a single version per kind.
 		ManagedKinds: []simple.AppManagedKind{
 			{
 				Kind: liveV1.ChannelKind(),
 			},
 		},
-		// VersionedCustomRoutes are the custom route handlers for routes defined at the version level of the manifest
-		// instead of for a specific kind. This are sometimes referred to as "resource routes"
-		// (as opposed to "subresource routes" which are attached to kinds).
 		VersionedCustomRoutes: map[string]simple.AppVersionRouteHandlers{
-			"v1alpha1": {
-				{
-					Namespaced: true,
-					Path:       "something",
-					Method:     "GET",
-				}: GetSomethingHandler,
-			},
+			"v1alpha1": routes,
 		},
 	}
 
@@ -61,9 +69,6 @@ func New(cfg app.Config) (app.App, error) {
 		return nil, err
 	}
 
-	// This makes it easier to catch problems at startup, rather than when something doesn't behave as expected.
-	// ValidateManifest will ensure that the capabilities you define in your simple.AppConfig
-	// match the capabilities described in the AppManifest.
 	err = a.ValidateManifest(cfg.ManifestData)
 	if err != nil {
 		return nil, err

--- a/packages/grafana-data/src/types/featureToggles.gen.ts
+++ b/packages/grafana-data/src/types/featureToggles.gen.ts
@@ -69,6 +69,11 @@ export interface FeatureToggles {
   */
   lokiQuerySplitting?: boolean;
   /**
+  * Registers a live apiserver
+  * @default false
+  */
+  ['live.runAPIServer']?: boolean;
+  /**
   * populate star status from apiserver
   * @default false
   */

--- a/pkg/api/org_users.go
+++ b/pkg/api/org_users.go
@@ -89,13 +89,53 @@ func (hs *HTTPServer) addOrgUserHelper(c *contextmodel.ReqContext, cmd org.AddOr
 
 	cmd.UserID = userToAdd.ID
 
-	if err := hs.orgService.AddOrgUser(c.Req.Context(), &cmd); err != nil {
+	ctx := c.Req.Context()
+	if hs.isKubernetesUsersRedirect(ctx) {
+		return hs.addOrgUserUsingK8s(c, cmd)
+	}
+
+	if err := hs.orgService.AddOrgUser(ctx, &cmd); err != nil {
 		if errors.Is(err, org.ErrOrgUserAlreadyAdded) {
 			return response.JSON(http.StatusConflict, util.DynMap{
 				"message": "User is already member of this organization",
 				"userId":  cmd.UserID,
 			})
 		}
+		return response.Error(http.StatusInternalServerError, "Could not add user to organization", err)
+	}
+
+	return response.JSON(http.StatusOK, util.DynMap{
+		"message": "User added to organization",
+		"userId":  cmd.UserID,
+	})
+}
+
+// addOrgUserUsingK8s assigns org membership via the IAM User role field when
+// kubernetesUsersRedirect is on (Cloud single-org). Membership is User.spec.role;
+// there is no separate OrgUser resource.
+func (hs *HTTPServer) addOrgUserUsingK8s(c *contextmodel.ReqContext, cmd org.AddOrgUserCommand) response.Response {
+	existing, err := hs.searchOrgUsersUsingK8s(c, &org.SearchOrgUsersQuery{
+		OrgID:  cmd.OrgID,
+		User:   c.SignedInUser,
+		UserID: cmd.UserID,
+		Limit:  1,
+		Page:   1,
+	})
+	if err != nil {
+		return response.Error(http.StatusInternalServerError, "Could not add user to organization", err)
+	}
+	if len(existing.OrgUsers) > 0 {
+		return response.JSON(http.StatusConflict, util.DynMap{
+			"message": "User is already member of this organization",
+			"userId":  cmd.UserID,
+		})
+	}
+
+	role := string(cmd.Role)
+	if err := hs.userService.Update(c.Req.Context(), &user.UpdateUserCommand{
+		UserID:  cmd.UserID,
+		OrgRole: &role,
+	}); err != nil {
 		return response.Error(http.StatusInternalServerError, "Could not add user to organization", err)
 	}
 
@@ -129,7 +169,7 @@ func (hs *HTTPServer) GetOrgUsersForCurrentOrg(c *contextmodel.ReqContext) respo
 	ctx := c.Req.Context()
 	var result *org.SearchOrgUsersQueryResult
 	var err error
-	if ofClient.Boolean(ctx, featuremgmt.FlagKubernetesUsersRedirect, false, openfeature.TransactionContext(ctx)) {
+	if hs.isKubernetesUsersRedirect(ctx) {
 		result, err = hs.searchOrgUsersUsingK8s(c, query)
 	} else {
 		result, err = hs.searchOrgUsersHelper(c, query)
@@ -157,50 +197,29 @@ func (hs *HTTPServer) GetOrgUsersForCurrentOrg(c *contextmodel.ReqContext) respo
 // 500: internalServerError
 
 func (hs *HTTPServer) GetOrgUsersForCurrentOrgLookup(c *contextmodel.ReqContext) response.Response {
-	ctx := c.Req.Context()
-	// Single-org with users in unified storage: the legacy org_user/user join is
-	// empty, so read the shared users via the k8s-redirected user search instead.
-	if hs.Cfg.RBAC.SingleOrganization && ofClient.Boolean(ctx, featuremgmt.FlagKubernetesUsersRedirect, false, openfeature.TransactionContext(ctx)) {
-		searchResult, err := hs.userService.Search(ctx, &user.SearchUsersQuery{
-			SignedInUser: c.SignedInUser,
-			OrgID:        c.GetOrgID(),
-			Query:        c.Query("query"),
-			Limit:        c.QueryInt("limit"),
-		})
-		if err != nil {
-			return response.Error(http.StatusInternalServerError, "Failed to get users for current organization", err)
-		}
-
-		result := make([]*dtos.UserLookupDTO, 0, len(searchResult.Users))
-		for _, u := range searchResult.Users {
-			avatarURL := u.AvatarURL
-			if avatarURL == "" {
-				avatarURL = dtos.GetGravatarUrl(hs.Cfg, u.Email)
-			}
-			result = append(result, &dtos.UserLookupDTO{
-				UID:       u.UID,
-				UserID:    u.ID,
-				Login:     u.Login,
-				AvatarURL: avatarURL,
-			})
-		}
-		return response.JSON(http.StatusOK, result)
-	}
-
-	orgUsersResult, err := hs.searchOrgUsersHelper(c, &org.SearchOrgUsersQuery{
+	query := &org.SearchOrgUsersQuery{
 		OrgID:                    c.GetOrgID(),
 		Query:                    c.Query("query"),
 		Limit:                    c.QueryInt("limit"),
 		User:                     c.SignedInUser,
 		DontEnforceAccessControl: !hs.License.FeatureEnabled("accesscontrol.enforcement"),
-	})
+	}
 
+	ctx := c.Req.Context()
+	var orgUsersResult *org.SearchOrgUsersQueryResult
+	var err error
+	// When kubernetesUsersRedirect is on (typically Cloud single-org), the legacy
+	// org_user/user join is empty — read via IAM user search instead.
+	if hs.isKubernetesUsersRedirect(ctx) {
+		orgUsersResult, err = hs.searchOrgUsersUsingK8s(c, query)
+	} else {
+		orgUsersResult, err = hs.searchOrgUsersHelper(c, query)
+	}
 	if err != nil {
 		return response.Error(http.StatusInternalServerError, "Failed to get users for current organization", err)
 	}
 
-	result := make([]*dtos.UserLookupDTO, 0)
-
+	result := make([]*dtos.UserLookupDTO, 0, len(orgUsersResult.OrgUsers))
 	for _, u := range orgUsersResult.OrgUsers {
 		result = append(result, &dtos.UserLookupDTO{
 			UID:       u.UID,
@@ -234,13 +253,20 @@ func (hs *HTTPServer) GetOrgUsers(c *contextmodel.ReqContext) response.Response 
 		return response.Error(http.StatusBadRequest, "orgId is invalid", err)
 	}
 
-	result, err := hs.searchOrgUsersHelper(c, &org.SearchOrgUsersQuery{
+	query := &org.SearchOrgUsersQuery{
 		OrgID: orgId,
 		Query: "",
 		Limit: 0,
 		User:  c.SignedInUser,
-	})
+	}
 
+	ctx := c.Req.Context()
+	var result *org.SearchOrgUsersQueryResult
+	if hs.isKubernetesUsersRedirect(ctx) {
+		result, err = hs.searchOrgUsersUsingK8s(c, query)
+	} else {
+		result, err = hs.searchOrgUsersHelper(c, query)
+	}
 	if err != nil {
 		return response.Error(http.StatusInternalServerError, "Failed to get users for organization", err)
 	}
@@ -284,15 +310,22 @@ func (hs *HTTPServer) SearchOrgUsers(c *contextmodel.ReqContext) response.Respon
 		return response.Err(err)
 	}
 
-	result, err := hs.searchOrgUsersHelper(c, &org.SearchOrgUsersQuery{
+	query := &org.SearchOrgUsersQuery{
 		OrgID:    orgID,
 		Query:    c.Query("query"),
 		Page:     page,
 		Limit:    perPage,
 		User:     c.SignedInUser,
 		SortOpts: sortOpts,
-	})
+	}
 
+	ctx := c.Req.Context()
+	var result *org.SearchOrgUsersQueryResult
+	if hs.isKubernetesUsersRedirect(ctx) {
+		result, err = hs.searchOrgUsersUsingK8s(c, query)
+	} else {
+		result, err = hs.searchOrgUsersHelper(c, query)
+	}
 	if err != nil {
 		return response.Error(http.StatusInternalServerError, "Failed to get users for organization", err)
 	}
@@ -328,10 +361,8 @@ func (hs *HTTPServer) SearchOrgUsersWithPaging(c *contextmodel.ReqContext) respo
 	}
 
 	ctx := c.Req.Context()
-	kubernetesUsersRedirect := openfeature.NewDefaultClient().Boolean(ctx, featuremgmt.FlagKubernetesUsersRedirect, false, openfeature.TransactionContext(ctx))
-
 	var result *org.SearchOrgUsersQueryResult
-	if kubernetesUsersRedirect {
+	if hs.isKubernetesUsersRedirect(ctx) {
 		result, err = hs.searchOrgUsersUsingK8s(c, query)
 	} else {
 		result, err = hs.searchOrgUsersHelper(c, query)
@@ -341,6 +372,10 @@ func (hs *HTTPServer) SearchOrgUsersWithPaging(c *contextmodel.ReqContext) respo
 	}
 
 	return response.JSON(http.StatusOK, result)
+}
+
+func (hs *HTTPServer) isKubernetesUsersRedirect(ctx context.Context) bool {
+	return ofClient.Boolean(ctx, featuremgmt.FlagKubernetesUsersRedirect, false, openfeature.TransactionContext(ctx))
 }
 
 func (hs *HTTPServer) searchOrgUsersHelper(c *contextmodel.ReqContext, query *org.SearchOrgUsersQuery) (*org.SearchOrgUsersQueryResult, error) {
@@ -570,8 +605,7 @@ func (hs *HTTPServer) updateOrgUserHelper(c *contextmodel.ReqContext, cmd org.Up
 	}
 
 	ctx := c.Req.Context()
-	if cmd.OrgID == c.GetOrgID() &&
-		ofClient.Boolean(ctx, featuremgmt.FlagKubernetesUsersRedirect, false, openfeature.TransactionContext(ctx)) {
+	if hs.isKubernetesUsersRedirect(ctx) {
 		if cmd.Role != org.RoleAdmin {
 			hasOtherAdmin, err := hs.orgHasOtherAdmin(c, cmd.OrgID, cmd.UserID)
 			if err != nil {
@@ -647,7 +681,7 @@ func (hs *HTTPServer) RemoveOrgUserForCurrentOrg(c *contextmodel.ReqContext) res
 		return response.Error(http.StatusBadRequest, "userId is invalid", err)
 	}
 
-	return hs.removeOrgUserHelper(c.Req.Context(), &org.RemoveOrgUserCommand{
+	return hs.removeOrgUserHelper(c, &org.RemoveOrgUserCommand{
 		UserID:                   userId,
 		OrgID:                    c.GetOrgID(),
 		ShouldDeleteOrphanedUser: true,
@@ -676,13 +710,18 @@ func (hs *HTTPServer) RemoveOrgUser(c *contextmodel.ReqContext) response.Respons
 	if err != nil {
 		return response.Error(http.StatusBadRequest, "orgId is invalid", err)
 	}
-	return hs.removeOrgUserHelper(c.Req.Context(), &org.RemoveOrgUserCommand{
+	return hs.removeOrgUserHelper(c, &org.RemoveOrgUserCommand{
 		UserID: userId,
 		OrgID:  orgId,
 	})
 }
 
-func (hs *HTTPServer) removeOrgUserHelper(ctx context.Context, cmd *org.RemoveOrgUserCommand) response.Response {
+func (hs *HTTPServer) removeOrgUserHelper(c *contextmodel.ReqContext, cmd *org.RemoveOrgUserCommand) response.Response {
+	ctx := c.Req.Context()
+	if hs.isKubernetesUsersRedirect(ctx) {
+		return hs.removeOrgUserUsingK8s(c, cmd)
+	}
+
 	if err := hs.orgService.RemoveOrgUser(ctx, cmd); err != nil {
 		if errors.Is(err, org.ErrLastOrgAdmin) {
 			return response.Error(http.StatusBadRequest, "Cannot remove last organization admin", nil)
@@ -703,6 +742,35 @@ func (hs *HTTPServer) removeOrgUserHelper(ctx context.Context, cmd *org.RemoveOr
 		hs.log.Warn("failed to delete permissions for user", "userID", cmd.UserID, "orgID", cmd.OrgID, "err", err)
 	}
 
+	return response.Success("User removed from organization")
+}
+
+// removeOrgUserUsingK8s deletes the IAM User when kubernetesUsersRedirect is on
+// (Cloud single-org: org membership is the User resource itself).
+func (hs *HTTPServer) removeOrgUserUsingK8s(c *contextmodel.ReqContext, cmd *org.RemoveOrgUserCommand) response.Response {
+	hasOtherAdmin, err := hs.orgHasOtherAdmin(c, cmd.OrgID, cmd.UserID)
+	if err != nil {
+		return response.Error(http.StatusInternalServerError, "Failed to remove user from organization", err)
+	}
+	if !hasOtherAdmin {
+		return response.Error(http.StatusBadRequest, "Cannot remove last organization admin", nil)
+	}
+
+	ctx := c.Req.Context()
+	if err := hs.userService.Delete(ctx, &user.DeleteUserCommand{UserID: cmd.UserID}); err != nil {
+		return response.Error(http.StatusInternalServerError, "Failed to remove user from organization", err)
+	}
+
+	if err := hs.accesscontrolService.DeleteUserPermissions(ctx, accesscontrol.GlobalOrgID, cmd.UserID); err != nil {
+		hs.log.Warn("failed to delete permissions for user", "userID", cmd.UserID, "orgID", accesscontrol.GlobalOrgID, "err", err)
+	}
+	if err := hs.accesscontrolService.DeleteUserPermissions(ctx, cmd.OrgID, cmd.UserID); err != nil {
+		hs.log.Warn("failed to delete permissions for user", "userID", cmd.UserID, "orgID", cmd.OrgID, "err", err)
+	}
+
+	if cmd.ShouldDeleteOrphanedUser {
+		return response.Success("User deleted")
+	}
 	return response.Success("User removed from organization")
 }
 

--- a/pkg/api/org_users_test.go
+++ b/pkg/api/org_users_test.go
@@ -1067,3 +1067,163 @@ func TestUpdateOrgUserForCurrentOrg_KubernetesUsersRedirect(t *testing.T) {
 		assert.Nil(t, d.updateCmd, "user service update should not be called on the legacy path")
 	})
 }
+
+func TestAddOrgUserToCurrentOrg_KubernetesUsersRedirect(t *testing.T) {
+	permissions := []accesscontrol.Permission{
+		{Action: accesscontrol.ActionOrgUsersAdd, Scope: "users:*"},
+	}
+
+	type deps struct {
+		updateCmd   *user.UpdateUserCommand
+		legacyError error
+		updateError error
+		searchUsers user.SearchUserQueryResult
+	}
+
+	setup := func(t *testing.T, d *deps) *webtest.Server {
+		return SetupAPITestServer(t, func(hs *HTTPServer) {
+			hs.Cfg = setting.NewCfg()
+			hs.userService = &usertest.FakeUserService{
+				ExpectedUser:        &user.User{ID: 42, Login: "jdoe", Email: "jdoe@example.com"},
+				ExpectedSearchUsers: d.searchUsers,
+				UpdateFn: func(_ context.Context, cmd *user.UpdateUserCommand) error {
+					d.updateCmd = cmd
+					return d.updateError
+				},
+			}
+			hs.orgService = &orgtest.FakeOrgService{ExpectedError: d.legacyError}
+			hs.accesscontrolService = &actest.FakeService{ExpectedPermissions: permissions}
+		})
+	}
+
+	sendPost := func(t *testing.T, server *webtest.Server, body string) int {
+		signedInUser := userWithPermissions(1, permissions)
+		signedInUser.OrgRole = identity.RoleAdmin
+		req := server.NewRequest(http.MethodPost, "/api/org/users", strings.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		res, err := server.Send(webtest.RequestWithSignedInUser(req, signedInUser))
+		require.NoError(t, err)
+		require.NoError(t, res.Body.Close())
+		return res.StatusCode
+	}
+
+	t.Run("routes add through user service Update when the flag is enabled", func(t *testing.T) {
+		setupOpenFeatureFlag(t, featuremgmt.FlagKubernetesUsersRedirect, true)
+
+		d := &deps{legacyError: errors.New("legacy path must not be called")}
+		statusCode := sendPost(t, setup(t, d), `{"loginOrEmail":"jdoe","role":"Editor"}`)
+
+		assert.Equal(t, http.StatusOK, statusCode)
+		require.NotNil(t, d.updateCmd)
+		assert.Equal(t, int64(42), d.updateCmd.UserID)
+		require.NotNil(t, d.updateCmd.OrgRole)
+		assert.Equal(t, "Editor", *d.updateCmd.OrgRole)
+	})
+
+	t.Run("returns 409 when the user is already a member", func(t *testing.T) {
+		setupOpenFeatureFlag(t, featuremgmt.FlagKubernetesUsersRedirect, true)
+
+		d := &deps{searchUsers: user.SearchUserQueryResult{
+			TotalCount: 1,
+			Users:      []*user.UserSearchHitDTO{{ID: 42, Login: "jdoe", Role: "Viewer"}},
+		}}
+		statusCode := sendPost(t, setup(t, d), `{"loginOrEmail":"jdoe","role":"Editor"}`)
+
+		assert.Equal(t, http.StatusConflict, statusCode)
+		assert.Nil(t, d.updateCmd)
+	})
+
+	t.Run("keeps using the legacy org service when the flag is disabled", func(t *testing.T) {
+		setupOpenFeatureFlag(t, featuremgmt.FlagKubernetesUsersRedirect, false)
+
+		d := &deps{}
+		statusCode := sendPost(t, setup(t, d), `{"loginOrEmail":"jdoe","role":"Editor"}`)
+
+		assert.Equal(t, http.StatusOK, statusCode)
+		assert.Nil(t, d.updateCmd)
+	})
+}
+
+func TestRemoveOrgUserForCurrentOrg_KubernetesUsersRedirect(t *testing.T) {
+	permissions := []accesscontrol.Permission{
+		{Action: accesscontrol.ActionOrgUsersRemove, Scope: "users:*"},
+		{Action: accesscontrol.ActionOrgUsersRead, Scope: "users:*"},
+	}
+
+	orgUsersWithTwoAdmins := user.SearchUserQueryResult{
+		TotalCount: 2,
+		Users: []*user.UserSearchHitDTO{
+			{ID: 1, Login: "target", Role: string(identity.RoleAdmin)},
+			{ID: 2, Login: "other", Role: string(identity.RoleAdmin)},
+		},
+	}
+
+	type deps struct {
+		deleteCmd   *user.DeleteUserCommand
+		legacyError error
+		deleteError error
+		searchUsers user.SearchUserQueryResult
+	}
+
+	setup := func(t *testing.T, d *deps) *webtest.Server {
+		return SetupAPITestServer(t, func(hs *HTTPServer) {
+			hs.Cfg = setting.NewCfg()
+			hs.userService = &usertest.FakeUserService{
+				ExpectedSearchUsers: d.searchUsers,
+				DeleteFn: func(_ context.Context, cmd *user.DeleteUserCommand) error {
+					d.deleteCmd = cmd
+					return d.deleteError
+				},
+			}
+			hs.orgService = &orgtest.FakeOrgService{ExpectedError: d.legacyError}
+			hs.accesscontrolService = &actest.FakeService{ExpectedPermissions: permissions}
+		})
+	}
+
+	sendDelete := func(t *testing.T, server *webtest.Server) int {
+		signedInUser := userWithPermissions(1, permissions)
+		signedInUser.OrgRole = identity.RoleAdmin
+		req := server.NewRequest(http.MethodDelete, "/api/org/users/1", nil)
+		res, err := server.Send(webtest.RequestWithSignedInUser(req, signedInUser))
+		require.NoError(t, err)
+		require.NoError(t, res.Body.Close())
+		return res.StatusCode
+	}
+
+	t.Run("routes remove through user service Delete when the flag is enabled", func(t *testing.T) {
+		setupOpenFeatureFlag(t, featuremgmt.FlagKubernetesUsersRedirect, true)
+
+		d := &deps{legacyError: errors.New("legacy path must not be called"), searchUsers: orgUsersWithTwoAdmins}
+		statusCode := sendDelete(t, setup(t, d))
+
+		assert.Equal(t, http.StatusOK, statusCode)
+		require.NotNil(t, d.deleteCmd)
+		assert.Equal(t, int64(1), d.deleteCmd.UserID)
+	})
+
+	t.Run("blocks removing the last org admin", func(t *testing.T) {
+		setupOpenFeatureFlag(t, featuremgmt.FlagKubernetesUsersRedirect, true)
+
+		d := &deps{searchUsers: user.SearchUserQueryResult{
+			TotalCount: 2,
+			Users: []*user.UserSearchHitDTO{
+				{ID: 1, Login: "target", Role: string(identity.RoleAdmin)},
+				{ID: 2, Login: "other", Role: string(identity.RoleViewer)},
+			},
+		}}
+		statusCode := sendDelete(t, setup(t, d))
+
+		assert.Equal(t, http.StatusBadRequest, statusCode)
+		assert.Nil(t, d.deleteCmd)
+	})
+
+	t.Run("keeps using the legacy org service when the flag is disabled", func(t *testing.T) {
+		setupOpenFeatureFlag(t, featuremgmt.FlagKubernetesUsersRedirect, false)
+
+		d := &deps{}
+		statusCode := sendDelete(t, setup(t, d))
+
+		assert.Equal(t, http.StatusOK, statusCode)
+		assert.Nil(t, d.deleteCmd)
+	})
+}

--- a/pkg/api/org_users_test.go
+++ b/pkg/api/org_users_test.go
@@ -1221,7 +1221,20 @@ func TestRemoveOrgUserForCurrentOrg_KubernetesUsersRedirect(t *testing.T) {
 		setupOpenFeatureFlag(t, featuremgmt.FlagKubernetesUsersRedirect, false)
 
 		d := &deps{}
-		statusCode := sendDelete(t, setup(t, d))
+		server := SetupAPITestServer(t, func(hs *HTTPServer) {
+			hs.Cfg = setting.NewCfg()
+			hs.userService = &usertest.FakeUserService{
+				DeleteFn: func(_ context.Context, cmd *user.DeleteUserCommand) error {
+					d.deleteCmd = cmd
+					return nil
+				},
+			}
+			hs.orgService = &orgtest.FakeOrgService{
+				ExpectedOrgListResponse: orgtest.OrgListResponse{{Response: nil}},
+			}
+			hs.accesscontrolService = &actest.FakeService{ExpectedPermissions: permissions}
+		})
+		statusCode := sendDelete(t, server)
 
 		assert.Equal(t, http.StatusOK, statusCode)
 		assert.Nil(t, d.deleteCmd)

--- a/pkg/apis/iam/v0alpha1/register.go
+++ b/pkg/apis/iam/v0alpha1/register.go
@@ -59,6 +59,11 @@ func AddKnownTypes(scheme *runtime.Scheme, version string) {
 	scheme.AddKnownTypes(
 		schema.GroupVersion{Group: GROUP, Version: version},
 		&UserTeamList{},
+		&UserOrgList{},
+		&UserAuthTokenList{},
+		&UserAuthTokenRevokeStatus{},
+		&UserUsingStatus{},
+		&UserPasswordStatus{},
 		&DisplayList{},
 		&SSOSetting{},
 		&SSOSettingList{},

--- a/pkg/apis/iam/v0alpha1/types_user_org.go
+++ b/pkg/apis/iam/v0alpha1/types_user_org.go
@@ -1,0 +1,57 @@
+package v0alpha1
+
+import metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+// +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
+type UserOrgList struct {
+	metav1.TypeMeta `json:",inline"`
+	metav1.ListMeta `json:"metadata,omitempty"`
+
+	Items []UserOrg `json:"items"`
+}
+
+type UserOrg struct {
+	OrgID int64  `json:"orgId"`
+	Name  string `json:"name"`
+	Role  string `json:"role"`
+}
+
+// +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
+type UserAuthTokenList struct {
+	metav1.TypeMeta `json:",inline"`
+	metav1.ListMeta `json:"metadata,omitempty"`
+
+	Items []UserAuthToken `json:"items"`
+}
+
+type UserAuthToken struct {
+	ID        int64  `json:"id"`
+	CreatedAt string `json:"createdAt,omitempty"`
+	SeenAt    string `json:"seenAt,omitempty"`
+	ClientIP  string `json:"clientIp,omitempty"`
+	UserAgent string `json:"userAgent,omitempty"`
+	AuthModule string `json:"authModule,omitempty"`
+	IsActive  bool   `json:"isActive"`
+}
+
+// +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
+type UserAuthTokenRevokeStatus struct {
+	metav1.TypeMeta `json:",inline"`
+
+	Message string `json:"message"`
+}
+
+// +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
+type UserUsingStatus struct {
+	metav1.TypeMeta `json:",inline"`
+
+	Message string `json:"message"`
+	OrgID   int64  `json:"orgId,omitempty"`
+}
+
+// +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
+type UserPasswordStatus struct {
+	metav1.TypeMeta `json:",inline"`
+
+	Message string `json:"message"`
+}

--- a/pkg/apis/iam/v0alpha1/zz_generated_user_org_deepcopy.go
+++ b/pkg/apis/iam/v0alpha1/zz_generated_user_org_deepcopy.go
@@ -1,0 +1,146 @@
+package v0alpha1
+
+import runtime "k8s.io/apimachinery/pkg/runtime"
+
+func (in *UserOrg) DeepCopyInto(out *UserOrg) {
+	*out = *in
+}
+
+func (in *UserOrg) DeepCopy() *UserOrg {
+	if in == nil {
+		return nil
+	}
+	out := new(UserOrg)
+	in.DeepCopyInto(out)
+	return out
+}
+
+func (in *UserOrgList) DeepCopyInto(out *UserOrgList) {
+	*out = *in
+	out.TypeMeta = in.TypeMeta
+	in.ListMeta.DeepCopyInto(&out.ListMeta)
+	if in.Items != nil {
+		in, out := &in.Items, &out.Items
+		*out = make([]UserOrg, len(*in))
+		copy(*out, *in)
+	}
+}
+
+func (in *UserOrgList) DeepCopy() *UserOrgList {
+	if in == nil {
+		return nil
+	}
+	out := new(UserOrgList)
+	in.DeepCopyInto(out)
+	return out
+}
+
+func (in *UserOrgList) DeepCopyObject() runtime.Object {
+	if c := in.DeepCopy(); c != nil {
+		return c
+	}
+	return nil
+}
+
+func (in *UserAuthToken) DeepCopyInto(out *UserAuthToken) {
+	*out = *in
+}
+
+func (in *UserAuthToken) DeepCopy() *UserAuthToken {
+	if in == nil {
+		return nil
+	}
+	out := new(UserAuthToken)
+	in.DeepCopyInto(out)
+	return out
+}
+
+func (in *UserAuthTokenList) DeepCopyInto(out *UserAuthTokenList) {
+	*out = *in
+	out.TypeMeta = in.TypeMeta
+	in.ListMeta.DeepCopyInto(&out.ListMeta)
+	if in.Items != nil {
+		in, out := &in.Items, &out.Items
+		*out = make([]UserAuthToken, len(*in))
+		copy(*out, *in)
+	}
+}
+
+func (in *UserAuthTokenList) DeepCopy() *UserAuthTokenList {
+	if in == nil {
+		return nil
+	}
+	out := new(UserAuthTokenList)
+	in.DeepCopyInto(out)
+	return out
+}
+
+func (in *UserAuthTokenList) DeepCopyObject() runtime.Object {
+	if c := in.DeepCopy(); c != nil {
+		return c
+	}
+	return nil
+}
+
+func (in *UserAuthTokenRevokeStatus) DeepCopyInto(out *UserAuthTokenRevokeStatus) {
+	*out = *in
+	out.TypeMeta = in.TypeMeta
+}
+
+func (in *UserAuthTokenRevokeStatus) DeepCopy() *UserAuthTokenRevokeStatus {
+	if in == nil {
+		return nil
+	}
+	out := new(UserAuthTokenRevokeStatus)
+	in.DeepCopyInto(out)
+	return out
+}
+
+func (in *UserAuthTokenRevokeStatus) DeepCopyObject() runtime.Object {
+	if c := in.DeepCopy(); c != nil {
+		return c
+	}
+	return nil
+}
+
+func (in *UserUsingStatus) DeepCopyInto(out *UserUsingStatus) {
+	*out = *in
+	out.TypeMeta = in.TypeMeta
+}
+
+func (in *UserUsingStatus) DeepCopy() *UserUsingStatus {
+	if in == nil {
+		return nil
+	}
+	out := new(UserUsingStatus)
+	in.DeepCopyInto(out)
+	return out
+}
+
+func (in *UserUsingStatus) DeepCopyObject() runtime.Object {
+	if c := in.DeepCopy(); c != nil {
+		return c
+	}
+	return nil
+}
+
+func (in *UserPasswordStatus) DeepCopyInto(out *UserPasswordStatus) {
+	*out = *in
+	out.TypeMeta = in.TypeMeta
+}
+
+func (in *UserPasswordStatus) DeepCopy() *UserPasswordStatus {
+	if in == nil {
+		return nil
+	}
+	out := new(UserPasswordStatus)
+	in.DeepCopyInto(out)
+	return out
+}
+
+func (in *UserPasswordStatus) DeepCopyObject() runtime.Object {
+	if c := in.DeepCopy(); c != nil {
+		return c
+	}
+	return nil
+}

--- a/pkg/middleware/gziper.go
+++ b/pkg/middleware/gziper.go
@@ -49,8 +49,9 @@ var gzipIgnoredPaths = []matcher{
 	prefix("/api/plugin-proxy/"),
 	prefix("/api/gnet/"), // Already gzipped by grafana.com.
 	prefix("/metrics"),
-	prefix("/api/live/ws"),   // WebSocket does not support gzip compression.
-	prefix("/api/live/push"), // WebSocket does not support gzip compression.
+	prefix("/api/live/ws"),                     // WebSocket does not support gzip compression.
+	prefix("/api/live/push"),                   // WebSocket does not support gzip compression.
+	prefix("/apis/live.grafana.app/"),          // Live /apis transport (ws/push) must not be gzipped.
 	substr("/resources"),
 }
 

--- a/pkg/registry/apis/iam/authorizer.go
+++ b/pkg/registry/apis/iam/authorizer.go
@@ -187,27 +187,49 @@ func allowSelfAuthorizer(base authorizer.Authorizer) authorizer.Authorizer {
 	})
 }
 
-// newUserAuthorizer creates an authorizer for users that handles the "teams" and "status" subresources.
-// "teams" is read-only (Connecter/GET), so it checks user get.
-// "status" supports both GET and PUT, so the check verb mirrors the request verb.
+// newUserAuthorizer creates an authorizer for users that handles the "teams", "status",
+// "orgs", "using", "tokens", and "password" subresources.
+// Read-only connecters check user get; write connecters check user update.
 func newUserAuthorizer(accessClient authlib.AccessClient) authorizer.Authorizer {
+	userGetCheck := func(ctx context.Context, ident authlib.AuthInfo, attr authorizer.Attributes) (authorizer.Decision, string, error) {
+		res, err := accessClient.Check(ctx, ident, authlib.CheckRequest{
+			Verb:      utils.VerbGet,
+			Group:     attr.GetAPIGroup(),
+			Resource:  attr.GetResource(),
+			Namespace: attr.GetNamespace(),
+			Name:      attr.GetName(),
+		}, "")
+		if err != nil {
+			return authorizer.DecisionDeny, "", err
+		}
+		if !res.Allowed {
+			return authorizer.DecisionDeny, "requires user get", nil
+		}
+		return authorizer.DecisionAllow, "", nil
+	}
+	userUpdateCheck := func(ctx context.Context, ident authlib.AuthInfo, attr authorizer.Attributes) (authorizer.Decision, string, error) {
+		res, err := accessClient.Check(ctx, ident, authlib.CheckRequest{
+			Verb:      utils.VerbUpdate,
+			Group:     attr.GetAPIGroup(),
+			Resource:  attr.GetResource(),
+			Namespace: attr.GetNamespace(),
+			Name:      attr.GetName(),
+		}, "")
+		if err != nil {
+			return authorizer.DecisionDeny, "", err
+		}
+		if !res.Allowed {
+			return authorizer.DecisionDeny, "requires user update", nil
+		}
+		return authorizer.DecisionAllow, "", nil
+	}
+
 	base := gfauthorizer.NewResourceAuthorizerWithSubresourceHandlers(accessClient, map[string]gfauthorizer.SubresourceCheck{
-		"teams": func(ctx context.Context, ident authlib.AuthInfo, attr authorizer.Attributes) (authorizer.Decision, string, error) {
-			res, err := accessClient.Check(ctx, ident, authlib.CheckRequest{
-				Verb:      utils.VerbGet,
-				Group:     attr.GetAPIGroup(),
-				Resource:  attr.GetResource(),
-				Namespace: attr.GetNamespace(),
-				Name:      attr.GetName(),
-			}, "")
-			if err != nil {
-				return authorizer.DecisionDeny, "", err
-			}
-			if !res.Allowed {
-				return authorizer.DecisionDeny, "requires user get", nil
-			}
-			return authorizer.DecisionAllow, "", nil
-		},
+		"teams":    userGetCheck,
+		"orgs":     userGetCheck,
+		"tokens":   userGetCheck,
+		"using":    userUpdateCheck,
+		"password": userUpdateCheck,
 		"status": func(ctx context.Context, ident authlib.AuthInfo, attr authorizer.Attributes) (authorizer.Decision, string, error) {
 			verb := utils.VerbGet
 			if attr.GetVerb() == utils.VerbUpdate || attr.GetVerb() == utils.VerbPatch {

--- a/pkg/registry/apis/iam/authorizer_test.go
+++ b/pkg/registry/apis/iam/authorizer_test.go
@@ -63,7 +63,7 @@ var authorizerScenarios = []authorizerScenario{
 		group:            iamv0.UserResourceInfo.GroupResource().Group,
 		resource:         iamv0.UserResourceInfo.GroupResource().Resource,
 		resourceName:     "user-xyz",
-		subResources:     []string{"teams", "status"},
+		subResources:     []string{"teams", "status", "orgs", "tokens"},
 		deniedReason:     "requires user get",
 		checkRequestVerb: "get", // shared tests use verb "get"; update verb tested separately
 	},

--- a/pkg/registry/apis/iam/models.go
+++ b/pkg/registry/apis/iam/models.go
@@ -23,9 +23,12 @@ import (
 	"github.com/grafana/grafana/pkg/registry/apis/iam/user"
 	"github.com/grafana/grafana/pkg/services/accesscontrol"
 	"github.com/grafana/grafana/pkg/services/apiserver/builder"
+	"github.com/grafana/grafana/pkg/services/auth"
 	"github.com/grafana/grafana/pkg/services/authz/zanzana"
+	"github.com/grafana/grafana/pkg/services/org"
 	settingsvc "github.com/grafana/grafana/pkg/services/setting"
 	"github.com/grafana/grafana/pkg/services/ssosettings"
+	legacyuser "github.com/grafana/grafana/pkg/services/user"
 	"github.com/grafana/grafana/pkg/storage/legacysql/dualwrite"
 	"github.com/grafana/grafana/pkg/storage/unified/resource"
 	"github.com/grafana/grafana/pkg/storage/unified/resourcepb"
@@ -116,6 +119,13 @@ type IdentityAccessManagementAPIBuilder struct {
 	// writes to setting.grafana.app). Built in RegisterAPIService when the
 	// kind's storage mode engages MT-Settings.
 	ssoSettingsClient settingsvc.Service
+
+	// Signed-in user subresources (orgs/using/tokens/password) need these when
+	// kubernetesUsersApi is enabled. Nil in multi-tenant NewAPIService paths that
+	// do not register those connecters.
+	orgService       org.Service
+	userService      legacyuser.Service
+	authTokenService auth.UserTokenService
 
 	// ofClient evaluates the feature flags gating the IAM APIs. The default
 	// client resolves the globally-registered provider at evaluation time.

--- a/pkg/registry/apis/iam/register.go
+++ b/pkg/registry/apis/iam/register.go
@@ -53,6 +53,7 @@ import (
 	"github.com/grafana/grafana/pkg/services/apiserver/auth/authorizer/storewrapper"
 	"github.com/grafana/grafana/pkg/services/apiserver/builder"
 	"github.com/grafana/grafana/pkg/services/apiserver/versionpolicy"
+	"github.com/grafana/grafana/pkg/services/auth"
 	"github.com/grafana/grafana/pkg/services/authz/zanzana"
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
 	"github.com/grafana/grafana/pkg/services/org"
@@ -92,6 +93,7 @@ func RegisterAPIService(
 	orgService org.Service,
 	userService legacyuser.Service,
 	teamService teamservice.Service,
+	authTokenService auth.UserTokenService,
 	restConfig apiserver.RestConfigProvider,
 	mappers *resourcepermission.MappersRegistry,
 ) (*IdentityAccessManagementAPIBuilder, error) {
@@ -181,6 +183,9 @@ func RegisterAPIService(
 		apiConfig: Config{
 			SingleOrganization: cfg.RBAC.SingleOrganization,
 		},
+		orgService:       orgService,
+		userService:      userService,
+		authTokenService: authTokenService,
 		display: display.NewDisplayHandler(
 			display.NewLegacyDisplayProvider(store),   // Do legacy first
 			display.NewSearchDisplayProvider(unified), // then use search index
@@ -669,6 +674,16 @@ func (b *IdentityAccessManagementAPIBuilder) UpdateUsersAPIGroup(opts builder.AP
 			)
 		}
 		storage[userResource.StoragePath("teams")] = user.NewUserTeamREST(teamSearchClient, b.teamGetter, b.tracing)
+		if b.orgService != nil {
+			storage[userResource.StoragePath("orgs")] = user.NewUserOrgREST(b.userGetter, b.orgService)
+		}
+		if b.orgService != nil && b.userService != nil {
+			storage[userResource.StoragePath("using")] = user.NewUserUsingREST(b.userGetter, b.orgService, b.userService)
+			storage[userResource.StoragePath("password")] = user.NewUserPasswordREST(b.userGetter, b.userService)
+		}
+		if b.authTokenService != nil {
+			storage[userResource.StoragePath("tokens")] = user.NewUserTokenREST(b.userGetter, b.authTokenService)
+		}
 	}
 
 	return nil

--- a/pkg/registry/apis/iam/register_test.go
+++ b/pkg/registry/apis/iam/register_test.go
@@ -111,6 +111,9 @@ var commonMultiVersionTypes = func() map[reflect.Type]bool {
 		// go through StorageOptsRegister with Scheme == nil.
 		&legacyiamv0.SSOSetting{}, &legacyiamv0.SSOSettingList{}, &legacyiamv0.UserTeamList{},
 		&legacyiamv0.DisplayList{}, &legacyiamv0.TeamMemberList{},
+		&legacyiamv0.UserOrgList{}, &legacyiamv0.UserAuthTokenList{},
+		&legacyiamv0.UserAuthTokenRevokeStatus{}, &legacyiamv0.UserUsingStatus{},
+		&legacyiamv0.UserPasswordStatus{},
 	} {
 		m[reflect.TypeOf(o).Elem()] = true
 	}

--- a/pkg/registry/apis/iam/user/rest_user_org.go
+++ b/pkg/registry/apis/iam/user/rest_user_org.go
@@ -1,0 +1,103 @@
+package user
+
+import (
+	"context"
+	"errors"
+	"net/http"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apiserver/pkg/registry/rest"
+
+	"github.com/grafana/grafana/pkg/apimachinery/utils"
+	legacyiamv0 "github.com/grafana/grafana/pkg/apis/iam/v0alpha1"
+	"github.com/grafana/grafana/pkg/services/org"
+)
+
+var (
+	_ rest.Storage         = (*UserOrgREST)(nil)
+	_ rest.StorageMetadata = (*UserOrgREST)(nil)
+	_ rest.Connecter       = (*UserOrgREST)(nil)
+)
+
+// UserOrgREST serves GET users/{name}/orgs — membership list for the signed-in-user
+// migration. Backed by the legacy org_user table (IAM User has no multi-org field).
+type UserOrgREST struct {
+	userGetter rest.Getter
+	orgService org.Service
+}
+
+func NewUserOrgREST(userGetter rest.Getter, orgService org.Service) *UserOrgREST {
+	return &UserOrgREST{userGetter: userGetter, orgService: orgService}
+}
+
+func (s *UserOrgREST) New() runtime.Object {
+	return &legacyiamv0.UserOrgList{}
+}
+
+func (s *UserOrgREST) Destroy() {}
+
+func (s *UserOrgREST) ProducesMIMETypes(verb string) []string {
+	return []string{"application/json"}
+}
+
+func (s *UserOrgREST) ProducesObject(verb string) interface{} {
+	return s.New()
+}
+
+func (s *UserOrgREST) Connect(ctx context.Context, name string, _ runtime.Object, responder rest.Responder) (http.Handler, error) {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			responder.Error(apierrors.NewMethodNotSupported(legacyiamv0.Resource("users"), r.Method))
+			return
+		}
+
+		userID, err := resolveUserInternalID(r.Context(), s.userGetter, name)
+		if err != nil {
+			responder.Error(err)
+			return
+		}
+
+		result, err := s.orgService.GetUserOrgList(r.Context(), &org.GetUserOrgListQuery{UserID: userID})
+		if err != nil {
+			responder.Error(apierrors.NewInternalError(err))
+			return
+		}
+
+		items := make([]legacyiamv0.UserOrg, 0, len(result))
+		for _, o := range result {
+			items = append(items, legacyiamv0.UserOrg{
+				OrgID: o.OrgID,
+				Name:  o.Name,
+				Role:  string(o.Role),
+			})
+		}
+
+		responder.Object(http.StatusOK, &legacyiamv0.UserOrgList{Items: items})
+	}), nil
+}
+
+func (s *UserOrgREST) NewConnectOptions() (runtime.Object, bool, string) {
+	return nil, false, ""
+}
+
+func (s *UserOrgREST) ConnectMethods() []string {
+	return []string{http.MethodGet}
+}
+
+func resolveUserInternalID(ctx context.Context, getter rest.Getter, name string) (int64, error) {
+	obj, err := getter.Get(ctx, name, &metav1.GetOptions{})
+	if err != nil {
+		return 0, err
+	}
+	meta, err := utils.MetaAccessor(obj)
+	if err != nil {
+		return 0, apierrors.NewInternalError(err)
+	}
+	id := meta.GetDeprecatedInternalID() // nolint:staticcheck
+	if id == 0 {
+		return 0, apierrors.NewInternalError(errors.New("user object missing internal id"))
+	}
+	return id, nil
+}

--- a/pkg/registry/apis/iam/user/rest_user_org_test.go
+++ b/pkg/registry/apis/iam/user/rest_user_org_test.go
@@ -1,0 +1,96 @@
+package user
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apiserver/pkg/registry/rest"
+
+	iamv0 "github.com/grafana/grafana/apps/iam/pkg/apis/iam/v0alpha1"
+	"github.com/grafana/grafana/pkg/apimachinery/utils"
+	legacyiamv0 "github.com/grafana/grafana/pkg/apis/iam/v0alpha1"
+	"github.com/grafana/grafana/pkg/services/org"
+	"github.com/grafana/grafana/pkg/services/org/orgtest"
+)
+
+type fakeUserGetter struct {
+	obj runtime.Object
+	err error
+}
+
+func (f *fakeUserGetter) Get(_ context.Context, _ string, _ *metav1.GetOptions) (runtime.Object, error) {
+	return f.obj, f.err
+}
+
+func testUserObject(t *testing.T, name string, internalID int64) runtime.Object {
+	t.Helper()
+	u := &iamv0.User{}
+	u.SetName(name)
+	meta, err := utils.MetaAccessor(u)
+	require.NoError(t, err)
+	meta.SetDeprecatedInternalID(internalID) // nolint:staticcheck
+	return u
+}
+
+type capturingResponder struct {
+	obj  runtime.Object
+	code int
+	err  error
+}
+
+func (c *capturingResponder) Object(code int, obj runtime.Object) {
+	c.code = code
+	c.obj = obj
+}
+
+func (c *capturingResponder) Error(err error) {
+	c.err = err
+}
+
+func TestUserOrgREST_Connect(t *testing.T) {
+	orgService := &orgtest.FakeOrgService{
+		ExpectedUserOrgDTO: []*org.UserOrgDTO{
+			{OrgID: 1, Name: "Main", Role: org.RoleAdmin},
+			{OrgID: 2, Name: "Other", Role: org.RoleViewer},
+		},
+	}
+	handler := NewUserOrgREST(&fakeUserGetter{obj: testUserObject(t, "u1", 42)}, orgService)
+	responder := &capturingResponder{}
+
+	h, err := handler.Connect(context.Background(), "u1", nil, responder)
+	require.NoError(t, err)
+
+	req := httptest.NewRequest(http.MethodGet, "/users/u1/orgs", nil)
+	h.ServeHTTP(httptest.NewRecorder(), req)
+	require.NoError(t, responder.err)
+	require.Equal(t, http.StatusOK, responder.code)
+
+	list, ok := responder.obj.(*legacyiamv0.UserOrgList)
+	require.True(t, ok)
+	require.Len(t, list.Items, 2)
+	require.Equal(t, int64(1), list.Items[0].OrgID)
+	require.Equal(t, "Main", list.Items[0].Name)
+}
+
+func TestParseUsingOrgID(t *testing.T) {
+	id, err := parseUsingOrgID("/apis/iam.grafana.app/v0alpha1/namespaces/default/users/u1/using/7")
+	require.NoError(t, err)
+	require.Equal(t, int64(7), id)
+}
+
+// Ensure rest.Responder compile-time usage stays intentional for fake getters.
+var _ rest.Getter = (*fakeUserGetter)(nil)
+
+func TestUserOrgListJSONShape(t *testing.T) {
+	raw, err := json.Marshal(&legacyiamv0.UserOrgList{
+		Items: []legacyiamv0.UserOrg{{OrgID: 1, Name: "Main", Role: "Admin"}},
+	})
+	require.NoError(t, err)
+	require.Contains(t, string(raw), `"orgId":1`)
+}

--- a/pkg/registry/apis/iam/user/rest_user_password.go
+++ b/pkg/registry/apis/iam/user/rest_user_password.go
@@ -1,0 +1,110 @@
+package user
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+
+	claims "github.com/grafana/authlib/types"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apiserver/pkg/registry/rest"
+
+	"github.com/grafana/grafana/pkg/apimachinery/identity"
+	legacyiamv0 "github.com/grafana/grafana/pkg/apis/iam/v0alpha1"
+	legacyuser "github.com/grafana/grafana/pkg/services/user"
+)
+
+var (
+	_ rest.Storage         = (*UserPasswordREST)(nil)
+	_ rest.StorageMetadata = (*UserPasswordREST)(nil)
+	_ rest.Connecter       = (*UserPasswordREST)(nil)
+)
+
+type changePasswordBody struct {
+	OldPassword string `json:"oldPassword"`
+	NewPassword string `json:"newPassword"`
+}
+
+// UserPasswordREST serves POST users/{name}/password. Password hashes stay in legacy SQL.
+type UserPasswordREST struct {
+	userGetter  rest.Getter
+	userService legacyuser.Service
+}
+
+func NewUserPasswordREST(userGetter rest.Getter, userService legacyuser.Service) *UserPasswordREST {
+	return &UserPasswordREST{userGetter: userGetter, userService: userService}
+}
+
+func (s *UserPasswordREST) New() runtime.Object {
+	return &legacyiamv0.UserPasswordStatus{}
+}
+
+func (s *UserPasswordREST) Destroy() {}
+
+func (s *UserPasswordREST) ProducesMIMETypes(verb string) []string {
+	return []string{"application/json"}
+}
+
+func (s *UserPasswordREST) ProducesObject(verb string) interface{} {
+	return s.New()
+}
+
+func (s *UserPasswordREST) Connect(ctx context.Context, name string, _ runtime.Object, responder rest.Responder) (http.Handler, error) {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost && r.Method != http.MethodPut {
+			responder.Error(apierrors.NewMethodNotSupported(legacyiamv0.Resource("users"), r.Method))
+			return
+		}
+
+		requester, err := identity.GetRequester(r.Context())
+		if err != nil || !claims.IsIdentityType(requester.GetIdentityType(), claims.TypeUser) {
+			responder.Error(apierrors.NewForbidden(legacyiamv0.Resource("users"), name, errors.New("entity not allowed to change password")))
+			return
+		}
+
+		userID, err := resolveUserInternalID(r.Context(), s.userGetter, name)
+		if err != nil {
+			responder.Error(err)
+			return
+		}
+
+		callerID, err := requester.GetInternalID()
+		if err != nil || callerID != userID {
+			responder.Error(apierrors.NewForbidden(legacyiamv0.Resource("users"), name, errors.New("can only change own password")))
+			return
+		}
+
+		var body changePasswordBody
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			responder.Error(apierrors.NewBadRequest("bad request data"))
+			return
+		}
+		if body.NewPassword == "" {
+			responder.Error(apierrors.NewBadRequest("newPassword is required"))
+			return
+		}
+
+		oldPassword := legacyuser.Password(body.OldPassword)
+		newPassword := legacyuser.Password(body.NewPassword)
+		if err := s.userService.Update(r.Context(), &legacyuser.UpdateUserCommand{
+			UserID:      userID,
+			Password:    &newPassword,
+			OldPassword: &oldPassword,
+		}); err != nil {
+			responder.Error(apierrors.NewBadRequest(err.Error()))
+			return
+		}
+
+		responder.Object(http.StatusOK, &legacyiamv0.UserPasswordStatus{Message: "User password changed"})
+	}), nil
+}
+
+func (s *UserPasswordREST) NewConnectOptions() (runtime.Object, bool, string) {
+	return nil, false, ""
+}
+
+func (s *UserPasswordREST) ConnectMethods() []string {
+	return []string{http.MethodPost, http.MethodPut}
+}

--- a/pkg/registry/apis/iam/user/rest_user_token.go
+++ b/pkg/registry/apis/iam/user/rest_user_token.go
@@ -1,0 +1,157 @@
+package user
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"time"
+
+	claims "github.com/grafana/authlib/types"
+	"github.com/ua-parser/uap-go/uaparser"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apiserver/pkg/registry/rest"
+
+	"github.com/grafana/grafana/pkg/apimachinery/identity"
+	legacyiamv0 "github.com/grafana/grafana/pkg/apis/iam/v0alpha1"
+	"github.com/grafana/grafana/pkg/services/auth"
+	"github.com/grafana/grafana/pkg/services/login"
+)
+
+var (
+	_ rest.Storage         = (*UserTokenREST)(nil)
+	_ rest.StorageMetadata = (*UserTokenREST)(nil)
+	_ rest.Connecter       = (*UserTokenREST)(nil)
+)
+
+// UserTokenREST serves GET/POST users/{name}/tokens for session auth-token list/revoke.
+// Cookie rotate stays on /api/user/auth-tokens/rotate.
+type UserTokenREST struct {
+	userGetter       rest.Getter
+	authTokenService auth.UserTokenService
+}
+
+func NewUserTokenREST(userGetter rest.Getter, authTokenService auth.UserTokenService) *UserTokenREST {
+	return &UserTokenREST{userGetter: userGetter, authTokenService: authTokenService}
+}
+
+func (s *UserTokenREST) New() runtime.Object {
+	return &legacyiamv0.UserAuthTokenList{}
+}
+
+func (s *UserTokenREST) Destroy() {}
+
+func (s *UserTokenREST) ProducesMIMETypes(verb string) []string {
+	return []string{"application/json"}
+}
+
+func (s *UserTokenREST) ProducesObject(verb string) interface{} {
+	switch verb {
+	case "POST":
+		return &legacyiamv0.UserAuthTokenRevokeStatus{}
+	default:
+		return &legacyiamv0.UserAuthTokenList{}
+	}
+}
+
+func (s *UserTokenREST) Connect(ctx context.Context, name string, _ runtime.Object, responder rest.Responder) (http.Handler, error) {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requester, err := identity.GetRequester(r.Context())
+		if err != nil || !claims.IsIdentityType(requester.GetIdentityType(), claims.TypeUser) {
+			responder.Error(apierrors.NewForbidden(legacyiamv0.Resource("users"), name, errors.New("entity not allowed to manage tokens")))
+			return
+		}
+
+		userID, err := resolveUserInternalID(r.Context(), s.userGetter, name)
+		if err != nil {
+			responder.Error(err)
+			return
+		}
+
+		callerID, err := requester.GetInternalID()
+		if err != nil || callerID != userID {
+			responder.Error(apierrors.NewForbidden(legacyiamv0.Resource("users"), name, errors.New("can only manage own auth tokens")))
+			return
+		}
+
+		switch r.Method {
+		case http.MethodGet:
+			s.listTokens(r, userID, responder)
+		case http.MethodPost:
+			s.revokeToken(r, userID, responder)
+		default:
+			responder.Error(apierrors.NewMethodNotSupported(legacyiamv0.Resource("users"), r.Method))
+		}
+	}), nil
+}
+
+func (s *UserTokenREST) listTokens(r *http.Request, userID int64, responder rest.Responder) {
+	tokens, err := s.authTokenService.GetUserTokens(r.Context(), userID)
+	if err != nil {
+		responder.Error(apierrors.NewInternalError(err))
+		return
+	}
+
+	parser := uaparser.NewFromSaved()
+	items := make([]legacyiamv0.UserAuthToken, 0, len(tokens))
+	for _, token := range tokens {
+		createdAt := time.Unix(token.CreatedAt, 0).Format(time.RFC3339)
+		seenAt := createdAt
+		if token.SeenAt != 0 {
+			seenAt = time.Unix(token.SeenAt, 0).Format(time.RFC3339)
+		}
+
+		client := parser.Parse(token.UserAgent)
+		authModule := ""
+		if token.ExternalSessionId != 0 {
+			if externalSession, err := s.authTokenService.GetExternalSession(r.Context(), token.ExternalSessionId); err == nil {
+				authModule = login.GetAuthProviderLabel(externalSession.AuthModule)
+			}
+		}
+
+		items = append(items, legacyiamv0.UserAuthToken{
+			ID:         token.Id,
+			CreatedAt:  createdAt,
+			SeenAt:     seenAt,
+			ClientIP:   token.ClientIp,
+			UserAgent:  client.UserAgent.Family + " on " + client.Os.Family,
+			AuthModule: authModule,
+		})
+	}
+
+	responder.Object(http.StatusOK, &legacyiamv0.UserAuthTokenList{Items: items})
+}
+
+func (s *UserTokenREST) revokeToken(r *http.Request, userID int64, responder rest.Responder) {
+	var cmd auth.RevokeAuthTokenCmd
+	if err := json.NewDecoder(r.Body).Decode(&cmd); err != nil {
+		responder.Error(apierrors.NewBadRequest("bad request data"))
+		return
+	}
+
+	token, err := s.authTokenService.GetUserToken(r.Context(), userID, cmd.AuthTokenId)
+	if err != nil {
+		if errors.Is(err, auth.ErrUserTokenNotFound) {
+			responder.Error(apierrors.NewNotFound(legacyiamv0.Resource("users"), "token"))
+			return
+		}
+		responder.Error(apierrors.NewInternalError(err))
+		return
+	}
+
+	if err := s.authTokenService.RevokeToken(r.Context(), token, false); err != nil {
+		responder.Error(apierrors.NewInternalError(err))
+		return
+	}
+
+	responder.Object(http.StatusOK, &legacyiamv0.UserAuthTokenRevokeStatus{Message: "User auth token revoked"})
+}
+
+func (s *UserTokenREST) NewConnectOptions() (runtime.Object, bool, string) {
+	return nil, false, ""
+}
+
+func (s *UserTokenREST) ConnectMethods() []string {
+	return []string{http.MethodGet, http.MethodPost}
+}

--- a/pkg/registry/apis/iam/user/rest_user_using.go
+++ b/pkg/registry/apis/iam/user/rest_user_using.go
@@ -1,0 +1,120 @@
+package user
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"strconv"
+	"strings"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apiserver/pkg/registry/rest"
+
+	legacyiamv0 "github.com/grafana/grafana/pkg/apis/iam/v0alpha1"
+	"github.com/grafana/grafana/pkg/services/org"
+	legacyuser "github.com/grafana/grafana/pkg/services/user"
+)
+
+var (
+	_ rest.Storage         = (*UserUsingREST)(nil)
+	_ rest.StorageMetadata = (*UserUsingREST)(nil)
+	_ rest.Connecter       = (*UserUsingREST)(nil)
+)
+
+// UserUsingREST serves POST users/{name}/using/{orgId} — active-org switch for the
+// signed-in-user migration. Active org lives on the legacy user row, not IAM User.spec.
+type UserUsingREST struct {
+	userGetter  rest.Getter
+	orgService  org.Service
+	userService legacyuser.Service
+}
+
+func NewUserUsingREST(userGetter rest.Getter, orgService org.Service, userService legacyuser.Service) *UserUsingREST {
+	return &UserUsingREST{
+		userGetter:  userGetter,
+		orgService:  orgService,
+		userService: userService,
+	}
+}
+
+func (s *UserUsingREST) New() runtime.Object {
+	return &legacyiamv0.UserUsingStatus{}
+}
+
+func (s *UserUsingREST) Destroy() {}
+
+func (s *UserUsingREST) ProducesMIMETypes(verb string) []string {
+	return []string{"application/json"}
+}
+
+func (s *UserUsingREST) ProducesObject(verb string) interface{} {
+	return s.New()
+}
+
+func (s *UserUsingREST) Connect(ctx context.Context, name string, _ runtime.Object, responder rest.Responder) (http.Handler, error) {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			responder.Error(apierrors.NewMethodNotSupported(legacyiamv0.Resource("users"), r.Method))
+			return
+		}
+
+		orgID, err := parseUsingOrgID(r.URL.Path)
+		if err != nil {
+			responder.Error(apierrors.NewBadRequest(err.Error()))
+			return
+		}
+
+		userID, err := resolveUserInternalID(r.Context(), s.userGetter, name)
+		if err != nil {
+			responder.Error(err)
+			return
+		}
+
+		orgs, err := s.orgService.GetUserOrgList(r.Context(), &org.GetUserOrgListQuery{UserID: userID})
+		if err != nil {
+			responder.Error(apierrors.NewInternalError(err))
+			return
+		}
+		valid := false
+		for _, o := range orgs {
+			if o.OrgID == orgID {
+				valid = true
+				break
+			}
+		}
+		if !valid {
+			responder.Error(apierrors.NewUnauthorized("Not a valid organization"))
+			return
+		}
+
+		if err := s.userService.Update(r.Context(), &legacyuser.UpdateUserCommand{UserID: userID, OrgID: &orgID}); err != nil {
+			responder.Error(apierrors.NewInternalError(err))
+			return
+		}
+
+		responder.Object(http.StatusOK, &legacyiamv0.UserUsingStatus{
+			Message: "Active organization changed",
+			OrgID:   orgID,
+		})
+	}), nil
+}
+
+func (s *UserUsingREST) NewConnectOptions() (runtime.Object, bool, string) {
+	// Trailing subpath carries the org id: .../using/{orgId}
+	return nil, true, ""
+}
+
+func (s *UserUsingREST) ConnectMethods() []string {
+	return []string{http.MethodPost}
+}
+
+func parseUsingOrgID(path string) (int64, error) {
+	// Path ends with /using/<id> or /using/<id>/
+	trimmed := strings.TrimSuffix(path, "/")
+	idx := strings.LastIndex(trimmed, "/")
+	if idx < 0 {
+		return 0, errors.New("org id is required")
+	}
+	return strconv.ParseInt(trimmed[idx+1:], 10, 64)
+}

--- a/pkg/registry/apps/live/handlers.go
+++ b/pkg/registry/apps/live/handlers.go
@@ -1,0 +1,112 @@
+package live
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"strings"
+
+	"github.com/grafana/grafana-app-sdk/app"
+	liveDto "github.com/grafana/grafana-plugin-sdk-go/live"
+
+	"github.com/grafana/grafana/pkg/apimachinery/identity"
+	"github.com/grafana/grafana/pkg/infra/log"
+	grafanalive "github.com/grafana/grafana/pkg/services/live"
+	"github.com/grafana/grafana/pkg/services/live/convert"
+	"github.com/grafana/grafana/pkg/services/live/pushurl"
+)
+
+var handlerLogger = log.New("live.apis")
+
+func newWebSocketHandler(gl *grafanalive.GrafanaLive) func(context.Context, app.CustomRouteResponseWriter, *app.CustomRouteRequest) error {
+	return func(ctx context.Context, writer app.CustomRouteResponseWriter, request *app.CustomRouteRequest) error {
+		gl.ServeWebSocket(writer, httpRequestFromCustom(ctx, request))
+		return nil
+	}
+}
+
+func newListHandler(gl *grafanalive.GrafanaLive) func(context.Context, app.CustomRouteResponseWriter, *app.CustomRouteRequest) error {
+	return func(ctx context.Context, writer app.CustomRouteResponseWriter, request *app.CustomRouteRequest) error {
+		gl.WriteChannelList(writer, httpRequestFromCustom(ctx, request))
+		return nil
+	}
+}
+
+func newPushGetHandler(gl *grafanalive.GrafanaLive) func(context.Context, app.CustomRouteResponseWriter, *app.CustomRouteRequest) error {
+	return func(ctx context.Context, writer app.CustomRouteResponseWriter, request *app.CustomRouteRequest) error {
+		streamID := streamIDFromRequest(request)
+		gl.ServePushWebSocket(writer, httpRequestFromCustom(ctx, request), streamID)
+		return nil
+	}
+}
+
+func newPushPostHandler(gl *grafanalive.GrafanaLive) func(context.Context, app.CustomRouteResponseWriter, *app.CustomRouteRequest) error {
+	converter := convert.NewConverter()
+	return func(ctx context.Context, writer app.CustomRouteResponseWriter, request *app.CustomRouteRequest) error {
+		user, err := identity.GetRequester(ctx)
+		if err != nil {
+			http.Error(writer, "unauthorized", http.StatusUnauthorized)
+			return nil
+		}
+
+		streamID := streamIDFromRequest(request)
+		stream, err := gl.ManagedStreamRunner.GetOrCreateStream(user.GetNamespace(), liveDto.ScopeStream, streamID)
+		if err != nil {
+			handlerLogger.Error("Error getting stream", "error", err)
+			http.Error(writer, "Error getting stream", http.StatusInternalServerError)
+			return nil
+		}
+
+		frameFormat := pushurl.FrameFormatFromValues(request.URL.Query())
+		body, err := io.ReadAll(io.LimitReader(request.Body, 500*1024))
+		if err != nil {
+			handlerLogger.Error("Error reading body", "error", err)
+			http.Error(writer, "Error reading body", http.StatusInternalServerError)
+			return nil
+		}
+
+		metricFrames, err := converter.Convert(body, frameFormat)
+		if err != nil {
+			handlerLogger.Error("Error converting metrics", "error", err, "frameFormat", frameFormat)
+			if err == convert.ErrUnsupportedFrameFormat {
+				http.Error(writer, "unsupported frame format", http.StatusBadRequest)
+			} else {
+				http.Error(writer, "Error converting metrics", http.StatusInternalServerError)
+			}
+			return nil
+		}
+
+		for _, mf := range metricFrames {
+			if err := stream.Push(ctx, mf.Key(), mf.Frame()); err != nil {
+				handlerLogger.Error("Error pushing frame", "error", err)
+				http.Error(writer, "Error publishing stream", http.StatusInternalServerError)
+				return nil
+			}
+		}
+
+		writer.WriteHeader(http.StatusOK)
+		return nil
+	}
+}
+
+func httpRequestFromCustom(ctx context.Context, request *app.CustomRouteRequest) *http.Request {
+	req := &http.Request{
+		Method: request.Method,
+		URL:    request.URL,
+		Header: request.Headers,
+		Body:   request.Body,
+	}
+	return req.WithContext(ctx)
+}
+
+func streamIDFromRequest(request *app.CustomRouteRequest) string {
+	if request == nil {
+		return ""
+	}
+	path := strings.Trim(request.Path, "/")
+	if after, ok := strings.CutPrefix(path, "push/"); ok {
+		return after
+	}
+	parts := strings.Split(path, "/")
+	return parts[len(parts)-1]
+}

--- a/pkg/registry/apps/live/handlers_test.go
+++ b/pkg/registry/apps/live/handlers_test.go
@@ -1,0 +1,27 @@
+package live
+
+import (
+	"testing"
+
+	"github.com/grafana/grafana-app-sdk/app"
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/grafana/pkg/services/featuremgmt"
+	grafanalive "github.com/grafana/grafana/pkg/services/live"
+	"github.com/grafana/grafana/pkg/setting"
+)
+
+func TestRegisterAppInstallerWiresTransportHandlers(t *testing.T) {
+	cfg := setting.NewCfg()
+	gl := &grafanalive.GrafanaLive{}
+
+	installer, err := RegisterAppInstaller(cfg, featuremgmt.WithFeatures(), gl)
+	require.NoError(t, err)
+	require.NotNil(t, installer)
+	require.NotNil(t, installer.AppInstaller)
+}
+
+func TestStreamIDFromRequest(t *testing.T) {
+	require.Equal(t, "metrics", streamIDFromRequest(&app.CustomRouteRequest{Path: "push/metrics"}))
+	require.Equal(t, "abc", streamIDFromRequest(&app.CustomRouteRequest{Path: "/push/abc/"}))
+}

--- a/pkg/registry/apps/live/register.go
+++ b/pkg/registry/apps/live/register.go
@@ -12,6 +12,7 @@ import (
 	apis "github.com/grafana/grafana/apps/live/pkg/apis/manifestdata"
 	liveapp "github.com/grafana/grafana/apps/live/pkg/app"
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
+	grafanalive "github.com/grafana/grafana/pkg/services/live"
 	"github.com/grafana/grafana/pkg/setting"
 )
 
@@ -27,6 +28,7 @@ type AppInstaller struct {
 func RegisterAppInstaller(
 	cfg *setting.Cfg,
 	features featuremgmt.FeatureToggles,
+	gl *grafanalive.GrafanaLive,
 ) (*AppInstaller, error) {
 	installer := &AppInstaller{
 		cfg: cfg,
@@ -38,8 +40,11 @@ func RegisterAppInstaller(
 		KubeConfig:   restclient.Config{},
 		ManifestData: *apis.LocalManifest().ManifestData,
 		SpecificConfig: &liveapp.LiveConfig{
-			Enable: true,
-			//	TagHandler: tagHandler,
+			Enable:           true,
+			WebSocketHandler: newWebSocketHandler(gl),
+			ListHandler:      newListHandler(gl),
+			PushGetHandler:   newPushGetHandler(gl),
+			PushPostHandler:  newPushPostHandler(gl),
 		},
 	}
 	i, err := appsdkapiserver.NewDefaultAppInstaller(provider, appConfig, apis.NewGoTypeAssociator())

--- a/pkg/server/bootstrap/wire/wire_gen.go
+++ b/pkg/server/bootstrap/wire/wire_gen.go
@@ -943,7 +943,7 @@ func Initialize(ctx context.Context, cfg *setting.Cfg, opts server.Options, apiO
 	noopSearchREST := externalgroupmapping.ProvideNoopSearchREST()
 	externalGroupReconciler := _wireNoopExternalGroupReconcilerValue
 	mappersRegistry := resourcepermission.ProvideMappersRegistry()
-	identityAccessManagementAPIBuilder, err := iam.RegisterAPIService(cfg, configProvider, apiserverService, ssosettingsimplService, sqlStore, accessControl, accessClient, zanzanaClient, registerer, roleApiInstaller, globalRoleApiInstaller, teamLBACApiInstaller, tracingService, roleBindingApiInstaller, teamGroupsHandlerProvider, noopSearchREST, externalGroupReconciler, dualwriteService, resourceClient, orgService, userimplService, teamimplService, eventualRestConfigProvider, mappersRegistry)
+	identityAccessManagementAPIBuilder, err := iam.RegisterAPIService(cfg, configProvider, apiserverService, ssosettingsimplService, sqlStore, accessControl, accessClient, zanzanaClient, registerer, roleApiInstaller, globalRoleApiInstaller, teamLBACApiInstaller, tracingService, roleBindingApiInstaller, teamGroupsHandlerProvider, noopSearchREST, externalGroupReconciler, dualwriteService, resourceClient, orgService, userimplService, teamimplService, userAuthTokenService, eventualRestConfigProvider, mappersRegistry)
 	if err != nil {
 		return nil, err
 	}
@@ -1704,7 +1704,7 @@ func InitializeForTest(ctx context.Context, t sqlutil.ITestDB, testingT interfac
 	noopSearchREST := externalgroupmapping.ProvideNoopSearchREST()
 	externalGroupReconciler := _wireNoopExternalGroupReconcilerValue
 	mappersRegistry := resourcepermission.ProvideMappersRegistry()
-	identityAccessManagementAPIBuilder, err := iam.RegisterAPIService(cfg, configProvider, apiserverService, ssosettingsimplService, sqlStore, accessControl, accessClient, zanzanaClient, registerer, roleApiInstaller, globalRoleApiInstaller, teamLBACApiInstaller, tracingService, roleBindingApiInstaller, teamGroupsHandlerProvider, noopSearchREST, externalGroupReconciler, dualwriteService, resourceClient, orgService, userimplService, teamimplService, eventualRestConfigProvider, mappersRegistry)
+	identityAccessManagementAPIBuilder, err := iam.RegisterAPIService(cfg, configProvider, apiserverService, ssosettingsimplService, sqlStore, accessControl, accessClient, zanzanaClient, registerer, roleApiInstaller, globalRoleApiInstaller, teamLBACApiInstaller, tracingService, roleBindingApiInstaller, teamGroupsHandlerProvider, noopSearchREST, externalGroupReconciler, dualwriteService, resourceClient, orgService, userimplService, teamimplService, userAuthTokenService, eventualRestConfigProvider, mappersRegistry)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/server/bootstrap/wire/wire_gen.go
+++ b/pkg/server/bootstrap/wire/wire_gen.go
@@ -817,7 +817,7 @@ func Initialize(ctx context.Context, cfg *setting.Cfg, opts server.Options, apiO
 	if err != nil {
 		return nil, err
 	}
-	liveAppInstaller, err := live2.RegisterAppInstaller(cfg, featureToggles)
+	liveAppInstaller, err := live2.RegisterAppInstaller(cfg, featureToggles, grafanaLive)
 	if err != nil {
 		return nil, err
 	}
@@ -1578,7 +1578,7 @@ func InitializeForTest(ctx context.Context, t sqlutil.ITestDB, testingT interfac
 	if err != nil {
 		return nil, err
 	}
-	liveAppInstaller, err := live2.RegisterAppInstaller(cfg, featureToggles)
+	liveAppInstaller, err := live2.RegisterAppInstaller(cfg, featureToggles, grafanaLive)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -107,7 +107,7 @@ var (
 			Owner:           grafanaAppPlatformSquad,
 			RequiresRestart: true,
 			Expression:      "false",
-			Generate:        Generate{Go: true},
+			Generate:        Generate{Go: true, LegacyFrontend: true},
 		},
 		{
 			Name:            "live.keepHAPrefixInCloud",

--- a/pkg/services/libraryelements/api.go
+++ b/pkg/services/libraryelements/api.go
@@ -292,16 +292,27 @@ func (l *LibraryElementService) patchHandler(c *contextmodel.ReqContext) respons
 // 500: internalServerError
 func (l *LibraryElementService) getConnectionsHandler(c *contextmodel.ReqContext) response.Response {
 	libraryPanelUID := web.Params(c.Req)[":uid"]
+	ctx := c.Req.Context()
+
+	shouldUseKubeApi := openfeature.NewDefaultClient().Boolean(ctx, featuremgmt.FlagLibraryelementsKubernetesLibraryPanels, false, openfeature.TransactionContext(ctx))
+	if shouldUseKubeApi {
+		return l.k8sHandler.getK8sLibraryElementConnections(c, l, libraryPanelUID)
+	}
 
 	// make sure the library element exists
-	element, err := l.getLibraryElementByUid(c.Req.Context(), c.SignedInUser, model.GetLibraryElementCommand{
+	element, err := l.getLibraryElementByUid(ctx, c.SignedInUser, model.GetLibraryElementCommand{
 		UID: libraryPanelUID,
 	}, nil)
 	if err != nil {
 		return l.toLibraryElementError(err, "Failed to get library element")
 	}
 
-	// now get all dashboards connected to this library element
+	return l.buildConnectionsResponse(c, element, libraryPanelUID)
+}
+
+// buildConnectionsResponse resolves connected dashboards via unified search and
+// returns the legacy connections DTO shape.
+func (l *LibraryElementService) buildConnectionsResponse(c *contextmodel.ReqContext, element model.LibraryElementDTO, libraryPanelUID string) response.Response {
 	dashboards, err := l.dashboardsService.GetDashboardsByLibraryPanelUID(c.Req.Context(), libraryPanelUID, c.GetOrgID())
 	if err != nil {
 		return l.toLibraryElementError(err, "Failed to get dashboards")
@@ -609,6 +620,30 @@ func (lk8s *libraryElementsK8sHandler) getK8sLibraryElement(c *contextmodel.ReqC
 		return
 	}
 	c.JSON(http.StatusOK, model.LibraryElementResponse{Result: *dto})
+}
+
+// getK8sLibraryElementConnections verifies the library panel via /apis then
+// reuses the search-backed connections builder (same as the legacy path).
+func (lk8s *libraryElementsK8sHandler) getK8sLibraryElementConnections(c *contextmodel.ReqContext, l *LibraryElementService, uid string) response.Response {
+	client, ok := lk8s.getClient(c)
+	if !ok {
+		return response.Error(http.StatusInternalServerError, "failed to get k8s client", nil)
+	}
+	out, err := client.Get(c.Req.Context(), uid, v1.GetOptions{})
+	if err != nil {
+		statusError, isStatus := err.(*k8serrors.StatusError)
+		if isStatus {
+			return response.Error(int(statusError.Status().Code), statusError.Status().Message, err)
+		}
+		return response.Error(http.StatusInternalServerError, "Failed to get library element", err)
+	}
+
+	dto, err := lk8s.unstructuredToLegacyLibraryPanelDTO(c, *out)
+	if err != nil {
+		return response.Error(http.StatusInternalServerError, "conversion error", err)
+	}
+
+	return l.buildConnectionsResponse(c, *dto, uid)
 }
 
 func (lk8s *libraryElementsK8sHandler) unstructuredToLegacyLibraryPanelDTO(c *contextmodel.ReqContext, item unstructured.Unstructured) (*model.LibraryElementDTO, error) {

--- a/pkg/services/live/live.go
+++ b/pkg/services/live/live.go
@@ -366,6 +366,9 @@ func ProvideService(cfg *setting.Cfg, routeRegister routing.RouteRegister, plugC
 		CheckOrigin:     checkOrigin,
 	})
 
+	g.centrifugeWSHandler = wsHandler
+	g.pushWSHandler = pushWSHandler
+
 	g.websocketHandler = func(ctx *contextmodel.ReqContext) {
 		user := ctx.SignedInUser
 		id, _ := user.GetInternalID()
@@ -509,6 +512,10 @@ type GrafanaLive struct {
 	websocketHandler             interface{}
 	pushWebsocketHandler         interface{}
 	pushPipelineWebsocketHandler interface{}
+
+	// Raw handlers for /apis live custom routes (same engines as legacy /api/live/*).
+	centrifugeWSHandler http.Handler
+	pushWSHandler       http.Handler
 
 	// Full channel handler
 	channels   map[string]model.ChannelHandler
@@ -1188,6 +1195,63 @@ func (g *GrafanaLive) HandleListHTTP(c *contextmodel.ReqContext) response.Respon
 		Channels: channels,
 	}
 	return response.JSONStreaming(http.StatusOK, info)
+}
+
+// ServeWebSocket upgrades a connection using the same Centrifuge handler as /api/live/ws.
+// Identity must already be present on r.Context() (apiserver auth).
+func (g *GrafanaLive) ServeWebSocket(w http.ResponseWriter, r *http.Request) {
+	if g.centrifugeWSHandler == nil {
+		http.Error(w, "live websocket not initialized", http.StatusServiceUnavailable)
+		return
+	}
+	user, err := identity.GetRequester(r.Context())
+	if err != nil {
+		http.Error(w, "unauthorized", http.StatusUnauthorized)
+		return
+	}
+	id, _ := user.GetInternalID()
+	cred := &centrifuge.Credentials{UserID: strconv.FormatInt(id, 10)}
+	ctx := centrifuge.SetCredentials(r.Context(), cred)
+	ctx = identity.WithRequester(ctx, user)
+	g.centrifugeWSHandler.ServeHTTP(w, r.WithContext(ctx))
+}
+
+// ServePushWebSocket upgrades a push websocket using the same handler as /api/live/push/:streamId.
+func (g *GrafanaLive) ServePushWebSocket(w http.ResponseWriter, r *http.Request, streamID string) {
+	if g.pushWSHandler == nil {
+		http.Error(w, "live push websocket not initialized", http.StatusServiceUnavailable)
+		return
+	}
+	user, err := identity.GetRequester(r.Context())
+	if err != nil {
+		http.Error(w, "unauthorized", http.StatusUnauthorized)
+		return
+	}
+	ctx := identity.WithRequester(r.Context(), user)
+	ctx = livecontext.SetContextStreamID(ctx, streamID)
+	g.pushWSHandler.ServeHTTP(w, r.WithContext(ctx))
+}
+
+// WriteChannelList writes the managed-stream channel list for the caller's namespace.
+func (g *GrafanaLive) WriteChannelList(w http.ResponseWriter, r *http.Request) {
+	user, err := identity.GetRequester(r.Context())
+	if err != nil {
+		http.Error(w, "unauthorized", http.StatusUnauthorized)
+		return
+	}
+	ns := user.GetNamespace()
+	var channels []*managedstream.ManagedChannel
+	if g.IsHA() {
+		channels, err = g.surveyCaller.CallManagedStreams(ns)
+	} else {
+		channels, err = g.ManagedStreamRunner.GetManagedChannels(ns)
+	}
+	if err != nil {
+		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(streamChannelListResponse{Channels: channels})
 }
 
 // HandleInfoHTTP special http response for

--- a/pkg/services/user/userimpl/user.go
+++ b/pkg/services/user/userimpl/user.go
@@ -138,11 +138,38 @@ func (s *Service) GetByEmail(ctx context.Context, cmd *user.GetUserByEmailQuery)
 }
 
 func (s *Service) Update(ctx context.Context, cmd *user.UpdateUserCommand) error {
+	// Active-org switch and password changes are SQL-only; IAM User.spec has neither field.
+	if isLegacyOnlyUserUpdate(cmd) {
+		return s.legacyService.Update(ctx, cmd)
+	}
+
 	if s.isKubernetesUserServiceEnabled(ctx) && !s.shouldFallbackToLegacy(ctx) {
 		return s.k8sService.Update(s.k8sCtxWithIdentity(ctx), cmd)
 	}
 
 	return s.legacyService.Update(ctx, cmd)
+}
+
+// isLegacyOnlyUserUpdate reports updates that cannot be represented on IAM User.spec.
+func isLegacyOnlyUserUpdate(cmd *user.UpdateUserCommand) bool {
+	if cmd == nil {
+		return false
+	}
+	hasOrg := cmd.OrgID != nil
+	hasPassword := cmd.Password != nil || cmd.OldPassword != nil
+	if !hasOrg && !hasPassword {
+		return false
+	}
+	// Theme is also legacy-only but often paired with profile fields; keep profile on k8s
+	// and only force legacy when the mutation is exclusively org/password.
+	if cmd.Name != "" || cmd.Email != "" || cmd.Login != "" {
+		return false
+	}
+	if cmd.IsDisabled != nil || cmd.EmailVerified != nil || cmd.IsGrafanaAdmin != nil ||
+		cmd.IsProvisioned != nil || cmd.OrgRole != nil || len(cmd.ExternalAuthInfo) > 0 {
+		return false
+	}
+	return true
 }
 
 func (s *Service) UpdateLastSeenAt(ctx context.Context, cmd *user.UpdateUserLastSeenAtCommand) error {

--- a/pkg/services/user/usertest/fake.go
+++ b/pkg/services/user/usertest/fake.go
@@ -24,6 +24,7 @@ type FakeUserService struct {
 	ExpectedUsageStats         map[string]any
 
 	UpdateFn            func(ctx context.Context, cmd *user.UpdateUserCommand) error
+	DeleteFn            func(ctx context.Context, cmd *user.DeleteUserCommand) error
 	GetSignedInUserFn   func(ctx context.Context, query *user.GetSignedInUserQuery) (*user.SignedInUser, error)
 	CreateFn            func(ctx context.Context, cmd *user.CreateUserCommand) (*user.User, error)
 	GetByLoginFn        func(ctx context.Context, query *user.GetUserByLoginQuery) (*user.User, error)
@@ -56,6 +57,9 @@ func (f *FakeUserService) CreateServiceAccount(ctx context.Context, cmd *user.Cr
 }
 
 func (f *FakeUserService) Delete(ctx context.Context, cmd *user.DeleteUserCommand) error {
+	if f.DeleteFn != nil {
+		return f.DeleteFn(ctx, cmd)
+	}
 	return f.ExpectedError
 }
 

--- a/pkg/tests/apis/folder/folders_test.go
+++ b/pkg/tests/apis/folder/folders_test.go
@@ -1611,14 +1611,14 @@ func TestIntegrationFolderDeletionBlockedByConnectedLibraryPanels(t *testing.T) 
 		t.Skip("test only on sqlite for now")
 	}
 
-	t.Skip("re-enable when we migrate /api to /apis for library connections")
-
-	// TODO: re-enable when we migrate /api to /apis for library connections, and begin to
-	// use search to return the connections, rather than the connections table.
+	// Library-panel connections are resolved via search when kubernetesLibraryPanels is on.
 	helper := apis.NewK8sTestHelper(t, testinfra.GrafanaOpts{
 		AppModeProduction:    true,
 		DisableAnonymous:     true,
 		APIServerStorageType: "unified",
+		EnableFeatureToggles: []string{
+			featuremgmt.FlagLibraryelementsKubernetesLibraryPanels,
+		},
 	})
 
 	client := helper.GetResourceClient(apis.ResourceClientArgs{
@@ -1789,6 +1789,7 @@ func createDashboardWithLibraryPanel(t *testing.T, helper *apis.K8sTestHelper, c
 			"title": "%s",
 			"panels": [{
 				"id": 1,
+				"type": "library-panel-ref",
 				"libraryPanel": {
 					"uid": "%s",
 					"name": "%s"

--- a/public/app/core/components/Select/UserPicker.tsx
+++ b/public/app/core/components/Select/UserPicker.tsx
@@ -4,9 +4,10 @@ import { useMemo, useState } from 'react';
 
 import { type SelectableValue } from '@grafana/data';
 import { t } from '@grafana/i18n';
-import { getBackendSrv } from '@grafana/runtime';
 import { AsyncSelect } from '@grafana/ui';
 import { type OrgUser } from 'app/types/user';
+
+import { lookupOrgUsers } from 'app/features/users/api';
 
 export interface Props {
   onSelected: (user: SelectableValue<OrgUser>) => void;
@@ -27,13 +28,12 @@ export const UserPicker = ({ className, onSelected, inputId }: Props) => {
             query = '';
           }
 
-          return getBackendSrv()
-            .get(`/api/org/users/lookup?query=${query}&limit=100`)
-            .then((result: OrgUser[]) => {
+          return lookupOrgUsers(query, 100)
+            .then((result) => {
               return result.map((user) => ({
                 id: user.userId,
                 uid: user.uid,
-                value: user,
+                value: user as OrgUser,
                 label: user.login,
                 imgUrl: user.avatarUrl,
                 login: user.login,

--- a/public/app/features/live/centrifuge/service.test.ts
+++ b/public/app/features/live/centrifuge/service.test.ts
@@ -42,6 +42,9 @@ jest.mock('centrifuge', () => ({
 
 jest.mock('@grafana/runtime', () => ({
   ...jest.requireActual('@grafana/runtime'),
+  config: {
+    featureToggles: {},
+  },
   getBackendSrv: jest.fn(() => ({ get: jest.fn() })),
 }));
 
@@ -150,5 +153,26 @@ describe('CentrifugeService', () => {
       'default/plugin/grafana-llm-app/stream/chat-completions',
       expect.anything()
     );
+  });
+
+  it('uses legacy /api/live/ws by default', () => {
+    const { Centrifuge } = jest.requireMock('centrifuge');
+    new CentrifugeService(makeDeps());
+    expect(Centrifuge).toHaveBeenCalledWith('ws://localhost:3000/api/live/ws', expect.anything());
+  });
+
+  it('uses /apis live ws when live.runAPIServer is on', () => {
+    const runtime = jest.requireMock('@grafana/runtime');
+    runtime.config.featureToggles = { 'live.runAPIServer': true };
+    const { Centrifuge } = jest.requireMock('centrifuge');
+    Centrifuge.mockClear();
+
+    new CentrifugeService(makeDeps({ namespace: 'stacks-1' }));
+    expect(Centrifuge).toHaveBeenCalledWith(
+      'ws://localhost:3000/apis/live.grafana.app/v1alpha1/namespaces/stacks-1/ws',
+      expect.anything()
+    );
+
+    runtime.config.featureToggles = {};
   });
 });

--- a/public/app/features/live/centrifuge/service.ts
+++ b/public/app/features/live/centrifuge/service.ts
@@ -26,6 +26,7 @@ import {
   StreamingFrameAction,
   type StreamingFrameOptions,
   type BackendDataSourceResponse,
+  config,
   getBackendSrv,
 } from '@grafana/runtime';
 
@@ -80,6 +81,11 @@ export class CentrifugeService implements CentrifugeSrv {
     this.dataStreamSubscriberReadiness = deps.dataStreamSubscriberReadiness.pipe(share(), startWith(true));
 
     let liveUrl = `${deps.appUrl.replace(/^http/, 'ws')}/api/live/ws`;
+    // Optional /apis transport when live.runAPIServer is on (dev-only experimental).
+    // Default remains /api/live/ws.
+    if (config.featureToggles?.['live.runAPIServer']) {
+      liveUrl = `${deps.appUrl.replace(/^http/, 'ws')}/apis/live.grafana.app/v1alpha1/namespaces/${deps.namespace}/ws`;
+    }
 
     const token = deps.grafanaAuthToken;
     if (token !== null && token !== '') {

--- a/public/app/features/org/state/actions.ts
+++ b/public/app/features/org/state/actions.ts
@@ -1,5 +1,7 @@
-import { getBackendSrv } from '@grafana/runtime';
+import { config, getBackendSrv } from '@grafana/runtime';
 import { updateConfigurationSubtitle } from 'app/core/reducers/navModel';
+import { contextSrv } from 'app/core/services/context_srv';
+import { isKubernetesUsersApiEnabled } from 'app/features/profile/api';
 import { type ThunkResult } from 'app/types/store';
 import { type UserOrg } from 'app/types/user';
 
@@ -36,7 +38,10 @@ export function setUserOrganization(
   dependencies: OrganizationDependencies = { getBackendSrv: getBackendSrv }
 ): ThunkResult<void> {
   return async (dispatch) => {
-    const organizationResponse = await dependencies.getBackendSrv().post('/api/user/using/' + orgId);
+    const url = isKubernetesUsersApiEnabled()
+      ? `/apis/iam.grafana.app/v0alpha1/namespaces/${config.namespace}/users/${contextSrv.user.uid}/using/${orgId}`
+      : '/api/user/using/' + orgId;
+    const organizationResponse = await dependencies.getBackendSrv().post(url);
 
     dispatch(updateConfigurationSubtitle(organizationResponse.name));
   };

--- a/public/app/features/profile/api.test.ts
+++ b/public/app/features/profile/api.test.ts
@@ -1,0 +1,100 @@
+import { config, getBackendSrv } from '@grafana/runtime';
+
+import { api, isKubernetesUsersApiEnabled } from './api';
+
+jest.mock('@grafana/runtime', () => ({
+  config: {
+    namespace: 'default',
+    featureToggles: {},
+  },
+  getBackendSrv: jest.fn(),
+}));
+
+jest.mock('app/core/services/context_srv', () => ({
+  contextSrv: {
+    user: {
+      uid: 'u-test',
+      id: 7,
+      orgId: 1,
+      orgName: 'Main',
+      orgRole: 'Admin',
+    },
+  },
+}));
+
+describe('profile api dual-path', () => {
+  const get = jest.fn();
+  const post = jest.fn();
+  const put = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (getBackendSrv as jest.Mock).mockReturnValue({ get, post, put });
+    (config as { featureToggles: Record<string, boolean> }).featureToggles = {};
+  });
+
+  it('uses legacy /api endpoints by default', async () => {
+    expect(isKubernetesUsersApiEnabled()).toBe(false);
+    get.mockResolvedValueOnce({ login: 'admin' });
+    await api.loadUser();
+    expect(get).toHaveBeenCalledWith('/api/user');
+
+    get.mockResolvedValueOnce([]);
+    await api.loadOrgs();
+    expect(get).toHaveBeenCalledWith('/api/user/orgs');
+
+    get.mockResolvedValueOnce([]);
+    await api.loadTeams();
+    expect(get).toHaveBeenCalledWith('/api/user/teams');
+
+    get.mockResolvedValueOnce([]);
+    await api.loadSessions();
+    expect(get).toHaveBeenCalledWith('/api/user/auth-tokens');
+  });
+
+  it('uses IAM /apis endpoints when kubernetesUsersApi is on', async () => {
+    (config as { featureToggles: Record<string, boolean> }).featureToggles = {
+      kubernetesUsersApi: true,
+    };
+    expect(isKubernetesUsersApiEnabled()).toBe(true);
+
+    get.mockResolvedValueOnce({
+      metadata: { name: 'u-test' },
+      spec: { login: 'admin', email: 'a@b.c', title: 'Admin' },
+    });
+    await api.loadUser();
+    expect(get).toHaveBeenCalledWith('/apis/iam.grafana.app/v0alpha1/namespaces/default/users/u-test');
+
+    get.mockResolvedValueOnce({ items: [{ orgId: 1, name: 'Main', role: 'Admin' }] });
+    await api.loadOrgs();
+    expect(get).toHaveBeenCalledWith(
+      '/apis/iam.grafana.app/v0alpha1/namespaces/default/users/u-test/orgs'
+    );
+
+    get.mockResolvedValueOnce({ items: [] });
+    await api.loadTeams();
+    expect(get).toHaveBeenCalledWith(
+      '/apis/iam.grafana.app/v0alpha1/namespaces/default/users/u-test/teams'
+    );
+
+    get.mockResolvedValueOnce({ items: [{ id: 9 }] });
+    await api.loadSessions();
+    expect(get).toHaveBeenCalledWith(
+      '/apis/iam.grafana.app/v0alpha1/namespaces/default/users/u-test/tokens'
+    );
+
+    post.mockResolvedValueOnce({});
+    await api.setUserOrg({ orgId: 2, name: 'Other', role: 'Viewer' });
+    expect(post).toHaveBeenCalledWith(
+      '/apis/iam.grafana.app/v0alpha1/namespaces/default/users/u-test/using/2',
+      {}
+    );
+
+    post.mockResolvedValueOnce({});
+    await api.revokeUserSession(9);
+    expect(post).toHaveBeenCalledWith(
+      '/apis/iam.grafana.app/v0alpha1/namespaces/default/users/u-test/tokens',
+      { authTokenId: 9 }
+    );
+  });
+});

--- a/public/app/features/profile/api.ts
+++ b/public/app/features/profile/api.ts
@@ -1,45 +1,179 @@
-import { getBackendSrv } from '@grafana/runtime';
+import { config, getBackendSrv } from '@grafana/runtime';
+import { contextSrv } from 'app/core/services/context_srv';
 import { type Team } from 'app/types/teams';
 import { type UserDTO, type UserOrg, type UserSession } from 'app/types/user';
 
 import { type ChangePasswordFields, type ProfileUpdateFields } from './types';
 
+export function isKubernetesUsersApiEnabled(): boolean {
+  return Boolean(config.featureToggles.kubernetesUsersApi);
+}
+
+function iamBaseURL(): string {
+  return `/apis/iam.grafana.app/v0alpha1/namespaces/${config.namespace}`;
+}
+
+function currentUserUID(): string {
+  return contextSrv.user.uid;
+}
+
+interface IamUser {
+  metadata?: { name?: string };
+  spec?: {
+    title?: string;
+    login?: string;
+    email?: string;
+    grafanaAdmin?: boolean;
+    disabled?: boolean;
+    role?: string;
+  };
+  status?: { lastSeenAt?: number };
+}
+
+interface IamUserOrgList {
+  items?: Array<{ orgId: number; name: string; role: string }>;
+}
+
+interface IamUserTeamList {
+  items?: Array<{
+    title?: string;
+    teamRef?: { name?: string };
+    permission?: string;
+  }>;
+}
+
+interface IamUserTokenList {
+  items?: Array<{
+    id: number;
+    createdAt?: string;
+    seenAt?: string;
+    clientIp?: string;
+    userAgent?: string;
+    authModule?: string;
+    isActive?: boolean;
+  }>;
+}
+
+function iamUserToDTO(user: IamUser): UserDTO {
+  return {
+    uid: user.metadata?.name || currentUserUID(),
+    id: contextSrv.user.id,
+    login: user.spec?.login || '',
+    email: user.spec?.email || '',
+    name: user.spec?.title || user.spec?.login || '',
+    isGrafanaAdmin: Boolean(user.spec?.grafanaAdmin),
+    isDisabled: Boolean(user.spec?.disabled),
+    orgId: contextSrv.user.orgId,
+    orgName: contextSrv.user.orgName,
+    orgRole: (user.spec?.role || contextSrv.user.orgRole) as UserDTO['orgRole'],
+  } as UserDTO;
+}
+
 async function changePassword(payload: ChangePasswordFields): Promise<void> {
   try {
+    if (isKubernetesUsersApiEnabled()) {
+      await getBackendSrv().post(`${iamBaseURL()}/users/${currentUserUID()}/password`, {
+        oldPassword: payload.oldPassword,
+        newPassword: payload.newPassword,
+      });
+      return;
+    }
     await getBackendSrv().put('/api/user/password', payload);
   } catch (err) {
     console.error(err);
   }
 }
 
-function loadUser(): Promise<UserDTO> {
+async function loadUser(): Promise<UserDTO> {
+  if (isKubernetesUsersApiEnabled()) {
+    const user = await getBackendSrv().get<IamUser>(`${iamBaseURL()}/users/${currentUserUID()}`);
+    return iamUserToDTO(user);
+  }
   return getBackendSrv().get('/api/user');
 }
 
-function loadTeams(): Promise<Team[]> {
+async function loadTeams(): Promise<Team[]> {
+  if (isKubernetesUsersApiEnabled()) {
+    const response = await getBackendSrv().get<IamUserTeamList>(
+      `${iamBaseURL()}/users/${currentUserUID()}/teams`
+    );
+    return (response.items || []).map((item, index) => ({
+      id: index,
+      uid: item.teamRef?.name || '',
+      name: item.title || item.teamRef?.name || '',
+      email: '',
+      avatarUrl: '',
+      memberCount: 0,
+      permission: 0,
+    })) as Team[];
+  }
   return getBackendSrv().get('/api/user/teams');
 }
 
-function loadOrgs(): Promise<UserOrg[]> {
+async function loadOrgs(): Promise<UserOrg[]> {
+  if (isKubernetesUsersApiEnabled()) {
+    const response = await getBackendSrv().get<IamUserOrgList>(
+      `${iamBaseURL()}/users/${currentUserUID()}/orgs`
+    );
+    return (response.items || []).map((item) => ({
+      orgId: item.orgId,
+      name: item.name,
+      role: item.role as UserOrg['role'],
+    }));
+  }
   return getBackendSrv().get('/api/user/orgs');
 }
 
-function loadSessions(): Promise<UserSession[]> {
+async function loadSessions(): Promise<UserSession[]> {
+  if (isKubernetesUsersApiEnabled()) {
+    const response = await getBackendSrv().get<IamUserTokenList>(
+      `${iamBaseURL()}/users/${currentUserUID()}/tokens`
+    );
+    return (response.items || []).map((item) => ({
+      id: item.id,
+      createdAt: item.createdAt || '',
+      clientIp: item.clientIp || '',
+      userAgent: item.userAgent || '',
+      authModule: item.authModule,
+      isActive: Boolean(item.isActive),
+      seenAt: item.seenAt || '',
+      browser: '',
+      browserVersion: '',
+      os: '',
+      osVersion: '',
+      device: '',
+    })) as UserSession[];
+  }
   return getBackendSrv().get('/api/user/auth-tokens');
 }
 
 async function revokeUserSession(tokenId: number): Promise<void> {
+  if (isKubernetesUsersApiEnabled()) {
+    await getBackendSrv().post(`${iamBaseURL()}/users/${currentUserUID()}/tokens`, {
+      authTokenId: tokenId,
+    });
+    return;
+  }
   await getBackendSrv().post('/api/user/revoke-auth-token', {
     authTokenId: tokenId,
   });
 }
 
 async function setUserOrg(org: UserOrg): Promise<void> {
+  if (isKubernetesUsersApiEnabled()) {
+    await getBackendSrv().post(`${iamBaseURL()}/users/${currentUserUID()}/using/${org.orgId}`, {});
+    return;
+  }
   await getBackendSrv().post('/api/user/using/' + org.orgId, {});
 }
 
 async function updateUserProfile(payload: ProfileUpdateFields): Promise<void> {
   try {
+    if (isKubernetesUsersApiEnabled()) {
+      // Theme stays on legacy /api until IAM User.spec supports it.
+      await getBackendSrv().put('/api/user', payload);
+      return;
+    }
     await getBackendSrv().put('/api/user', payload);
   } catch (err) {
     console.error(err);

--- a/public/app/features/users/api.test.ts
+++ b/public/app/features/users/api.test.ts
@@ -1,0 +1,134 @@
+import { config, getBackendSrv } from '@grafana/runtime';
+
+import {
+  isKubernetesUsersApiEnabled,
+  lookupOrgUsers,
+  removeOrgUser,
+  searchOrgUsers,
+  updateOrgUserRole,
+} from './api';
+
+jest.mock('@grafana/runtime', () => ({
+  config: {
+    namespace: 'default',
+    featureToggles: {},
+  },
+  getBackendSrv: jest.fn(),
+}));
+
+jest.mock('app/core/services/context_srv', () => ({
+  contextSrv: {
+    user: { orgId: 1 },
+  },
+}));
+
+const getBackendSrvMock = getBackendSrv as jest.MockedFunction<typeof getBackendSrv>;
+
+describe('users/api dual-path', () => {
+  const get = jest.fn();
+  const patch = jest.fn();
+  const del = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    config.featureToggles = {};
+    getBackendSrvMock.mockReturnValue({ get, patch, delete: del } as never);
+  });
+
+  it('reports kubernetesUsersApi as disabled by default', () => {
+    expect(isKubernetesUsersApiEnabled()).toBe(false);
+  });
+
+  describe('when kubernetesUsersApi is off', () => {
+    it('searchOrgUsers calls legacy /api/org/users/search', async () => {
+      get.mockResolvedValue({ orgUsers: [], totalCount: 0, page: 1, perPage: 50 });
+      await searchOrgUsers({ perPage: 50, page: 1, query: 'alice' });
+      expect(get).toHaveBeenCalledWith(
+        '/api/org/users/search',
+        expect.objectContaining({ perpage: 50, page: 1, query: 'alice' })
+      );
+    });
+
+    it('updateOrgUserRole patches legacy /api/org/users/:id', async () => {
+      patch.mockResolvedValue(undefined);
+      await updateOrgUserRole({ userId: 7, uid: 'u7', role: 'Editor' } as never);
+      expect(patch).toHaveBeenCalledWith('/api/org/users/7', { role: 'Editor' });
+    });
+
+    it('removeOrgUser deletes legacy /api/org/users/:id', async () => {
+      del.mockResolvedValue(undefined);
+      await removeOrgUser({ userId: 7, uid: 'u7' });
+      expect(del).toHaveBeenCalledWith('/api/org/users/7');
+    });
+
+    it('lookupOrgUsers calls legacy lookup', async () => {
+      get.mockResolvedValue([]);
+      await lookupOrgUsers('bob');
+      expect(get).toHaveBeenCalledWith('/api/org/users/lookup?query=bob&limit=100');
+    });
+  });
+
+  describe('when kubernetesUsersApi is on', () => {
+    beforeEach(() => {
+      config.featureToggles = { kubernetesUsersApi: true };
+    });
+
+    it('searchOrgUsers calls IAM searchUsers and maps hits', async () => {
+      get.mockResolvedValue({
+        totalHits: 1,
+        hits: [
+          {
+            name: 'uid-alice',
+            title: 'Alice',
+            login: 'alice',
+            email: 'a@example.com',
+            role: 'Admin',
+            internalId: 42,
+            lastSeenAtAge: '1d',
+          },
+        ],
+      });
+
+      const result = await searchOrgUsers({ perPage: 50, page: 1, query: 'alice' });
+
+      expect(get).toHaveBeenCalledWith(
+        '/apis/iam.grafana.app/v0alpha1/namespaces/default/searchUsers',
+        expect.objectContaining({ limit: 50, page: 1, query: 'alice' })
+      );
+      expect(result.orgUsers).toHaveLength(1);
+      expect(result.orgUsers[0]).toMatchObject({
+        uid: 'uid-alice',
+        userId: 42,
+        login: 'alice',
+        role: 'Admin',
+      });
+      expect(result.totalCount).toBe(1);
+    });
+
+    it('updateOrgUserRole patches IAM User by uid', async () => {
+      patch.mockResolvedValue(undefined);
+      await updateOrgUserRole({ userId: 7, uid: 'u7', role: 'Editor' } as never);
+      expect(patch).toHaveBeenCalledWith('/apis/iam.grafana.app/v0alpha1/namespaces/default/users/u7', {
+        spec: { role: 'Editor' },
+      });
+    });
+
+    it('removeOrgUser deletes IAM User by uid', async () => {
+      del.mockResolvedValue(undefined);
+      await removeOrgUser({ userId: 7, uid: 'u7' });
+      expect(del).toHaveBeenCalledWith('/apis/iam.grafana.app/v0alpha1/namespaces/default/users/u7');
+    });
+
+    it('lookupOrgUsers calls IAM searchUsers', async () => {
+      get.mockResolvedValue({
+        hits: [{ name: 'uid-bob', login: 'bob', email: 'b@x.com', role: 'Viewer', internalId: 9 }],
+      });
+      const users = await lookupOrgUsers('bob');
+      expect(get).toHaveBeenCalledWith(
+        '/apis/iam.grafana.app/v0alpha1/namespaces/default/searchUsers',
+        expect.objectContaining({ query: 'bob', limit: 100 })
+      );
+      expect(users[0]).toMatchObject({ uid: 'uid-bob', userId: 9, login: 'bob' });
+    });
+  });
+});

--- a/public/app/features/users/api.ts
+++ b/public/app/features/users/api.ts
@@ -1,0 +1,146 @@
+import { type OrgRole } from '@grafana/data';
+import { config, getBackendSrv } from '@grafana/runtime';
+import { accessControlQueryParam } from 'app/core/utils/accessControl';
+import { contextSrv } from 'app/core/services/context_srv';
+import { type OrgUser } from 'app/types/user';
+
+/** IAM search hit shape from /apis/iam.grafana.app/.../searchUsers */
+export interface SearchUsersHit {
+  name: string;
+  title?: string;
+  login: string;
+  email: string;
+  role: string;
+  lastSeenAt?: number;
+  lastSeenAtAge?: string;
+  provisioned?: boolean;
+  disabled?: boolean;
+  internalId: number;
+  created?: number;
+  accessControl?: Record<string, boolean>;
+  externalAuthModules?: string[];
+}
+
+interface SearchUsersResponse {
+  hits?: SearchUsersHit[];
+  totalHits?: number;
+}
+
+interface OrgUsersSearchResult {
+  orgUsers: OrgUser[];
+  totalCount: number;
+  page: number;
+  perPage: number;
+}
+
+export function isKubernetesUsersApiEnabled(): boolean {
+  return Boolean(config.featureToggles.kubernetesUsersApi);
+}
+
+function iamBaseURL(): string {
+  return `/apis/iam.grafana.app/v0alpha1/namespaces/${config.namespace}`;
+}
+
+function searchHitToOrgUser(hit: SearchUsersHit): OrgUser {
+  return {
+    uid: hit.name,
+    userId: hit.internalId,
+    login: hit.login,
+    email: hit.email,
+    name: hit.title || hit.login,
+    role: hit.role as OrgRole,
+    orgId: contextSrv.user.orgId,
+    avatarUrl: '',
+    lastSeenAt: hit.lastSeenAt ? new Date(hit.lastSeenAt).toISOString() : '',
+    lastSeenAtAge: hit.lastSeenAtAge || '',
+    isDisabled: Boolean(hit.disabled),
+    isProvisioned: Boolean(hit.provisioned),
+    accessControl: hit.accessControl,
+    authLabels: hit.externalAuthModules,
+  };
+}
+
+/**
+ * Search org users. When kubernetesUsersApi is on, calls IAM searchUsers;
+ * otherwise the legacy /api/org/users/search endpoint (default).
+ */
+export async function searchOrgUsers(params: {
+  perPage: number;
+  page: number;
+  query?: string;
+  sort?: string;
+}): Promise<OrgUsersSearchResult> {
+  if (isKubernetesUsersApiEnabled()) {
+    const response = await getBackendSrv().get<SearchUsersResponse>(
+      `${iamBaseURL()}/searchUsers`,
+      accessControlQueryParam({
+        limit: params.perPage,
+        page: params.page,
+        query: params.query,
+        sort: params.sort,
+        accesscontrol: true,
+      })
+    );
+    const hits = response.hits ?? [];
+    return {
+      orgUsers: hits.map(searchHitToOrgUser),
+      totalCount: response.totalHits ?? hits.length,
+      page: params.page,
+      perPage: params.perPage,
+    };
+  }
+
+  return getBackendSrv().get(
+    `/api/org/users/search`,
+    accessControlQueryParam({
+      perpage: params.perPage,
+      page: params.page,
+      query: params.query,
+      sort: params.sort,
+    })
+  );
+}
+
+/**
+ * Update an org user's role. IAM path patches User.spec.role by UID.
+ */
+export async function updateOrgUserRole(user: OrgUser): Promise<void> {
+  if (isKubernetesUsersApiEnabled() && user.uid) {
+    await getBackendSrv().patch(`${iamBaseURL()}/users/${user.uid}`, {
+      spec: { role: user.role },
+    });
+    return;
+  }
+  await getBackendSrv().patch(`/api/org/users/${user.userId}`, { role: user.role });
+}
+
+/**
+ * Remove an org user. IAM path deletes the User resource by UID (single-org).
+ */
+export async function removeOrgUser(user: { userId: number; uid?: string }): Promise<void> {
+  if (isKubernetesUsersApiEnabled() && user.uid) {
+    await getBackendSrv().delete(`${iamBaseURL()}/users/${user.uid}`);
+    return;
+  }
+  await getBackendSrv().delete(`/api/org/users/${user.userId}`);
+}
+
+/**
+ * Lookup users for pickers. IAM path uses searchUsers; default stays on /api lookup.
+ */
+export async function lookupOrgUsers(query: string, limit = 100): Promise<Array<Partial<OrgUser>>> {
+  if (isKubernetesUsersApiEnabled()) {
+    const response = await getBackendSrv().get<SearchUsersResponse>(`${iamBaseURL()}/searchUsers`, {
+      query,
+      limit,
+    });
+    return (response.hits ?? []).map((hit) => ({
+      uid: hit.name,
+      userId: hit.internalId,
+      login: hit.login,
+      avatarUrl: '',
+    }));
+  }
+
+  return getBackendSrv().get(`/api/org/users/lookup?query=${encodeURIComponent(query)}&limit=${limit}`);
+}

--- a/public/app/features/users/state/actions.ts
+++ b/public/app/features/users/state/actions.ts
@@ -1,13 +1,13 @@
 import { debounce } from 'lodash';
 
-import { getBackendSrv } from '@grafana/runtime';
-import { type FetchDataArgs } from '@grafana/ui';
 import { contextSrv } from 'app/core/services/context_srv';
-import { accessControlQueryParam } from 'app/core/utils/accessControl';
 import { AccessControlAction } from 'app/types/accessControl';
 import { type ThunkResult } from 'app/types/store';
 import { type OrgUser } from 'app/types/user';
+import { type FetchDataArgs } from '@grafana/ui';
+import { getBackendSrv } from '@grafana/runtime';
 
+import { removeOrgUser, searchOrgUsers, updateOrgUserRole } from './api';
 import {
   usersLoaded,
   pageChanged,
@@ -24,10 +24,12 @@ export function loadUsers(): ThunkResult<void> {
     try {
       dispatch(usersFetchBegin());
       const { perPage, page, searchQuery, sort } = getState().users;
-      const users = await getBackendSrv().get(
-        `/api/org/users/search`,
-        accessControlQueryParam({ perpage: perPage, page, query: searchQuery, sort })
-      );
+      const users = await searchOrgUsers({
+        perPage,
+        page,
+        query: searchQuery,
+        sort,
+      });
 
       if (
         contextSrv.licensedAccessControlEnabled() &&
@@ -56,14 +58,15 @@ const fetchUsersWithDebounce = debounce((dispatch) => dispatch(loadUsers()), 300
 
 export function updateUser(user: OrgUser): ThunkResult<void> {
   return async (dispatch) => {
-    await getBackendSrv().patch(`/api/org/users/${user.userId}`, { role: user.role });
+    await updateOrgUserRole(user);
     dispatch(loadUsers());
   };
 }
 
 export function removeUser(userId: number): ThunkResult<void> {
-  return async (dispatch) => {
-    await getBackendSrv().delete(`/api/org/users/${userId}`);
+  return async (dispatch, getState) => {
+    const user = getState().users.users.find((u) => u.userId === userId);
+    await removeOrgUser({ userId, uid: user?.uid });
     dispatch(loadUsers());
   };
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
**What is this feature?**

Implements `/apis` dual-path support for the four leftover fully-`/api` slices (org users, library-panel connections, signed-in user, live), gated behind existing experimental flags. Default Grafana traffic stays on `/api`.

**Why do we need this feature?**

Completes the dual-path foundation so these surfaces can later cut over without flipping flags in this PR.

**Who is this feature for?**

Identity/access, dashboards (library panels), and live platform engineers enabling experimental `/apis` paths in non-default configs.

**Which issue(s) does this PR fix?**:

N/A — migration plan execution.

**Special notes for your reviewer:**

### Slices

1. **Org users** — `/api/org/users*` add/update/remove/lookup use IAM User service when `kubernetesUsersRedirect` is on; FE helpers call `/apis/iam.grafana.app` when `kubernetesUsersApi` is on.
2. **Library connections** — when `libraryelements.kubernetesLibraryPanels` is on, connections GET verifies the panel via `/apis` then reuses search-backed connections; folder deletion integration test unskipped under that flag.
3. **Signed-in user** — IAM User subresources `orgs`, `using`, `tokens`, `password`; profile FE + org switcher branch when `kubernetesUsersApi` is on. Signup + cookie token rotate stay on `/api`. Active-org and password updates force legacy `user.Update`.
4. **Live** — `/apis/live.grafana.app` custom routes `ws`, `list`, `push/{streamId}` behind `live.runAPIServer`; centrifuge optionally uses `/apis` ws when flag on. Default remains `/api/live/ws`.

### Constraints honored

- Flags stay experimental with `Expression: false` (`kubernetesUsersApi`, `kubernetesUsersRedirect`, `libraryelements.kubernetesLibraryPanels`, `live.runAPIServer`).
- Live keeps `RequiresDevMode`.
- `/api` handlers are not deleted.
- Stars and preferences are out of scope.

### Tests run

- `go test ./pkg/api/ -run 'TestRemoveOrgUserForCurrentOrg_KubernetesUsersRedirect|TestAddOrgUserToCurrentOrg_KubernetesUsersRedirect'`
- `go test ./pkg/registry/apis/iam/ ./pkg/registry/apis/iam/user/ ./pkg/registry/apps/live/ ./apps/live/pkg/app/`
- `yarn jest --no-watch public/app/features/users/api.test.ts public/app/features/profile/api.test.ts public/app/features/live/centrifuge/service.test.ts`

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4a8b9c16-8902-402c-9c0a-8c3e0380af32?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4a8b9c16-8902-402c-9c0a-8c3e0380af32&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

