### PR TITLE
Time Series: panel-level linear regression and moving average overlays

### DIFF
--- a/docs/sources/visualizations/panels-visualizations/visualizations/time-series/index.md
+++ b/docs/sources/visualizations/panels-visualizations/visualizations/time-series/index.md
@@ -211,6 +211,15 @@ The tooltip also provides the following options:
 
 For more information, refer to the [Configure legend documentation](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/visualizations/panels-visualizations/configure-legend/#series-visibility).
 
+### Overlay options
+
+Overlay options draw a calculated line on top of each series without adding a transformation.
+
+- **Mode**: Choose **Off**, **Linear regression**, or **Moving average**.
+- **Window size**: When mode is **Moving average**, the number of points in the trailing window. Grafana includes the current point and ignores nulls.
+
+Linear regression fits a least-squares line to each numeric series over the visible time range. Moving average plots the trailing mean of the last N samples. Overlay series appear in the legend so you can hide them independently of the source series.
+
 ### Axis options
 
 {{< docs/shared lookup="visualizations/axis-options-1.md" source="grafana" version="<GRAFANA_VERSION>" leveloffset="+1" >}}

--- a/packages/grafana-schema/src/raw/composable/timeseries/panelcfg/x/types.gen.ts
+++ b/packages/grafana-schema/src/raw/composable/timeseries/panelcfg/x/types.gen.ts
@@ -24,10 +24,27 @@ export const defaultTimeSeriesLegendOptions: Partial<TimeSeriesLegendOptions> = 
   facetedFilterPinned: false,
 };
 
+export enum TimeSeriesOverlayMode {
+  LinearRegression = 'linearRegression',
+  MovingAverage = 'movingAverage',
+  Off = 'off',
+}
+
+export interface TimeSeriesOverlayOptions {
+  mode: (TimeSeriesOverlayMode | 'off');
+  windowSize?: number;
+}
+
+export const defaultTimeSeriesOverlayOptions: Partial<TimeSeriesOverlayOptions> = {
+  mode: 'off',
+  windowSize: 7,
+};
+
 export interface Options extends common.OptionsWithTimezones, common.OptionsWithAnnotations {
   disableKeyboardEvents?: boolean;
   legend: TimeSeriesLegendOptions;
   orientation?: common.VizOrientation;
+  overlay?: TimeSeriesOverlayOptions;
   timeCompare?: common.TimeCompareOptions;
   tooltip: common.VizTooltipOptions;
 }

--- a/public/app/plugins/panel/timeseries/TimeSeriesPanel.lines.canvas.test.tsx
+++ b/public/app/plugins/panel/timeseries/TimeSeriesPanel.lines.canvas.test.tsx
@@ -7,6 +7,15 @@ import {
   setupCanvasCapture,
   withFieldConfig,
 } from './TimeSeriesPanel.canvasTestUtils';
+import { TimeSeriesOverlayMode } from './panelcfg.gen';
+
+import {
+  type CanvasCase,
+  fixedBlue,
+  renderCanvasCase,
+  setupCanvasCapture,
+  withFieldConfig,
+} from './TimeSeriesPanel.canvasTestUtils';
 
 jest.mock('@grafana/ui/src/utils/measureText', () =>
   require('@grafana/test-utils/canvas').createGrafanaUiMeasureTextJestMock(() =>
@@ -51,5 +60,13 @@ describe('TimeSeriesPanel (canvas) — line rendering', () => {
     })),
     // orientation is a panel option, not field config; Vertical puts time on the Y axis.
     { name: 'orientation: vertical', options: { orientation: VizOrientation.Vertical } },
+    {
+      name: 'overlay: linearRegression',
+      options: { overlay: { mode: TimeSeriesOverlayMode.LinearRegression } },
+    },
+    {
+      name: 'overlay: movingAverage',
+      options: { overlay: { mode: TimeSeriesOverlayMode.MovingAverage, windowSize: 3 } },
+    },
   ])('$name', (testCase) => renderCanvasCase(testCase));
 });

--- a/public/app/plugins/panel/timeseries/TimeSeriesPanel.test.tsx
+++ b/public/app/plugins/panel/timeseries/TimeSeriesPanel.test.tsx
@@ -9,7 +9,7 @@ import { PanelContextProvider } from '@grafana/ui';
 import { getPanelProps } from '../test-utils';
 
 import { TimeSeriesPanel } from './TimeSeriesPanel';
-import { type Options } from './panelcfg.gen';
+import { TimeSeriesOverlayMode, type Options } from './panelcfg.gen';
 
 const defaultOptions: Options = {
   legend: {
@@ -146,6 +146,21 @@ describe('TimeSeriesPanel', () => {
     renderPanel({ legend: { ...defaultOptions.legend, showLegend: false } });
 
     expect(screen.queryByTestId(selectors.components.VizLayout.legend)).not.toBeInTheDocument();
+  });
+
+  it('lists overlay series in the legend when linear regression is enabled', () => {
+    renderPanel({ overlay: { mode: TimeSeriesOverlayMode.LinearRegression } });
+
+    expect(screen.getByTestId(selectors.components.VizLegend.seriesName('value'))).toBeInTheDocument();
+    expect(
+      screen.getByTestId(selectors.components.VizLegend.seriesName('value (linear regression)'))
+    ).toBeInTheDocument();
+  });
+
+  it('lists overlay series in the legend when moving average is enabled', () => {
+    renderPanel({ overlay: { mode: TimeSeriesOverlayMode.MovingAverage, windowSize: 2 } });
+
+    expect(screen.getByTestId(selectors.components.VizLegend.seriesName('value (moving average)'))).toBeInTheDocument();
   });
 
   describe('faceted filter pin-to-sidebar persistence', () => {

--- a/public/app/plugins/panel/timeseries/TimeSeriesPanel.tsx
+++ b/public/app/plugins/panel/timeseries/TimeSeriesPanel.tsx
@@ -26,6 +26,7 @@ import { TimeSeries } from 'app/core/components/TimeSeries/TimeSeries';
 import { getFilterByGroupedLabels } from 'app/features/panel/filters/adhoc';
 
 import { TimeSeriesTooltip } from './TimeSeriesTooltip';
+import { applyTimeSeriesOverlays } from './overlays';
 import { type Options } from './panelcfg.gen';
 import { AnnotationsPlugin } from './plugins/AnnotationsPlugin';
 import { ExemplarsPlugin, getVisibleLabels } from './plugins/ExemplarsPlugin';
@@ -70,19 +71,12 @@ export const TimeSeriesPanel = ({
   const { frames, compareDiffMs } = useMemo(() => {
     let frames = prepareGraphableFields(data.series, theme, timeRange);
     if (frames != null) {
-      let compareDiffMs: number[] = [0];
       // Held separately from `frames` below: TS won't retain the null-check narrowing of `frames`
       // inside the .map callback once `frames` itself gets reassigned in this scope.
       const originalFrames = frames;
 
       frames = originalFrames.map((frame: DataFrame) => {
         const diffMs = frame.meta?.timeCompare?.diffMs ?? 0;
-
-        frame.fields.forEach((field) => {
-          if (field.type !== FieldType.time) {
-            compareDiffMs.push(diffMs);
-          }
-        });
 
         if (diffMs !== 0) {
           // Check if the compared frame needs time alignment
@@ -97,11 +91,24 @@ export const TimeSeriesPanel = ({
         return frame;
       });
 
+      frames = applyTimeSeriesOverlays(frames, options.overlay, theme);
+
+      // Index 0 is reserved for the time field in the aligned tooltip frame.
+      const compareDiffMs: number[] = [0];
+      for (const frame of frames) {
+        const diffMs = frame.meta?.timeCompare?.diffMs ?? 0;
+        for (const field of frame.fields) {
+          if (field.type !== FieldType.time) {
+            compareDiffMs.push(diffMs);
+          }
+        }
+      }
+
       return { frames, compareDiffMs };
     }
 
     return { frames };
-  }, [data.series, timeRange, theme]);
+  }, [data.series, timeRange, theme, options.overlay]);
 
   const timezones = useMemo(() => getTimezones(options.timezone, timeZone), [options.timezone, timeZone]);
   const suggestions = useMemo(() => {

--- a/public/app/plugins/panel/timeseries/__snapshots__/TimeSeriesPanel.lines.canvas.test.tsx.snap
+++ b/public/app/plugins/panel/timeseries/__snapshots__/TimeSeriesPanel.lines.canvas.test.tsx.snap
@@ -3217,3 +3217,939 @@ exports[`TimeSeriesPanel (canvas) — line rendering orientation: vertical 1`] =
   },
 ]
 `;
+
+exports[`TimeSeriesPanel (canvas) — line rendering overlay: linearRegression 1`] = `
+[
+  {
+    "props": {
+      "x": 0.5,
+      "y": 0.5,
+    },
+    "type": "translate",
+  },
+  {
+    "props": {
+      "value": "#808080",
+    },
+    "type": "strokeStyle",
+  },
+  {
+    "props": {
+      "value": "rgba(0, 0, 0, 0)",
+    },
+    "type": "fillStyle",
+  },
+  {
+    "props": {},
+    "type": "save",
+  },
+  {
+    "props": {
+      "fillRule": "nonzero",
+      "path": [
+        {
+          "props": {
+            "height": 350,
+            "width": 617,
+            "x": 23.5,
+            "y": 7.5,
+          },
+          "type": "rect",
+        },
+      ],
+    },
+    "type": "clip",
+  },
+  {
+    "props": {
+      "path": [
+        {
+          "props": {
+            "x": 24,
+            "y": 320,
+          },
+          "type": "lineTo",
+        },
+        {
+          "props": {
+            "x": 178,
+            "y": 137,
+          },
+          "type": "lineTo",
+        },
+        {
+          "props": {
+            "x": 332,
+            "y": 228,
+          },
+          "type": "lineTo",
+        },
+        {
+          "props": {
+            "x": 486,
+            "y": 45,
+          },
+          "type": "lineTo",
+        },
+        {
+          "props": {
+            "x": 640,
+            "y": 173,
+          },
+          "type": "lineTo",
+        },
+      ],
+    },
+    "type": "stroke",
+  },
+  {
+    "props": {},
+    "type": "restore",
+  },
+  {
+    "props": {
+      "x": -0.5,
+      "y": -0.5,
+    },
+    "type": "translate",
+  },
+  {
+    "props": {
+      "x": 0.5,
+      "y": 0.5,
+    },
+    "type": "translate",
+  },
+  {
+    "props": {
+      "value": "#808080",
+    },
+    "type": "fillStyle",
+  },
+  {
+    "props": {},
+    "type": "save",
+  },
+  {
+    "props": {
+      "fillRule": "nonzero",
+      "path": [
+        {
+          "props": {
+            "height": 357,
+            "width": 624,
+            "x": 20,
+            "y": 4,
+          },
+          "type": "rect",
+        },
+      ],
+    },
+    "type": "clip",
+  },
+  {
+    "props": {
+      "fillRule": "nonzero",
+      "path": [
+        {
+          "props": {
+            "x": 26,
+            "y": 320,
+          },
+          "type": "moveTo",
+        },
+        {
+          "props": {
+            "anticlockwise": false,
+            "endAngle": 6.283185307179586,
+            "radius": 2,
+            "startAngle": 0,
+            "x": 24,
+            "y": 320,
+          },
+          "type": "arc",
+        },
+        {
+          "props": {
+            "x": 180,
+            "y": 137,
+          },
+          "type": "moveTo",
+        },
+        {
+          "props": {
+            "anticlockwise": false,
+            "endAngle": 6.283185307179586,
+            "radius": 2,
+            "startAngle": 0,
+            "x": 178,
+            "y": 137,
+          },
+          "type": "arc",
+        },
+        {
+          "props": {
+            "x": 334,
+            "y": 228,
+          },
+          "type": "moveTo",
+        },
+        {
+          "props": {
+            "anticlockwise": false,
+            "endAngle": 6.283185307179586,
+            "radius": 2,
+            "startAngle": 0,
+            "x": 332,
+            "y": 228,
+          },
+          "type": "arc",
+        },
+        {
+          "props": {
+            "x": 488,
+            "y": 45,
+          },
+          "type": "moveTo",
+        },
+        {
+          "props": {
+            "anticlockwise": false,
+            "endAngle": 6.283185307179586,
+            "radius": 2,
+            "startAngle": 0,
+            "x": 486,
+            "y": 45,
+          },
+          "type": "arc",
+        },
+        {
+          "props": {
+            "x": 642,
+            "y": 173,
+          },
+          "type": "moveTo",
+        },
+        {
+          "props": {
+            "anticlockwise": false,
+            "endAngle": 6.283185307179586,
+            "radius": 2,
+            "startAngle": 0,
+            "x": 640,
+            "y": 173,
+          },
+          "type": "arc",
+        },
+      ],
+    },
+    "type": "fill",
+  },
+  {
+    "props": {
+      "path": [
+        {
+          "props": {
+            "x": 26,
+            "y": 320,
+          },
+          "type": "moveTo",
+        },
+        {
+          "props": {
+            "anticlockwise": false,
+            "endAngle": 6.283185307179586,
+            "radius": 2,
+            "startAngle": 0,
+            "x": 24,
+            "y": 320,
+          },
+          "type": "arc",
+        },
+        {
+          "props": {
+            "x": 180,
+            "y": 137,
+          },
+          "type": "moveTo",
+        },
+        {
+          "props": {
+            "anticlockwise": false,
+            "endAngle": 6.283185307179586,
+            "radius": 2,
+            "startAngle": 0,
+            "x": 178,
+            "y": 137,
+          },
+          "type": "arc",
+        },
+        {
+          "props": {
+            "x": 334,
+            "y": 228,
+          },
+          "type": "moveTo",
+        },
+        {
+          "props": {
+            "anticlockwise": false,
+            "endAngle": 6.283185307179586,
+            "radius": 2,
+            "startAngle": 0,
+            "x": 332,
+            "y": 228,
+          },
+          "type": "arc",
+        },
+        {
+          "props": {
+            "x": 488,
+            "y": 45,
+          },
+          "type": "moveTo",
+        },
+        {
+          "props": {
+            "anticlockwise": false,
+            "endAngle": 6.283185307179586,
+            "radius": 2,
+            "startAngle": 0,
+            "x": 486,
+            "y": 45,
+          },
+          "type": "arc",
+        },
+        {
+          "props": {
+            "x": 642,
+            "y": 173,
+          },
+          "type": "moveTo",
+        },
+        {
+          "props": {
+            "anticlockwise": false,
+            "endAngle": 6.283185307179586,
+            "radius": 2,
+            "startAngle": 0,
+            "x": 640,
+            "y": 173,
+          },
+          "type": "arc",
+        },
+      ],
+    },
+    "type": "stroke",
+  },
+  {
+    "props": {},
+    "type": "restore",
+  },
+  {
+    "props": {
+      "x": -0.5,
+      "y": -0.5,
+    },
+    "type": "translate",
+  },
+  {
+    "props": {
+      "value": "rgba(0, 0, 0, 0)",
+    },
+    "type": "fillStyle",
+  },
+  {
+    "props": {
+      "value": 2,
+    },
+    "type": "lineWidth",
+  },
+  {
+    "props": {
+      "segments": [
+        10,
+        10,
+      ],
+    },
+    "type": "setLineDash",
+  },
+  {
+    "props": {},
+    "type": "save",
+  },
+  {
+    "props": {
+      "fillRule": "nonzero",
+      "path": [
+        {
+          "props": {
+            "height": 351,
+            "width": 618,
+            "x": 23,
+            "y": 7,
+          },
+          "type": "rect",
+        },
+      ],
+    },
+    "type": "clip",
+  },
+  {
+    "props": {
+      "path": [
+        {
+          "props": {
+            "x": 24,
+            "y": 258,
+          },
+          "type": "lineTo",
+        },
+        {
+          "props": {
+            "x": 178,
+            "y": 219,
+          },
+          "type": "lineTo",
+        },
+        {
+          "props": {
+            "x": 332,
+            "y": 181,
+          },
+          "type": "lineTo",
+        },
+        {
+          "props": {
+            "x": 486,
+            "y": 142,
+          },
+          "type": "lineTo",
+        },
+        {
+          "props": {
+            "x": 640,
+            "y": 104,
+          },
+          "type": "lineTo",
+        },
+      ],
+    },
+    "type": "stroke",
+  },
+  {
+    "props": {},
+    "type": "restore",
+  },
+  {
+    "props": {},
+    "type": "save",
+  },
+  {
+    "props": {},
+    "type": "beginPath",
+  },
+  {
+    "props": {
+      "height": 349,
+      "width": 616,
+      "x": 24,
+      "y": 8,
+    },
+    "type": "rect",
+  },
+  {
+    "props": {
+      "fillRule": "nonzero",
+      "path": [
+        {
+          "props": {},
+          "type": "beginPath",
+        },
+        {
+          "props": {
+            "height": 349,
+            "width": 616,
+            "x": 24,
+            "y": 8,
+          },
+          "type": "rect",
+        },
+      ],
+    },
+    "type": "clip",
+  },
+  {
+    "props": {},
+    "type": "restore",
+  },
+]
+`;
+
+exports[`TimeSeriesPanel (canvas) — line rendering overlay: movingAverage 1`] = `
+[
+  {
+    "props": {
+      "x": 0.5,
+      "y": 0.5,
+    },
+    "type": "translate",
+  },
+  {
+    "props": {
+      "value": "#808080",
+    },
+    "type": "strokeStyle",
+  },
+  {
+    "props": {
+      "value": "rgba(0, 0, 0, 0)",
+    },
+    "type": "fillStyle",
+  },
+  {
+    "props": {},
+    "type": "save",
+  },
+  {
+    "props": {
+      "fillRule": "nonzero",
+      "path": [
+        {
+          "props": {
+            "height": 350,
+            "width": 617,
+            "x": 23.5,
+            "y": 7.5,
+          },
+          "type": "rect",
+        },
+      ],
+    },
+    "type": "clip",
+  },
+  {
+    "props": {
+      "path": [
+        {
+          "props": {
+            "x": 24,
+            "y": 320,
+          },
+          "type": "lineTo",
+        },
+        {
+          "props": {
+            "x": 178,
+            "y": 137,
+          },
+          "type": "lineTo",
+        },
+        {
+          "props": {
+            "x": 332,
+            "y": 228,
+          },
+          "type": "lineTo",
+        },
+        {
+          "props": {
+            "x": 486,
+            "y": 45,
+          },
+          "type": "lineTo",
+        },
+        {
+          "props": {
+            "x": 640,
+            "y": 173,
+          },
+          "type": "lineTo",
+        },
+      ],
+    },
+    "type": "stroke",
+  },
+  {
+    "props": {},
+    "type": "restore",
+  },
+  {
+    "props": {
+      "x": -0.5,
+      "y": -0.5,
+    },
+    "type": "translate",
+  },
+  {
+    "props": {
+      "x": 0.5,
+      "y": 0.5,
+    },
+    "type": "translate",
+  },
+  {
+    "props": {
+      "value": "#808080",
+    },
+    "type": "fillStyle",
+  },
+  {
+    "props": {},
+    "type": "save",
+  },
+  {
+    "props": {
+      "fillRule": "nonzero",
+      "path": [
+        {
+          "props": {
+            "height": 357,
+            "width": 624,
+            "x": 20,
+            "y": 4,
+          },
+          "type": "rect",
+        },
+      ],
+    },
+    "type": "clip",
+  },
+  {
+    "props": {
+      "fillRule": "nonzero",
+      "path": [
+        {
+          "props": {
+            "x": 26,
+            "y": 320,
+          },
+          "type": "moveTo",
+        },
+        {
+          "props": {
+            "anticlockwise": false,
+            "endAngle": 6.283185307179586,
+            "radius": 2,
+            "startAngle": 0,
+            "x": 24,
+            "y": 320,
+          },
+          "type": "arc",
+        },
+        {
+          "props": {
+            "x": 180,
+            "y": 137,
+          },
+          "type": "moveTo",
+        },
+        {
+          "props": {
+            "anticlockwise": false,
+            "endAngle": 6.283185307179586,
+            "radius": 2,
+            "startAngle": 0,
+            "x": 178,
+            "y": 137,
+          },
+          "type": "arc",
+        },
+        {
+          "props": {
+            "x": 334,
+            "y": 228,
+          },
+          "type": "moveTo",
+        },
+        {
+          "props": {
+            "anticlockwise": false,
+            "endAngle": 6.283185307179586,
+            "radius": 2,
+            "startAngle": 0,
+            "x": 332,
+            "y": 228,
+          },
+          "type": "arc",
+        },
+        {
+          "props": {
+            "x": 488,
+            "y": 45,
+          },
+          "type": "moveTo",
+        },
+        {
+          "props": {
+            "anticlockwise": false,
+            "endAngle": 6.283185307179586,
+            "radius": 2,
+            "startAngle": 0,
+            "x": 486,
+            "y": 45,
+          },
+          "type": "arc",
+        },
+        {
+          "props": {
+            "x": 642,
+            "y": 173,
+          },
+          "type": "moveTo",
+        },
+        {
+          "props": {
+            "anticlockwise": false,
+            "endAngle": 6.283185307179586,
+            "radius": 2,
+            "startAngle": 0,
+            "x": 640,
+            "y": 173,
+          },
+          "type": "arc",
+        },
+      ],
+    },
+    "type": "fill",
+  },
+  {
+    "props": {
+      "path": [
+        {
+          "props": {
+            "x": 26,
+            "y": 320,
+          },
+          "type": "moveTo",
+        },
+        {
+          "props": {
+            "anticlockwise": false,
+            "endAngle": 6.283185307179586,
+            "radius": 2,
+            "startAngle": 0,
+            "x": 24,
+            "y": 320,
+          },
+          "type": "arc",
+        },
+        {
+          "props": {
+            "x": 180,
+            "y": 137,
+          },
+          "type": "moveTo",
+        },
+        {
+          "props": {
+            "anticlockwise": false,
+            "endAngle": 6.283185307179586,
+            "radius": 2,
+            "startAngle": 0,
+            "x": 178,
+            "y": 137,
+          },
+          "type": "arc",
+        },
+        {
+          "props": {
+            "x": 334,
+            "y": 228,
+          },
+          "type": "moveTo",
+        },
+        {
+          "props": {
+            "anticlockwise": false,
+            "endAngle": 6.283185307179586,
+            "radius": 2,
+            "startAngle": 0,
+            "x": 332,
+            "y": 228,
+          },
+          "type": "arc",
+        },
+        {
+          "props": {
+            "x": 488,
+            "y": 45,
+          },
+          "type": "moveTo",
+        },
+        {
+          "props": {
+            "anticlockwise": false,
+            "endAngle": 6.283185307179586,
+            "radius": 2,
+            "startAngle": 0,
+            "x": 486,
+            "y": 45,
+          },
+          "type": "arc",
+        },
+        {
+          "props": {
+            "x": 642,
+            "y": 173,
+          },
+          "type": "moveTo",
+        },
+        {
+          "props": {
+            "anticlockwise": false,
+            "endAngle": 6.283185307179586,
+            "radius": 2,
+            "startAngle": 0,
+            "x": 640,
+            "y": 173,
+          },
+          "type": "arc",
+        },
+      ],
+    },
+    "type": "stroke",
+  },
+  {
+    "props": {},
+    "type": "restore",
+  },
+  {
+    "props": {
+      "x": -0.5,
+      "y": -0.5,
+    },
+    "type": "translate",
+  },
+  {
+    "props": {
+      "value": "rgba(0, 0, 0, 0)",
+    },
+    "type": "fillStyle",
+  },
+  {
+    "props": {
+      "value": 2,
+    },
+    "type": "lineWidth",
+  },
+  {
+    "props": {
+      "segments": [
+        10,
+        10,
+      ],
+    },
+    "type": "setLineDash",
+  },
+  {
+    "props": {},
+    "type": "save",
+  },
+  {
+    "props": {
+      "fillRule": "nonzero",
+      "path": [
+        {
+          "props": {
+            "height": 351,
+            "width": 618,
+            "x": 23,
+            "y": 7,
+          },
+          "type": "rect",
+        },
+      ],
+    },
+    "type": "clip",
+  },
+  {
+    "props": {
+      "path": [
+        {
+          "props": {
+            "x": 24,
+            "y": 320,
+          },
+          "type": "lineTo",
+        },
+        {
+          "props": {
+            "x": 178,
+            "y": 228,
+          },
+          "type": "lineTo",
+        },
+        {
+          "props": {
+            "x": 332,
+            "y": 228,
+          },
+          "type": "lineTo",
+        },
+        {
+          "props": {
+            "x": 486,
+            "y": 137,
+          },
+          "type": "lineTo",
+        },
+        {
+          "props": {
+            "x": 640,
+            "y": 149,
+          },
+          "type": "lineTo",
+        },
+      ],
+    },
+    "type": "stroke",
+  },
+  {
+    "props": {},
+    "type": "restore",
+  },
+  {
+    "props": {},
+    "type": "save",
+  },
+  {
+    "props": {},
+    "type": "beginPath",
+  },
+  {
+    "props": {
+      "height": 349,
+      "width": 616,
+      "x": 24,
+      "y": 8,
+    },
+    "type": "rect",
+  },
+  {
+    "props": {
+      "fillRule": "nonzero",
+      "path": [
+        {
+          "props": {},
+          "type": "beginPath",
+        },
+        {
+          "props": {
+            "height": 349,
+            "width": 616,
+            "x": 24,
+            "y": 8,
+          },
+          "type": "rect",
+        },
+      ],
+    },
+    "type": "clip",
+  },
+  {
+    "props": {},
+    "type": "restore",
+  },
+]
+`;

--- a/public/app/plugins/panel/timeseries/module.tsx
+++ b/public/app/plugins/panel/timeseries/module.tsx
@@ -8,7 +8,7 @@ import { TimeSeriesPanel } from './TimeSeriesPanel';
 import { TimezonesEditor } from './TimezonesEditor';
 import { defaultGraphConfig, getGraphFieldConfig } from './config';
 import { graphPanelChangedHandler } from './migrations';
-import { type FieldConfig, type Options } from './panelcfg.gen';
+import { defaultTimeSeriesOverlayOptions, type FieldConfig, type Options, TimeSeriesOverlayMode } from './panelcfg.gen';
 import { timeseriesPresetsSupplier } from './presets';
 import { timeseriesSuggestionsSupplier } from './suggestions';
 
@@ -42,6 +42,48 @@ export const plugin = new PanelPlugin<Options, FieldConfig>(TimeSeriesPanel)
     });
 
     addAnnotationOptions(builder);
+
+    const overlayCategory = [t('timeseries.overlay.category', 'Overlay')];
+
+    builder
+      .addRadio({
+        path: 'overlay.mode',
+        name: t('timeseries.overlay.name-mode', 'Mode'),
+        description: t(
+          'timeseries.overlay.description-mode',
+          'Draw a linear regression or moving average on each series without adding a transformation'
+        ),
+        category: overlayCategory,
+        defaultValue: defaultTimeSeriesOverlayOptions.mode,
+        settings: {
+          options: [
+            { value: TimeSeriesOverlayMode.Off, label: t('timeseries.overlay.mode-options.label-off', 'Off') },
+            {
+              value: TimeSeriesOverlayMode.LinearRegression,
+              label: t('timeseries.overlay.mode-options.label-linear-regression', 'Linear regression'),
+            },
+            {
+              value: TimeSeriesOverlayMode.MovingAverage,
+              label: t('timeseries.overlay.mode-options.label-moving-average', 'Moving average'),
+            },
+          ],
+        },
+      })
+      .addNumberInput({
+        path: 'overlay.windowSize',
+        name: t('timeseries.overlay.name-window-size', 'Window size'),
+        description: t(
+          'timeseries.overlay.description-window-size',
+          'Number of points included in the trailing moving average'
+        ),
+        category: overlayCategory,
+        defaultValue: defaultTimeSeriesOverlayOptions.windowSize,
+        settings: {
+          min: 2,
+          step: 1,
+        },
+        showIf: (config) => config.overlay?.mode === TimeSeriesOverlayMode.MovingAverage,
+      });
   })
   .setSuggestionsSupplier(timeseriesSuggestionsSupplier)
   .setPresetsSupplier(timeseriesPresetsSupplier)

--- a/public/app/plugins/panel/timeseries/overlays.test.ts
+++ b/public/app/plugins/panel/timeseries/overlays.test.ts
@@ -1,0 +1,100 @@
+import { createDataFrame, createTheme, FieldType } from '@grafana/data';
+
+import { applyTimeSeriesOverlays, linearRegressionValues, trailingMovingAverage } from './overlays';
+import { TimeSeriesOverlayMode } from './panelcfg.gen';
+
+describe('trailingMovingAverage', () => {
+  it('computes a trailing mean of the last windowSize samples', () => {
+    expect(trailingMovingAverage([1, 2, 3, 4, 5], 3)).toEqual([1, 1.5, 2, 3, 4]);
+  });
+
+  it('skips nulls inside the window and returns null when the window is empty', () => {
+    expect(trailingMovingAverage([10, null, 30], 2)).toEqual([10, 10, 30]);
+    expect(trailingMovingAverage([null, null, 4], 2)).toEqual([null, null, 4]);
+  });
+
+  it('treats window sizes below 2 as 2', () => {
+    expect(trailingMovingAverage([2, 4, 6], 1)).toEqual([2, 3, 5]);
+  });
+});
+
+describe('linearRegressionValues', () => {
+  it('fits an exact line when y increases linearly with time', () => {
+    expect(linearRegressionValues([1000, 2000, 3000], [10, 20, 30])).toEqual([10, 20, 30]);
+  });
+
+  it('returns a horizontal line when y is constant', () => {
+    expect(linearRegressionValues([0, 1, 2, 3], [5, 5, 5, 5])).toEqual([5, 5, 5, 5]);
+  });
+
+  it('returns nulls when fewer than two finite points exist', () => {
+    expect(linearRegressionValues([1, 2, 3], [null, 8, null])).toEqual([null, null, null]);
+  });
+});
+
+describe('applyTimeSeriesOverlays', () => {
+  const theme = createTheme();
+
+  it('leaves frames unchanged when overlay mode is off', () => {
+    const frame = createDataFrame({
+      fields: [
+        { name: 'time', type: FieldType.time, values: [1, 2, 3] },
+        { name: 'value', type: FieldType.number, values: [1, 2, 3] },
+      ],
+    });
+
+    const frames = [frame];
+    const result = applyTimeSeriesOverlays(frames, { mode: TimeSeriesOverlayMode.Off }, theme);
+    expect(result).toBe(frames);
+    expect(result[0].fields).toHaveLength(2);
+  });
+
+  it('appends a dashed linear regression series per numeric field', () => {
+    const frame = createDataFrame({
+      fields: [
+        { name: 'time', type: FieldType.time, values: [1000, 2000, 3000] },
+        { name: 'value', type: FieldType.number, values: [10, 20, 30], config: { custom: {} } },
+      ],
+    });
+
+    const [out] = applyTimeSeriesOverlays([frame], { mode: TimeSeriesOverlayMode.LinearRegression }, theme);
+    expect(out.fields.map((field) => field.name)).toEqual(['time', 'value', 'value__timeseriesOverlay']);
+    expect(out.fields[2].values).toEqual([10, 20, 30]);
+    expect(out.fields[2].config.displayName).toBe('value (linear regression)');
+    expect(out.fields[2].state?.displayName).toBe('value (linear regression)');
+    expect(out.fields[2].config.custom?.lineStyle).toEqual({ fill: 'dash', dash: [10, 10] });
+    expect(out.fields[2].config.custom?.fillOpacity).toBe(0);
+  });
+
+  it('appends a moving average series using the configured window size', () => {
+    const frame = createDataFrame({
+      fields: [
+        { name: 'time', type: FieldType.time, values: [1, 2, 3, 4, 5] },
+        { name: 'cpu', type: FieldType.number, values: [1, 2, 3, 4, 5], config: { custom: {} } },
+      ],
+    });
+
+    const [out] = applyTimeSeriesOverlays([frame], { mode: TimeSeriesOverlayMode.MovingAverage, windowSize: 3 }, theme);
+
+    expect(out.fields[2].values).toEqual([1, 1.5, 2, 3, 4]);
+    expect(out.fields[2].config.displayName).toBe('cpu (moving average)');
+  });
+
+  it('does not overlay hidden or boolean series', () => {
+    const frame = createDataFrame({
+      fields: [
+        { name: 'time', type: FieldType.time, values: [1, 2, 3] },
+        {
+          name: 'hidden',
+          type: FieldType.number,
+          values: [1, 2, 3],
+          config: { custom: { hideFrom: { viz: true, legend: false, tooltip: false } } },
+        },
+        { name: 'flag', type: FieldType.number, values: [0, 1, 0], config: { unit: 'bool', custom: {} } },
+      ],
+    });
+
+    const [out] = applyTimeSeriesOverlays([frame], { mode: TimeSeriesOverlayMode.LinearRegression }, theme);
+    expect(out.fields).toHaveLength(3);
+  });
+});

--- a/public/app/plugins/panel/timeseries/overlays.ts
+++ b/public/app/plugins/panel/timeseries/overlays.ts
@@ -1,0 +1,198 @@
+import { SimpleLinearRegression } from 'ml-regression-simple-linear';
+
+import {
+  type DataFrame,
+  type Field,
+  FieldType,
+  getDisplayProcessor,
+  getFieldDisplayName,
+  type GrafanaTheme2,
+} from '@grafana/data';
+import { t } from '@grafana/i18n';
+import { GraphDrawStyle, type GraphFieldConfig, StackingMode, VisibilityMode } from '@grafana/schema';
+
+import { TimeSeriesOverlayMode, type TimeSeriesOverlayOptions } from './panelcfg.gen';
+
+export const DEFAULT_OVERLAY_WINDOW_SIZE = 7;
+export const OVERLAY_FIELD_MARKER = '__timeseriesOverlay';
+
+const overlayLineStyle = { fill: 'dash' as const, dash: [10, 10] };
+
+export function trailingMovingAverage(
+  values: ReadonlyArray<number | null | undefined>,
+  windowSize: number
+): Array<number | null> {
+  const window = Math.max(2, Math.floor(windowSize));
+  const out: Array<number | null> = [];
+  let sum = 0;
+  let count = 0;
+
+  for (let i = 0; i < values.length; i++) {
+    const current = values[i];
+    if (isFiniteNumber(current)) {
+      sum += current;
+      count += 1;
+    }
+
+    if (i >= window) {
+      const leaving = values[i - window];
+      if (isFiniteNumber(leaving)) {
+        sum -= leaving;
+        count -= 1;
+      }
+    }
+
+    out.push(count === 0 ? null : sum / count);
+  }
+
+  return out;
+}
+
+export function linearRegressionValues(
+  x: ReadonlyArray<number | null | undefined>,
+  y: ReadonlyArray<number | null | undefined>
+): Array<number | null> {
+  const xs: number[] = [];
+  const ys: number[] = [];
+  let xMin = Infinity;
+
+  const length = Math.min(x.length, y.length);
+  for (let i = 0; i < length; i++) {
+    const xv = x[i];
+    const yv = y[i];
+    if (!isFiniteNumber(xv) || !isFiniteNumber(yv)) {
+      continue;
+    }
+    if (xv < xMin) {
+      xMin = xv;
+    }
+    xs.push(xv);
+    ys.push(yv);
+  }
+
+  if (xs.length < 2) {
+    return Array.from({ length: y.length }, () => null);
+  }
+
+  const model = new SimpleLinearRegression(
+    xs.map((value) => value - xMin),
+    ys
+  );
+
+  return x.map((xv) => {
+    if (!isFiniteNumber(xv)) {
+      return null;
+    }
+    return model.predict(xv - xMin);
+  });
+}
+
+export function applyTimeSeriesOverlays(
+  frames: DataFrame[],
+  overlay: TimeSeriesOverlayOptions | undefined,
+  theme: GrafanaTheme2
+): DataFrame[] {
+  if (!overlay || overlay.mode === TimeSeriesOverlayMode.Off) {
+    return frames;
+  }
+
+  return frames.map((frame) => applyOverlayToFrame(frame, overlay, theme));
+}
+
+function applyOverlayToFrame(frame: DataFrame, overlay: TimeSeriesOverlayOptions, theme: GrafanaTheme2): DataFrame {
+  const timeField = frame.fields.find((field) => field.type === FieldType.time);
+  if (!timeField) {
+    return frame;
+  }
+
+  const overlayFields: Field[] = [];
+  for (const field of frame.fields) {
+    if (!shouldOverlayField(field)) {
+      continue;
+    }
+
+    const values =
+      overlay.mode === TimeSeriesOverlayMode.MovingAverage
+        ? trailingMovingAverage(field.values, overlay.windowSize ?? DEFAULT_OVERLAY_WINDOW_SIZE)
+        : linearRegressionValues(timeField.values, field.values);
+
+    if (values.every((value) => value == null)) {
+      continue;
+    }
+
+    overlayFields.push(createOverlayField(field, frame, values, overlay.mode, theme));
+  }
+
+  if (overlayFields.length === 0) {
+    return frame;
+  }
+
+  return {
+    ...frame,
+    fields: [...frame.fields, ...overlayFields],
+  };
+}
+
+function shouldOverlayField(field: Field): boolean {
+  if (field.type !== FieldType.number) {
+    return false;
+  }
+  if (field.name.endsWith(OVERLAY_FIELD_MARKER)) {
+    return false;
+  }
+  if (field.config.unit === 'bool') {
+    return false;
+  }
+  if (field.config.custom?.hideFrom?.viz) {
+    return false;
+  }
+  return true;
+}
+
+function createOverlayField(
+  source: Field,
+  frame: DataFrame,
+  values: Array<number | null>,
+  mode: TimeSeriesOverlayMode,
+  theme: GrafanaTheme2
+): Field {
+  const sourceName = getFieldDisplayName(source, frame);
+  const displayName =
+    mode === TimeSeriesOverlayMode.MovingAverage
+      ? t('timeseries.overlay.moving-average-series', '{{name}} (moving average)', { name: sourceName })
+      : t('timeseries.overlay.linear-regression-series', '{{name}} (linear regression)', { name: sourceName });
+
+  const custom: GraphFieldConfig = {
+    ...(source.config.custom ?? {}),
+    drawStyle: GraphDrawStyle.Line,
+    lineInterpolation: source.config.custom?.lineInterpolation,
+    lineWidth: Math.max(source.config.custom?.lineWidth ?? 1, 2),
+    lineStyle: overlayLineStyle,
+    fillOpacity: 0,
+    showPoints: VisibilityMode.Never,
+    gradientMode: undefined,
+    stacking: { mode: StackingMode.None, group: 'A' },
+  };
+
+  const overlayField: Field = {
+    ...source,
+    name: `${source.name}${OVERLAY_FIELD_MARKER}`,
+    values,
+    config: {
+      ...source.config,
+      displayName,
+      custom,
+    },
+    state: {
+      ...source.state,
+      displayName,
+    },
+  };
+
+  overlayField.display = getDisplayProcessor({ field: overlayField, theme });
+  return overlayField;
+}
+
+function isFiniteNumber(value: unknown): value is number {
+  return typeof value === 'number' && Number.isFinite(value);
+}

--- a/public/app/plugins/panel/timeseries/panelcfg.cue
+++ b/public/app/plugins/panel/timeseries/panelcfg.cue
@@ -27,6 +27,14 @@ composableKinds: PanelCfg: lineage: {
 				enableFacetedFilter?: bool | *false
 				facetedFilterPinned?: bool | *false
 			} @cuetsy(kind="interface")
+
+			TimeSeriesOverlayMode: "off" | "linearRegression" | "movingAverage" @cuetsy(kind="enum")
+
+			TimeSeriesOverlayOptions: {
+				mode:        TimeSeriesOverlayMode | *"off"
+				windowSize?: int32 & >=2 | *7
+			} @cuetsy(kind="interface")
+
 			Options: {
 				common.OptionsWithTimezones
 				common.OptionsWithAnnotations
@@ -37,6 +45,7 @@ composableKinds: PanelCfg: lineage: {
 				orientation?:           common.VizOrientation
 				annotations?:           common.VizAnnotations
 				disableKeyboardEvents?: bool
+				overlay?:               TimeSeriesOverlayOptions
 			} @cuetsy(kind="interface")
 
 			FieldConfig: common.GraphFieldConfig & {} @cuetsy(kind="interface")

--- a/public/app/plugins/panel/timeseries/panelcfg.gen.ts
+++ b/public/app/plugins/panel/timeseries/panelcfg.gen.ts
@@ -22,10 +22,27 @@ export const defaultTimeSeriesLegendOptions: Partial<TimeSeriesLegendOptions> = 
   facetedFilterPinned: false,
 };
 
+export enum TimeSeriesOverlayMode {
+  LinearRegression = 'linearRegression',
+  MovingAverage = 'movingAverage',
+  Off = 'off',
+}
+
+export interface TimeSeriesOverlayOptions {
+  mode: (TimeSeriesOverlayMode | 'off');
+  windowSize?: number;
+}
+
+export const defaultTimeSeriesOverlayOptions: Partial<TimeSeriesOverlayOptions> = {
+  mode: 'off',
+  windowSize: 7,
+};
+
 export interface Options extends common.OptionsWithTimezones, common.OptionsWithAnnotations {
   disableKeyboardEvents?: boolean;
   legend: TimeSeriesLegendOptions;
   orientation?: common.VizOrientation;
+  overlay?: TimeSeriesOverlayOptions;
   timeCompare?: common.TimeCompareOptions;
   tooltip: common.VizTooltipOptions;
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
**What is this feature?**

Adds a panel-level **Overlay** option to the Time Series visualization so you can draw a linear regression or trailing moving average on each series without adding a transformation.

**Why do we need this feature?**

CUR-72: trend and smoothing overlays should be available from panel options, rather than requiring the Regression analysis or Add field from calculation transformations.

**Who is this feature for?**

Dashboard authors using Time Series panels who want a trendline or moving average on existing series.

**Which issue(s) does this PR fix?**:

Fixes CUR-72 (https://fe-cursor-demos.atlassian.net/browse/CUR-72)

**Special notes for your reviewer:**

Stack:
1. `feat(timeseries): add overlay schema and series calculation` — CUE options + OLS / trailing-mean helpers
2. `feat(timeseries): apply overlays from panel options` — Overlay editor + series appended after `prepareGraphableFields`
3. `test(timeseries): cover overlay math, legend, and canvas` — frozen expected values, legend labels, canvas snapshots
4. `docs(timeseries): document panel overlay options`

Overlay series are dashed, unstacked, hidden from point markers, and listed in the legend independently.

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a notable improvement, it's added to What's New.

Target repo: fieldsphere/grafana

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1c47dae4-0987-486f-b7cb-7edbf97e314b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1c47dae4-0987-486f-b7cb-7edbf97e314b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

