### PR TITLE
Chore: replace frontend console calls with structured logging

### DIFF
--- a/packages/grafana-alerting/src/grafana/notificationPolicies/components/RoutingTreeSelector/RoutingTreeSelector.tsx
+++ b/packages/grafana-alerting/src/grafana/notificationPolicies/components/RoutingTreeSelector/RoutingTreeSelector.tsx
@@ -1,12 +1,15 @@
 import { type ComponentProps, useMemo } from 'react';
 
 import { type RoutingTree } from '@grafana/api-clients/rtkq/notifications.alerting/v1beta1';
+import { createStructuredLogger } from '@grafana/data';
 import { t } from '@grafana/i18n';
 import { Alert, Combobox, type ComboboxOption, MultiCombobox } from '@grafana/ui';
 
 import { type CustomComboBoxProps } from '../../../common/ComboBox.types';
 import { useListRoutingTrees } from '../../hooks/useRoutingTrees';
 import { isDefaultRoutingTreeName } from '../../routingTrees';
+
+const logger = createStructuredLogger('grafana/alerting');
 
 const collator = new Intl.Collator('en', { sensitivity: 'accent' });
 
@@ -126,7 +129,7 @@ function RoutingTreeSelector(props: RoutingTreeSelectorProps) {
     if (selectedOption) {
       const tree = treeLookup.get(selectedOption.value);
       if (!tree) {
-        console.warn(`RoutingTreeSelector: could not find routing tree for value "${selectedOption.value}"`);
+        logger.warn(`RoutingTreeSelector: could not find routing tree for value "${selectedOption.value}"`);
         return;
       }
 

--- a/packages/grafana-data/src/dataframe/FieldCache.ts
+++ b/packages/grafana-data/src/dataframe/FieldCache.ts
@@ -1,6 +1,9 @@
 import { type DataFrame, type Field, FieldType } from '../types/dataFrame';
+import { createStructuredLogger } from '../utils/logger';
 
 import { guessFieldTypeForField } from './guessFieldType';
+
+const logger = createStructuredLogger('grafana/data');
 
 export interface FieldWithIndex extends Field {
   index: number;
@@ -36,7 +39,7 @@ export class FieldCache {
       });
 
       if (this.fieldByName[field.name]) {
-        console.warn('Duplicate field names in DataFrame: ', field.name);
+        logger.warn('Duplicate field names in DataFrame: ', field.name);
       } else {
         this.fieldByName[field.name] = { ...field, index: i };
       }

--- a/packages/grafana-data/src/dataframe/processDataFrame.ts
+++ b/packages/grafana-data/src/dataframe/processDataFrame.ts
@@ -18,10 +18,13 @@ import {
 import { type DataQueryResponseData } from '../types/datasource';
 import { type GraphSeriesXY, type GraphSeriesValue } from '../types/graph';
 import { type PanelData } from '../types/panel';
+import { createStructuredLogger } from '../utils/logger';
 
 import { arrayToDataFrame } from './ArrayDataFrame';
 import { dataFrameFromJSON } from './DataFrameJSON';
 import { guessFieldTypeForField, guessFieldTypes } from './guessFieldType';
+
+const logger = createStructuredLogger('grafana/data');
 
 function convertTableToDataFrame(table: TableData): DataFrame {
   const fields = table.columns.map((c) => {
@@ -214,7 +217,7 @@ export function toDataFrame(data: any): DataFrame {
     return arrayToDataFrame(data);
   }
 
-  console.warn('Can not convert', data);
+  logger.warn('Can not convert', data);
   throw new Error('Unsupported data format');
 }
 

--- a/packages/grafana-data/src/field/fieldOverrides.ts
+++ b/packages/grafana-data/src/field/fieldOverrides.ts
@@ -42,6 +42,9 @@ import { getDisplayProcessor, getRawDisplayProcessor } from './displayProcessor'
 import { getMinMaxAndDelta } from './scale';
 import { standardFieldConfigEditorRegistry } from './standardFieldConfigEditorRegistry';
 
+import { createStructuredLogger } from '../utils/logger';
+const logger = createStructuredLogger('grafana/data');
+
 interface OverrideProps {
   match: FieldMatcher;
   properties: DynamicConfigValue[];
@@ -125,7 +128,7 @@ export function applyFieldOverrides(
       const info = fieldMatchers.getIfExists(rule.matcher.id);
 
       if (!info) {
-        console.warn(`Unknown field matcher id: "${rule.matcher.id}", skipping override rule`);
+        logger.warn(`Unknown field matcher id: "${rule.matcher.id}", skipping override rule`);
         continue;
       }
 

--- a/packages/grafana-data/src/index.ts
+++ b/packages/grafana-data/src/index.ts
@@ -250,6 +250,17 @@ export {
 } from './utils/datasource';
 export { deprecationWarning } from './utils/deprecationWarning';
 export {
+  createStructuredLogger,
+  defaultLogSink,
+  resetLogSink,
+  setLogSink,
+  type LogContext as StructuredLogContext,
+  type LogLevel as StructuredLogLevel,
+  type LogRecord,
+  type LogSink,
+  type StructuredLogger,
+} from './utils/logger';
+export {
   CSVHeaderStyle,
   type CSVConfig,
   type CSVParseCallbacks,

--- a/packages/grafana-data/src/text/sanitize.ts
+++ b/packages/grafana-data/src/text/sanitize.ts
@@ -2,6 +2,9 @@ import { sanitizeUrl as braintreeSanitizeUrl } from '@braintree/sanitize-url';
 import DOMPurify from 'dompurify';
 import * as xss from 'xss';
 
+import { createStructuredLogger } from '../utils/logger';
+const logger = createStructuredLogger('grafana/data');
+
 const XSSWL = Object.keys(xss.whiteList).reduce<xss.IWhiteList>((acc, element) => {
   acc[element] = xss.whiteList[element]?.concat(['class', 'style']);
   return acc;
@@ -72,7 +75,7 @@ export function sanitize(unsanitizedString: string): string {
       ADD_ATTR: ['target'],
     });
   } catch (error) {
-    console.error('String could not be sanitized', unsanitizedString);
+    logger.error('String could not be sanitized', unsanitizedString);
     return escapeHtml(unsanitizedString);
   } finally {
     DOMPurify.removeHook('afterSanitizeAttributes');
@@ -103,7 +106,7 @@ export function sanitizeTextPanelContent(unsanitizedString: string): string {
   try {
     return sanitizeTextPanelWhitelist.process(unsanitizedString);
   } catch (error) {
-    console.error('String could not be sanitized', unsanitizedString);
+    logger.error('String could not be sanitized', unsanitizedString);
     return 'Text string could not be sanitized';
   }
 }

--- a/packages/grafana-data/src/themes/colorManipulator.ts
+++ b/packages/grafana-data/src/themes/colorManipulator.ts
@@ -12,10 +12,14 @@ import tinycolor from 'tinycolor2';
  * @returns A number in the range [min, max]
  * @beta
  */
+import { createStructuredLogger } from '../utils/logger';
+
+const logger = createStructuredLogger('grafana/data');
+
 function clamp(value: number, min = 0, max = 1) {
   if (process.env.NODE_ENV !== 'production') {
     if (value < min || value > max) {
-      console.error(`The value provided ${value} is out of range [${min}, ${max}].`);
+      logger.error(`The value provided ${value} is out of range [${min}, ${max}].`);
     }
   }
 

--- a/packages/grafana-data/src/themes/createSpacing.ts
+++ b/packages/grafana-data/src/themes/createSpacing.ts
@@ -4,6 +4,10 @@
 import * as z from 'zod';
 
 /** @internal */
+import { createStructuredLogger } from '../utils/logger';
+
+const logger = createStructuredLogger('grafana/data');
+
 export const ThemeSpacingOptionsSchema = z.object({
   gridSize: z.int().positive().optional(),
 });
@@ -52,7 +56,7 @@ export function createSpacing(options: ThemeSpacingOptions = {}): ThemeSpacing {
 
     if (process.env.NODE_ENV !== 'production') {
       if (typeof value !== 'number') {
-        console.error(`Expected spacing argument to be a number or a string, got ${value}.`);
+        logger.error(`Expected spacing argument to be a number or a string, got ${value}.`);
       }
     }
     return value * gridSize;
@@ -61,7 +65,7 @@ export function createSpacing(options: ThemeSpacingOptions = {}): ThemeSpacing {
   const spacing = (...args: Array<number | string>): string => {
     if (process.env.NODE_ENV !== 'production') {
       if (!(args.length <= 4)) {
-        console.error(`Too many arguments provided, expected between 0 and 4, got ${args.length}`);
+        logger.error(`Too many arguments provided, expected between 0 and 4, got ${args.length}`);
       }
     }
 

--- a/packages/grafana-data/src/themes/createTypography.ts
+++ b/packages/grafana-data/src/themes/createTypography.ts
@@ -6,6 +6,10 @@ import * as z from 'zod';
 import { type ThemeColors } from './createColors';
 
 /** @beta */
+import { createStructuredLogger } from '../utils/logger';
+
+const logger = createStructuredLogger('grafana/data');
+
 export interface ThemeTypography extends ThemeTypographyVariantTypes {
   fontFamily: string;
   fontFamilyMonospace: string;
@@ -76,11 +80,11 @@ export function createTypography(colors: ThemeColors, typographyInput: ThemeTypo
 
   if (process.env.NODE_ENV !== 'production') {
     if (typeof fontSize !== 'number') {
-      console.error('Grafana-UI: `fontSize` is required to be a number.');
+      logger.error('Grafana-UI: `fontSize` is required to be a number.');
     }
 
     if (typeof htmlFontSize !== 'number') {
-      console.error('Grafana-UI: `htmlFontSize` is required to be a number.');
+      logger.error('Grafana-UI: `htmlFontSize` is required to be a number.');
     }
   }
 

--- a/packages/grafana-data/src/themes/registry.ts
+++ b/packages/grafana-data/src/themes/registry.ts
@@ -21,6 +21,9 @@ import visual_refresh_light from './themeDefinitions/visual_refresh_light.json';
 import zen from './themeDefinitions/zen.json';
 import { type GrafanaTheme2 } from './types';
 
+import { createStructuredLogger } from '../utils/logger';
+const logger = createStructuredLogger('grafana/data');
+
 export interface ThemeRegistryItem extends RegistryItem {
   isExtra?: boolean;
   build: () => GrafanaTheme2;
@@ -93,7 +96,7 @@ const themeRegistry = new Registry<ThemeRegistryItem>(() => {
 for (const [name, json] of Object.entries(extraThemes)) {
   const result = NewThemeOptionsSchema.safeParse(json);
   if (!result.success) {
-    console.error(`Invalid theme definition for theme ${name}: ${result.error.message}`);
+    logger.error(`Invalid theme definition for theme ${name}: ${result.error.message}`);
   } else {
     const theme = result.data;
     themeRegistry.register({

--- a/packages/grafana-data/src/transformations/matchers/nameMatcher.ts
+++ b/packages/grafana-data/src/transformations/matchers/nameMatcher.ts
@@ -5,6 +5,9 @@ import { type FieldMatcher, type FieldMatcherInfo, type FrameMatcherInfo } from 
 
 import { FieldMatcherID, FrameMatcherID } from './ids';
 
+import { createStructuredLogger } from '../../utils/logger';
+const logger = createStructuredLogger('grafana/data');
+
 export interface RegexpOrNamesMatcherOptions {
   pattern?: string;
   names?: string[];
@@ -201,7 +204,7 @@ const patternToRegex = (pattern?: string): RegExp | undefined => {
   try {
     return stringToJsRegex(pattern);
   } catch (error) {
-    console.error(error);
+    logger.error(error);
     return undefined;
   }
 };

--- a/packages/grafana-data/src/transformations/matchers/refIdMatcher.ts
+++ b/packages/grafana-data/src/transformations/matchers/refIdMatcher.ts
@@ -5,6 +5,10 @@ import { type FrameMatcherInfo } from '../../types/transformations';
 import { FrameMatcherID } from './ids';
 
 // General Field matcher
+import { createStructuredLogger } from '../../utils/logger';
+
+const logger = createStructuredLogger('grafana/data');
+
 const refIdMatcher: FrameMatcherInfo<string> = {
   id: FrameMatcherID.byRefId,
   name: 'Query refId',
@@ -19,7 +23,7 @@ const refIdMatcher: FrameMatcherInfo<string> = {
         regex = stringToJsRegex(pattern);
       } catch (error) {
         if (error instanceof Error) {
-          console.warn(error.message);
+          logger.warn(error.message);
         }
       }
     }

--- a/packages/grafana-data/src/transformations/transformers/filterByValue.ts
+++ b/packages/grafana-data/src/transformations/transformers/filterByValue.ts
@@ -8,6 +8,9 @@ import { getValueMatcher } from '../matchers';
 import { DataTransformerID } from './ids';
 import { noopTransformer } from './noop';
 
+import { createStructuredLogger } from '../../utils/logger';
+const logger = createStructuredLogger('grafana/data');
+
 export enum FilterByValueType {
   exclude = 'exclude',
   include = 'include',
@@ -139,7 +142,7 @@ const createFilterValueMatchers = (
     const fieldIndex = fieldIndexByName[filter.fieldName] ?? -1;
 
     if (fieldIndex < 0) {
-      console.warn(`[FilterByValue] Could not find index for field name: ${filter.fieldName}`);
+      logger.warn(`[FilterByValue] Could not find index for field name: ${filter.fieldName}`);
       return noop;
     }
 

--- a/packages/grafana-data/src/types/app.ts
+++ b/packages/grafana-data/src/types/app.ts
@@ -16,6 +16,10 @@ import {
  * @public
  * The app container that is loading another plugin (panel or query editor)
  * */
+import { createStructuredLogger } from '../utils/logger';
+
+const logger = createStructuredLogger('grafana/data');
+
 export enum CoreApp {
   CloudAlerting = 'cloud-alerting',
   UnifiedAlerting = 'unified-alerting',
@@ -94,7 +98,7 @@ export class AppPlugin<T extends KeyValue = KeyValue> extends GrafanaPlugin<AppP
           const exp = pluginExports[include.component];
 
           if (!exp) {
-            console.warn('App Page uses unknown component: ', include.component, this.meta);
+            logger.warn('App Page uses unknown component: ', include.component, this.meta);
             continue;
           }
         }

--- a/packages/grafana-data/src/types/plugin.ts
+++ b/packages/grafana-data/src/types/plugin.ts
@@ -4,6 +4,10 @@ import { type KeyValue } from './data';
 import { type IconName } from './icon';
 
 /** Describes plugins life cycle status */
+import { createStructuredLogger } from '../utils/logger';
+
+const logger = createStructuredLogger('grafana/data');
+
 export enum PluginState {
   alpha = 'alpha', // Only included if `enable_alpha` config option is true
   beta = 'beta', // Will show a warning banner
@@ -268,7 +272,7 @@ export class GrafanaPlugin<T extends PluginMeta = PluginMeta> {
    * @deprecated -- this is no longer necessary and will be removed
    */
   setChannelSupport() {
-    console.warn('[deprecation] plugin is using ignored option: setChannelSupport', this.meta);
+    logger.warn('[deprecation] plugin is using ignored option: setChannelSupport', this.meta);
     return this;
   }
 

--- a/packages/grafana-data/src/utils/LocalStorageValueProvider.tsx
+++ b/packages/grafana-data/src/utils/LocalStorageValueProvider.tsx
@@ -3,6 +3,9 @@ import * as React from 'react';
 
 import { store } from './store';
 
+import { createStructuredLogger } from './logger';
+const logger = createStructuredLogger('grafana/data');
+
 interface Props<T> {
   storageKey: string;
   defaultValue: T;
@@ -32,7 +35,7 @@ export const LocalStorageValueProvider = <T,>(props: Props<T>) => {
     try {
       store.setObject(storageKey, value);
     } catch (error) {
-      console.error(error);
+      logger.error(error);
     }
     setState({ value });
   };
@@ -41,7 +44,7 @@ export const LocalStorageValueProvider = <T,>(props: Props<T>) => {
     try {
       store.delete(storageKey);
     } catch (error) {
-      console.log(error);
+      logger.info(error);
     }
     setState({ value: defaultValue });
   };

--- a/packages/grafana-data/src/utils/deprecationWarning.ts
+++ b/packages/grafana-data/src/utils/deprecationWarning.ts
@@ -1,5 +1,9 @@
 import { type KeyValue } from '../types/data';
 
+import { createStructuredLogger } from './logger';
+
+const logger = createStructuredLogger('grafana/data');
+
 // Avoid writing the warning message more than once every 10s
 const history: KeyValue<number> = {};
 
@@ -11,7 +15,7 @@ export const deprecationWarning = (file: string, oldName: string, newName?: stri
   const now = Date.now();
   const last = history[message];
   if (!last || now - last > 10000) {
-    console.warn(message);
+    logger.warn(message);
     history[message] = now;
   }
 };

--- a/packages/grafana-data/src/utils/logger.test.ts
+++ b/packages/grafana-data/src/utils/logger.test.ts
@@ -1,0 +1,53 @@
+import { createStructuredLogger, defaultLogSink, resetLogSink, setLogSink, type LogRecord } from './logger';
+
+describe('createStructuredLogger', () => {
+  afterEach(() => {
+    resetLogSink();
+  });
+
+  it('sends level, source, and string message to the sink', () => {
+    const records: LogRecord[] = [];
+    setLogSink((record) => records.push(record));
+
+    const logger = createStructuredLogger('grafana/data');
+
+    logger.warn('something went wrong');
+
+    expect(records).toEqual([
+      {
+        level: 'warn',
+        source: 'grafana/data',
+        message: 'something went wrong',
+        error: undefined,
+        context: undefined,
+      },
+    ]);
+  });
+
+  it('captures Error instances and remaining args as context', () => {
+    const records: LogRecord[] = [];
+    setLogSink((record) => records.push(record));
+
+    const err = new Error('boom');
+    const logger = createStructuredLogger('features.scopes');
+
+    logger.error('Failed to load node', err, { id: 'n1' });
+
+    expect(records).toHaveLength(1);
+    expect(records[0].level).toBe('error');
+    expect(records[0].source).toBe('features.scopes');
+    expect(records[0].error).toBe(err);
+    expect(records[0].message).toBe('Failed to load node');
+    expect(records[0].context).toEqual({ id: 'n1' });
+  });
+
+  it('default sink writes to console with a source tag', () => {
+    const warn = jest.spyOn(console, 'warn').mockImplementation();
+    setLogSink(defaultLogSink);
+
+    createStructuredLogger('grafana/ui').warn('Unknown stats');
+
+    expect(warn).toHaveBeenCalledWith('Unknown stats', { source: 'grafana/ui' });
+    warn.mockRestore();
+  });
+});

--- a/packages/grafana-data/src/utils/logger.ts
+++ b/packages/grafana-data/src/utils/logger.ts
@@ -1,0 +1,134 @@
+export type LogLevel = 'debug' | 'info' | 'warn' | 'error';
+
+export type LogContext = Record<string, string>;
+
+export interface LogRecord {
+  level: LogLevel;
+  source: string;
+  message: string;
+  error?: Error;
+  context?: LogContext;
+}
+
+export type LogSink = (record: LogRecord) => void;
+
+function serialize(value: unknown): string {
+  if (value === undefined) {
+    return 'undefined';
+  }
+  if (value === null) {
+    return 'null';
+  }
+  if (typeof value === 'string') {
+    return value;
+  }
+  if (typeof value === 'number' || typeof value === 'boolean' || typeof value === 'bigint') {
+    return String(value);
+  }
+  if (value instanceof Error) {
+    return value.stack ?? value.message;
+  }
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return String(value);
+  }
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function normalizeArgs(args: unknown[]): { message: string; error?: Error; context?: LogContext } {
+  const error = args.find((arg): arg is Error => arg instanceof Error);
+  const withoutError = args.filter((arg) => arg !== error);
+
+  let message: string;
+  let extra: unknown[];
+  if (typeof withoutError[0] === 'string') {
+    message = withoutError[0];
+    extra = withoutError.slice(1);
+  } else if (withoutError.length === 0) {
+    message = error?.message ?? '';
+    extra = [];
+  } else {
+    extra = withoutError;
+    message = error?.message ?? serialize(withoutError[0]);
+  }
+
+  const context: LogContext = {};
+  if (extra.length === 1 && isPlainObject(extra[0])) {
+    for (const [key, value] of Object.entries(extra[0])) {
+      context[key] = serialize(value);
+    }
+  } else if (extra.length > 0) {
+    context.args = extra.map(serialize).join(' ');
+  }
+
+  return { message, error, context: Object.keys(context).length > 0 ? context : undefined };
+}
+
+/**
+ * Default sink: print a message plus a `{ source, ...context }` object so browser
+ * consoles and tests still see a readable first argument.
+ */
+export const defaultLogSink: LogSink = (record) => {
+  const meta = { source: record.source, ...record.context };
+  const print =
+    record.level === 'debug'
+      ? // eslint-disable-next-line no-console
+        console.debug
+      : record.level === 'info'
+        ? console.log
+        : record.level === 'warn'
+          ? console.warn
+          : console.error;
+
+  if (record.error) {
+    print(record.message, meta, record.error);
+    return;
+  }
+
+  print(record.message, meta);
+};
+
+let sink: LogSink = defaultLogSink;
+
+export function setLogSink(next: LogSink) {
+  sink = next;
+}
+
+export function resetLogSink() {
+  sink = defaultLogSink;
+}
+
+export interface StructuredLogger {
+  debug: (...args: unknown[]) => void;
+  info: (...args: unknown[]) => void;
+  warn: (...args: unknown[]) => void;
+  error: (...args: unknown[]) => void;
+}
+
+/**
+ * Creates a source-tagged logger. Call sites pass the same arguments they used
+ * to pass to `console.*`; the sink records level, source, message, and context.
+ */
+export function createStructuredLogger(source: string): StructuredLogger {
+  const emit = (level: LogLevel, args: unknown[]) => {
+    const normalized = normalizeArgs(args);
+    sink({
+      level,
+      source,
+      message: normalized.message,
+      error: normalized.error,
+      context: normalized.context,
+    });
+  };
+
+  return {
+    debug: (...args: unknown[]) => emit('debug', args),
+    info: (...args: unknown[]) => emit('info', args),
+    warn: (...args: unknown[]) => emit('warn', args),
+    error: (...args: unknown[]) => emit('error', args),
+  };
+}

--- a/packages/grafana-data/src/utils/store.ts
+++ b/packages/grafana-data/src/utils/store.ts
@@ -1,4 +1,8 @@
 /* eslint-disable @grafana/no-direct-local-storage-access */
+import { createStructuredLogger } from './logger';
+
+const logger = createStructuredLogger('grafana/data');
+
 type StoreValue = string | number | boolean | null;
 type StoreSubscriber = () => void;
 
@@ -75,7 +79,7 @@ export class Store {
       try {
         ret = JSON.parse(json);
       } catch (error) {
-        console.error(`Error parsing store object: ${key}. Returning default: ${def}. [${error}]`);
+        logger.error(`Error parsing store object: ${key}. Returning default: ${def}. [${error}]`);
       }
     }
     return ret;

--- a/packages/grafana-data/src/utils/url.ts
+++ b/packages/grafana-data/src/utils/url.ts
@@ -11,6 +11,10 @@ import { type RawTimeRange } from '../types/time';
  *
  * @public
  */
+import { createStructuredLogger } from './logger';
+
+const logger = createStructuredLogger('grafana/data');
+
 export type UrlQueryValue = string | number | boolean | string[] | number[] | boolean[] | undefined | null;
 
 /**
@@ -226,7 +230,7 @@ export const urlUtil = {
  */
 export function serializeStateToUrlParam(urlState: Partial<ExploreUrlState>, compact?: boolean): string {
   if (compact !== undefined) {
-    console.warn('`compact` parameter is deprecated and will be removed in a future release');
+    logger.warn('`compact` parameter is deprecated and will be removed in a future release');
   }
   return JSON.stringify(urlState);
 }

--- a/packages/grafana-data/src/vector/ArrayVector.ts
+++ b/packages/grafana-data/src/vector/ArrayVector.ts
@@ -1,3 +1,7 @@
+import { createStructuredLogger } from '../utils/logger';
+
+const logger = createStructuredLogger('grafana/data');
+
 const notice = 'ArrayVector is deprecated and will be removed in Grafana 11. Please use plain arrays for field.values.';
 let notified = false;
 
@@ -47,7 +51,7 @@ export class ArrayVector<T = unknown> extends Array<T> {
     this.buffer = buffer ?? [];
 
     if (!notified) {
-      console.warn(notice);
+      logger.warn(notice);
       notified = true;
     }
   }

--- a/packages/grafana-i18n/src/i18n.tsx
+++ b/packages/grafana-i18n/src/i18n.tsx
@@ -6,6 +6,7 @@ import { initReactI18next, setDefaults, setI18n, Trans as I18NextTrans, getI18n 
 
 import { DEFAULT_LANGUAGE, PSEUDO_LOCALE } from './constants';
 import { LANGUAGES } from './languages';
+import { logger } from './logger';
 import { type ResourceLoader, type Resources, type TFunction, type TransProps, type TransType } from './types';
 
 let tFunc: I18NextTFunction<string[], undefined> | undefined;
@@ -49,7 +50,7 @@ export async function loadNamespacedResources(namespace: string, language: strin
         const resources = await loader(resolvedLanguage);
         addResourceBundle(resolvedLanguage, namespace, resources);
       } catch (error) {
-        console.error(`Error loading resources for namespace ${namespace} and language: ${resolvedLanguage}`, error);
+        logger.error(`Error loading resources for namespace ${namespace} and language: ${resolvedLanguage}`, error);
       }
     })
   );
@@ -202,7 +203,7 @@ export const t: TFunction = (id: string, defaultMessage: string, values?: Record
   initDefaultI18nInstance();
   if (!tFunc) {
     if (process.env.NODE_ENV !== 'test') {
-      console.warn(
+      logger.warn(
         't() was called before i18n was initialized. This is probably caused by calling t() in the root module scope, instead of lazily on render'
       );
     }

--- a/packages/grafana-i18n/src/logger.ts
+++ b/packages/grafana-i18n/src/logger.ts
@@ -1,0 +1,18 @@
+/**
+ * Lightweight structured logger for @grafana/i18n.
+ *
+ * This package cannot import `@grafana/data` (grafana-data depends on grafana-i18n).
+ * Keep the payload shape aligned with `createStructuredLogger`: message + `{ source }`.
+ */
+const source = 'grafana/i18n';
+
+export const logger = {
+  warn: (message: string, ...args: unknown[]) => {
+    // eslint-disable-next-line no-console
+    console.warn(message, { source }, ...args);
+  },
+  error: (message: string, ...args: unknown[]) => {
+    // eslint-disable-next-line no-console
+    console.error(message, { source }, ...args);
+  },
+};

--- a/packages/grafana-runtime/src/config.ts
+++ b/packages/grafana-runtime/src/config.ts
@@ -27,12 +27,15 @@ import {
   type UnifiedAlertingConfig,
   type GrafanaConfig,
   type CurrentUserDTO,
+  createStructuredLogger,
 } from '@grafana/data';
 
 /**
  * @deprecated Use the type from `@grafana/data`
  */
 // TODO remove in G13
+const logger = createStructuredLogger('grafana/runtime');
+
 export interface AzureSettings {
   cloud?: string;
   clouds?: AzureCloudInfo[];
@@ -312,7 +315,7 @@ function overrideFeatureTogglesFromLocalStorage(config: GrafanaBootConfig) {
       const toggleState = featureValue === 'true' || featureValue === '1';
       // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
       featureToggles[featureName as keyof FeatureToggles] = toggleState;
-      console.log(`Setting feature toggle ${featureName} = ${toggleState} via localstorage`);
+      logger.info(`Setting feature toggle ${featureName} = ${toggleState} via localstorage`);
     }
   }
 }
@@ -338,9 +341,9 @@ function overrideFeatureTogglesFromUrl(config: GrafanaBootConfig) {
       if (toggleState !== featureToggles[key]) {
         if (isDevelopment || safeRuntimeFeatureFlags.has(featureName)) {
           featureToggles[featureName] = toggleState;
-          console.log(`Setting feature toggle ${featureName} = ${toggleState} via url`);
+          logger.info(`Setting feature toggle ${featureName} = ${toggleState} via url`);
         } else {
-          console.log(`Unable to change feature toggle ${featureName} via url in production.`);
+          logger.info(`Unable to change feature toggle ${featureName} via url in production.`);
         }
       }
     }
@@ -351,7 +354,7 @@ let bootData = window.grafanaBootData;
 
 if (!bootData) {
   if (process.env.NODE_ENV !== 'test') {
-    console.error('window.grafanaBootData was not set by the time config was initialized');
+    logger.error('window.grafanaBootData was not set by the time config was initialized');
   }
 
   bootData = {

--- a/packages/grafana-runtime/src/internal/openFeature/index.ts
+++ b/packages/grafana-runtime/src/internal/openFeature/index.ts
@@ -8,6 +8,9 @@ import { logError } from '../../utils/logging';
 // Ensure the module augmentation is pulled in
 import './openfeature-types.gen.d.ts';
 
+import { createStructuredLogger } from '@grafana/data';
+const logger = createStructuredLogger('grafana/runtime');
+
 function checkDefaultProvider(event?: EventDetails) {
   if (event?.domain) {
     return;
@@ -20,7 +23,7 @@ function checkDefaultProvider(event?: EventDetails) {
       'OpenFeature default domain provider has been unexpectedly changed. This may be caused by a plugin that is incorrectly using the default domain.',
       { cause: OpenFeature.getProvider() }
     );
-    console.error(err);
+    logger.error(err);
     logError(err);
   }
 }

--- a/packages/grafana-runtime/src/services/logging/loggers.ts
+++ b/packages/grafana-runtime/src/services/logging/loggers.ts
@@ -8,6 +8,8 @@ export const Loggers = {
   'grafana/runtime.plugins.settings': { logToConsole: true },
   'grafana/runtime.plugins.datasource': { logToConsole: true },
   'grafana/runtime.utils.getCachedPromise': {},
+  /* catch-all for createStructuredLogger records forwarded to Faro */
+  'grafana.frontend': {},
 
   /* existing loggers that keep their existing source name */
   sandbox: {},

--- a/packages/grafana-runtime/src/services/logging/registry.ts
+++ b/packages/grafana-runtime/src/services/logging/registry.ts
@@ -1,8 +1,42 @@
+import { defaultLogSink, resetLogSink, setLogSink, type LogRecord } from '@grafana/data';
+
 import { createMonitoringLogger, logWarning, type MonitoringLogger } from '../../utils/logging';
 
 import { Loggers, type LoggerDefaults, type LoggerSource } from './loggers';
 
 let loggersRegistry: Partial<Record<LoggerSource, MonitoringLogger>> = {};
+
+function faroContext(record: LogRecord) {
+  return {
+    loggerSource: record.source,
+    ...record.context,
+  };
+}
+
+function forwardStructuredLogToFaro(record: LogRecord) {
+  defaultLogSink(record);
+
+  const logger = loggersRegistry['grafana.frontend'];
+  if (!logger) {
+    return;
+  }
+
+  const context = faroContext(record);
+  switch (record.level) {
+    case 'debug':
+      logger.logDebug(record.message, context);
+      return;
+    case 'info':
+      logger.logInfo(record.message, context);
+      return;
+    case 'warn':
+      logger.logWarning(record.message, context);
+      return;
+    case 'error':
+      logger.logError(record.error ?? new Error(record.message), context);
+      return;
+  }
+}
 
 export function initializeLoggersRegistry() {
   // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
@@ -10,6 +44,8 @@ export function initializeLoggersRegistry() {
   for (const [source, defaults] of entries) {
     addLogger(source, defaults);
   }
+
+  setLogSink(forwardStructuredLogToFaro);
 }
 
 export function addLogger(source: LoggerSource, defaults?: LoggerDefaults): void {
@@ -55,4 +91,5 @@ export function clearLoggerRegistry() {
   }
 
   loggersRegistry = {};
+  resetLogSink();
 }

--- a/packages/grafana-runtime/src/utils/chromeHeaderHeight.ts
+++ b/packages/grafana-runtime/src/utils/chromeHeaderHeight.ts
@@ -1,3 +1,7 @@
+import { createStructuredLogger } from '@grafana/data';
+
+const logger = createStructuredLogger('grafana/runtime');
+
 type ChromeHeaderHeightHook = () => number;
 
 let chromeHeaderHeightHook: ChromeHeaderHeightHook | undefined = undefined;
@@ -11,7 +15,7 @@ export const useChromeHeaderHeight = () => {
     if (process.env.NODE_ENV !== 'production') {
       throw new Error('useChromeHeaderHeight hook not found in @grafana/runtime');
     }
-    console.error('useChromeHeaderHeight hook not found');
+    logger.error('useChromeHeaderHeight hook not found');
   }
 
   return chromeHeaderHeightHook?.();

--- a/packages/grafana-runtime/src/utils/getCachedPromise.ts
+++ b/packages/grafana-runtime/src/utils/getCachedPromise.ts
@@ -1,12 +1,14 @@
 import { hash } from 'immutable';
 import { LRUCache } from 'lru-cache';
 
-import { generateUUID } from '@grafana/data';
+import { generateUUID, createStructuredLogger } from '@grafana/data';
 import { type LogContext } from '@grafana/faro-web-sdk';
 
 import { getLogger } from '../services/logging/registry';
 
 import { TracedError } from './TracedError';
+
+const logger = createStructuredLogger('grafana/runtime');
 
 // 500 is our best guestimate right now. If a session
 // goes past 500 entries, the LRU evicts the oldest one, at worst a refetch,
@@ -168,7 +170,7 @@ function logError({ error, key }: LogErrorArgs): void {
     const contexts = { ...additional, key, originMessage, originStack };
     logger.logDebug(traced.message, contexts);
   } catch (error) {
-    console.error(error);
+    logger.error(error);
   }
 }
 

--- a/packages/grafana-runtime/src/utils/megaMenuOpen.ts
+++ b/packages/grafana-runtime/src/utils/megaMenuOpen.ts
@@ -1,3 +1,7 @@
+import { createStructuredLogger } from '@grafana/data';
+
+const logger = createStructuredLogger('grafana/runtime');
+
 type MegaMenuOpenHook = () => Readonly<[boolean, (open: boolean, persist?: boolean) => void]>;
 
 let megaMenuOpenHook: MegaMenuOpenHook | undefined = undefined;
@@ -15,7 +19,7 @@ export const useMegaMenuOpen: MegaMenuOpenHook = () => {
     if (process.env.NODE_ENV !== 'production') {
       throw new Error('useMegaMenuOpen hook not found in @grafana/runtime');
     }
-    return [false, () => console.error('MegaMenuOpen hook not found')];
+    return [false, () => logger.error('MegaMenuOpen hook not found')];
   }
 
   return megaMenuOpenHook();

--- a/packages/grafana-runtime/src/utils/plugin.ts
+++ b/packages/grafana-runtime/src/utils/plugin.ts
@@ -1,4 +1,4 @@
-import { type PanelPlugin } from '@grafana/data';
+import { type PanelPlugin, createStructuredLogger } from '@grafana/data';
 
 import { config } from '../config';
 
@@ -8,6 +8,8 @@ import { config } from '../config';
  *
  * @public
  */
+const logger = createStructuredLogger('grafana/runtime');
+
 export interface PluginCssOptions {
   light: string;
   dark: string;
@@ -25,7 +27,7 @@ export async function loadPluginCss(options: PluginCssOptions): Promise<System.M
     const cssPath = config.bootData.user.theme === 'light' ? options.light : options.dark;
     return window.System.import(cssPath);
   } catch (err) {
-    console.error(err);
+    logger.error(err);
   }
 }
 

--- a/packages/grafana-runtime/src/utils/qscheck.ts
+++ b/packages/grafana-runtime/src/utils/qscheck.ts
@@ -1,4 +1,6 @@
-import { type DataSourceInstanceSettings, type DataSourceJsonData } from '@grafana/data';
+import { type DataSourceInstanceSettings, type DataSourceJsonData, createStructuredLogger } from '@grafana/data';
+
+const logger = createStructuredLogger('grafana/runtime');
 
 interface JsonData extends DataSourceJsonData {
   oauthPassThru?: unknown; // we do not assume boolean, to be more robust
@@ -48,11 +50,11 @@ function parseAllowedTypes(data: unknown): AllowedTypes {
     if (types.every((x) => typeof x === 'string')) {
       return { types };
     } else {
-      console.error('qscheck.parseFlags: non-string item in allowed');
+      logger.error('qscheck.parseFlags: non-string item in allowed');
       return { types: [] };
     }
   } else {
-    console.error('qscheck.parseFlags: invalid data');
+    logger.error('qscheck.parseFlags: invalid data');
     return { types: [] };
   }
 }

--- a/packages/grafana-runtime/src/utils/returnToPrevious.ts
+++ b/packages/grafana-runtime/src/utils/returnToPrevious.ts
@@ -1,3 +1,7 @@
+import { createStructuredLogger } from '@grafana/data';
+
+const logger = createStructuredLogger('grafana/runtime');
+
 type ReturnToPreviousHook = () => (title: string, href?: string) => void;
 
 let rtpHook: ReturnToPreviousHook | undefined = undefined;
@@ -16,7 +20,7 @@ export const useReturnToPrevious: ReturnToPreviousHook = () => {
     if (process.env.NODE_ENV !== 'production') {
       throw new Error('useReturnToPrevious hook not found in @grafana/runtime');
     }
-    return () => console.error('ReturnToPrevious hook not found');
+    return () => logger.error('ReturnToPrevious hook not found');
   }
 
   return rtpHook();

--- a/packages/grafana-sql/src/datasource/SqlDatasource.ts
+++ b/packages/grafana-sql/src/datasource/SqlDatasource.ts
@@ -16,6 +16,7 @@ import {
   type LegacyMetricFindQueryOptions,
   type VariableWithMultiSupport,
   type TimeRange,
+  createStructuredLogger,
 } from '@grafana/data';
 import { EditorMode } from '@grafana/plugin-ui';
 import {
@@ -34,6 +35,8 @@ import { SqlQueryEditorLazy } from '../components/QueryEditorLazy';
 import { MACRO_NAMES } from '../constants';
 import { type DB, type SQLQuery, type SQLOptions, type SqlQueryModel, QueryFormat, type SQLDialect } from '../types';
 import migrateAnnotation from '../utils/migration';
+
+const logger = createStructuredLogger('grafana/sql');
 
 export abstract class SqlDatasource extends DataSourceWithBackend<SQLQuery, SQLOptions> {
   uid: string;
@@ -215,7 +218,7 @@ export abstract class SqlDatasource extends DataSourceWithBackend<SQLQuery, SQLO
     try {
       response = await this.runMetaQuery(interpolatedQuery, range);
     } catch (error) {
-      console.error(error);
+      logger.error(error);
       throw new Error('error when executing the sql query');
     }
     return this.getResponseParser().transformMetricFindResponse(response);

--- a/packages/grafana-ui/src/components/Combobox/useOptions.ts
+++ b/packages/grafana-ui/src/components/Combobox/useOptions.ts
@@ -10,6 +10,9 @@ import { fuzzyFind, itemToString } from './filter';
 import { type ComboboxOption } from './types';
 import { StaleResultError, useLatestAsyncCall } from './useLatestAsyncCall';
 
+import { createStructuredLogger } from '@grafana/data';
+const logger = createStructuredLogger('grafana/ui');
+
 type AsyncOptions<T extends string | number> =
   | Array<ComboboxOption<T>>
   | ((inputValue: string) => Promise<Array<ComboboxOption<T>>>);
@@ -62,7 +65,7 @@ export function useOptions<T extends string | number>(
               setAsyncLoading(false);
 
               if (error) {
-                console.error('Error loading async options for Combobox', error);
+                logger.error('Error loading async options for Combobox', error);
               }
             }
           });

--- a/packages/grafana-ui/src/components/Combobox/utils.ts
+++ b/packages/grafana-ui/src/components/Combobox/utils.ts
@@ -1,6 +1,8 @@
-import { isIconName, type SelectableValue } from '@grafana/data';
+import { isIconName, type SelectableValue, createStructuredLogger } from '@grafana/data';
 
 import { type ComboboxOption } from './types';
+
+const logger = createStructuredLogger('grafana/ui');
 
 export const isNewGroup = <T extends string | number>(option: ComboboxOption<T>, prevOption?: ComboboxOption<T>) => {
   const currentGroup = option.group;
@@ -25,11 +27,11 @@ export const selectableValueToComboboxOption = <T extends string | number>(
   v: SelectableValue<T>
 ): ComboboxOption<T> | undefined => {
   if (v == null || v.value == null) {
-    console.warn('selectableValueToComboboxOption: value is null or undefined', v);
+    logger.warn('selectableValueToComboboxOption: value is null or undefined', v);
     return undefined;
   }
   if (v.icon != null && !isIconName(v.icon)) {
-    console.warn('selectableValueToComboboxOption: icon is not a valid icon name', v.icon);
+    logger.warn('selectableValueToComboboxOption: icon is not a valid icon name', v.icon);
     return undefined;
   }
   return {

--- a/packages/grafana-ui/src/components/DateTimePickers/TimeRangePicker/CalendarBody.tsx
+++ b/packages/grafana-ui/src/components/DateTimePickers/TimeRangePicker/CalendarBody.tsx
@@ -2,7 +2,7 @@ import { css } from '@emotion/css';
 import { useCallback } from 'react';
 import Calendar, { type CalendarType } from 'react-calendar';
 
-import { type GrafanaTheme2, dateTimeParse, type DateTime, type TimeZone } from '@grafana/data';
+import { type GrafanaTheme2, dateTimeParse, type DateTime, type TimeZone, createStructuredLogger } from '@grafana/data';
 import { t } from '@grafana/i18n';
 
 import { useStyles2 } from '../../../themes/ThemeContext';
@@ -11,6 +11,8 @@ import { getWeekStart, type WeekStart } from '../WeekStartPicker';
 import { adjustDateForReactCalendar } from '../utils/adjustDateForReactCalendar';
 
 import { type TimePickerCalendarProps } from './TimePickerCalendar';
+
+const logger = createStructuredLogger('grafana/ui');
 
 const weekStartMap: Record<WeekStart, CalendarType> = {
   saturday: 'islamic',
@@ -70,7 +72,8 @@ function useOnCalendarChange(onChange: (from: DateTime, to: DateTime) => void, t
   return useCallback<NonNullable<React.ComponentProps<typeof Calendar>['onChange']>>(
     (value) => {
       if (!Array.isArray(value)) {
-        return console.error('onCalendarChange: should be run in selectRange={true}');
+        logger.error('onCalendarChange: should be run in selectRange={true}');
+        return;
       }
 
       if (value[0] && value[1]) {

--- a/packages/grafana-ui/src/components/Icon/Icon.tsx
+++ b/packages/grafana-ui/src/components/Icon/Icon.tsx
@@ -2,13 +2,15 @@ import { css, cx } from '@emotion/css';
 import { useCallback, useState, useRef, memo, forwardRef } from 'react';
 import SVG from 'react-inlinesvg';
 
-import { type GrafanaTheme2, isIconName } from '@grafana/data';
+import { type GrafanaTheme2, isIconName, createStructuredLogger } from '@grafana/data';
 
 import { useStyles2 } from '../../themes/ThemeContext';
 import { type IconName, type IconType, type IconSize } from '../../types/icon';
 import { spin } from '../../utils/keyframes';
 
 import { getIconPath, getSvgSize } from './utils';
+
+const logger = createStructuredLogger('grafana/ui');
 
 export interface IconProps extends Omit<React.SVGProps<SVGElement>, 'onLoad' | 'onError' | 'ref'> {
   name: IconName;
@@ -96,7 +98,7 @@ export const Icon = memo(
       const { nameToUse: name, handleLoad } = useIconWorkaround(nameProp);
 
       if (!isIconName(name)) {
-        console.warn('Icon component passed an invalid icon name', name);
+        logger.warn('Icon component passed an invalid icon name', name);
       }
 
       // handle the deprecated 'fa fa-spinner'

--- a/packages/grafana-ui/src/components/Input/AutoSizeInput.tsx
+++ b/packages/grafana-ui/src/components/Input/AutoSizeInput.tsx
@@ -6,6 +6,9 @@ import { measureText } from '../../utils/measureText';
 import { AutoSizeInputContext } from './AutoSizeInputContext';
 import { Input, type Props as InputProps } from './Input';
 
+import { createStructuredLogger } from '@grafana/data';
+const logger = createStructuredLogger('grafana/ui');
+
 export interface Props extends InputProps {
   /** Sets the min-width to a multiple of 8px. Default value is 10*/
   minWidth?: number;
@@ -119,7 +122,7 @@ function useControlledState<T>(controlledValue: T, onChange: Function | undefine
 
   const hasLoggedControlledWarning = useRef(false);
   if (isControlledNow !== isControlledRef.current && !hasLoggedControlledWarning.current) {
-    console.warn(
+    logger.warn(
       'An AutoSizeInput is changing from an uncontrolled to a controlled input. If you want to control the input, the empty value should be an empty string.'
     );
     hasLoggedControlledWarning.current = true;

--- a/packages/grafana-ui/src/components/Monaco/CodeEditor.tsx
+++ b/packages/grafana-ui/src/components/Monaco/CodeEditor.tsx
@@ -2,7 +2,7 @@ import { css, cx } from '@emotion/css';
 import type * as monacoType from 'monaco-editor/esm/vs/editor/editor.api';
 import { PureComponent } from 'react';
 
-import { type GrafanaTheme2, monacoLanguageRegistry } from '@grafana/data';
+import { type GrafanaTheme2, monacoLanguageRegistry, createStructuredLogger } from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';
 
 import { withTheme2 } from '../../themes/ThemeContext';
@@ -11,6 +11,8 @@ import { type Themeable2 } from '../../types/theme';
 import { ReactMonacoEditorLazy } from './ReactMonacoEditorLazy';
 import { registerSuggestions } from './suggestions';
 import { type CodeEditorProps, type Monaco, type MonacoEditor as MonacoEditorType, type MonacoOptions } from './types';
+
+const logger = createStructuredLogger('grafana/ui');
 
 type Props = CodeEditorProps & Themeable2;
 
@@ -43,7 +45,7 @@ class UnthemedCodeEditor extends PureComponent<Props> {
       }
 
       if (!this.monaco) {
-        console.warn('Monaco instance not loaded yet');
+        logger.warn('Monaco instance not loaded yet');
         return;
       }
 

--- a/packages/grafana-ui/src/components/StatsPicker/StatsPicker.tsx
+++ b/packages/grafana-ui/src/components/StatsPicker/StatsPicker.tsx
@@ -1,7 +1,7 @@
 import { difference } from 'lodash';
 import { memo, useEffect } from 'react';
 
-import { fieldReducers, type FieldReducerInfo } from '@grafana/data';
+import { fieldReducers, type FieldReducerInfo, createStructuredLogger } from '@grafana/data';
 import { t } from '@grafana/i18n';
 
 import { Combobox, type ComboboxProps } from '../Combobox/Combobox';
@@ -12,6 +12,8 @@ import { selectableValueToComboboxOption } from '../Combobox/utils';
 import { pickComboboxLayout } from './pickComboboxLayout';
 
 /** Props managed by StatsPicker — forwarded combobox props must not replace these. */
+const logger = createStructuredLogger('grafana/ui');
+
 type ComboboxManagedProps = 'value' | 'options' | 'onChange' | 'isClearable' | 'width' | 'minWidth' | 'maxWidth';
 
 /** Forwarded props (managed keys + layout are applied after the spread). */
@@ -53,13 +55,13 @@ export const StatsPicker = memo<StatsPickerProps>(
       if (current.length !== stats.length) {
         const found = current.map((v) => v.id);
         const notFound = difference(stats, found);
-        console.warn('Unknown stats', notFound, stats);
+        logger.warn('Unknown stats', notFound, stats);
         onChange(current.map((stat) => stat.id));
       }
 
       // Make sure there is only one
       if (!allowMultiple && stats.length > 1) {
-        console.warn('Removing extra stat', stats);
+        logger.warn('Removing extra stat', stats);
         onChange([stats[0]]);
       }
 

--- a/packages/grafana-ui/src/components/Table/TableNG/utils.ts
+++ b/packages/grafana-ui/src/components/Table/TableNG/utils.ts
@@ -19,6 +19,7 @@ import {
   ReducerID,
   type FieldSparkline,
   type DecimalCount,
+  createStructuredLogger,
 } from '@grafana/data';
 import { type ColumnWidth, type ColumnWidths, type SortColumn } from '@grafana/react-data-grid';
 import {
@@ -52,6 +53,8 @@ import {
 // inferPills lives here rather than in PillCell.tsx to avoid a circular dependency:
 // styles.ts → utils.tsx → renderers.tsx → PillCell.tsx → styles.ts
 /* ---------------------------- Pill inference ----------------------------- */
+const logger = createStructuredLogger('grafana/ui');
+
 const SPLIT_RE = /\s*,\s*/;
 
 function inferPillsImpl(rawValue: unknown): unknown[] {
@@ -1778,7 +1781,7 @@ export function parseStyleJson(rawValue: unknown): CSSProperties | void {
       }
     } catch (e) {
       if (!warnedAboutStyleJsonSet.has(rawValue)) {
-        console.error(`encountered invalid cell style JSON: ${rawValue}`, e);
+        logger.error(`encountered invalid cell style JSON: ${rawValue}`, e);
         warnedAboutStyleJsonSet.add(rawValue);
       }
     }

--- a/packages/grafana-ui/src/components/ThemeDemos/EmotionPerfTest.tsx
+++ b/packages/grafana-ui/src/components/ThemeDemos/EmotionPerfTest.tsx
@@ -4,14 +4,16 @@ import { css, cx } from '@emotion/css';
 import classnames from 'clsx';
 import React, { Profiler, type ProfilerOnRenderCallback, useState, type FC } from 'react';
 
-import { type GrafanaTheme2 } from '@grafana/data';
+import { type GrafanaTheme2, createStructuredLogger } from '@grafana/data';
 
 import { useStyles2, useTheme2 } from '../../themes/ThemeContext';
 import { Button } from '../Button/Button';
 import { Stack } from '../Layout/Stack/Stack';
 
+const logger = createStructuredLogger('grafana/ui');
+
 export function EmotionPerfTest() {
-  console.log('process.env.NODE_ENV', process.env.NODE_ENV);
+  logger.info('process.env.NODE_ENV', process.env.NODE_ENV);
 
   return (
     <Stack direction="column">
@@ -126,7 +128,7 @@ function NoStyles({ index }: TestComponentProps) {
 
 function MeasureRender({ children, id }: { children: React.ReactNode; id: string }) {
   const onRender: ProfilerOnRenderCallback = (id, phase, actualDuration, baseDuration, startTime, commitTime) => {
-    console.log('Profile ' + id, actualDuration);
+    logger.info('Profile ' + id, actualDuration);
   };
 
   return (

--- a/packages/grafana-ui/src/components/VizTooltip/VizTooltipRow.tsx
+++ b/packages/grafana-ui/src/components/VizTooltip/VizTooltipRow.tsx
@@ -3,7 +3,7 @@ import clsx from 'clsx';
 import { type CSSProperties, type ReactNode, useEffect, useRef, useState } from 'react';
 import * as React from 'react';
 
-import { type GrafanaTheme2 } from '@grafana/data';
+import { type GrafanaTheme2, createStructuredLogger } from '@grafana/data';
 
 import { useStyles2 } from '../../themes/ThemeContext';
 import { InlineToast } from '../InlineToast/InlineToast';
@@ -11,6 +11,8 @@ import { Tooltip } from '../Tooltip/Tooltip';
 
 import { ColorIndicatorPosition, VizTooltipColorIndicator } from './VizTooltipColorIndicator';
 import { VizTooltipColorPlacement, type VizTooltipItem } from './types';
+
+const logger = createStructuredLogger('grafana/ui');
 
 interface VizTooltipRowProps extends Omit<VizTooltipItem, 'value'> {
   /** The formatted value to display. Widened from `VizTooltipItem.value` to also accept numbers, null, and ReactNode. */
@@ -124,7 +126,7 @@ export const VizTooltipRow = ({
         setShowCopySuccess(true);
       }
     } catch (err) {
-      console.error('Unable to copy to clipboard', err);
+      logger.error('Unable to copy to clipboard', err);
     }
 
     textarea.remove();

--- a/packages/grafana-ui/src/components/VizTooltip/utils.test.ts
+++ b/packages/grafana-ui/src/components/VizTooltip/utils.test.ts
@@ -558,7 +558,10 @@ describe('utils', () => {
       const result = getTooltipDisplayValue(value, mockField);
       expect(result.text).toBe('[object Object]');
       expect(result.numeric).toBeNaN();
-      expect(warn).toHaveBeenCalledWith('Cannot render tooltip value', expect.objectContaining({ value }));
+      expect(warn).toHaveBeenCalledWith(
+        'Cannot render tooltip value',
+        expect.objectContaining({ source: 'grafana/ui' })
+      );
 
       warn.mockRestore();
     });

--- a/packages/grafana-ui/src/components/VizTooltip/utils.ts
+++ b/packages/grafana-ui/src/components/VizTooltip/utils.ts
@@ -5,10 +5,13 @@ import {
   formattedValueToString,
   getFieldColorModeForField,
   type LinkModel,
+  createStructuredLogger,
 } from '@grafana/data';
 import { SortOrder, TooltipDisplayMode } from '@grafana/schema';
 
 /** @alpha */
+const logger = createStructuredLogger('grafana/ui');
+
 export interface TooltipScrollableOptions {
   mode: TooltipDisplayMode;
   maxHeight?: number;
@@ -100,7 +103,7 @@ const stringifyValue = (value: unknown): string => {
     return JSON.stringify(value);
   } catch (error) {
     // This path shouldn't be hittable
-    console.warn('Cannot render tooltip value', { error, value });
+    logger.warn('Cannot render tooltip value', { error, value });
     return String(value);
   }
 };

--- a/packages/grafana-ui/src/utils/logOptions.test.ts
+++ b/packages/grafana-ui/src/utils/logOptions.test.ts
@@ -21,6 +21,7 @@ describe('logOptions', () => {
     logOptions(15, RECOMMENDED_AMOUNT, 'test-id', 'test-aria');
 
     expect(console.warn).toHaveBeenCalledWith('[Combobox] Items exceed the recommended amount 10.', {
+      source: 'grafana/ui',
       itemsCount: '15',
       recommendedAmount: '10',
       'aria-labelledby': 'test-aria',

--- a/packages/grafana-ui/src/utils/logOptions.ts
+++ b/packages/grafana-ui/src/utils/logOptions.ts
@@ -1,9 +1,9 @@
+import { createStructuredLogger } from '@grafana/data';
+
+const logger = createStructuredLogger('grafana/ui');
+
 /**
  * This function logs a warning if the amount of items exceeds the recommended amount.
- *
- * @param amount
- * @param id
- * @param ariaLabelledBy
  */
 export function logOptions(
   amount: number,
@@ -13,7 +13,7 @@ export function logOptions(
 ): void {
   if (amount > recommendedAmount) {
     const msg = `[Combobox] Items exceed the recommended amount ${recommendedAmount}.`;
-    console.warn(msg, {
+    logger.warn(msg, {
       itemsCount: '' + amount,
       recommendedAmount: '' + recommendedAmount,
       'aria-labelledby': ariaLabelledBy ?? '',

--- a/public/app/AppWrapper.tsx
+++ b/public/app/AppWrapper.tsx
@@ -29,6 +29,9 @@ import { type PluginExtensionRegistries } from './features/plugins/extensions/re
 import { ScopesContextProvider } from './features/scopes/ScopesContextProvider';
 import { RouterWrapper } from './routes/RoutesWrapper';
 
+import { createStructuredLogger } from '@grafana/data';
+const logger = createStructuredLogger('features.app');
+
 interface AppWrapperProps {
   context: GrafanaContextType;
 }
@@ -87,7 +90,7 @@ export function AppWrapper({ context }: AppWrapperProps) {
     if (preloader) {
       preloader.remove();
     } else {
-      console.warn('Preloader element not found');
+      logger.warn('Preloader element not found');
     }
   }
 

--- a/public/app/api/clients/provisioning/utils/createOnCacheEntryAdded.ts
+++ b/public/app/api/clients/provisioning/utils/createOnCacheEntryAdded.ts
@@ -4,6 +4,9 @@ import { type Subscription } from 'rxjs';
 import { ScopedResourceClient } from 'app/features/apiserver/client';
 import { type ListOptions, type GeneratedResourceList as ResourceList } from 'app/features/apiserver/types';
 
+import { createStructuredLogger } from '@grafana/data';
+const logger = createStructuredLogger('features.provisioning');
+
 interface OnCacheEntryAddedOptions<List = unknown> {
   onError?: (
     error: unknown,
@@ -108,7 +111,7 @@ export function createOnCacheEntryAdded<Spec, Status>(
           },
         });
     } catch (error) {
-      console.error('Error in onCacheEntryAdded:', error);
+      logger.error('Error in onCacheEntryAdded:', error);
       return;
     }
 

--- a/public/app/api/clients/provisioning/v0alpha1/index.ts
+++ b/public/app/api/clients/provisioning/v0alpha1/index.ts
@@ -26,6 +26,9 @@ import { refetchChildren } from '../../../../features/browse-dashboards/state/ac
 import { handleError } from '../../../utils';
 import { createOnCacheEntryAdded } from '../utils/createOnCacheEntryAdded';
 
+import { createStructuredLogger } from '@grafana/data';
+const logger = createStructuredLogger('features.provisioning');
+
 const handleProvisioningFormError = (e: unknown, dispatch: ThunkDispatch, title: string) => {
   if (typeof e === 'object' && e && 'error' in e && isFetchError(e.error)) {
     if (e.error.data.kind === 'Status' && e.error.data.status === 'Failure') {
@@ -271,7 +274,7 @@ export const provisioningAPIv0alpha1 = generatedAPI.enhanceEndpoints({
             dispatch(clearFolders(childrenKeys));
           }
         } catch (e) {
-          console.error('Error in getRepositoryJobsWithPath:', e);
+          logger.error('Error in getRepositoryJobsWithPath:', e);
         }
       },
     },

--- a/public/app/app.ts
+++ b/public/app/app.ts
@@ -18,6 +18,7 @@ import {
   standardEditorsRegistry,
   standardFieldConfigEditorRegistry,
   standardTransformersRegistry,
+  createStructuredLogger,
 } from '@grafana/data';
 import { DEFAULT_LANGUAGE } from '@grafana/i18n';
 import { initializeI18n, loadNamespacedResources } from '@grafana/i18n/internal';
@@ -141,6 +142,8 @@ import { createTextBoxVariableAdapter } from './features/variables/textbox/adapt
 import { configureStore } from './store/configureStore';
 
 // import symlinked extensions
+const logger = createStructuredLogger('features.app');
+
 const extensionsIndex = require.context('.', true, /extensions\/index.ts/);
 const extensionsExports = extensionsIndex.keys().map((key) => {
   return extensionsIndex(key);
@@ -171,7 +174,7 @@ export class GrafanaApp {
         try {
           await initOpenFeature();
         } catch (err) {
-          console.error('Failed to initialize OpenFeature provider', err);
+          logger.error('Failed to initialize OpenFeature provider', err);
         }
       }
 
@@ -341,7 +344,7 @@ export class GrafanaApp {
       try {
         cleanupOldExpandedFolders();
       } catch (err) {
-        console.warn('Failed to clean up old expanded folders', err);
+        logger.warn('Failed to clean up old expanded folders', err);
       }
 
       this.context = {
@@ -371,7 +374,7 @@ export class GrafanaApp {
 
       await postInitTasks();
     } catch (error) {
-      console.error('Failed to start Grafana', error);
+      logger.error('Failed to start Grafana', error);
       window.__grafana_load_failed(error);
     } finally {
       stopMeasure('frontend_app_init');

--- a/public/app/core/components/AccessControl/Permissions.tsx
+++ b/public/app/core/components/AccessControl/Permissions.tsx
@@ -4,7 +4,7 @@ import { useEffect, useMemo, useState } from 'react';
 import * as React from 'react';
 import useAsyncFn from 'react-use/lib/useAsyncFn';
 
-import { type GrafanaTheme2 } from '@grafana/data';
+import { type GrafanaTheme2, createStructuredLogger } from '@grafana/data';
 import { Trans, t } from '@grafana/i18n';
 import { Text, Box, Button, useStyles2, LoadingPlaceholder } from '@grafana/ui';
 import { SlideDown } from 'app/core/components/Animations/SlideDown';
@@ -13,6 +13,8 @@ import { getBackendSrv } from 'app/core/services/backend_srv';
 import { AddPermission } from './AddPermission';
 import { PermissionList } from './PermissionList';
 import { PermissionTarget, type ResourcePermission, type SetPermission, type Description } from './types';
+
+const logger = createStructuredLogger('features.core');
 
 const EMPTY_PERMISSION = '';
 
@@ -239,7 +241,7 @@ const getDescription = async (resource: string, queryParams?: Record<string, str
   try {
     return await getBackendSrv().get(`/api/access-control/${resource}/description`, queryParams);
   } catch (e) {
-    console.error('failed to load resource description: ', e);
+    logger.error('failed to load resource description: ', e);
     return INITIAL_DESCRIPTION;
   }
 };

--- a/public/app/core/components/AppChrome/TopBar/InviteUserButton.tsx
+++ b/public/app/core/components/AppChrome/TopBar/InviteUserButton.tsx
@@ -1,6 +1,6 @@
 import { skipToken } from '@reduxjs/toolkit/query';
 
-import { PluginExtensionPoints } from '@grafana/data';
+import { PluginExtensionPoints, createStructuredLogger } from '@grafana/data';
 import { t } from '@grafana/i18n';
 import { renderLimitedComponents } from '@grafana/runtime';
 import { ToolbarButton } from '@grafana/ui';
@@ -17,6 +17,8 @@ import {
   shouldRenderInviteUserButton,
   shouldRenderUpgradeUserButton,
 } from './InviteUserButtonUtils';
+
+const logger = createStructuredLogger('features.core');
 
 export function NavRightButton() {
   const { components } = usePluginComponents({
@@ -61,7 +63,7 @@ function InviteUserButton() {
         performInviteUserClick('top_bar_right', 'invite-user-top-bar');
       }
     } catch (error) {
-      console.error('Failed to handle invite/upgrade user click:', error);
+      logger.error('Failed to handle invite/upgrade user click:', error);
     }
   };
 

--- a/public/app/core/components/Login/LoginCtrl.tsx
+++ b/public/app/core/components/Login/LoginCtrl.tsx
@@ -6,6 +6,9 @@ import config from 'app/core/config';
 
 import { type LoginDTO } from './types';
 
+import { createStructuredLogger } from '@grafana/data';
+const logger = createStructuredLogger('features.core');
+
 const isOauthEnabled = () => {
   return !!config.oauth && Object.keys(config.oauth).length > 0;
 };
@@ -88,7 +91,7 @@ const LoginCtrl = memo(({ resetCode, children }: Props) => {
           .then(() => {
             toGrafana();
           })
-          .catch((err) => console.error(err));
+          .catch((err) => logger.error(err));
       }
     },
     [resetCode, toGrafana]

--- a/public/app/core/components/NavLandingPage/NavLandingPage.tsx
+++ b/public/app/core/components/NavLandingPage/NavLandingPage.tsx
@@ -1,13 +1,15 @@
 import { css } from '@emotion/css';
 import * as React from 'react';
 
-import { type GrafanaTheme2, type NavModelItem } from '@grafana/data';
+import { type GrafanaTheme2, type NavModelItem, createStructuredLogger } from '@grafana/data';
 import { usePluginComponents, usePluginLinks } from '@grafana/runtime';
 import { useStyles2 } from '@grafana/ui';
 import { Page } from 'app/core/components/Page/Page';
 import { useNavModel } from 'app/core/hooks/useNavModel';
 
 import { NavLandingPageCard } from './NavLandingPageCard';
+
+const logger = createStructuredLogger('features.core');
 
 interface Props {
   navId: string;
@@ -36,7 +38,7 @@ export function NavLandingPage({ navId, header }: Props) {
   // Warn if both extension points are being used (they are mutually exclusive)
   React.useEffect(() => {
     if (components && components.length > 0 && additionalCards && additionalCards.length > 0) {
-      console.warn(
+      logger.warn(
         `[NavLandingPage] Both NavLandingPage and NavLandingPageCards extensions are registered for "${node.id}". ` +
           `The NavLandingPage extension will take precedence and NavLandingPageCards will be ignored. ` +
           `Please use only one extension point.`

--- a/public/app/core/components/RolePicker/TeamRolePicker.tsx
+++ b/public/app/core/components/RolePicker/TeamRolePicker.tsx
@@ -7,6 +7,9 @@ import { AccessControlAction, type Role } from 'app/types/accessControl';
 
 import { RolePicker } from './RolePicker';
 
+import { createStructuredLogger } from '@grafana/data';
+const logger = createStructuredLogger('features.core');
+
 export interface Props {
   teamId: number;
   orgId?: number;
@@ -79,7 +82,7 @@ export const TeamRolePicker = ({
           },
         }).unwrap();
       } catch (error) {
-        console.error('Error updating team roles', error);
+        logger.error('Error updating team roles', error);
       }
     } else if (onApplyRoles) {
       onApplyRoles(newRoles);

--- a/public/app/core/components/RolePicker/UserRolePicker.tsx
+++ b/public/app/core/components/RolePicker/UserRolePicker.tsx
@@ -1,12 +1,14 @@
 import { skipToken } from '@reduxjs/toolkit/query';
 import { useMemo } from 'react';
 
-import { type OrgRole } from '@grafana/data';
+import { type OrgRole, createStructuredLogger } from '@grafana/data';
 import { useListUserRolesQuery, useSetUserRolesMutation } from 'app/api/clients/roles';
 import { contextSrv } from 'app/core/services/context_srv';
 import { AccessControlAction, type Role } from 'app/types/accessControl';
 
 import { RolePicker } from './RolePicker';
+
+const logger = createStructuredLogger('features.core');
 
 export interface Props {
   basicRole: OrgRole;
@@ -90,7 +92,7 @@ export const UserRolePicker = ({
           },
         }).unwrap();
       } catch (error) {
-        console.error('Error updating user roles', error);
+        logger.error('Error updating user roles', error);
       }
     } else if (onApplyRoles) {
       onApplyRoles(newRoles, userId, orgId);

--- a/public/app/core/components/TimePicker/TimePickerWithHistory.tsx
+++ b/public/app/core/components/TimePicker/TimePickerWithHistory.tsx
@@ -7,10 +7,13 @@ import {
   type TimeRange,
   isDateTime,
   rangeUtil,
+  createStructuredLogger,
 } from '@grafana/data';
 import { t } from '@grafana/i18n';
 import { type TimeRangePickerProps, TimeRangePicker } from '@grafana/ui';
 import { appEvents } from 'app/core/app_events';
+
+const logger = createStructuredLogger('features.core');
 
 const LOCAL_STORAGE_KEY = 'grafana.dashboard.timepicker.history';
 const MAX_HISTORY_ITEMS = 4;
@@ -136,7 +139,8 @@ function convertToISOString(value: DateTime | string): string {
   }
 
   if (!value?.toISOString) {
-    throw console.error('Invalid DateTime object passed to convertToISOString');
+    logger.error('Invalid DateTime object passed to convertToISOString');
+    throw new Error('Invalid DateTime object passed to convertToISOString');
   }
 
   return value.toISOString();

--- a/public/app/core/history/RichHistoryIndexedDBStorage.ts
+++ b/public/app/core/history/RichHistoryIndexedDBStorage.ts
@@ -1,7 +1,7 @@
 import { openDB, type DBSchema, type IDBPDatabase } from 'idb';
 import { isEqual, omit } from 'lodash';
 
-import { type DataQuery, generateUUID } from '@grafana/data';
+import { type DataQuery, generateUUID, createStructuredLogger } from '@grafana/data';
 import { reportInteraction } from '@grafana/runtime';
 import {
   DEFAULT_RICH_HISTORY_SETTINGS as DEFAULT_SETTINGS,
@@ -18,6 +18,8 @@ import {
   type RichHistoryStorageWarningDetails,
 } from './RichHistoryStorage';
 import { migrateToIndexedDB } from './indexedDBMigration';
+
+const logger = createStructuredLogger('features.core');
 
 const DB_NAME = 'grafana-query-history';
 const DB_VERSION = 1;
@@ -126,7 +128,7 @@ export default class RichHistoryIndexedDBStorage implements RichHistoryStorage, 
     if (!this.migrationPromise) {
       this.migrationPromise = migrateToIndexedDB(this).catch((error) => {
         // Log but don't block — user can still use storage
-        console.error('Query history migration failed:', error);
+        logger.error('Query history migration failed:', error);
         // Reset so it retries on next access
         this.migrationPromise = undefined;
       });
@@ -228,7 +230,7 @@ export default class RichHistoryIndexedDBStorage implements RichHistoryStorage, 
     // (the no-time-range branch, or a time range wider than the retention
     // window); this self-heals once the next cleanup commits. Acceptable for GC.
     void this.maybeRunRetentionCleanup(db).catch((error) => {
-      console.error('Query history retention cleanup failed:', error);
+      logger.error('Query history retention cleanup failed:', error);
     });
 
     // 1. Index-based retrieval — narrow at the DB level

--- a/public/app/core/history/indexedDBMigration.ts
+++ b/public/app/core/history/indexedDBMigration.ts
@@ -1,6 +1,6 @@
 import { lastValueFrom } from 'rxjs';
 
-import { type DataQuery, generateUUID, store } from '@grafana/data';
+import { type DataQuery, generateUUID, store, createStructuredLogger } from '@grafana/data';
 import { config, getBackendSrv, reportInteraction } from '@grafana/runtime';
 import { getDataSourceInstanceSettings } from '@grafana/runtime/unstable';
 import { DEFAULT_RICH_HISTORY_SETTINGS } from 'app/core/utils/richHistoryTypes';
@@ -8,6 +8,8 @@ import { DEFAULT_RICH_HISTORY_SETTINGS } from 'app/core/utils/richHistoryTypes';
 import type { IndexedDBMigrationAccess } from './RichHistoryIndexedDBStorage';
 import { RICH_HISTORY_KEY, type RichHistoryLocalStorageDTO } from './RichHistoryLocalStorage';
 import { RICH_HISTORY_SETTING_KEYS } from './richHistoryLocalStorageUtils';
+
+const logger = createStructuredLogger('features.core');
 
 const METADATA_MIGRATION_COMPLETE = 'migrationComplete';
 const METADATA_MIGRATION_ATTEMPTS = 'migrationAttempts';
@@ -136,7 +138,7 @@ async function runMigration(indexedDBStorage: IndexedDBMigrationAccess): Promise
 
   if (currentAttempts >= MAX_MIGRATION_ATTEMPTS) {
     reportInteraction('grafana_query_history_migration_abandoned', { attempts: currentAttempts });
-    console.warn(
+    logger.warn(
       `Query history migration to IndexedDB did not succeed after ${MAX_MIGRATION_ATTEMPTS} attempts. ` +
         `Existing query history remains in localStorage and/or the remote API. ` +
         `Set localStorage key '${RESET_MIGRATION_KEY}' to true and reload to retry the migration.`

--- a/public/app/core/journeys/utils.ts
+++ b/public/app/core/journeys/utils.ts
@@ -4,6 +4,10 @@ import { type JourneyHandle, locationService } from '@grafana/runtime';
  * Collects cleanup functions so journey wiring doesn't need
  * manual unsub1/unsub2/unsub3 bookkeeping.
  */
+import { createStructuredLogger } from '@grafana/data';
+
+const logger = createStructuredLogger('features.core');
+
 export function collectUnsubs() {
   const unsubs: Array<() => void> = [];
   return {
@@ -54,7 +58,7 @@ function warnUnsupported(kind: string): void {
     return;
   }
   warnedTypes.add(kind);
-  console.warn(
+  logger.warn(
     `[CUJ] str() received unsupported value of type "${kind}"; coerced to ''. ` +
       `Pass primitives (string/number/boolean) to reportInteraction so journey attributes stay queryable in Tempo.`
   );

--- a/public/app/core/navigation/errorModels.ts
+++ b/public/app/core/navigation/errorModels.ts
@@ -1,7 +1,9 @@
-import { type NavModel, type NavModelItem } from '@grafana/data';
+import { type NavModel, type NavModelItem, createStructuredLogger } from '@grafana/data';
+
+const logger = createStructuredLogger('features.core');
 
 export function getExceptionNav(error: unknown): NavModel {
-  console.error(error);
+  logger.error(error);
   return getWarningNav('Exception thrown', 'See console for details');
 }
 

--- a/public/app/core/reducers/appNotification.ts
+++ b/public/app/core/reducers/appNotification.ts
@@ -1,7 +1,9 @@
 import { createSelector, createSlice, type PayloadAction } from '@reduxjs/toolkit';
 
-import { store } from '@grafana/data';
+import { store, createStructuredLogger } from '@grafana/data';
 import { type AppNotification, AppNotificationSeverity, type AppNotificationsState } from 'app/types/appNotifications';
+
+const logger = createStructuredLogger('features.core');
 
 const MAX_STORED_NOTIFICATIONS = 25;
 const STORAGE_KEY = 'notifications';
@@ -121,7 +123,7 @@ function serializeNotifications(notifs: Record<string, StoredNotification>) {
   try {
     store.set(STORAGE_KEY, JSON.stringify(reducedNotifs));
   } catch (err) {
-    console.error('Unable to persist notifications to local storage');
-    console.error(err);
+    logger.error('Unable to persist notifications to local storage');
+    logger.error(err);
   }
 }

--- a/public/app/core/services/FetchQueue.ts
+++ b/public/app/core/services/FetchQueue.ts
@@ -2,6 +2,9 @@ import { type Observable, Subject } from 'rxjs';
 
 import { type BackendSrvRequest } from '@grafana/runtime';
 
+import { createStructuredLogger } from '@grafana/data';
+const logger = createStructuredLogger('features.core');
+
 export interface QueueState extends Record<string, { state: FetchStatus; options: BackendSrvRequest }> {}
 
 export enum FetchStatus {
@@ -90,8 +93,8 @@ export class FetchQueue {
       []
     );
 
-    console.log('FetchQueue noOfStarted', update.noOfInProgress);
-    console.log('FetchQueue noOfNotStarted', update.noOfPending);
-    console.log('FetchQueue state', entriesWithoutOptions);
+    logger.info('FetchQueue noOfStarted', update.noOfInProgress);
+    logger.info('FetchQueue noOfNotStarted', update.noOfPending);
+    logger.info('FetchQueue state', entriesWithoutOptions);
   };
 }

--- a/public/app/core/services/backend_srv.ts
+++ b/public/app/core/services/backend_srv.ts
@@ -25,7 +25,7 @@ import {
   throwIfEmpty,
 } from 'rxjs/operators';
 
-import { AppEvents, DataQueryErrorType, deprecationWarning, generateUUID } from '@grafana/data';
+import { AppEvents, DataQueryErrorType, deprecationWarning, generateUUID, createStructuredLogger } from '@grafana/data';
 import {
   type BackendSrv as BackendService,
   type BackendSrvRequest,
@@ -51,6 +51,8 @@ import { FetchQueue } from './FetchQueue';
 import { FetchQueueWorker } from './FetchQueueWorker';
 import { ResponseQueue } from './ResponseQueue';
 import { type ContextSrv, contextSrv } from './context_srv';
+
+const logger = createStructuredLogger('features.core');
 
 const CANCEL_ALL_REQUESTS_REQUEST_ID = 'cancel_all_requests_request_id';
 
@@ -116,7 +118,7 @@ export class BackendSrv implements BackendService {
       const result = await fp.get();
       this.deviceID = result.visitorId;
     } catch (error) {
-      console.error(error);
+      logger.error(error);
     }
   }
 
@@ -241,7 +243,7 @@ export class BackendSrv implements BackendService {
             observer.complete();
           }) // runs in background
           .catch((e) => {
-            console.log(requestId, 'catch', e);
+            logger.info(requestId, 'catch', e);
             observer.error(e);
           }); // from abort
       },

--- a/public/app/core/services/context_srv.ts
+++ b/public/app/core/services/context_srv.ts
@@ -8,6 +8,7 @@ import {
   userHasPermission,
   userHasPermissionInMetadata,
   userHasAnyPermission,
+  createStructuredLogger,
 } from '@grafana/data';
 import { featureEnabled, getBackendSrv } from '@grafana/runtime';
 import { canRotateSessionToken, getSessionExpiry } from 'app/core/utils/auth';
@@ -18,6 +19,8 @@ import config from '../../core/config';
 
 // When set to auto, the interval will be based on the query range
 // NOTE: this is defined here rather than TimeSrv so we avoid circular dependencies
+const logger = createStructuredLogger('features.core');
+
 export const AutoRefreshInterval = 'auto';
 export const RedirectToUrlKey = 'redirectTo';
 
@@ -108,7 +111,7 @@ export class ContextSrv {
         reloadcache: true,
       });
     } catch (e) {
-      console.error(e);
+      logger.error(e);
     }
   }
 
@@ -263,7 +266,7 @@ export class ContextSrv {
         }
       })
       .catch((e) => {
-        console.error(e);
+        logger.error(e);
       });
   }
 }

--- a/public/app/core/services/echo/Echo.ts
+++ b/public/app/core/services/echo/Echo.ts
@@ -13,6 +13,9 @@ import { contextSrv } from '../context_srv';
 
 import { echoLog } from './utils';
 
+import { createStructuredLogger } from '@grafana/data';
+const logger = createStructuredLogger('features.core');
+
 interface EchoConfig {
   // How often should metrics be reported
   flushInterval: number;
@@ -76,7 +79,7 @@ export class Echo implements EchoSrv {
             try {
               cb(payload.properties ?? {});
             } catch (err) {
-              console.error(`[Echo] onInteraction subscriber error for "${payload.interactionName}":`, err);
+              logger.error(`[Echo] onInteraction subscriber error for "${payload.interactionName}":`, err);
             }
           }
         }

--- a/public/app/core/services/echo/init.ts
+++ b/public/app/core/services/echo/init.ts
@@ -6,6 +6,10 @@ import { contextSrv } from '../context_srv';
 import { Echo } from './Echo';
 
 // Initialise EchoSrv backends, calls during frontend app startup
+import { createStructuredLogger } from '@grafana/data';
+
+const logger = createStructuredLogger('features.core');
+
 export async function initEchoSrv() {
   setEchoSrv(new Echo({ debug: process.env.NODE_ENV === 'development' }));
 
@@ -28,49 +32,49 @@ export async function initEchoSrv() {
   try {
     await initPerformanceBackend();
   } catch (error) {
-    console.error('Error initializing EchoSrv Performance backend', error);
+    logger.error('Error initializing EchoSrv Performance backend', error);
   }
 
   try {
     await initFaroBackend();
   } catch (error) {
-    console.error('Error initializing EchoSrv Faro backend', error);
+    logger.error('Error initializing EchoSrv Faro backend', error);
   }
 
   try {
     await initGoogleAnalyticsBackend();
   } catch (error) {
-    console.error('Error initializing EchoSrv GoogleAnalytics backend', error);
+    logger.error('Error initializing EchoSrv GoogleAnalytics backend', error);
   }
 
   try {
     await initGoogleAnalaytics4Backend();
   } catch (error) {
-    console.error('Error initializing EchoSrv GoogleAnalaytics4 backend', error);
+    logger.error('Error initializing EchoSrv GoogleAnalaytics4 backend', error);
   }
 
   try {
     await initRudderstackBackend();
   } catch (error) {
-    console.error('Error initializing EchoSrv Rudderstack backend', error);
+    logger.error('Error initializing EchoSrv Rudderstack backend', error);
   }
 
   try {
     await initAzureAppInsightsBackend();
   } catch (error) {
-    console.error('Error initializing EchoSrv AzureAppInsights backend', error);
+    logger.error('Error initializing EchoSrv AzureAppInsights backend', error);
   }
 
   try {
     await initPostHogBackend();
   } catch (error) {
-    console.error('Error initializing EchoSrv PostHog backend', error);
+    logger.error('Error initializing EchoSrv PostHog backend', error);
   }
 
   try {
     await initConsoleBackend();
   } catch (error) {
-    console.error('Error initializing EchoSrv Console backend', error);
+    logger.error('Error initializing EchoSrv Console backend', error);
   }
 }
 

--- a/public/app/core/services/journey/JourneyRegistryImpl.test.ts
+++ b/public/app/core/services/journey/JourneyRegistryImpl.test.ts
@@ -343,7 +343,10 @@ describe('JourneyRegistryImpl', () => {
     registry.warnUnregistered();
 
     expect(warnSpy).toHaveBeenCalledTimes(1);
-    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('"another_journey" has no triggers registered'));
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('"another_journey" has no triggers registered'),
+      expect.objectContaining({ source: 'features.core' })
+    );
 
     warnSpy.mockRestore();
   });

--- a/public/app/core/services/journey/JourneyRegistryImpl.ts
+++ b/public/app/core/services/journey/JourneyRegistryImpl.ts
@@ -10,6 +10,9 @@ import {
 import { type JourneyStartOptions } from '@grafana/runtime/internal';
 import { createDebugLog } from 'app/core/utils/debugLog';
 
+import { createStructuredLogger } from '@grafana/data';
+const logger = createStructuredLogger('features.core');
+
 const debugLog = createDebugLog('journeyTracker', 'JourneyRegistry');
 
 const JOURNEY_TYPE_PATTERN = /^[a-z][a-z0-9_]*$/;
@@ -150,7 +153,7 @@ export class JourneyRegistryImpl implements JourneyRegistry {
     }
     for (const [type] of this.metadata) {
       if (!this.registeredTriggers.has(type)) {
-        console.warn(
+        logger.warn(
           `[JourneyRegistry] Registry entry "${type}" has no triggers registered. ` +
             `Did you forget to import its wiring module?`
         );

--- a/public/app/core/services/journey/JourneyTrackerImpl.ts
+++ b/public/app/core/services/journey/JourneyTrackerImpl.ts
@@ -11,6 +11,9 @@ import {
 import { type JourneyStartOptions } from '@grafana/runtime/internal';
 import { createDebugLog } from 'app/core/utils/debugLog';
 
+import { createStructuredLogger } from '@grafana/data';
+const logger = createStructuredLogger('features.core');
+
 const DEFAULT_TIMEOUT_MS = 5 * 60 * 1000; // 5 minutes
 const ABANDONED_TAB_HIDDEN_MS = 60 * 1000; // 60 seconds
 
@@ -422,7 +425,7 @@ class JourneyHandleImpl implements JourneyHandle {
       try {
         cb();
       } catch (err) {
-        console.error(`[JourneyTracker] onEnd callback error for "${this.journeyType}":`, err);
+        logger.error(`[JourneyTracker] onEnd callback error for "${this.journeyType}":`, err);
       }
     }
   }

--- a/public/app/core/services/meticulous.ts
+++ b/public/app/core/services/meticulous.ts
@@ -1,3 +1,7 @@
+import { createStructuredLogger } from '@grafana/data';
+
+const logger = createStructuredLogger('features.core');
+
 const AUTH_PATH_PREFIXES = ['/login', '/signup', '/invite/', '/verify', '/user/password/', '/profile/password'];
 
 function isAuthPath(pathname: string): boolean {
@@ -18,6 +22,6 @@ export async function updateMeticulousRecording(pathname: string): Promise<void>
   try {
     window.__meticulous.stopRecording();
   } catch (error) {
-    console.error('Error stopping Meticulous recording:', error);
+    logger.error('Error stopping Meticulous recording:', error);
   }
 }

--- a/public/app/core/trustedTypePolicies.ts
+++ b/public/app/core/trustedTypePolicies.ts
@@ -1,5 +1,7 @@
-import { textUtil } from '@grafana/data';
+import { textUtil, createStructuredLogger } from '@grafana/data';
 import { config } from '@grafana/runtime';
+
+const logger = createStructuredLogger('features.core');
 
 const CSP_REPORT_ONLY_ENABLED = config.cspReportOnlyEnabled;
 
@@ -8,7 +10,7 @@ export const defaultTrustedTypesPolicy = {
     if (!CSP_REPORT_ONLY_ENABLED) {
       return string.replace(/<script/gi, '&lt;script');
     }
-    console.error('[HTML not sanitized with Trusted Types]', string, source, sink);
+    logger.error('[HTML not sanitized with Trusted Types]', string, source, sink);
     return string;
   },
   createScript: (string: string) => string,
@@ -16,7 +18,7 @@ export const defaultTrustedTypesPolicy = {
     if (!CSP_REPORT_ONLY_ENABLED) {
       return textUtil.sanitizeUrl(string);
     }
-    console.error('[ScriptURL not sanitized with Trusted Types]', string, source, sink);
+    logger.error('[ScriptURL not sanitized with Trusted Types]', string, source, sink);
     return string;
   },
 };

--- a/public/app/core/utils/debugLog.ts
+++ b/public/app/core/utils/debugLog.ts
@@ -1,4 +1,4 @@
-import { store } from '@grafana/data';
+import { store, createStructuredLogger } from '@grafana/data';
 
 /**
  * Creates a debug logger gated by a localStorage key.
@@ -6,12 +6,14 @@ import { store } from '@grafana/data';
  * Enable in browser console:
  *   localStorage.setItem('grafana.debug.<key>', 'true')
  */
+const logger = createStructuredLogger('features.core');
+
 export function createDebugLog(key: string, prefix: string) {
   const storageKey = `grafana.debug.${key}`;
 
   return function debugLog(message: string, ...args: unknown[]) {
     if (store.get(storageKey) === 'true') {
-      console.log(`[${prefix}] ${message}`, ...args);
+      logger.info(`[${prefix}] ${message}`, ...args);
     }
   };
 }

--- a/public/app/core/utils/explore.ts
+++ b/public/app/core/utils/explore.ts
@@ -23,11 +23,14 @@ import {
   toURLRange,
   urlUtil,
   generateUUID,
+  createStructuredLogger,
 } from '@grafana/data';
 import { getDataSourceInstance } from '@grafana/runtime/unstable';
 import { RefreshPicker } from '@grafana/ui';
 import { ExpressionDatasourceUID } from 'app/features/expressions/types';
 import { type QueryOptions, type QueryTransaction } from 'app/types/explore';
+
+const logger = createStructuredLogger('features.core');
 
 export const DEFAULT_UI_STATE = {
   dedupStrategy: LogsDedupStrategy.none,
@@ -159,7 +162,7 @@ export const safeStringifyValue = (value: unknown, space?: number) => {
   try {
     return JSON.stringify(value, null, space);
   } catch (error) {
-    console.error(error);
+    logger.error(error);
   }
 
   return '';
@@ -232,7 +235,7 @@ export async function ensureQueries(
         try {
           await getDataSourceInstance(query.datasource.uid);
         } catch {
-          console.error(`One of the queries has a datasource that is no longer available and was removed.`);
+          logger.error(`One of the queries has a datasource that is no longer available and was removed.`);
           validDS = false;
         }
       }

--- a/public/app/core/utils/fetch.ts
+++ b/public/app/core/utils/fetch.ts
@@ -1,8 +1,10 @@
 import { omitBy } from 'lodash';
 import { type Observable, of, throwError } from 'rxjs';
 
-import { deprecationWarning, validatePath } from '@grafana/data';
+import { deprecationWarning, validatePath, createStructuredLogger } from '@grafana/data';
 import { type BackendSrvRequest } from '@grafana/runtime';
+
+const logger = createStructuredLogger('features.core');
 
 export const parseInitFromOptions = (options: BackendSrvRequest): RequestInit => {
   const method = options.method;
@@ -139,7 +141,7 @@ export async function parseResponseBody<T>(
         // An empty string is not a valid JSON.
         // Sometimes (unfortunately) our APIs declare their Content-Type as JSON, however they return an empty body.
         if (response.headers.get('Content-Length') === '0') {
-          console.warn(`${response.url} returned an invalid JSON`);
+          logger.warn(`${response.url} returned an invalid JSON`);
           return {} as T;
         }
         return await response.json();

--- a/public/app/core/utils/metrics.ts
+++ b/public/app/core/utils/metrics.ts
@@ -1,5 +1,8 @@
 import { reportPerformance } from '../services/echo/EchoSrv';
 
+import { createStructuredLogger } from '@grafana/data';
+const logger = createStructuredLogger('features.core');
+
 export function startMeasure(eventName: string) {
   if (!performance || !performance.mark) {
     return;
@@ -8,7 +11,7 @@ export function startMeasure(eventName: string) {
   try {
     performance.mark(`${eventName}_started`);
   } catch (error) {
-    console.error(`[Metrics] Failed to startMeasure ${eventName}`, error);
+    logger.error(`[Metrics] Failed to startMeasure ${eventName}`, error);
   }
 }
 
@@ -31,7 +34,7 @@ export function stopMeasure(eventName: string) {
     performance.clearMeasures(measured);
     return measure;
   } catch (error) {
-    console.error(`[Metrics] Failed to stopMeasure ${eventName}`, error);
+    logger.error(`[Metrics] Failed to stopMeasure ${eventName}`, error);
     return;
   }
 }

--- a/public/app/core/utils/shortLinks.ts
+++ b/public/app/core/utils/shortLinks.ts
@@ -1,6 +1,6 @@
 import memoizeOne from 'memoize-one';
 
-import { type AbsoluteTimeRange, type LogRowModel, type UrlQueryMap } from '@grafana/data';
+import { type AbsoluteTimeRange, type LogRowModel, type UrlQueryMap, createStructuredLogger } from '@grafana/data';
 import { t } from '@grafana/i18n';
 import { getBackendSrv, config, locationService } from '@grafana/runtime';
 import { FlagKeys, getFeatureFlagClient } from '@grafana/runtime/internal';
@@ -17,6 +17,8 @@ import { type ShareLinkConfiguration } from '../../features/dashboard-scene/shar
 import { notifyApp } from '../reducers/appNotification';
 
 import { copyStringToClipboard } from './explore';
+
+const logger = createStructuredLogger('features.core');
 
 function buildHostUrl() {
   return `${window.location.protocol}//${window.location.host}${config.appSubUrl}`;
@@ -74,7 +76,7 @@ export const createShortLink = memoizeOne(async (path: string): Promise<string> 
       return await createShortLinkLegacy(path);
     }
   } catch (err) {
-    console.error('Error when creating shortened link: ', err);
+    logger.error('Error when creating shortened link: ', err);
     dispatch(notifyApp(createErrorNotification('Error generating shortened link')));
     createShortLink.clear();
     throw err; // Re-throw so callers know it failed
@@ -105,7 +107,7 @@ export const createAndCopyShortLink = async (path: string) => {
     }
   } catch (error) {
     // createShortLink already handles error notifications, just log
-    console.error('Error in createAndCopyShortLink:', error);
+    logger.error('Error in createAndCopyShortLink:', error);
   }
 };
 

--- a/public/app/core/utils/timeRegions.ts
+++ b/public/app/core/utils/timeRegions.ts
@@ -1,6 +1,14 @@
 import { Cron } from 'croner';
 
-import { type AbsoluteTimeRange, type TimeRange, durationToMilliseconds, parseDuration } from '@grafana/data';
+import {
+  type AbsoluteTimeRange,
+  type TimeRange,
+  durationToMilliseconds,
+  parseDuration,
+  createStructuredLogger,
+} from '@grafana/data';
+
+const logger = createStructuredLogger('features.core');
 
 export type TimeRegionMode = null | 'cron';
 export interface TimeRegionConfig {
@@ -160,7 +168,7 @@ export function calculateTimesWithin(cfg: TimeRegionConfig, tRange: TimeRange): 
     }
   } catch (e) {
     // invalid expression
-    console.error(e);
+    logger.error(e);
   }
 
   return ranges;

--- a/public/app/features/actions/utils.ts
+++ b/public/app/features/actions/utils.ts
@@ -15,6 +15,7 @@ import {
   type ScopedVars,
   textUtil,
   type ValueLinkConfig,
+  createStructuredLogger,
 } from '@grafana/data';
 import { type BackendSrvRequest, config as grafanaConfig, getBackendSrv } from '@grafana/runtime';
 import { appEvents } from 'app/core/app_events';
@@ -27,6 +28,8 @@ import { getNextRequestId } from '../query/state/PanelQueryRunner';
 import { reportActionTrigger } from './analytics';
 
 /** @internal */
+const logger = createStructuredLogger('features.actions');
+
 export const isInfinityActionWithAuth = (action: Action): boolean => {
   return (grafanaConfig.featureToggles.vizActionsAuth ?? false) && action.type === ActionType.Infinity;
 };
@@ -120,7 +123,7 @@ export const getActions = (
                   appEvents.emit(AppEvents.alertError, [
                     'An error has occurred. Check console output for more details.',
                   ]);
-                  console.error(error);
+                  logger.error(error);
                 },
                 complete: () => {
                   appEvents.emit(AppEvents.alertSuccess, ['API call was successful']);
@@ -128,7 +131,7 @@ export const getActions = (
               });
           } catch (error) {
             appEvents.emit(AppEvents.alertError, ['An error has occurred. Check console output for more details.']);
-            console.error(error);
+            logger.error(error);
             return;
           }
         },

--- a/public/app/features/admin/UserOrgs.tsx
+++ b/public/app/features/admin/UserOrgs.tsx
@@ -1,7 +1,7 @@
 import { css, cx } from '@emotion/css';
 import { memo, type ReactElement, useEffect, useRef, useState } from 'react';
 
-import { type GrafanaTheme2, OrgRole } from '@grafana/data';
+import { type GrafanaTheme2, OrgRole, createStructuredLogger } from '@grafana/data';
 import { Trans, t } from '@grafana/i18n';
 import { Button, ConfirmButton, Field, Icon, Modal, Tooltip, useStyles2, Stack, TextLink } from '@grafana/ui';
 import { UserRolePicker } from 'app/core/components/RolePicker/UserRolePicker';
@@ -13,6 +13,8 @@ import { type Organization } from 'app/types/organization';
 import { type UserOrg, type UserDTO } from 'app/types/user';
 
 import { OrgRolePicker } from './OrgRolePicker';
+
+const logger = createStructuredLogger('features.admin');
 
 interface Props {
   orgs: UserOrg[];
@@ -128,7 +130,7 @@ const OrgRow = memo(({ user, org, isExternalUser, onOrgRemove, onOrgRoleChange }
       if (contextSrv.hasPermission(AccessControlAction.ActionRolesList)) {
         fetchRoleOptions(org.orgId)
           .then((roles) => setRoleOptions(roles))
-          .catch((e) => console.error(e));
+          .catch((e) => logger.error(e));
       }
     }
   }, [org.orgId]);
@@ -266,7 +268,7 @@ const AddToOrgModal = memo(({ isOpen, user, userOrgs, onOrgAdd, onDismiss }: Add
       if (contextSrv.hasPermission(AccessControlAction.ActionRolesList)) {
         fetchRoleOptions(org.value?.id)
           .then((roles) => setRoleOptions(roles))
-          .catch((e) => console.error(e));
+          .catch((e) => logger.error(e));
       }
     }
   };

--- a/public/app/features/admin/Users/OrgUsersTable.tsx
+++ b/public/app/features/admin/Users/OrgUsersTable.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useState } from 'react';
 
-import { type OrgRole } from '@grafana/data';
+import { type OrgRole, createStructuredLogger } from '@grafana/data';
 import { selectors as e2eSelectors } from '@grafana/e2e-selectors';
 import { Trans, t } from '@grafana/i18n';
 import { config } from '@grafana/runtime';
@@ -30,6 +30,8 @@ import { AccessControlAction, type Role } from 'app/types/accessControl';
 import { type OrgUser } from 'app/types/user';
 
 import { OrgRolePicker } from '../OrgRolePicker';
+
+const logger = createStructuredLogger('features.admin');
 
 type Cell<T extends keyof OrgUser = keyof OrgUser> = CellProps<OrgUser, OrgUser[T]>;
 
@@ -79,7 +81,7 @@ export const OrgUsersTable = ({
           setRoleOptions(options);
         }
       } catch (e) {
-        console.error('Error loading options');
+        logger.error('Error loading options');
       }
     }
     if (contextSrv.licensedAccessControlEnabled()) {

--- a/public/app/features/admin/state/actions.ts
+++ b/public/app/features/admin/state/actions.ts
@@ -1,6 +1,6 @@
 import { debounce } from 'lodash';
 
-import { dateTimeFormatTimeAgo } from '@grafana/data';
+import { dateTimeFormatTimeAgo, createStructuredLogger } from '@grafana/data';
 import { featureEnabled, getBackendSrv, isFetchError, locationService } from '@grafana/runtime';
 import { type FetchDataArgs } from '@grafana/ui';
 import config from 'app/core/config';
@@ -38,6 +38,8 @@ import {
 } from './reducers';
 // UserAdminPage
 
+const logger = createStructuredLogger('features.admin');
+
 export function loadAdminUserPage(userUid: string): ThunkResult<void> {
   return async (dispatch) => {
     try {
@@ -50,7 +52,7 @@ export function loadAdminUserPage(userUid: string): ThunkResult<void> {
       }
       dispatch(userAdminPageLoadedAction(true));
     } catch (error) {
-      console.error(error);
+      logger.error(error);
 
       if (isFetchError(error)) {
         const userError = {
@@ -300,7 +302,7 @@ export function fetchUsers(): ThunkResult<void> {
       dispatch(usersFetched(result));
     } catch (error) {
       usersFetchEnd();
-      console.error(error);
+      logger.error(error);
     }
   };
 }
@@ -366,7 +368,7 @@ export function fetchUsersAnonymousDevices(): ThunkResult<void> {
       const result = await getBackendSrv().get(url);
       dispatch(usersAnonymousDevicesFetched(result));
     } catch (error) {
-      console.error(error);
+      logger.error(error);
     }
   };
 }

--- a/public/app/features/admin/state/apis.tsx
+++ b/public/app/features/admin/state/apis.tsx
@@ -1,5 +1,8 @@
 import { getBackendSrv } from '@grafana/runtime';
 
+import { createStructuredLogger } from '@grafana/data';
+const logger = createStructuredLogger('features.admin');
+
 interface AnonServerStat {
   activeDevices?: number;
 }
@@ -28,7 +31,7 @@ export const getServerStats = async (): Promise<ServerStat | null> => {
   return getBackendSrv()
     .get('api/admin/stats')
     .catch((err) => {
-      console.error(err);
+      logger.error(err);
       return null;
     });
 };

--- a/public/app/features/alerting/unified/components/receivers/form/fields/OptionField.tsx
+++ b/public/app/features/alerting/unified/components/receivers/form/fields/OptionField.tsx
@@ -2,7 +2,7 @@ import { css } from '@emotion/css';
 import { type FC } from 'react';
 import { Controller, type DeepMap, type FieldError, useFormContext } from 'react-hook-form';
 
-import { type GrafanaTheme2 } from '@grafana/data';
+import { type GrafanaTheme2, createStructuredLogger } from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';
 import { t } from '@grafana/i18n';
 import {
@@ -30,6 +30,8 @@ import { StringArrayInput } from './StringArrayInput';
 import { SubformArrayField } from './SubformArrayField';
 import { SubformField } from './SubformField';
 import { WrapWithTemplateSelection } from './TemplateSelector';
+
+const logger = createStructuredLogger('features.alerting');
 
 interface Props {
   defaultValue: any;
@@ -319,7 +321,7 @@ const OptionInput: FC<Props & { id: string }> = ({
       );
 
     default:
-      console.error('Element not supported', option.element);
+      logger.error('Element not supported', option.element);
       return null;
   }
 };

--- a/public/app/features/alerting/unified/components/rule-editor/labels/LabelsField.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/labels/LabelsField.tsx
@@ -3,7 +3,7 @@ import { type FC, useCallback, useMemo } from 'react';
 import { Controller, FormProvider, useFieldArray, useForm, useFormContext } from 'react-hook-form';
 
 import { AlertLabels } from '@grafana/alerting/unstable';
-import { type GrafanaTheme2, type SelectableValue } from '@grafana/data';
+import { type GrafanaTheme2, type SelectableValue, createStructuredLogger } from '@grafana/data';
 import { Trans, t } from '@grafana/i18n';
 import { Button, type ComboboxOption, Field, InlineLabel, Input, Space, Stack, Text, useStyles2 } from '@grafana/ui';
 
@@ -19,6 +19,8 @@ import { NeedHelpInfo } from '../NeedHelpInfo';
 import { useGetLabelsFromDataSourceName } from '../useAlertRuleSuggestions';
 
 import { AddButton, RemoveButton } from './LabelsButtons';
+
+const logger = createStructuredLogger('features.alerting');
 
 const useGetOpsLabelsKeys = (skip: boolean) => {
   const { currentData, isLoading: isloadingLabels } = labelsApi.endpoints.getLabels.useQuery(undefined, {
@@ -183,7 +185,7 @@ function useCombinedLabels(
               opsValues = result.values.map((value) => value.name);
             }
           } catch (error) {
-            console.error('Failed to fetch label values for key:', key, error);
+            logger.error('Failed to fetch label values for key:', key, error);
           }
         }
 

--- a/public/app/features/alerting/unified/components/rule-editor/useDashboardQuery.ts
+++ b/public/app/features/alerting/unified/components/rule-editor/useDashboardQuery.ts
@@ -9,6 +9,9 @@ import { type DashboardDTO } from 'app/types/dashboard';
 
 import { DashboardModel } from '../../../../dashboard/state/DashboardModel';
 
+import { createStructuredLogger } from '@grafana/data';
+const logger = createStructuredLogger('features.alerting');
+
 export type DashboardResponse = DashboardDTO | DashboardWithAccessInfo<DashboardV2Spec>;
 
 const ensureV1PanelsHaveIds = memoizeOne((dashboardDTO: DashboardDTO): DashboardResponse => {
@@ -36,11 +39,11 @@ export function useDashboardQuery(dashboardUid?: string) {
           } else if (isDashboardV2Resource(dashboardDTO)) {
             setDashboard(dashboardDTO);
           } else {
-            console.error('Something went wrong, unexpected dashboard format');
+            logger.error('Something went wrong, unexpected dashboard format');
           }
         })
         .catch((error) => {
-          console.error('Failed to fetch dashboard', error);
+          logger.error('Failed to fetch dashboard', error);
         })
         .finally(() => {
           setIsFetching(false);

--- a/public/app/features/alerting/unified/components/rule-editor/util.ts
+++ b/public/app/features/alerting/unified/components/rule-editor/util.ts
@@ -7,6 +7,7 @@ import {
   type ThresholdsConfig,
   ThresholdsMode,
   isTimeSeriesFrames,
+  createStructuredLogger,
 } from '@grafana/data';
 import { config } from '@grafana/runtime';
 import { GraphThresholdsStyleMode } from '@grafana/schema';
@@ -16,6 +17,8 @@ import { type ClassicCondition, ExpressionQueryType } from 'app/features/express
 import { type AlertQuery } from 'app/types/unified-alerting-dto';
 
 import { createDagFromQueries, getOriginOfRefId } from './dag';
+
+const logger = createStructuredLogger('features.alerting');
 
 export function queriesWithUpdatedReferences(
   queries: AlertQuery[],
@@ -216,7 +219,7 @@ export function getThresholdsForQueries(queries: AlertQuery[], condition: string
           }
         });
       } catch (err) {
-        console.error('Failed to parse thresholds', err);
+        logger.error('Failed to parse thresholds', err);
         return;
       }
     });

--- a/public/app/features/alerting/unified/rule-list/hooks/grafanaFilter.ts
+++ b/public/app/features/alerting/unified/rule-list/hooks/grafanaFilter.ts
@@ -29,6 +29,10 @@ import {
 /**
  * Determines if client-side filtering is needed for Grafana-managed rules.
  */
+import { createStructuredLogger } from '@grafana/data';
+
+const logger = createStructuredLogger('features.alerting');
+
 export function hasGrafanaClientSideFilters(filterState: Partial<RulesFilter>): boolean {
   const { ruleFilterConfig, groupFilterConfig } = buildGrafanaFilterConfigs();
 
@@ -154,7 +158,7 @@ function labelMatchersToBackendFormat(labels: string[]): string[] {
     const result = attempt(() => JSON.stringify(parseMatcher(label)));
 
     if (isError(result)) {
-      console.warn('Failed to parse label matcher:', label, result);
+      logger.warn('Failed to parse label matcher:', label, result);
     } else {
       acc.push(result);
     }

--- a/public/app/features/alerting/unified/state/AlertingQueryRunner.ts
+++ b/public/app/features/alerting/unified/state/AlertingQueryRunner.ts
@@ -13,6 +13,7 @@ import {
   preProcessPanelData,
   rangeUtil,
   withLoadingIndicator,
+  createStructuredLogger,
 } from '@grafana/data';
 import { t } from '@grafana/i18n';
 import { DataSourceWithBackend, type FetchResponse, getDataSourceSrv, toDataQueryError } from '@grafana/runtime';
@@ -24,6 +25,8 @@ import { type AlertQuery } from 'app/types/unified-alerting-dto';
 
 import { type LinkError, createDAGFromQueriesSafe, getDescendants } from '../components/rule-editor/dag';
 import { getTimeRangeForExpression } from '../utils/timeRange';
+
+const logger = createStructuredLogger('features.alerting');
 
 interface AlertingQueryResult {
   error?: string;
@@ -214,7 +217,7 @@ const getTimeRange = (query: AlertQuery, queries: AlertQuery[]): TimeRange => {
   }
 
   if (!query.relativeTimeRange) {
-    console.warn(`Query with refId: ${query.refId} did not have any relative time range, using default.`);
+    logger.warn(`Query with refId: ${query.refId} did not have any relative time range, using default.`);
     return getDefaultTimeRange();
   }
 

--- a/public/app/features/annotations/components/StandardAnnotationQueryEditor.tsx
+++ b/public/app/features/annotations/components/StandardAnnotationQueryEditor.tsx
@@ -8,6 +8,7 @@ import {
   type DataSourceInstanceSettings,
   DataSourcePluginContextProvider,
   LoadingState,
+  createStructuredLogger,
 } from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';
 import { Trans, t } from '@grafana/i18n';
@@ -24,6 +25,8 @@ import { updateAnnotationFromSavedQuery } from '../utils/savedQueryUtils';
 
 import { AnnotationQueryEditorActionsWrapper } from './AnnotationQueryEditorActionsWrapper';
 import { AnnotationFieldMapper } from './AnnotationResultMapper';
+
+const logger = createStructuredLogger('features.annotations');
 
 export interface Props {
   datasource: DataSourceApi;
@@ -211,7 +214,7 @@ export default memo(function StandardAnnotationQueryEditor({
       skipNextVerificationRef.current = true;
       onChange(preparedAnnotation);
     } catch (error) {
-      console.error('Failed to replace annotation query:', error);
+      logger.error('Failed to replace annotation query:', error);
       // On error, reset the replacing state but don't change the annotation
     }
   };

--- a/public/app/features/annotations/standardAnnotationSupport.ts
+++ b/public/app/features/annotations/standardAnnotationSupport.ts
@@ -17,9 +17,12 @@ import {
   getFieldDisplayName,
   type KeyValue,
   standardTransformersRegistry,
+  createStructuredLogger,
 } from '@grafana/data';
 import { t } from '@grafana/i18n';
 import { config } from '@grafana/runtime';
+
+const logger = createStructuredLogger('features.annotations');
 
 export const standardAnnotationSupport: AnnotationSupport = {
   /**
@@ -232,7 +235,7 @@ export function getAnnotationsFromData(
       }
 
       if (!hasTime || !hasText) {
-        console.error('Cannot process annotation fields. No time or text present.');
+        logger.error('Cannot process annotation fields. No time or text present.');
         return [];
       }
 

--- a/public/app/features/annotations/utils/savedQueryUtils.ts
+++ b/public/app/features/annotations/utils/savedQueryUtils.ts
@@ -4,6 +4,7 @@ import {
   type DataSourceApi,
   hasQueryExportSupport,
   hasQueryImportSupport,
+  createStructuredLogger,
 } from '@grafana/data';
 import { getDataSourceSrv } from '@grafana/runtime';
 import { type DataQuery } from '@grafana/schema';
@@ -14,6 +15,8 @@ import { standardAnnotationSupport } from '../standardAnnotationSupport';
  * Converts an AnnotationQuery to DataQuery format for SavedQueryButtons.
  * Supports both v1 dashboards (uses target field) and v2 dashboards (uses query.spec field).
  */
+const logger = createStructuredLogger('features.annotations');
+
 export function getDataQueryFromAnnotationForSavedQueries(
   annotation: AnnotationQuery,
   datasource: DataSourceApi
@@ -128,7 +131,7 @@ export async function updateAnnotationFromSavedQuery(
 
     return preparedAnnotation;
   } catch (error) {
-    console.warn('Could not prepare annotation with new datasource:', error);
+    logger.warn('Could not prepare annotation with new datasource:', error);
     // Return structurally correct annotation even if preparation fails
     const { datasource, ...queryFields } = replacedQuery;
     return { ...cleanAnnotation, target: queryFields };

--- a/public/app/features/apiserver/client.ts
+++ b/public/app/features/apiserver/client.ts
@@ -1,6 +1,11 @@
 import { Observable, from, retry, catchError, filter, map, mergeMap } from 'rxjs';
 
-import { isLiveChannelMessageEvent, isLiveChannelStatusEvent, LiveChannelScope } from '@grafana/data';
+import {
+  isLiveChannelMessageEvent,
+  isLiveChannelStatusEvent,
+  LiveChannelScope,
+  createStructuredLogger,
+} from '@grafana/data';
 import { config, getBackendSrv, getGrafanaLiveSrv } from '@grafana/runtime';
 import { contextSrv } from 'app/core/services/context_srv';
 
@@ -24,6 +29,8 @@ import {
   type GroupVersionResource,
   type TableResponse,
 } from './types';
+
+const logger = createStructuredLogger('features.apiserver');
 
 export class ScopedResourceClient<T = object, S = object, K = string> implements ResourceClient<T, S, K> {
   readonly url: string;
@@ -70,7 +77,7 @@ export class ScopedResourceClient<T = object, S = object, K = string> implements
           filter((event) => isLiveChannelMessageEvent(event)),
           map((event) => event.message),
           catchError((error) => {
-            console.warn('Live channel watch failed, falling back to polling:', error);
+            logger.warn('Live channel watch failed, falling back to polling:', error);
             return this.createPollingFallback(params, error);
           })
         );
@@ -101,14 +108,14 @@ export class ScopedResourceClient<T = object, S = object, K = string> implements
           try {
             return JSON.parse(line);
           } catch (e) {
-            console.warn('Invalid JSON in watch stream:', e, line);
+            logger.warn('Invalid JSON in watch stream:', e, line);
             return null;
           }
         }),
         filter((event): event is ResourceEvent<T, S, K> => event !== null),
         retry({ count: 3, delay: 1000 }),
         catchError((error) => {
-          console.error('Watch stream error:', error);
+          logger.error('Watch stream error:', error);
           throw error;
         })
       );
@@ -262,7 +269,7 @@ export class ScopedResourceClient<T = object, S = object, K = string> implements
             return;
           }
           // Transient failure: log and retry next cycle.
-          console.warn(
+          logger.warn(
             `Polling fallback error (${consecutiveFailures}/${ScopedResourceClient.MAX_CONSECUTIVE_POLL_FAILURES}):`,
             pollError
           );

--- a/public/app/features/auth-config/FieldRenderer.tsx
+++ b/public/app/features/auth-config/FieldRenderer.tsx
@@ -2,12 +2,14 @@ import { css } from '@emotion/css';
 import { useEffect, useState } from 'react';
 import { type UseFormReturn, Controller } from 'react-hook-form';
 
-import { type SelectableValue } from '@grafana/data';
+import { type SelectableValue, createStructuredLogger } from '@grafana/data';
 import { Checkbox, Field, Input, SecretInput, Select, Switch, useTheme2 } from '@grafana/ui';
 
 import { fieldMap } from './fields';
 import { type SSOProviderDTO, type SSOSettingsField } from './types';
 import { isSelectableValueArray } from './utils/guards';
+
+const logger = createStructuredLogger('features.auth-config');
 
 interface FieldRendererProps
   extends Pick<
@@ -78,7 +80,7 @@ export const FieldRenderer = ({
   }, [isDisabled, disabledWhen?.disabledValue, name, setValue]);
 
   if (!field) {
-    console.log('missing field:', name);
+    logger.info('missing field:', name);
     return null;
   }
 
@@ -190,7 +192,7 @@ export const FieldRenderer = ({
         </Field>
       );
     default:
-      console.error(`Unknown field type: ${fieldData.type}`);
+      logger.error(`Unknown field type: ${fieldData.type}`);
       return null;
   }
 };

--- a/public/app/features/auth-config/state/actions.ts
+++ b/public/app/features/auth-config/state/actions.ts
@@ -19,6 +19,9 @@ import {
   settingsUpdated,
 } from './reducers';
 
+import { createStructuredLogger } from '@grafana/data';
+const logger = createStructuredLogger('features.auth-config');
+
 export function loadSettings(showSpinner = true): ThunkResult<Promise<Settings>> {
   return async (dispatch) => {
     if (contextSrv.hasPermission(AccessControlAction.SettingsRead)) {
@@ -78,7 +81,7 @@ export function saveSettings(data: UpdateSettingsQuery): ThunkResult<Promise<boo
         dispatch(resetError());
         return true;
       } catch (error) {
-        console.log(error);
+        logger.info(error);
         if (isFetchError(error)) {
           error.isHandled = true;
           const updateErr: SettingsError = {

--- a/public/app/features/browse-dashboards/api/browseDashboardsAPI.ts
+++ b/public/app/features/browse-dashboards/api/browseDashboardsAPI.ts
@@ -4,7 +4,7 @@ import { handleRequestError } from '@grafana/api-clients';
 import { generatedAPI as legacyUserAPI } from '@grafana/api-clients/internal/rtkq/legacy/user';
 import { createBaseQuery } from '@grafana/api-clients/rtkq';
 import { invalidateQuotaUsage } from '@grafana/api-clients/rtkq/quotas/v0alpha1';
-import { AppEvents, locationUtil } from '@grafana/data';
+import { AppEvents, locationUtil, createStructuredLogger } from '@grafana/data';
 import { t } from '@grafana/i18n';
 import { config, getBackendSrv } from '@grafana/runtime';
 import { type Dashboard } from '@grafana/schema';
@@ -40,6 +40,8 @@ import { getFolderURL } from '../utils/dashboards';
 
 import { PAGE_SIZE } from './constants';
 import { isProvisionedDashboard } from './isProvisioned';
+
+const logger = createStructuredLogger('features.browse-dashboards');
 
 async function refreshTeamFolders() {
   dispatch(refetchChildren({ parentUID: TEAM_FOLDERS_UID, pageSize: PAGE_SIZE }));
@@ -494,7 +496,7 @@ export const browseDashboardsAPI = createApi({
           try {
             await contextSrv.fetchUserPermissions();
           } catch (err) {
-            console.error('Failed to refresh user permissions after save', err);
+            logger.error('Failed to refresh user permissions after save', err);
           }
           dispatch(
             refetchChildren({

--- a/public/app/features/browse-dashboards/api/recentlyViewed.ts
+++ b/public/app/features/browse-dashboards/api/recentlyViewed.ts
@@ -5,6 +5,10 @@ import { type DashboardQueryResult } from 'app/features/search/service/types';
 /**
  * Returns dashboard search results ordered the same way the user opened them.
  */
+import { createStructuredLogger } from '@grafana/data';
+
+const logger = createStructuredLogger('features.browse-dashboards');
+
 export async function getRecentlyViewedDashboards(maxItems = 5): Promise<DashboardQueryResult[]> {
   try {
     const recentlyOpened = (await impressionSrv.getDashboardOpened()).slice(0, maxItems);
@@ -30,7 +34,7 @@ export async function getRecentlyViewedDashboards(maxItems = 5): Promise<Dashboa
     dashboards.sort((a, b) => order(a.uid) - order(b.uid));
     return dashboards;
   } catch (error) {
-    console.error('Failed to load recently viewed dashboards', error);
+    logger.error('Failed to load recently viewed dashboards', error);
     return [];
   }
 }

--- a/public/app/features/browse-dashboards/api/useRecentlyDeletedStateManager.ts
+++ b/public/app/features/browse-dashboards/api/useRecentlyDeletedStateManager.ts
@@ -1,4 +1,4 @@
-import { type SelectableValue, store } from '@grafana/data';
+import { type SelectableValue, store, createStructuredLogger } from '@grafana/data';
 import { t } from '@grafana/i18n';
 import { type TermCount } from 'app/core/components/TagFilter/TagFilter';
 import {
@@ -14,6 +14,8 @@ import { initialState, SearchStateManager } from '../../search/state/SearchState
 // Subclass SearchStateManager to customize the setStateAndDoSearch behavior.
 // We want to clear the search results when the user clears any search input
 // to trigger the skeleton state.
+const logger = createStructuredLogger('features.browse-dashboards');
+
 export class TrashStateManager extends SearchStateManager {
   protected sortStorageKey = SEARCH_SELECTED_SORT_DELETED;
   protected layoutStorageKey = SEARCH_SELECTED_LAYOUT_DELETED;
@@ -83,7 +85,7 @@ export class TrashStateManager extends SearchStateManager {
 
       return termCounts.sort((a, b) => b.count - a.count);
     } catch (error) {
-      console.error('Failed to get tags from deleted dashboards:', error);
+      logger.error('Failed to get tags from deleted dashboards:', error);
       return [];
     }
   };

--- a/public/app/features/browse-dashboards/state/actions.ts
+++ b/public/app/features/browse-dashboards/state/actions.ts
@@ -9,11 +9,14 @@ import { reapplyVirtualFolderPrefix, stripVirtualFolderPrefix } from '../utils/d
 
 import { findItem } from './utils';
 
+import { createStructuredLogger } from '@grafana/data';
+const logger = createStructuredLogger('features.browse-dashboards');
+
 async function listSafe(label: string, load: () => Promise<DashboardViewItem[]>): Promise<DashboardViewItem[]> {
   try {
     return await load();
   } catch (error) {
-    console.error(`Failed to load ${label}`, error);
+    logger.error(`Failed to load ${label}`, error);
     return [];
   }
 }
@@ -173,7 +176,7 @@ export const fetchNextChildrenPage = createAsyncThunk(
       fetchKind = 'folder';
     } else if (collection.lastFetchedKind === 'dashboard' && !collection.lastKindHasMoreItems) {
       // There's nothing to load at all
-      console.warn(`fetchNextChildrenPage called for ${uid} but that collection is fully loaded`);
+      logger.warn(`fetchNextChildrenPage called for ${uid} but that collection is fully loaded`);
       // return;
     } else if (collection.lastFetchedKind === 'folder' && collection.lastKindHasMoreItems) {
       // Load additional pages of folders

--- a/public/app/features/canvas/runtime/frame.tsx
+++ b/public/app/features/canvas/runtime/frame.tsx
@@ -15,6 +15,9 @@ import { type RootElement } from './root';
 import { type Scene } from './scene';
 import { initMoveable } from './sceneAbleManagement';
 
+import { createStructuredLogger } from '@grafana/data';
+const logger = createStructuredLogger('features.canvas');
+
 const DEFAULT_OFFSET = 10;
 const HORIZONTAL_OFFSET = 50;
 
@@ -129,7 +132,7 @@ export class FrameState extends ElementState {
         break;
       case LayerActionID.Duplicate:
         if (element.item.id === 'frame') {
-          console.log('Can not duplicate frames (yet)', action, element);
+          logger.info('Can not duplicate frames (yet)', action, element);
           return;
         }
         const opts = cloneDeep(element.options);
@@ -239,7 +242,7 @@ export class FrameState extends ElementState {
         break;
 
       default:
-        console.log('DO action', action, element);
+        logger.info('DO action', action, element);
         return;
     }
   };

--- a/public/app/features/commandPalette/actions/deepSearchActions.ts
+++ b/public/app/features/commandPalette/actions/deepSearchActions.ts
@@ -7,6 +7,10 @@ import { type DeepSearchPanelResult, searchDashboardVector } from '../api/deepSe
 
 // Results are panel-level, so fetch well past the per-dashboard display count
 // to give grouping enough hits to rank dashboards by match count
+import { createStructuredLogger } from '@grafana/data';
+
+const logger = createStructuredLogger('features.commandPalette');
+
 const DEEP_SEARCH_FETCH_LIMIT = 50;
 const MAX_SNIPPETS_PER_DASHBOARD = 3;
 
@@ -253,7 +257,7 @@ export function useDeepSearchResults({ searchQuery, show, enabled }: UseDeepSear
         // The vector backend may be unconfigured (501) or the feature toggle
         // off (404) — callers gate on the toggle via the enabled flag, so
         // degrade to an empty column but log for anyone calling without the gate
-        console.error('Deep search failed. The vector search backend may be unavailable.', error);
+        logger.error('Deep search failed. The vector search backend may be unavailable.', error);
       }
 
       // Skip state updates when the effect has been cleaned up, and only keep

--- a/public/app/features/commandPalette/actions/useActions.tsx
+++ b/public/app/features/commandPalette/actions/useActions.tsx
@@ -10,6 +10,10 @@ import useExtensionActions from './useExtensionActions';
 /**
  * Register navigation actions to different parts of grafana or some preferences stuff like themes.
  */
+import { createStructuredLogger } from '@grafana/data';
+
+const logger = createStructuredLogger('features.commandPalette');
+
 export function useRegisterStaticActions() {
   const extensionActions = useExtensionActions();
   const staticActions = useStaticActions();
@@ -27,7 +31,7 @@ export function useRegisterRecentDashboardsActions() {
     getRecentDashboardActions()
       .then((recentDashboardActions) => setRecentDashboardActions(recentDashboardActions))
       .catch((err) => {
-        console.error('Error loading recent dashboard actions', err);
+        logger.error('Error loading recent dashboard actions', err);
       });
   }, []);
 

--- a/public/app/features/dashboard-scene/behaviors/DashboardAnalyticsInitializerBehavior.ts
+++ b/public/app/features/dashboard-scene/behaviors/DashboardAnalyticsInitializerBehavior.ts
@@ -11,11 +11,15 @@ import { type DashboardScene } from '../scene/DashboardScene';
  * initialized globally to avoid timing issues. This behavior only sets
  * dashboard-specific context.
  */
+import { createStructuredLogger } from '@grafana/data';
+
+const logger = createStructuredLogger('features.dashboard-scene');
+
 export function dashboardAnalyticsInitializer(dashboard: DashboardScene) {
   const { uid, title } = dashboard.state;
 
   if (!uid) {
-    console.warn('dashboardAnalyticsInitializer: Dashboard UID is missing');
+    logger.warn('dashboardAnalyticsInitializer: Dashboard UID is missing');
     return;
   }
 

--- a/public/app/features/dashboard-scene/behaviors/DefaultControlsBehavior.ts
+++ b/public/app/features/dashboard-scene/behaviors/DefaultControlsBehavior.ts
@@ -6,6 +6,9 @@ import { loadDefaultControlsShared$, loadDefaultLinks$, loadDefaultVariables$ } 
 import { getDsRefsFromScene } from '../utils/dashboardDsRefs';
 import { getDashboardSceneFor } from '../utils/utils';
 
+import { createStructuredLogger } from '@grafana/data';
+const logger = createStructuredLogger('features.dashboard-scene');
+
 export class DefaultControlsBehavior extends SceneObjectBase<SceneObjectState> {
   private _variablesSub?: Subscription;
   private _linksSub?: Subscription;
@@ -32,7 +35,7 @@ export class DefaultControlsBehavior extends SceneObjectBase<SceneObjectState> {
     this._variablesSub = loadDefaultVariables$(shared$).subscribe({
       next: (vars) => dashboard.setDefaultVariables(vars),
       error: (err) => {
-        console.warn('Failed to load default variables', err);
+        logger.warn('Failed to load default variables', err);
         dashboard.setState({ defaultVariablesLoading: false });
       },
       complete: () => dashboard.setState({ defaultVariablesLoading: false }),
@@ -41,7 +44,7 @@ export class DefaultControlsBehavior extends SceneObjectBase<SceneObjectState> {
     this._linksSub = loadDefaultLinks$(shared$).subscribe({
       next: (links) => dashboard.setDefaultLinks(links),
       error: (err) => {
-        console.warn('Failed to load default links', err);
+        logger.warn('Failed to load default links', err);
         dashboard.setState({ defaultLinksLoading: false });
       },
       complete: () => dashboard.setState({ defaultLinksLoading: false }),

--- a/public/app/features/dashboard-scene/inspect/HelpWizard/SupportSnapshotService.ts
+++ b/public/app/features/dashboard-scene/inspect/HelpWizard/SupportSnapshotService.ts
@@ -1,6 +1,12 @@
 import saveAs from 'file-saver';
 
-import { dateTimeFormat, formattedValueToString, getValueFormat, type SelectableValue } from '@grafana/data';
+import {
+  dateTimeFormat,
+  formattedValueToString,
+  getValueFormat,
+  type SelectableValue,
+  createStructuredLogger,
+} from '@grafana/data';
 import { t } from '@grafana/i18n';
 import { sceneGraph, type SceneObject, type VizPanel } from '@grafana/scenes';
 import { StateManagerBase } from 'app/core/services/StateManagerBase';
@@ -9,6 +15,8 @@ import { transformSaveModelToScene } from '../../serialization/transformSaveMode
 
 import { type Randomize } from './randomizer';
 import { getDebugDashboard, getGithubMarkdown } from './utils';
+
+const logger = createStructuredLogger('features.dashboard-scene');
 
 interface SupportSnapshotState {
   currentTab: SnapshotTab;
@@ -84,7 +92,7 @@ export class SupportSnapshotService extends StateManagerBase<SupportSnapshotStat
         const dash = transformSaveModelToScene({ dashboard: snapshot, meta: { isEmbedded: true } });
         scene = dash.state.body; // skip the wrappers
       } catch (ex) {
-        console.log('Error creating scene:', ex);
+        logger.info('Error creating scene:', ex);
       }
     }
 

--- a/public/app/features/dashboard-scene/inspect/InspectJsonTab.tsx
+++ b/public/app/features/dashboard-scene/inspect/InspectJsonTab.tsx
@@ -1,7 +1,7 @@
 import { isEqual } from 'lodash';
 import AutoSizer from 'react-virtualized-auto-sizer';
 
-import { type SelectableValue } from '@grafana/data';
+import { type SelectableValue, createStructuredLogger } from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';
 import { Trans, t } from '@grafana/i18n';
 import {
@@ -43,6 +43,8 @@ import {
   isLibraryPanel,
 } from '../utils/utils';
 import { isGridLayoutItemKind, isPanelKindV2 } from '../v2schema/validation';
+
+const logger = createStructuredLogger('features.dashboard-scene');
 
 export type ShowContent = 'panel-json' | 'panel-data' | 'data-frames' | 'panel-layout';
 
@@ -165,7 +167,7 @@ export class InspectJsonTab extends SceneObjectBase<InspectJsonTabState> {
     const gridItem = panel.parent;
 
     if (!(gridItem instanceof DashboardGridItem)) {
-      console.error('Cannot update layout: panel parent is not a DashboardGridItem');
+      logger.error('Cannot update layout: panel parent is not a DashboardGridItem');
       return;
     }
 
@@ -259,7 +261,7 @@ export class InspectJsonTab extends SceneObjectBase<InspectJsonTabState> {
     const newState = sceneUtils.cloneSceneObjectState(gridItem.state);
 
     if (!(panel.parent instanceof DashboardGridItem)) {
-      console.error('Cannot update state of panel', panel, gridItem);
+      logger.error('Cannot update state of panel', panel, gridItem);
       return;
     }
 

--- a/public/app/features/dashboard-scene/mutation-api/clientBridge.ts
+++ b/public/app/features/dashboard-scene/mutation-api/clientBridge.ts
@@ -8,6 +8,10 @@
  */
 
 /** Which document is mounted, and therefore which commands its client is built with. */
+import { createStructuredLogger } from '@grafana/data';
+
+const logger = createStructuredLogger('features.dashboard-scene');
+
 export type MutationResource = 'dashboard' | 'notebook';
 
 type CreateMutationClient = (scene: unknown, resource: MutationResource) => () => void;
@@ -24,9 +28,7 @@ export function provideMutationClientFactory(create: CreateMutationClient): void
  */
 export function createMutationClient(scene: unknown, resource: MutationResource): () => void {
   if (!_create) {
-    console.warn(
-      'createMutationClient called before provideMutationClientFactory. Mutation API will not be available.'
-    );
+    logger.warn('createMutationClient called before provideMutationClientFactory. Mutation API will not be available.');
     return () => {};
   }
   const teardown = _create(scene, resource);

--- a/public/app/features/dashboard-scene/pages/DashboardScenePage.tsx
+++ b/public/app/features/dashboard-scene/pages/DashboardScenePage.tsx
@@ -2,7 +2,7 @@ import { useEffect, useRef } from 'react';
 import { type Params, useParams } from 'react-router-dom-v5-compat';
 import { usePrevious } from 'react-use';
 
-import { PageLayoutType } from '@grafana/data';
+import { PageLayoutType, createStructuredLogger } from '@grafana/data';
 import { locationService } from '@grafana/runtime';
 import { UrlSyncContextProvider } from '@grafana/scenes';
 import { Box } from '@grafana/ui';
@@ -39,6 +39,8 @@ import { useScenesFlickeringFix } from '../utils/utils';
 
 import { getDashboardScenePageStateManager } from './DashboardScenePageStateManager';
 import { shouldHideDashboardKioskFooter } from './utils';
+
+const logger = createStructuredLogger('features.dashboard-scene');
 
 export interface Props
   extends Omit<GrafanaRouteComponentProps<DashboardPageRouteParams, DashboardPageRouteSearchParams>, 'match'> {}
@@ -147,7 +149,7 @@ export function DashboardScenePage({ route, queryParams, location }: Props) {
   // A bit tricky for transition to or from Home dashboard that does not have a uid in the url (but could have it in the dashboard model)
   // if prevMatch is undefined we are going from normal route to home route or vice versa
   if (type !== 'snapshot' && (!prevMatch || uid !== prevMatch?.params.uid)) {
-    console.log('skipping rendering');
+    logger.info('skipping rendering');
     return null;
   }
 

--- a/public/app/features/dashboard-scene/pages/DashboardScenePageStateManager.ts
+++ b/public/app/features/dashboard-scene/pages/DashboardScenePageStateManager.ts
@@ -1,4 +1,4 @@
-import { locationUtil, type UrlQueryMap } from '@grafana/data';
+import { locationUtil, type UrlQueryMap, createStructuredLogger } from '@grafana/data';
 import { t } from '@grafana/i18n';
 import { config, getBackendSrv, getDataSourceSrv, isFetchError, locationService } from '@grafana/runtime';
 import { FlagKeys, getFeatureFlagClient, UserStorage } from '@grafana/runtime/internal';
@@ -85,6 +85,8 @@ import { processQueryParamsForDashboardLoad, updateNavModel } from './utils';
 /**
  * Initialize both performance services to ensure they're ready before profiling starts
  */
+const logger = createStructuredLogger('features.dashboard-scene');
+
 function initializeDashboardPerformanceServices(): void {
   initializeScenePerformanceLogger();
   initializeDashboardAnalyticsAggregator();
@@ -511,7 +513,7 @@ abstract class DashboardScenePageStateManagerBase<T>
       });
 
       if (!isFetchError(err)) {
-        console.error('Error loading dashboard:', err);
+        logger.error('Error loading dashboard:', err);
       }
 
       // If the error is a DashboardVersionError, we want to throw it so that the error boundary is triggered

--- a/public/app/features/dashboard-scene/pages/utils.ts
+++ b/public/app/features/dashboard-scene/pages/utils.ts
@@ -1,16 +1,18 @@
-import { type UrlQueryMap, getTimeZone, getDefaultTimeRange, dateMath } from '@grafana/data';
+import { type UrlQueryMap, getTimeZone, getDefaultTimeRange, dateMath, createStructuredLogger } from '@grafana/data';
 import { locationService } from '@grafana/runtime';
 import { getFolderByUidFacade } from 'app/api/clients/folder/v1beta1/hooks';
 import { updateNavIndex } from 'app/core/reducers/navModel';
 import { buildNavModel } from 'app/features/folders/state/navModel';
 import { store } from 'app/store/store';
 
+const logger = createStructuredLogger('features.dashboard-scene');
+
 export async function updateNavModel(folderUid: string) {
   try {
     const folder = await getFolderByUidFacade(folderUid);
     store.dispatch(updateNavIndex(buildNavModel(folder)));
   } catch (err) {
-    console.warn('Error fetching parent folder', folderUid, 'for dashboard', err);
+    logger.warn('Error fetching parent folder', folderUid, 'for dashboard', err);
   }
 }
 

--- a/public/app/features/dashboard-scene/panel-edit/PanelDataPane/PanelDataQueriesTab.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelDataPane/PanelDataQueriesTab.tsx
@@ -1,6 +1,12 @@
 import { useCallback, useMemo } from 'react';
 
-import { CoreApp, type DataSourceApi, type DataSourceInstanceSettings, getDataSourceRef } from '@grafana/data';
+import {
+  CoreApp,
+  type DataSourceApi,
+  type DataSourceInstanceSettings,
+  getDataSourceRef,
+  createStructuredLogger,
+} from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';
 import { t, Trans } from '@grafana/i18n';
 import { config, getDataSourceSrv, reportInteraction } from '@grafana/runtime';
@@ -45,6 +51,8 @@ import { trackAddQuery } from '../PanelEditNext/tracking';
 
 import { type PanelDataPaneTab, type PanelDataTabHeaderProps, TabId } from './types';
 import { hasBackendDatasource } from './utils';
+
+const logger = createStructuredLogger('features.dashboard-scene');
 
 interface PanelDataQueriesTabState extends SceneObjectState {
   datasource?: DataSourceApi;
@@ -165,7 +173,7 @@ export class PanelDataQueriesTab extends SceneObjectBase<PanelDataQueriesTabStat
         });
       }
 
-      console.error(err);
+      logger.error(err);
     }
   }
 

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/PanelDataPaneNext.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/PanelDataPaneNext.tsx
@@ -8,6 +8,7 @@ import {
   getDataSourceRef,
   getNextRefId,
   type ScopedVars,
+  createStructuredLogger,
 } from '@grafana/data';
 import { config, isExpressionReference, reportInteraction } from '@grafana/runtime';
 import { getDataSourceInstance, getDataSourceInstanceSettings } from '@grafana/runtime/unstable';
@@ -33,6 +34,8 @@ import { getDashboardSceneFor, getQueryRunnerFor } from '../../utils/utils';
 import { QueryEditorContent } from './QueryEditor/QueryEditorContent';
 import { filterDataTransformerConfigs, getPanelScopedVars } from './QueryEditor/utils';
 import { TRANSFORMATION_EDIT_INTERACTION_THROTTLE_TIME } from './constants';
+
+const logger = createStructuredLogger('features.dashboard-scene');
 
 const reportTransformationEditInteraction = throttle((context: string, type: string) => {
   reportInteraction('grafana_panel_transformations_clicked', {
@@ -228,7 +231,7 @@ export class PanelDataPaneNext extends SceneObjectBase<PanelDataPaneNextState> {
       this.setState({ datasource, dsSettings, dsError: undefined });
       storeLastUsedDataSourceInLocalStorage(getDataSourceRef(dsSettings) || { default: true });
     } catch (err) {
-      console.error('Failed to load datasource:', err);
+      logger.error('Failed to load datasource:', err);
 
       // Fallback to default datasource (parity with PanelDataQueriesTab)
       try {
@@ -242,7 +245,7 @@ export class PanelDataPaneNext extends SceneObjectBase<PanelDataPaneNextState> {
           // resolveDatasourceRef() handles the stale-ref case on the next activation.
         }
       } catch (fallbackErr) {
-        console.error('Failed to load default datasource:', fallbackErr);
+        logger.error('Failed to load default datasource:', fallbackErr);
         this.setState({
           datasource: undefined,
           dsSettings: undefined,

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Header/PluginActions.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Header/PluginActions.tsx
@@ -4,6 +4,7 @@ import {
   type CoreApp,
   PluginExtensionPoints,
   type PluginExtensionQueryEditorRowAdaptiveTelemetryV1Context,
+  createStructuredLogger,
 } from '@grafana/data';
 import { renderLimitedComponents, usePluginComponents } from '@grafana/runtime';
 import { type DataQuery } from '@grafana/schema';
@@ -12,6 +13,8 @@ import { type QueryActionComponent, RowActionComponents } from 'app/features/que
 
 import { QueryEditorType } from '../../constants';
 import { useActionsContext, useQueryEditorUIContext, useQueryRunnerContext } from '../QueryEditorContext';
+
+const logger = createStructuredLogger('features.dashboard-scene');
 
 interface PluginActionsProps {
   app?: CoreApp;
@@ -94,7 +97,7 @@ function useAdaptiveTelemetryComponents(query: DataQuery | null) {
       pluginId: /grafana-adaptive.*/,
     });
   } catch (error) {
-    console.error('Failed to render adaptive telemetry components:', error);
+    logger.error('Failed to render adaptive telemetry components:', error);
     return null;
   }
 }

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/localStorageWithTTL.ts
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/localStorageWithTTL.ts
@@ -1,4 +1,6 @@
-import { store } from '@grafana/data';
+import { store, createStructuredLogger } from '@grafana/data';
+
+const logger = createStructuredLogger('features.dashboard-scene');
 
 interface StoredValueWithTTL<T> {
   value: T;
@@ -20,7 +22,7 @@ export const setLocalStorageWithTTL = <T>(key: string, value: T) => {
   try {
     store.setObject(key, item);
   } catch (error) {
-    console.error('Failed to persist value with TTL', error);
+    logger.error('Failed to persist value with TTL', error);
   }
 };
 

--- a/public/app/features/dashboard-scene/scene/DashboardLayoutOrchestrator.tsx
+++ b/public/app/features/dashboard-scene/scene/DashboardLayoutOrchestrator.tsx
@@ -2,7 +2,7 @@ import { css } from '@emotion/css';
 import { type PointerEvent as ReactPointerEvent } from 'react';
 import { createPortal } from 'react-dom';
 
-import { type GrafanaTheme2 } from '@grafana/data';
+import { type GrafanaTheme2, createStructuredLogger } from '@grafana/data';
 import { logWarning } from '@grafana/runtime';
 import {
   sceneGraph,
@@ -34,6 +34,8 @@ import {
   type DashboardDropTarget,
   isDashboardDropTarget,
 } from './types/DashboardDropTarget';
+
+const logger = createStructuredLogger('features.dashboard-scene');
 
 const TAB_ACTIVATION_DELAY_MS = 600;
 
@@ -242,7 +244,7 @@ export class DashboardLayoutOrchestrator extends SceneObjectBase<DashboardLayout
             }
           } else {
             const warningMessage = 'No grid item to drag';
-            console.warn(warningMessage);
+            logger.warn(warningMessage);
             logWarning(warningMessage);
           }
         });

--- a/public/app/features/dashboard-scene/scene/DashboardMacro.ts
+++ b/public/app/features/dashboard-scene/scene/DashboardMacro.ts
@@ -5,6 +5,10 @@ import { getDashboardSceneFor } from '../utils/utils';
 /**
  * Handles expressions like ${__dashboard.uid}
  */
+import { createStructuredLogger } from '@grafana/data';
+
+const logger = createStructuredLogger('features.dashboard-scene');
+
 class DashboardMacro implements FormatVariable {
   public state: { name: string; type: string };
 
@@ -39,7 +43,7 @@ export function registerDashboardMacro() {
 
     return () => unregister();
   } catch (e) {
-    console.error('Error registering dashboard macro', e);
+    logger.error('Error registering dashboard macro', e);
     return () => {};
   }
 }

--- a/public/app/features/dashboard-scene/scene/DashboardScene.tsx
+++ b/public/app/features/dashboard-scene/scene/DashboardScene.tsx
@@ -11,6 +11,7 @@ import {
   type NavIndex,
   type NavModelItem,
   store,
+  createStructuredLogger,
 } from '@grafana/data';
 import { t } from '@grafana/i18n';
 import { config, getDataSourceSrv, locationService, RefreshEvent, reportInteraction } from '@grafana/runtime';
@@ -122,6 +123,8 @@ import { clearClipboard } from './layouts-shared/paste';
 import { getUpdatedHoverHeader } from './panel-timerange/utils';
 import { type AnyDashboardLayoutManager, type DashboardLayoutManager } from './types/DashboardLayoutManager';
 import { type DashboardSceneLike, type DashboardSceneState } from './types/dashboard';
+
+const logger = createStructuredLogger('features.dashboard-scene');
 
 export const PERSISTED_PROPS = ['title', 'description', 'tags', 'editable', 'graphTooltip', 'links', 'meta', 'preload'];
 const PANEL_SEARCH_VAR = 'systemPanelFilterVar';
@@ -310,7 +313,7 @@ export class DashboardScene extends SceneObjectBase<DashboardSceneState> impleme
         try {
           return createSceneVariableFromVariableModelV2(v);
         } catch (err) {
-          console.error(err);
+          logger.error(err);
           return null;
         }
       })
@@ -338,7 +341,7 @@ export class DashboardScene extends SceneObjectBase<DashboardSceneState> impleme
         try {
           return createSceneVariableFromVariableModelV2(v);
         } catch (err) {
-          console.error(err);
+          logger.error(err);
           return null;
         }
       })
@@ -503,7 +506,7 @@ export class DashboardScene extends SceneObjectBase<DashboardSceneState> impleme
 
   public exitEditMode({ skipConfirm, restoreInitialState }: { skipConfirm: boolean; restoreInitialState?: boolean }) {
     if (!this.canDiscard()) {
-      console.error('Trying to discard back to a state that does not exist, initialState undefined');
+      logger.error('Trying to discard back to a state that does not exist, initialState undefined');
       return;
     }
 
@@ -618,7 +621,7 @@ export class DashboardScene extends SceneObjectBase<DashboardSceneState> impleme
    */
   public discardChangesAndKeepEditing() {
     if (!this.canDiscard()) {
-      console.error('Trying to discard back to a state that does not exist, initialState undefined');
+      logger.error('Trying to discard back to a state that does not exist, initialState undefined');
       return;
     }
 
@@ -879,7 +882,7 @@ export class DashboardScene extends SceneObjectBase<DashboardSceneState> impleme
         clearClipboard();
         store.set(LS_PANEL_COPY_KEY, JSON.stringify({ elements, gridItem: gridItemKind }));
       } else {
-        console.error('Trying to copy a panel that is not DashboardGridItem child');
+        logger.error('Trying to copy a panel that is not DashboardGridItem child');
         throw new Error('Trying to copy a panel that is not DashboardGridItem child');
       }
       return;
@@ -892,7 +895,7 @@ export class DashboardScene extends SceneObjectBase<DashboardSceneState> impleme
     let gridItem = vizPanel.parent;
 
     if (!(gridItem instanceof DashboardGridItem)) {
-      console.error('Trying to copy a panel that is not DashboardGridItem child');
+      logger.error('Trying to copy a panel that is not DashboardGridItem child');
       throw new Error('Trying to copy a panel that is not DashboardGridItem child');
     }
 
@@ -1047,7 +1050,7 @@ export class DashboardScene extends SceneObjectBase<DashboardSceneState> impleme
 
       appEvents.emit('alert-success', ['Panel styles applied.']);
     } catch (e) {
-      console.error('Error pasting panel styles:', e);
+      logger.error('Error pasting panel styles:', e);
       appEvents.emit('alert-error', ['Error pasting panel styles.']);
       DashboardInteractions.panelStylesMenuClicked(
         'paste',
@@ -1133,7 +1136,7 @@ export class DashboardScene extends SceneObjectBase<DashboardSceneState> impleme
       return;
     }
 
-    console.error('Trying to unlink a lib panel in a layout that is not DashboardGridItem or AutoGridItem');
+    logger.error('Trying to unlink a lib panel in a layout that is not DashboardGridItem or AutoGridItem');
   }
 
   public showModal(modal: SceneObject) {

--- a/public/app/features/dashboard-scene/scene/DashboardSceneUrlSync.ts
+++ b/public/app/features/dashboard-scene/scene/DashboardSceneUrlSync.ts
@@ -13,6 +13,9 @@ import { UNCONFIGURED_PANEL_PLUGIN_ID } from './UnconfiguredPanel';
 import { DefaultGridLayoutManager } from './layout-default/DefaultGridLayoutManager';
 import { type DashboardSceneState } from './types/dashboard';
 
+import { createStructuredLogger } from '@grafana/data';
+const logger = createStructuredLogger('features.dashboard-scene');
+
 export class DashboardSceneUrlSync implements SceneObjectUrlSyncHandler {
   /**
    * Panel id of an editor that is open as far as the URL is concerned but has no pane yet: the id
@@ -99,7 +102,7 @@ export class DashboardSceneUrlSync implements SceneObjectUrlSyncHandler {
       const panel = findEditPanel(this._scene, values.editPanel);
 
       if (!panel) {
-        console.warn(`Panel ${values.editPanel} not found`);
+        logger.warn(`Panel ${values.editPanel} not found`);
         // A rebuild that dropped the panel: release the hold and force the state change that
         // writes `?editPanel=` out, or the URL keeps naming a panel the tree does not have.
         const wasHeld = this._heldEditPanelId !== undefined;

--- a/public/app/features/dashboard-scene/scene/GoToSnapshotOriginButton.tsx
+++ b/public/app/features/dashboard-scene/scene/GoToSnapshotOriginButton.tsx
@@ -1,12 +1,14 @@
 import { css } from '@emotion/css';
 
-import { textUtil } from '@grafana/data';
+import { textUtil, createStructuredLogger } from '@grafana/data';
 import { t } from '@grafana/i18n';
 import { config, locationService } from '@grafana/runtime';
 import { ConfirmModal, ToolbarButton } from '@grafana/ui';
 
 import { appEvents } from '../../../core/app_events';
 import { ShowModalReactEvent } from '../../../types/events';
+
+const logger = createStructuredLogger('features.dashboard-scene');
 
 export function GoToSnapshotOriginButton(props: { originalURL: string }) {
   return (
@@ -59,6 +61,6 @@ export const onOpenSnapshotOriginalDashboard = (originalUrl: string) => {
       locationService.push(sanitizedRelativeURL);
     }
   } catch (err) {
-    console.error('Failed to open original dashboard', err);
+    logger.error('Failed to open original dashboard', err);
   }
 };

--- a/public/app/features/dashboard-scene/scene/export/exporters.ts
+++ b/public/app/features/dashboard-scene/scene/export/exporters.ts
@@ -1,6 +1,6 @@
 import { defaults, each, sortBy } from 'lodash';
 
-import { type DataSourceRef, type VariableOption, VariableRefresh } from '@grafana/data';
+import { type DataSourceRef, type VariableOption, VariableRefresh, createStructuredLogger } from '@grafana/data';
 import { getDataSourceSrv } from '@grafana/runtime';
 import { getPanelPluginMeta } from '@grafana/runtime/internal';
 import { type Panel } from '@grafana/schema';
@@ -31,6 +31,8 @@ import { isConstant } from '../../../variables/guard';
 
 // This label is used to store the export label for a datasource when exporting a V2 dashboard for external sharing.
 // E.g. if a dashboard has two datasources with the same type, the export label will be used to distinguish them.
+const logger = createStructuredLogger('features.dashboard-scene');
+
 export const ExportLabel = 'grafana.app/export-label';
 
 // This label is used to store the original datasource display name when exporting a V2 dashboard.
@@ -357,7 +359,7 @@ export async function makeExportableV1(dashboard: DashboardModel) {
 
     return newObj;
   } catch (err) {
-    console.error('Export failed:', err);
+    logger.error('Export failed:', err);
     return {
       error: err,
     };
@@ -379,7 +381,7 @@ async function convertLibraryPanelToInlinePanel(libraryPanelElement: LibraryPane
     inlinePanel.spec.id = id;
     return inlinePanel;
   } catch (error) {
-    console.error(`Failed to load library panel ${libraryPanel.uid}:`, error);
+    logger.error(`Failed to load library panel ${libraryPanel.uid}:`, error);
 
     const errorMessage = error instanceof Error ? error.message : 'Unknown error';
     dispatch(
@@ -600,7 +602,7 @@ export async function makeExportableV2(dashboard: DashboardV2Spec, isSharingExte
 
     return dashboard;
   } catch (err) {
-    console.error('Export failed:', err);
+    logger.error('Export failed:', err);
     return {
       error: err,
     };

--- a/public/app/features/dashboard-scene/scene/layout-auto-grid/AutoGridItem.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-auto-grid/AutoGridItem.tsx
@@ -24,6 +24,9 @@ import { getOptions } from './AutoGridItemEditor';
 import { AutoGridItemRenderer } from './AutoGridItemRenderer';
 import { AutoGridLayout } from './AutoGridLayout';
 
+import { createStructuredLogger } from '@grafana/data';
+const logger = createStructuredLogger('features.dashboard-scene');
+
 export interface AutoGridItemState extends SceneObjectState {
   body: VizPanel;
   hideWhenNoData?: boolean;
@@ -91,7 +94,7 @@ export class AutoGridItem extends SceneObjectBase<AutoGridItemState> implements 
       });
 
     if (!(variable instanceof MultiValueVariable)) {
-      console.error('DashboardGridItem: Variable is not a MultiValueVariable');
+      logger.error('DashboardGridItem: Variable is not a MultiValueVariable');
       return;
     }
 

--- a/public/app/features/dashboard-scene/scene/layout-auto-grid/AutoGridLayoutManager.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-auto-grid/AutoGridLayoutManager.tsx
@@ -1,4 +1,4 @@
-import { AppEvents } from '@grafana/data';
+import { AppEvents, createStructuredLogger } from '@grafana/data';
 import { t } from '@grafana/i18n';
 import { config, getAppEvents } from '@grafana/runtime';
 import {
@@ -38,6 +38,8 @@ import { type LayoutRegistryItem } from '../types/LayoutRegistryItem';
 import { AutoGridItem } from './AutoGridItem';
 import { AutoGridLayout } from './AutoGridLayout';
 import { getSidebarOptions } from './AutoGridLayoutManagerEditor';
+
+const logger = createStructuredLogger('features.dashboard-scene');
 
 interface AutoGridLayoutManagerState extends SceneObjectState {
   layout: AutoGridLayout;
@@ -254,7 +256,7 @@ export class AutoGridLayoutManager
   public duplicatePanel(panel: VizPanel) {
     const gridItem = panel.parent;
     if (!(gridItem instanceof AutoGridItem)) {
-      console.error('Trying to duplicate a panel that is not inside a DashboardGridItem');
+      logger.error('Trying to duplicate a panel that is not inside a DashboardGridItem');
       return;
     }
 

--- a/public/app/features/dashboard-scene/scene/layout-default/DashboardGridItem.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-default/DashboardGridItem.tsx
@@ -28,6 +28,9 @@ import { DashboardGridItemRenderer } from './DashboardGridItemRenderer';
 import { DashboardGridItemVariableDependencyHandler } from './DashboardGridItemVariableDependencyHandler';
 import { RowRepeaterBehavior } from './RowRepeaterBehavior';
 
+import { createStructuredLogger } from '@grafana/data';
+const logger = createStructuredLogger('features.dashboard-scene');
+
 export interface DashboardGridItemState extends SceneGridItemStateLike {
   body: VizPanel;
   repeatedPanels?: VizPanel[];
@@ -150,7 +153,7 @@ export class DashboardGridItem
       });
 
     if (!(variable instanceof MultiValueVariable)) {
-      console.error('DashboardGridItem: Variable is not a MultiValueVariable');
+      logger.error('DashboardGridItem: Variable is not a MultiValueVariable');
       return;
     }
 

--- a/public/app/features/dashboard-scene/scene/layout-default/DefaultGridLayoutManager.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-default/DefaultGridLayoutManager.tsx
@@ -1,6 +1,6 @@
 import { css, cx } from '@emotion/css';
 
-import { AppEvents, type GrafanaTheme2 } from '@grafana/data';
+import { AppEvents, type GrafanaTheme2, createStructuredLogger } from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';
 import { t } from '@grafana/i18n';
 import { config, getAppEvents } from '@grafana/runtime';
@@ -58,6 +58,8 @@ import { DashboardGridItem } from './DashboardGridItem';
 import { RowRepeaterBehavior } from './RowRepeaterBehavior';
 import { findSpaceForNewPanel } from './findSpaceForNewPanel';
 import { RowActions } from './row-actions/RowActions';
+
+const logger = createStructuredLogger('features.dashboard-scene');
 
 interface DefaultGridLayoutManagerState extends SceneObjectState {
   grid: SceneGridLayout;
@@ -265,7 +267,7 @@ export class DefaultGridLayoutManager
   public duplicatePanel(vizPanel: VizPanel) {
     const gridItem = vizPanel.parent;
     if (!(gridItem instanceof DashboardGridItem)) {
-      console.error('Trying to duplicate a panel that is not inside a DashboardGridItem');
+      logger.error('Trying to duplicate a panel that is not inside a DashboardGridItem');
       return;
     }
 

--- a/public/app/features/dashboard-scene/scene/layout-default/RowRepeaterBehavior.ts
+++ b/public/app/features/dashboard-scene/scene/layout-default/RowRepeaterBehavior.ts
@@ -15,6 +15,9 @@ import {
 import { getCloneKey, getLocalVariableValueSet } from '../../utils/clone';
 import { getMultiVariableValues } from '../../utils/utils';
 
+import { createStructuredLogger } from '@grafana/data';
+const logger = createStructuredLogger('features.dashboard-scene');
+
 interface RowRepeaterBehaviorState extends SceneObjectState {
   variableName: string;
 }
@@ -97,12 +100,12 @@ export class RowRepeaterBehavior extends SceneObjectBase<RowRepeaterBehaviorStat
     const variable = sceneGraph.lookupVariable(this.state.variableName, this.parent?.parent!);
 
     if (!variable) {
-      console.error('RepeatedRowBehavior: Variable not found');
+      logger.error('RepeatedRowBehavior: Variable not found');
       return;
     }
 
     if (!(variable instanceof MultiValueVariable)) {
-      console.error('RepeatedRowBehavior: Variable is not a MultiValueVariable');
+      logger.error('RepeatedRowBehavior: Variable is not a MultiValueVariable');
       return;
     }
 

--- a/public/app/features/dashboard-scene/scene/layout-rows/RowItem.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-rows/RowItem.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { store } from '@grafana/data';
+import { store, createStructuredLogger } from '@grafana/data';
 import { t } from '@grafana/i18n';
 import { config, logWarning } from '@grafana/runtime';
 import {
@@ -44,6 +44,8 @@ import { useSidebarOptions } from './RowItemEditor';
 import { RowItemRenderer } from './RowItemRenderer';
 import { RowItems } from './RowItems';
 import { RowsLayoutManager } from './RowsLayoutManager';
+
+const logger = createStructuredLogger('features.dashboard-scene');
 
 export interface RowItemState extends SceneObjectState {
   layout: DashboardLayoutManager;
@@ -251,7 +253,7 @@ export class RowItem
         layout.setState({ children: newChildren });
       } else {
         const warningMessage = 'Grid item has unexpected parent type';
-        console.warn(warningMessage);
+        logger.warn(warningMessage);
         logWarning(warningMessage);
       }
     }
@@ -266,7 +268,7 @@ export class RowItem
       layout.addGridItem(gridItem);
     } else {
       const warningMessage = 'Layout manager does not support addGridItem';
-      console.warn(warningMessage);
+      logger.warn(warningMessage);
       logWarning(warningMessage);
     }
     this.setIsDropTarget(false);

--- a/public/app/features/dashboard-scene/scene/layout-tabs/TabItem.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-tabs/TabItem.tsx
@@ -1,6 +1,6 @@
 import type React from 'react';
 
-import { store } from '@grafana/data';
+import { store, createStructuredLogger } from '@grafana/data';
 import { t } from '@grafana/i18n';
 import { config, logWarning } from '@grafana/runtime';
 import {
@@ -46,6 +46,8 @@ import { useSidebarOptions } from './TabItemEditor';
 import { TabItemRenderer } from './TabItemRenderer';
 import { TabItems } from './TabItems';
 import { TabsLayoutManager } from './TabsLayoutManager';
+
+const logger = createStructuredLogger('features.dashboard-scene');
 
 export interface TabItemState extends SceneObjectState {
   layout: DashboardLayoutManager;
@@ -259,7 +261,7 @@ export class TabItem
         layout.setState({ children: newChildren });
       } else {
         const warningMessage = 'Grid item has unexpected parent type';
-        console.warn(warningMessage);
+        logger.warn(warningMessage);
         logWarning(warningMessage);
       }
     }
@@ -281,13 +283,13 @@ export class TabItem
           rowLayout.addGridItem(gridItem);
         } else {
           const warningMessage = 'First row layout does not support addGridItem';
-          console.warn(warningMessage);
+          logger.warn(warningMessage);
           logWarning(warningMessage);
         }
       }
     } else {
       const warningMessage = 'Layout manager does not support addGridItem';
-      console.warn(warningMessage);
+      logger.warn(warningMessage);
       logWarning(warningMessage);
     }
     this.setIsDropTarget(false);

--- a/public/app/features/dashboard-scene/serialization/DashboardSceneSerializer.ts
+++ b/public/app/features/dashboard-scene/serialization/DashboardSceneSerializer.ts
@@ -31,6 +31,10 @@ import { transformSceneToSaveModelSchemaV2 } from './transformSceneToSaveModelSc
  * M is the type of the metadata
  * I is the type of the initial save model. By default it's the same as T.
  */
+import { createStructuredLogger } from '@grafana/data';
+
+const logger = createStructuredLogger('features.dashboard-scene');
+
 export interface DashboardSceneSerializerLike<T, M, I = T, E = T | { error: unknown }> {
   /**
    * The save model which the dashboard scene was originally created from
@@ -368,7 +372,7 @@ export class V2DashboardSerializer
           }
         } else {
           const warningMsg = 'Dashboard serializer: Undefined variable found in dashboard save model, ignoring it';
-          console.warn(warningMsg);
+          logger.warn(warningMsg);
           logWarning(warningMsg);
         }
       }

--- a/public/app/features/dashboard-scene/serialization/angularMigration.test.ts
+++ b/public/app/features/dashboard-scene/serialization/angularMigration.test.ts
@@ -243,7 +243,8 @@ describe('getV2AngularMigrationHandler', () => {
 
       // Verify deprecation warning was logged
       expect(warnSpy).toHaveBeenCalledWith(
-        'Accessing the targets property when migrating a panel plugin is deprecated. Changes to this property will be ignored.'
+        'Accessing the targets property when migrating a panel plugin is deprecated. Changes to this property will be ignored.',
+        expect.objectContaining({ source: 'features.dashboard-scene' })
       );
 
       warnSpy.mockRestore();

--- a/public/app/features/dashboard-scene/serialization/angularMigration.ts
+++ b/public/app/features/dashboard-scene/serialization/angularMigration.ts
@@ -1,11 +1,13 @@
 import { defaults, cloneDeep } from 'lodash';
 
-import { type PanelModel as PanelModelFromData, type PanelPlugin } from '@grafana/data';
+import { type PanelModel as PanelModelFromData, type PanelPlugin, createStructuredLogger } from '@grafana/data';
 import { autoMigrateAngular, type PanelModel } from 'app/features/dashboard/state/PanelModel';
 
 /**
  * Data structure for Angular migration information stored in v2 schema options.
  */
+const logger = createStructuredLogger('features.dashboard-scene');
+
 export interface AngularMigrationData {
   /** The original panel type before migration (e.g., "singlestat", "graph") */
   autoMigrateFrom: string;
@@ -42,7 +44,7 @@ export function getAngularPanelMigrationHandler(oldModel: PanelModel) {
       const targetClone = cloneDeep(oldModel.targets);
       Object.defineProperty(panel, 'targets', {
         get: function () {
-          console.warn(
+          logger.warn(
             'Accessing the targets property when migrating a panel plugin is deprecated. Changes to this property will be ignored.'
           );
           return targetClone;
@@ -108,7 +110,7 @@ export function getV2AngularMigrationHandler(migrationData: AngularMigrationData
     const targetClone = cloneDeep(panel.targets);
     Object.defineProperty(panel, 'targets', {
       get: function () {
-        console.warn(
+        logger.warn(
           'Accessing the targets property when migrating a panel plugin is deprecated. Changes to this property will be ignored.'
         );
         return targetClone;

--- a/public/app/features/dashboard-scene/serialization/layoutSerializers/utils.ts
+++ b/public/app/features/dashboard-scene/serialization/layoutSerializers/utils.ts
@@ -1,4 +1,4 @@
-import { getNextRefId } from '@grafana/data';
+import { getNextRefId, createStructuredLogger } from '@grafana/data';
 import { config } from '@grafana/runtime';
 import { getPanelPluginMetasMapSync, type PanelPluginMetas } from '@grafana/runtime/internal';
 import {
@@ -54,6 +54,8 @@ import { normalizeTransformation } from '../transformationCompat';
  * buildVizPanel layers the dashboard-only chrome on top (menu, header actions, sub header, panel
  * context — all of which reach the root via getDashboardSceneFor and would throw elsewhere).
  */
+const logger = createStructuredLogger('features.dashboard-scene');
+
 export function buildVizPanelState(panel: PanelKind, id?: number): VizPanelState {
   const titleItems: SceneObject[] = [];
 
@@ -405,7 +407,7 @@ export function getDataSourceForQuery(querySpecDS: DataSourceRef | undefined | n
     // In the datasource list from bootData "id" is the type and the uid could be uid or the name
     // in cases like grafana, dashboard or mixed datasource
 
-    console.warn(
+    logger.warn(
       `Could not find datasource for query kind ${queryKind}, defaulting to ${dsList[defaultDatasource].meta.id}`
     );
     return {

--- a/public/app/features/dashboard-scene/serialization/transformSaveModelSchemaV2ToScene.ts
+++ b/public/app/features/dashboard-scene/serialization/transformSaveModelSchemaV2ToScene.ts
@@ -95,6 +95,9 @@ import {
 } from './transformToV1TypesUtils';
 import { LEGACY_STRING_VALUE_KEY } from './transformToV2TypesUtils';
 
+import { createStructuredLogger } from '@grafana/data';
+const logger = createStructuredLogger('features.dashboard-scene');
+
 const DEFAULT_DATASOURCE = 'default';
 
 export type TypedVariableModelV2 =
@@ -313,7 +316,7 @@ function createVariablesForDashboard(dashboard: DashboardV2Spec, defaultVariable
       try {
         return createSceneVariableFromVariableModel(v);
       } catch (err) {
-        console.error(err);
+        logger.error(err);
         return null;
       }
     })
@@ -329,7 +332,7 @@ function createVariablesForDashboard(dashboard: DashboardV2Spec, defaultVariable
       try {
         return createSceneVariableFromVariableModel(v);
       } catch (err) {
-        console.error(err);
+        logger.error(err);
         return null;
       }
     })
@@ -625,7 +628,7 @@ function createVariablesForSnapshot(dashboard: DashboardV2Spec): SceneVariableSe
         // for other variable types we are using the SnapshotVariable
         return createSnapshotVariable(v);
       } catch (err) {
-        console.error(err);
+        logger.error(err);
         return null;
       }
     })

--- a/public/app/features/dashboard-scene/serialization/transformSceneToSaveModelSchemaV2.ts
+++ b/public/app/features/dashboard-scene/serialization/transformSceneToSaveModelSchemaV2.ts
@@ -1,6 +1,12 @@
 import { omit } from 'lodash';
 
-import { type AnnotationQuery, getDataSourceRef, isEmptyObject, type TimeRange } from '@grafana/data';
+import {
+  type AnnotationQuery,
+  getDataSourceRef,
+  isEmptyObject,
+  type TimeRange,
+  createStructuredLogger,
+} from '@grafana/data';
 import { config, getDataSourceSrv } from '@grafana/runtime';
 import { ExpressionDatasourceRef } from '@grafana/runtime/internal';
 import {
@@ -71,6 +77,8 @@ import { sceneVariablesSetToSchemaV2Variables } from './sceneVariablesSetToVaria
 import { buildTimeSettingsSpec } from './shared/timeSettings';
 import { colorIdEnumToColorIdV2, transformCursorSynctoEnum } from './transformToV2TypesUtils';
 // FIXME: This is temporary to avoid creating partial types for all the new schema, it has some performance implications, but it's fine for now
+const logger = createStructuredLogger('features.dashboard-scene');
+
 type DeepPartial<T> = T extends object
   ? {
       [P in keyof T]?: DeepPartial<T[P]>;
@@ -167,7 +175,7 @@ export function transformSceneToSaveModelSchemaV2(scene: DashboardScene, isSnaps
     // should never reach this point, validation should throw an error
     throw new Error('Error we could transform the dashboard to schema v2: ' + dashboardSchemaV2);
   } catch (reason) {
-    console.error('Error transforming dashboard to schema v2: ' + reason, dashboardSchemaV2);
+    logger.error('Error transforming dashboard to schema v2: ' + reason, dashboardSchemaV2);
     throw new Error('Error transforming dashboard to schema v2: ' + reason);
   }
 }
@@ -675,7 +683,7 @@ function getAnnotations(state: DashboardSceneState, dsReferencesMapping?: DSRefe
       // for layers created for v2 schema. See transform transformSaveModelSchemaV2ToScene.ts.
       // In this case we will resolve default data source
       layerDs = getDefaultDataSourceRef();
-      console.error(
+      logger.error(
         'Misconfigured AnnotationsDataLayer: Data source is required for annotations. Resolving default data source',
         layer,
         layerDs

--- a/public/app/features/dashboard-scene/serialization/transformToV1TypesUtils.test.ts
+++ b/public/app/features/dashboard-scene/serialization/transformToV1TypesUtils.test.ts
@@ -41,7 +41,10 @@ describe('transformToV1TypesUtils', () => {
       const result = transformMappingsToV1(makeFieldConfig([makeSpecialMapping('unknown_value' as SpecialValueMatch)]));
 
       expect(result.defaults.mappings).toHaveLength(0);
-      expect(warnSpy).toHaveBeenCalledWith('Skipping special value mapping with unknown match type: "unknown_value"');
+      expect(warnSpy).toHaveBeenCalledWith(
+        'Skipping special value mapping with unknown match type: "unknown_value"',
+        expect.objectContaining({ source: 'features.dashboard-scene' })
+      );
       warnSpy.mockRestore();
     });
   });

--- a/public/app/features/dashboard-scene/serialization/transformToV1TypesUtils.ts
+++ b/public/app/features/dashboard-scene/serialization/transformToV1TypesUtils.ts
@@ -1,4 +1,8 @@
-import { type FieldConfigSource as FieldConfigSourceV1, SpecialValueMatch as SpecialValueMatchV1 } from '@grafana/data';
+import {
+  type FieldConfigSource as FieldConfigSourceV1,
+  SpecialValueMatch as SpecialValueMatchV1,
+  createStructuredLogger,
+} from '@grafana/data';
 import {
   VariableHide as VariableHideV1,
   VariableRefresh as VariableRefreshV1,
@@ -16,6 +20,8 @@ import {
   type SpecialValueMatch,
   type ThresholdsMode,
 } from '@grafana/schema/apis/dashboard.grafana.app/v2';
+
+const logger = createStructuredLogger('features.dashboard-scene');
 
 export function transformVariableRefreshToEnumV1(refresh?: VariableRefresh): VariableRefreshV1 {
   switch (refresh) {
@@ -98,7 +104,7 @@ function transformSpecialValueMatchToV1(match: SpecialValueMatch): SpecialValueM
     case 'empty':
       return SpecialValueMatchV1.Empty;
     default:
-      console.warn(`Skipping special value mapping with unknown match type: "${match}"`);
+      logger.warn(`Skipping special value mapping with unknown match type: "${match}"`);
       return undefined;
   }
 }

--- a/public/app/features/dashboard-scene/settings/AnnotationsEditView.tsx
+++ b/public/app/features/dashboard-scene/settings/AnnotationsEditView.tsx
@@ -4,6 +4,7 @@ import {
   type NavModel,
   type NavModelItem,
   PageLayoutType,
+  createStructuredLogger,
 } from '@grafana/data';
 import { t, Trans } from '@grafana/i18n';
 import { config, getDataSourceSrv, locationService } from '@grafana/runtime';
@@ -29,6 +30,8 @@ import { EditListViewSceneUrlSync } from './EditListViewSceneUrlSync';
 import { AnnotationSettingsEdit } from './annotations/AnnotationSettingsEdit';
 import { AnnotationSettingsList } from './annotations/AnnotationSettingsList';
 import { type DashboardEditView, type DashboardEditViewState, useDashboardEditPageNav } from './utils';
+
+const logger = createStructuredLogger('features.dashboard-scene');
 
 export enum MoveDirection {
   UP = -1,
@@ -73,7 +76,7 @@ export class AnnotationsEditView extends SceneObjectBase<AnnotationsEditViewStat
     const defaultInstanceDS = getDataSourceSrv().getInstanceSettings(null);
     // check for an annotation flag in the plugin json to see if it supports annotations
     if (!defaultInstanceDS || !defaultInstanceDS.meta.annotations) {
-      console.error('Default datasource does not support annotations');
+      logger.error('Default datasource does not support annotations');
       return undefined;
     }
     return getDataSourceRef(defaultInstanceDS);

--- a/public/app/features/dashboard-scene/settings/GeneralSettingsEditView.tsx
+++ b/public/app/features/dashboard-scene/settings/GeneralSettingsEditView.tsx
@@ -1,6 +1,6 @@
 import { type ChangeEvent } from 'react';
 
-import { PageLayoutType } from '@grafana/data';
+import { PageLayoutType, createStructuredLogger } from '@grafana/data';
 import { Trans, t } from '@grafana/i18n';
 import { config } from '@grafana/runtime';
 import { type SceneComponentProps, SceneObjectBase, behaviors, sceneGraph } from '@grafana/scenes';
@@ -35,6 +35,8 @@ import { getDashboardSceneFor } from '../utils/utils';
 import { DeleteDashboardButton } from './DeleteDashboardButton';
 import { TimePickerSettings } from './TimePickerSettings';
 import { type DashboardEditView, type DashboardEditViewState, useDashboardEditPageNav } from './utils';
+
+const logger = createStructuredLogger('features.dashboard-scene');
 
 export interface GeneralSettingsEditViewState extends DashboardEditViewState {
   showMoveModal?: boolean;
@@ -159,7 +161,7 @@ export class GeneralSettingsEditView
       const liveNow = this.getLiveNowTimer();
       enable ? liveNow.enable() : liveNow.disable();
     } catch (err) {
-      console.error(err);
+      logger.error(err);
     }
   };
 

--- a/public/app/features/dashboard-scene/settings/VariablesEditView.tsx
+++ b/public/app/features/dashboard-scene/settings/VariablesEditView.tsx
@@ -1,6 +1,6 @@
 import { useMemo } from 'react';
 
-import { type NavModel, type NavModelItem, PageLayoutType, generateUUID } from '@grafana/data';
+import { type NavModel, type NavModelItem, PageLayoutType, generateUUID, createStructuredLogger } from '@grafana/data';
 import { t, Trans } from '@grafana/i18n';
 import { config, locationService } from '@grafana/runtime';
 import { useFlagGrafanaDashboardSettingsRedesign } from '@grafana/runtime/internal';
@@ -44,6 +44,8 @@ import {
   restoreUnshadowedPredefinedVariables,
 } from './variables/utils';
 
+const logger = createStructuredLogger('features.dashboard-scene');
+
 export interface VariablesEditViewState extends DashboardEditViewState {
   editIndex?: number | undefined;
 }
@@ -78,7 +80,7 @@ export class VariablesEditView extends SceneObjectBase<VariablesEditViewState> i
 
     if (!variable) {
       // Handle the case where the variable is not found
-      console.error('Variable not found');
+      logger.error('Variable not found');
       return;
     }
 
@@ -94,7 +96,7 @@ export class VariablesEditView extends SceneObjectBase<VariablesEditViewState> i
     const { variables } = this.getVariableSet().state;
     if (variableIndex === -1) {
       // Handle the case where the variable is not found
-      console.error('Variable not found');
+      logger.error('Variable not found');
       return;
     }
 
@@ -120,7 +122,7 @@ export class VariablesEditView extends SceneObjectBase<VariablesEditViewState> i
     const variables = this.getVariableSet().state.variables;
 
     if (variableIndex === -1) {
-      console.error('Variable not found');
+      logger.error('Variable not found');
       return;
     }
 
@@ -153,7 +155,7 @@ export class VariablesEditView extends SceneObjectBase<VariablesEditViewState> i
     }
     // check the index are within the variables array
     if (fromIndex < 0 || fromIndex >= variables.length || toIndex < 0 || toIndex >= variables.length) {
-      console.error('Invalid index');
+      logger.error('Invalid index');
       return;
     }
     const updatedVariables = [...variables];
@@ -167,7 +169,7 @@ export class VariablesEditView extends SceneObjectBase<VariablesEditViewState> i
   public onEdit = (identifier: string) => {
     const variableIndex = this.getVariableIndex(identifier);
     if (variableIndex === -1) {
-      console.error('Variable not found');
+      logger.error('Variable not found');
       return;
     }
     this.setState({ editIndex: variableIndex });
@@ -191,7 +193,7 @@ export class VariablesEditView extends SceneObjectBase<VariablesEditViewState> i
 
     if (!variable) {
       // Handle the case where the variable is not found
-      console.error('Variable not found');
+      logger.error('Variable not found');
       return;
     }
 

--- a/public/app/features/dashboard-scene/settings/VersionsEditView.tsx
+++ b/public/app/features/dashboard-scene/settings/VersionsEditView.tsx
@@ -2,7 +2,7 @@ import { skipToken } from '@reduxjs/toolkit/query/react';
 import * as React from 'react';
 import { useMemo } from 'react';
 
-import { PageLayoutType, dateTimeFormat, dateTimeFormatTimeAgo } from '@grafana/data';
+import { PageLayoutType, dateTimeFormat, dateTimeFormatTimeAgo, createStructuredLogger } from '@grafana/data';
 import { Trans } from '@grafana/i18n';
 import { type SceneComponentProps, SceneObjectBase, sceneGraph } from '@grafana/scenes';
 import { Alert, Spinner, Stack } from '@grafana/ui';
@@ -33,6 +33,8 @@ import { VersionsHistoryButtons } from './version-history/VersionHistoryButtons'
 import { VersionHistoryComparison } from './version-history/VersionHistoryComparison';
 import { VersionHistoryHeader } from './version-history/VersionHistoryHeader';
 import { VersionHistoryTable } from './version-history/VersionHistoryTable';
+
+const logger = createStructuredLogger('features.dashboard-scene');
 
 export interface VersionsEditViewState extends DashboardEditViewState {
   versions?: DecoratedRevisionModel[];
@@ -133,7 +135,7 @@ export class VersionsEditView extends SceneObjectBase<VersionsEditViewState> imp
         // Update the continueToken for the next request, if available
         this._continueToken = result.metadata.continue ?? '';
       })
-      .catch((err) => console.log(err))
+      .catch((err) => logger.info(err))
       .finally(() => this.setState({ isAppending: false }));
   };
 

--- a/public/app/features/dashboard-scene/settings/annotations/AnnotationQueryOptions.tsx
+++ b/public/app/features/dashboard-scene/settings/annotations/AnnotationQueryOptions.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useState } from 'react';
 import { useAsync } from 'react-use';
 
-import { AppEvents } from '@grafana/data';
+import { AppEvents, createStructuredLogger } from '@grafana/data';
 import { t, Trans } from '@grafana/i18n';
 import { getAppEvents, getDataSourceSrv } from '@grafana/runtime';
 import { type DataQuery } from '@grafana/schema';
@@ -11,6 +11,8 @@ import { useQueryLibraryContext } from 'app/features/explore/QueryLibrary/QueryL
 
 import { type AnnotationLayer } from './AnnotationEditableElement';
 import { AnnotationQueryEditorModal } from './AnnotationQueryEditorModal';
+
+const logger = createStructuredLogger('features.dashboard-scene');
 
 export function AnnotationQueryEditorButton({ layer }: { layer: AnnotationLayer }) {
   const { queryLibraryEnabled } = useQueryLibraryContext();
@@ -58,7 +60,7 @@ function QueryLibraryButton({ layer, onQuerySelected }: { layer: AnnotationLayer
           layer.setState({ query: updatedQuery });
           layer.runLayer();
         } catch (error) {
-          console.error('Failed to replace annotation query!', error);
+          logger.error('Failed to replace annotation query!', error);
           getAppEvents().publish({
             type: AppEvents.alertError.name,
             payload: ['Failed to create annotation query!', error instanceof Error ? error.message : error],

--- a/public/app/features/dashboard-scene/settings/variables/editors/AdHocFiltersVariableEditor.tsx
+++ b/public/app/features/dashboard-scene/settings/variables/editors/AdHocFiltersVariableEditor.tsx
@@ -7,6 +7,7 @@ import {
   type MetricFindValue,
   type SelectableValue,
   getDataSourceRef,
+  createStructuredLogger,
 } from '@grafana/data';
 import { t } from '@grafana/i18n';
 import { config, getDataSourceSrv, reportInteraction } from '@grafana/runtime';
@@ -15,6 +16,8 @@ import { OptionsPaneItemDescriptor } from 'app/features/dashboard/components/Pan
 
 import { AdHocOriginFiltersController } from '../components/AdHocOriginFiltersController';
 import { AdHocVariableForm } from '../components/AdHocVariableForm';
+
+const logger = createStructuredLogger('features.dashboard-scene');
 
 interface AdHocFiltersVariableEditorProps {
   variable: AdHocFiltersVariable;
@@ -173,7 +176,7 @@ export function AdHocFiltersVariableEditor(props: AdHocFiltersVariableEditorProp
 
 export function getAdHocFilterOptions(variable: SceneVariable): OptionsPaneItemDescriptor[] {
   if (!(variable instanceof AdHocFiltersVariable)) {
-    console.warn('getAdHocFilterOptions: variable is not an AdHocFiltersVariable');
+    logger.warn('getAdHocFilterOptions: variable is not an AdHocFiltersVariable');
     return [];
   }
 

--- a/public/app/features/dashboard-scene/settings/variables/editors/ConstantVariableEditor.tsx
+++ b/public/app/features/dashboard-scene/settings/variables/editors/ConstantVariableEditor.tsx
@@ -8,6 +8,9 @@ import { OptionsPaneItemDescriptor } from 'app/features/dashboard/components/Pan
 
 import { ConstantVariableForm } from '../components/ConstantVariableForm';
 
+import { createStructuredLogger } from '@grafana/data';
+const logger = createStructuredLogger('features.dashboard-scene');
+
 interface ConstantVariableEditorProps {
   variable: ConstantVariable;
 }
@@ -24,7 +27,7 @@ export function ConstantVariableEditor({ variable }: ConstantVariableEditorProps
 
 export function getConstantVariableOptions(variable: SceneVariable): OptionsPaneItemDescriptor[] {
   if (!(variable instanceof ConstantVariable)) {
-    console.warn('getConstantVariableOptions: variable is not a ConstantVariable');
+    logger.warn('getConstantVariableOptions: variable is not a ConstantVariable');
     return [];
   }
 

--- a/public/app/features/dashboard-scene/settings/variables/editors/GroupByVariableEditor.tsx
+++ b/public/app/features/dashboard-scene/settings/variables/editors/GroupByVariableEditor.tsx
@@ -7,12 +7,15 @@ import {
   type MetricFindValue,
   type SelectableValue,
   getDataSourceRef,
+  createStructuredLogger,
 } from '@grafana/data';
 import { getDataSourceSrv } from '@grafana/runtime';
 import { GroupByVariable, type SceneVariable } from '@grafana/scenes';
 import { OptionsPaneItemDescriptor } from 'app/features/dashboard/components/PanelEditor/OptionsPaneItemDescriptor';
 
 import { GroupByVariableForm } from '../components/GroupByVariableForm';
+
+const logger = createStructuredLogger('features.dashboard-scene');
 
 interface GroupByVariableEditorProps {
   variable: GroupByVariable;
@@ -106,7 +109,7 @@ export function GroupByVariableEditor(props: GroupByVariableEditorProps) {
 
 export function getGroupByVariableOptions(variable: SceneVariable): OptionsPaneItemDescriptor[] {
   if (!(variable instanceof GroupByVariable)) {
-    console.warn('getAdHocFilterOptions: variable is not an AdHocFiltersVariable');
+    logger.warn('getAdHocFilterOptions: variable is not an AdHocFiltersVariable');
     return [];
   }
 

--- a/public/app/features/dashboard-scene/settings/variables/editors/IntervalVariableEditor.tsx
+++ b/public/app/features/dashboard-scene/settings/variables/editors/IntervalVariableEditor.tsx
@@ -1,7 +1,7 @@
 import { noop } from 'lodash';
 import { type ChangeEvent, type FormEvent } from 'react';
 
-import { type SelectableValue } from '@grafana/data';
+import { type SelectableValue, createStructuredLogger } from '@grafana/data';
 import { IntervalVariable, type SceneVariable } from '@grafana/scenes';
 import { OptionsPaneItemDescriptor } from 'app/features/dashboard/components/PanelEditor/OptionsPaneItemDescriptor';
 import {
@@ -10,6 +10,8 @@ import {
 } from 'app/features/dashboard-scene/utils/utils';
 
 import { IntervalVariableForm } from '../components/IntervalVariableForm';
+
+const logger = createStructuredLogger('features.dashboard-scene');
 
 interface IntervalVariableEditorProps {
   variable: IntervalVariable;
@@ -65,7 +67,7 @@ export function IntervalVariableEditor({ variable, onRunQuery, inline }: Interva
 
 export function getIntervalVariableOptions(variable: SceneVariable): OptionsPaneItemDescriptor[] {
   if (!(variable instanceof IntervalVariable)) {
-    console.warn('getIntervalVariableOptions: variable is not an IntervalVariable');
+    logger.warn('getIntervalVariableOptions: variable is not an IntervalVariable');
     return [];
   }
 

--- a/public/app/features/dashboard-scene/settings/variables/editors/QueryVariableEditor/getQueryVariableOptions.tsx
+++ b/public/app/features/dashboard-scene/settings/variables/editors/QueryVariableEditor/getQueryVariableOptions.tsx
@@ -4,9 +4,12 @@ import { OptionsPaneItemDescriptor } from '../../../../../dashboard/components/P
 
 import { PaneItem } from './PaneItem';
 
+import { createStructuredLogger } from '@grafana/data';
+const logger = createStructuredLogger('features.dashboard-scene');
+
 export function getQueryVariableOptions(variable: SceneVariable): OptionsPaneItemDescriptor[] {
   if (!(variable instanceof QueryVariable)) {
-    console.warn('getQueryVariableOptions: variable is not a QueryVariable');
+    logger.warn('getQueryVariableOptions: variable is not a QueryVariable');
     return [];
   }
 

--- a/public/app/features/dashboard-scene/settings/variables/editors/SwitchVariableEditor.tsx
+++ b/public/app/features/dashboard-scene/settings/variables/editors/SwitchVariableEditor.tsx
@@ -3,6 +3,9 @@ import { OptionsPaneItemDescriptor } from 'app/features/dashboard/components/Pan
 
 import { SwitchVariableForm } from '../components/SwitchVariableForm';
 
+import { createStructuredLogger } from '@grafana/data';
+const logger = createStructuredLogger('features.dashboard-scene');
+
 interface SwitchVariableEditorProps {
   variable: SwitchVariable;
   inline?: boolean;
@@ -44,7 +47,7 @@ export function SwitchVariableEditor({ variable, inline = false }: SwitchVariabl
 
 export function getSwitchVariableOptions(variable: SceneVariable): OptionsPaneItemDescriptor[] {
   if (!(variable instanceof SwitchVariable)) {
-    console.warn('getSwitchVariableOptions: variable is not a SwitchVariable');
+    logger.warn('getSwitchVariableOptions: variable is not a SwitchVariable');
     return [];
   }
 

--- a/public/app/features/dashboard-scene/settings/variables/editors/TextBoxVariableEditor.tsx
+++ b/public/app/features/dashboard-scene/settings/variables/editors/TextBoxVariableEditor.tsx
@@ -7,6 +7,9 @@ import { OptionsPaneItemDescriptor } from 'app/features/dashboard/components/Pan
 
 import { TextBoxVariableForm } from '../components/TextBoxVariableForm';
 
+import { createStructuredLogger } from '@grafana/data';
+const logger = createStructuredLogger('features.dashboard-scene');
+
 interface TextBoxVariableEditorProps {
   variable: TextBoxVariable;
   onChange: (variable: TextBoxVariable) => void;
@@ -25,7 +28,7 @@ export function TextBoxVariableEditor({ variable, inline }: TextBoxVariableEdito
 
 export function getTextBoxVariableOptions(variable: SceneVariable): OptionsPaneItemDescriptor[] {
   if (!(variable instanceof TextBoxVariable)) {
-    console.warn('getTextBoxVariableOptions: variable is not a TextBoxVariable');
+    logger.warn('getTextBoxVariableOptions: variable is not a TextBoxVariable');
     return [];
   }
 

--- a/public/app/features/dashboard-scene/sharing/DownloadDiagnostics.tsx
+++ b/public/app/features/dashboard-scene/sharing/DownloadDiagnostics.tsx
@@ -2,7 +2,7 @@ import { css } from '@emotion/css';
 import { useEffect, useRef } from 'react';
 import { useAsyncFn } from 'react-use';
 
-import { type GrafanaTheme2 } from '@grafana/data';
+import { type GrafanaTheme2, createStructuredLogger } from '@grafana/data';
 import { Trans, t } from '@grafana/i18n';
 import { isFetchError, logError } from '@grafana/runtime';
 import {
@@ -28,6 +28,8 @@ import { interpolateDiagnosticsQueries } from 'app/features/query/diagnostics/in
 import { type DashboardScene } from '../scene/DashboardScene';
 
 import { type SceneShareTabState, type ShareView } from './types';
+
+const logger = createStructuredLogger('features.dashboard-scene');
 
 export interface DownloadDiagnosticsState extends SceneShareTabState {
   // The panel this diagnostics bundle is scoped to.
@@ -195,7 +197,7 @@ function DownloadDiagnosticsRenderer({ model }: SceneComponentProps<DownloadDiag
       dashboardModel = dashboard?.getSaveModel();
       panelModel = dashboard ? findPanelSaveModel(dashboardModel, panel, dashboard) : undefined;
     } catch (error) {
-      console.warn(SAVE_MODEL_FAILURE_MESSAGE, error);
+      logger.warn(SAVE_MODEL_FAILURE_MESSAGE, error);
       logError(error instanceof Error ? error : new Error(SAVE_MODEL_FAILURE_MESSAGE), {
         panelKey: panel.state.key ?? '',
         dashboardUid: dashboard?.state.uid ?? '',
@@ -219,7 +221,7 @@ function DownloadDiagnosticsRenderer({ model }: SceneComponentProps<DownloadDiag
       JSON.stringify(captured);
       panelData = captured;
     } catch (error) {
-      console.warn(PANEL_DATA_FAILURE_MESSAGE, error);
+      logger.warn(PANEL_DATA_FAILURE_MESSAGE, error);
       logError(error instanceof Error ? error : new Error(PANEL_DATA_FAILURE_MESSAGE), {
         panelKey: panel.state.key ?? '',
       });

--- a/public/app/features/dashboard-scene/sharing/ExportButton/ExportAsImage.tsx
+++ b/public/app/features/dashboard-scene/sharing/ExportButton/ExportAsImage.tsx
@@ -3,7 +3,7 @@ import { saveAs } from 'file-saver';
 import { useEffect } from 'react';
 import { useAsyncFn } from 'react-use';
 
-import { type GrafanaTheme2 } from '@grafana/data';
+import { type GrafanaTheme2, createStructuredLogger } from '@grafana/data';
 import { Trans, t } from '@grafana/i18n';
 import { config } from '@grafana/runtime';
 import { type SceneComponentProps, SceneObjectBase } from '@grafana/scenes';
@@ -15,6 +15,8 @@ import { ImagePreview } from '../components/ImagePreview';
 import { type SceneShareTabState, type ShareView } from '../types';
 
 import { generateDashboardImage } from './utils';
+
+const logger = createStructuredLogger('features.dashboard-scene');
 
 export class ExportAsImage extends SceneObjectBase<SceneShareTabState> implements ShareView {
   static Component = ExportAsImageRenderer;
@@ -48,7 +50,7 @@ function ExportAsImageRenderer({ model }: SceneComponentProps<ExportAsImage>) {
 
       return result.blob;
     } catch (error) {
-      console.error('Error exporting image:', error);
+      logger.error('Error exporting image:', error);
       DashboardInteractions.generateDashboardImageClicked({
         scale: config.rendererDefaultImageScale || 1,
         shareResource: 'dashboard',

--- a/public/app/features/dashboard-scene/sidebar/DashboardSidebar.tsx
+++ b/public/app/features/dashboard-scene/sidebar/DashboardSidebar.tsx
@@ -30,6 +30,9 @@ import {
 import { DashboardOutline } from './outline/DashboardOutline';
 import { type DashboardSidebarPane, type DashboardSidebarLike, type DashboardSidebarState } from './types';
 
+import { createStructuredLogger } from '@grafana/data';
+const logger = createStructuredLogger('features.dashboard-scene');
+
 export class DashboardSidebar extends SceneObjectBase<DashboardSidebarState> implements DashboardSidebarLike {
   public constructor(state?: Partial<DashboardSidebarState>) {
     super({
@@ -232,7 +235,7 @@ export class DashboardSidebar extends SceneObjectBase<DashboardSidebarState> imp
   private selectElement(element: ElementSelectionContextItem, options: ElementSelectionOnSelectOptions) {
     let obj = sceneGraph.findByKey(this, element.id);
     if (!obj) {
-      console.warn('Cannot find element by key="%s"!', element.id);
+      logger.warn('Cannot find element by key="%s"!', element.id);
       return;
     }
 
@@ -240,7 +243,7 @@ export class DashboardSidebar extends SceneObjectBase<DashboardSidebarState> imp
     if (sourceKey) {
       obj = sceneGraph.findByKey(this, sourceKey);
       if (!obj) {
-        console.warn('Cannot find element by source key="%s"!', sourceKey);
+        logger.warn('Cannot find element by source key="%s"!', sourceKey);
         return;
       }
     }

--- a/public/app/features/dashboard-scene/utils/DashboardModelCompatibilityWrapper.ts
+++ b/public/app/features/dashboard-scene/utils/DashboardModelCompatibilityWrapper.ts
@@ -6,6 +6,7 @@ import {
   dateTimeFormat,
   type DateTimeInput,
   EventBusSrv,
+  createStructuredLogger,
 } from '@grafana/data';
 import { TimeRangeUpdatedEvent } from '@grafana/runtime';
 import { behaviors, sceneGraph, type SceneObject, VizPanel } from '@grafana/scenes';
@@ -20,6 +21,8 @@ import { findVizPanelByKey, getVizPanelKeyForPanelId } from './utils';
 /**
  * Will move this to make it the main way we remain somewhat compatible with getDashboardSrv().getCurrent
  */
+const logger = createStructuredLogger('features.dashboard-scene');
+
 export class DashboardModelCompatibilityWrapper {
   public events = new EventBusSrv();
   private _subs = new Subscription();
@@ -157,7 +160,7 @@ export class DashboardModelCompatibilityWrapper {
   public removePanel(panel: PanelModelCompatibilityWrapper) {
     const vizPanel = findVizPanelByKey(this._scene, getVizPanelKeyForPanelId(panel.id));
     if (!vizPanel) {
-      console.error('Trying to remove a panel that was not found in scene', panel);
+      logger.error('Trying to remove a panel that was not found in scene', panel);
       return;
     }
 

--- a/public/app/features/dashboard-scene/utils/PanelModelCompatibilityWrapper.ts
+++ b/public/app/features/dashboard-scene/utils/PanelModelCompatibilityWrapper.ts
@@ -1,8 +1,10 @@
-import { type PanelModel } from '@grafana/data';
+import { type PanelModel, createStructuredLogger } from '@grafana/data';
 import { SceneDataTransformer, type VizPanel } from '@grafana/scenes';
 import { type DataSourceRef, type DataTransformerConfig } from '@grafana/schema';
 
 import { getPanelIdForVizPanel, getQueryRunnerFor } from './utils';
+
+const logger = createStructuredLogger('features.dashboard-scene');
 
 export class PanelModelCompatibilityWrapper implements PanelModel {
   constructor(private _vizPanel: VizPanel) {}
@@ -11,7 +13,7 @@ export class PanelModelCompatibilityWrapper implements PanelModel {
     const id = getPanelIdForVizPanel(this._vizPanel);
 
     if (isNaN(id)) {
-      console.error('VizPanel key could not be translated to a legacy numeric panel id', this._vizPanel);
+      logger.error('VizPanel key could not be translated to a legacy numeric panel id', this._vizPanel);
       return 0;
     }
 

--- a/public/app/features/dashboard-scene/utils/dashboardControls.ts
+++ b/public/app/features/dashboard-scene/utils/dashboardControls.ts
@@ -1,10 +1,12 @@
 import { filter, Observable, scan, share, type Subscriber } from 'rxjs';
 
-import { type DataSourceApi } from '@grafana/data';
+import { type DataSourceApi, createStructuredLogger } from '@grafana/data';
 import { getDataSourceSrv } from '@grafana/runtime';
 import { type SceneVariable } from '@grafana/scenes';
 import { type DashboardLink, type DataSourceRef } from '@grafana/schema';
 import { type VariableKind } from '@grafana/schema/apis/dashboard.grafana.app/v2';
+
+const logger = createStructuredLogger('features.dashboard-scene');
 
 export type DefaultControlEvent =
   | { type: 'variables'; data: VariableKind[] }
@@ -68,7 +70,7 @@ async function loadControlsFromRef(ref: DataSourceRef, subscriber: Subscriber<De
   try {
     ds = await getDataSourceSrv().get(ref);
   } catch (e) {
-    console.warn('Failed to load datasource', ref, e);
+    logger.warn('Failed to load datasource', ref, e);
     return;
   }
 
@@ -98,7 +100,7 @@ async function emitDefaultVariables(ds: DataSourceApi, subscriber: Subscriber<De
       subscriber.next({ type: 'variables', data });
     }
   } catch (e) {
-    console.warn('Failed to load default variables from datasource', ds.type, e);
+    logger.warn('Failed to load default variables from datasource', ds.type, e);
   }
 }
 
@@ -120,7 +122,7 @@ async function emitDefaultLinks(ds: DataSourceApi, subscriber: Subscriber<Defaul
       });
     }
   } catch (e) {
-    console.warn('Failed to load default links from datasource', ds.type, e);
+    logger.warn('Failed to load default links from datasource', ds.type, e);
   }
 }
 

--- a/public/app/features/dashboard-scene/utils/predefinedVariables.ts
+++ b/public/app/features/dashboard-scene/utils/predefinedVariables.ts
@@ -13,6 +13,9 @@ import { getVariableKind, getVariableSpecName } from 'app/features/variables-man
  * persisted dashboard spec and out of the editable variables list.
  */
 
+import { createStructuredLogger } from '@grafana/data';
+const logger = createStructuredLogger('features.dashboard-scene');
+
 interface GlobalControlSourceRef {
   type: 'global';
 }
@@ -99,7 +102,7 @@ export async function fetchPredefinedVariables(folderUid?: string): Promise<Vari
     cache.set(cacheKey, { ts: Date.now(), variables });
     return variables;
   } catch (err) {
-    console.warn('Failed to load predefined dashboard variables', err);
+    logger.warn('Failed to load predefined dashboard variables', err);
     return null;
   }
 }

--- a/public/app/features/dashboard-scene/utils/variables.ts
+++ b/public/app/features/dashboard-scene/utils/variables.ts
@@ -1,4 +1,4 @@
-import { type AdHocVariableFilter, type TypedVariableModel } from '@grafana/data';
+import { type AdHocVariableFilter, type TypedVariableModel, createStructuredLogger } from '@grafana/data';
 import { config, getDataSourceSrv } from '@grafana/runtime';
 import {
   AdHocFiltersVariable,
@@ -25,6 +25,8 @@ import { migrateGroupByVariablesV1 } from '../serialization/groupByMigration';
 import { createSceneVariableFromVariableModel as createSceneVariableFromVariableModelV2 } from '../serialization/transformSaveModelSchemaV2ToScene';
 
 import { getCurrentValueForOldIntervalModel, getIntervalsFromQueryString } from './utils';
+
+const logger = createStructuredLogger('features.dashboard-scene');
 
 const DEFAULT_DATASOURCE = 'default';
 
@@ -80,7 +82,7 @@ export function createVariablesForDashboard(oldModel: DashboardModel, defaultVar
       try {
         return createSceneVariableFromVariableModel(v);
       } catch (err) {
-        console.error(err);
+        logger.error(err);
         return null;
       }
     })
@@ -93,7 +95,7 @@ export function createVariablesForDashboard(oldModel: DashboardModel, defaultVar
       try {
         return createSceneVariableFromVariableModelV2(v);
       } catch (err) {
-        console.error(err);
+        logger.error(err);
         return null;
       }
     })
@@ -139,7 +141,7 @@ export function createVariablesForSnapshot(oldModel: DashboardModel) {
         // for other variable types we are using the SnapshotVariable
         return createSnapshotVariable(v);
       } catch (err) {
-        console.error(err);
+        logger.error(err);
         return null;
       }
     })

--- a/public/app/features/dashboard/api/DashboardAPIVersionResolver.test.ts
+++ b/public/app/features/dashboard/api/DashboardAPIVersionResolver.test.ts
@@ -158,13 +158,20 @@ describe('DashboardAPIVersionResolver', () => {
       it('should log resolved versions', async () => {
         mockDiscoveryResponse(['v2', 'v1']);
         await dashboardAPIVersionResolver.resolve();
-        expect(console.log).toHaveBeenCalledWith(expect.stringContaining('Version negotiation'));
+        expect(console.log).toHaveBeenCalledWith(
+          expect.stringContaining('Version negotiation'),
+          expect.objectContaining({ source: 'features.core' })
+        );
       });
 
       it('should log on discovery failure', async () => {
         mockDiscoveryFailure();
         await dashboardAPIVersionResolver.resolve();
-        expect(console.log).toHaveBeenCalledWith(expect.stringContaining('discovery failed'), expect.any(Error));
+        expect(console.log).toHaveBeenCalledWith(
+          expect.stringContaining('discovery failed'),
+          expect.objectContaining({ source: 'features.core' }),
+          expect.any(Error)
+        );
       });
     });
 

--- a/public/app/features/dashboard/api/ResponseTransformers.ts
+++ b/public/app/features/dashboard/api/ResponseTransformers.ts
@@ -1,4 +1,9 @@
-import { type MetricFindValue, type TypedVariableModel, type AnnotationQuery } from '@grafana/data';
+import {
+  type MetricFindValue,
+  type TypedVariableModel,
+  type AnnotationQuery,
+  createStructuredLogger,
+} from '@grafana/data';
 import { config } from '@grafana/runtime';
 import {
   type DataQuery,
@@ -86,6 +91,8 @@ import { type DashboardDataDTO, type DashboardDTO } from 'app/types/dashboard';
 
 import { type DashboardWithAccessInfo } from './types';
 import { isDashboardResource, isDashboardV0Spec, isDashboardV2Resource, isDashboardV2Spec } from './utils';
+
+const logger = createStructuredLogger('features.dashboards');
 
 export function ensureV2Response(
   dto: DashboardDTO | DashboardWithAccessInfo<DashboardDataDTO> | DashboardWithAccessInfo<DashboardV2Spec>
@@ -728,7 +735,7 @@ function getVariables(vars: TypedVariableModel[]): DashboardV2Spec['variables'] 
         let query = v.query || {};
 
         if (typeof query === 'string') {
-          console.warn(
+          logger.warn(
             'Query variable query is a string which is deprecated in the schema v2. It should extend DataQuery'
           );
           query = {
@@ -941,7 +948,7 @@ function getVariables(vars: TypedVariableModel[]): DashboardV2Spec['variables'] 
         break;
       default:
         // do not throw error, just log it
-        console.error(`Variable transformation not implemented: ${v.type}`);
+        logger.error(`Variable transformation not implemented: ${v.type}`);
     }
   }
   return variables;
@@ -1154,7 +1161,7 @@ function getVariablesV1(vars: DashboardV2Spec['variables']): VariableModel[] {
         break;
       default:
         // do not throw error, just log it
-        console.error(`Variable transformation not implemented: ${v}`);
+        logger.error(`Variable transformation not implemented: ${v}`);
     }
   }
   return variables;
@@ -1410,7 +1417,7 @@ function transformSpecialValueMatchToV1(match: SpecialValueMatch): SpecialValueM
     case 'empty':
       return SpecialValueMatchV1.Empty;
     default:
-      console.warn(`Skipping special value mapping with unknown match type: "${match}"`);
+      logger.warn(`Skipping special value mapping with unknown match type: "${match}"`);
       return undefined;
   }
 }

--- a/public/app/features/dashboard/components/DashExportModal/DashboardExporter.ts
+++ b/public/app/features/dashboard/components/DashExportModal/DashboardExporter.ts
@@ -1,6 +1,6 @@
 import { defaults, each, sortBy } from 'lodash';
 
-import { type DataSourceRef, type VariableOption, VariableRefresh } from '@grafana/data';
+import { type DataSourceRef, type VariableOption, VariableRefresh, createStructuredLogger } from '@grafana/data';
 import { getDataSourceSrv } from '@grafana/runtime';
 import { getPanelPluginMeta } from '@grafana/runtime/internal';
 import config from 'app/core/config';
@@ -14,6 +14,8 @@ import { type DashboardJson } from '../../../manage-dashboards/types';
 import { isConstant } from '../../../variables/guard';
 import { type DashboardModel } from '../../state/DashboardModel';
 import { type GridPos } from '../../state/PanelModel';
+
+const logger = createStructuredLogger('features.dashboards');
 
 interface InputUsage {
   libraryPanels?: LibraryPanel[];
@@ -318,7 +320,7 @@ export class DashboardExporter {
 
       return newObj;
     } catch (err) {
-      console.error('Export failed:', err);
+      logger.error('Export failed:', err);
       return {
         error: err,
       };

--- a/public/app/features/dashboard/components/GenAI/hooks.ts
+++ b/public/app/features/dashboard/components/GenAI/hooks.ts
@@ -10,6 +10,10 @@ import { DEFAULT_LLM_MODEL, isLLMPluginEnabled } from './utils';
 
 // Declared instead of imported from utils to make this hook modular
 // Ideally we will want to move the hook itself to a different scope later.
+import { createStructuredLogger } from '@grafana/data';
+
+const logger = createStructuredLogger('features.dashboards');
+
 type Message = llm.Message;
 
 export enum StreamStatus {
@@ -69,7 +73,7 @@ export function useLLMStream(options: Options = defaultOptions): UseLLMStreamRes
         'Failed to generate content using LLM',
         'Please try again or if the problem persists, contact your organization admin.'
       );
-      console.error(e);
+      logger.error(e);
       getLogger('features.dashboards.genai').logError(e, {
         messages: JSON.stringify(messages),
         model,

--- a/public/app/features/dashboard/components/HelpWizard/SupportSnapshotService.ts
+++ b/public/app/features/dashboard/components/HelpWizard/SupportSnapshotService.ts
@@ -1,6 +1,12 @@
 import saveAs from 'file-saver';
 
-import { dateTimeFormat, formattedValueToString, getValueFormat, type SelectableValue } from '@grafana/data';
+import {
+  dateTimeFormat,
+  formattedValueToString,
+  getValueFormat,
+  type SelectableValue,
+  createStructuredLogger,
+} from '@grafana/data';
 import { t } from '@grafana/i18n';
 import { type SceneObject } from '@grafana/scenes';
 import { StateManagerBase } from 'app/core/services/StateManagerBase';
@@ -12,6 +18,8 @@ import { DashboardModel } from '../../state/DashboardModel';
 import { type PanelModel } from '../../state/PanelModel';
 
 import { getDebugDashboard, getGithubMarkdown } from './utils';
+
+const logger = createStructuredLogger('features.dashboards');
 
 interface SupportSnapshotState {
   currentTab: SnapshotTab;
@@ -88,7 +96,7 @@ export class SupportSnapshotService extends StateManagerBase<SupportSnapshotStat
       const dash = createDashboardSceneFromDashboardModel(oldModel, snapshot);
       scene = dash.state.body; // skip the wrappers
     } catch (ex) {
-      console.log('Error creating scene:', ex);
+      logger.info('Error creating scene:', ex);
     }
 
     this.setState({ snapshot, snapshotText, markdownText, snapshotSize, snapshotUpdate: snapshotUpdate + 1, scene });

--- a/public/app/features/dashboard/dashgrid/DashboardLibrary/DashboardCard.tsx
+++ b/public/app/features/dashboard/dashgrid/DashboardLibrary/DashboardCard.tsx
@@ -6,7 +6,7 @@ import { useRef, useState } from 'react';
 import Skeleton from 'react-loading-skeleton';
 
 import { createAssistantContextItem, useAssistant } from '@grafana/assistant';
-import { type GrafanaTheme2 } from '@grafana/data';
+import { type GrafanaTheme2, createStructuredLogger } from '@grafana/data';
 import { t, Trans } from '@grafana/i18n';
 import { config } from '@grafana/runtime';
 import {
@@ -33,6 +33,8 @@ import { NewTemplateDashboardInteractions } from './analytics/main';
 import { CONTENT_KINDS } from './constants';
 import { type GnetDashboard } from './types';
 import { buildAssistantPrompt, buildTemplateContextData, buildTemplateContextTitle } from './utils/assistantHelpers';
+
+const logger = createStructuredLogger('features.dashboards');
 
 interface Details {
   id: string;
@@ -234,7 +236,7 @@ function DashboardCardComponent({
               kind === 'suggested_dashboard' ? styles.thumbnailCoverImage : styles.thumbnailContainImage
             )}
             onError={(e) => {
-              console.error('Failed to load image for:', title, 'URL:', imageUrl);
+              logger.error('Failed to load image for:', title, 'URL:', imageUrl);
               e.currentTarget.style.display = 'none';
             }}
           />

--- a/public/app/features/dashboard/dashgrid/DashboardLibrary/GrafanaTemplatesTab.tsx
+++ b/public/app/features/dashboard/dashgrid/DashboardLibrary/GrafanaTemplatesTab.tsx
@@ -1,7 +1,7 @@
 import { type MutableRefObject, useEffect } from 'react';
 import { useAsync } from 'react-use';
 
-import { type DataSourceInstanceListItem } from '@grafana/data';
+import { type DataSourceInstanceListItem, createStructuredLogger } from '@grafana/data';
 import { t } from '@grafana/i18n';
 import { getBackendSrv, locationService } from '@grafana/runtime';
 import {
@@ -23,6 +23,8 @@ import {
 import { TemplateDashboardInteractions } from './interactions';
 import { type GnetDashboard, type GnetDashboardsResponse, type Link } from './types';
 import { getTemplateDashboardUrl } from './utils/templateDashboardHelpers';
+
+const logger = createStructuredLogger('features.dashboards');
 
 interface GrafanaTemplatesTabProps {
   /** Raw `source` search param value, mapped to a known entry point when fired. */
@@ -60,7 +62,7 @@ export const GrafanaTemplatesTab = ({
 
       return response.items;
     } catch (error) {
-      console.error('Error loading template dashboards ', error);
+      logger.error('Error loading template dashboards ', error);
       return [];
     }
   }, []);

--- a/public/app/features/dashboard/dashgrid/DashboardLibrary/SuggestedDashboardsList/SuggestedDashboardsList.tsx
+++ b/public/app/features/dashboard/dashgrid/DashboardLibrary/SuggestedDashboardsList/SuggestedDashboardsList.tsx
@@ -3,7 +3,7 @@ import { useBooleanFlagValue } from '@openfeature/react-sdk';
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { useAsyncFn, useDebounce } from 'react-use';
 
-import { type GrafanaTheme2 } from '@grafana/data';
+import { type GrafanaTheme2, createStructuredLogger } from '@grafana/data';
 import { t } from '@grafana/i18n';
 import { config, isFetchError, locationService } from '@grafana/runtime';
 import { getDataSourceInstanceSettings } from '@grafana/runtime/unstable';
@@ -26,6 +26,8 @@ import { getPageSlice } from '../utils/suggestedDashboardHelpers';
 import { DashboardResultsGrid } from './DashboardResultsGrid';
 import { EmptyResults } from './EmptyResults';
 import { ListHeader } from './ListHeader';
+
+const logger = createStructuredLogger('features.dashboards');
 
 const SEARCH_DEBOUNCE_MS = 500;
 const DEFAULT_SORT_ORDER = 'downloads';
@@ -253,7 +255,7 @@ export const SuggestedDashboardsList = ({
           });
         }
       } catch (err) {
-        console.error('Error loading community dashboards', err);
+        logger.error('Error loading community dashboards', err);
       } finally {
         setIsCommunityLoading(false);
       }
@@ -424,7 +426,7 @@ export const SuggestedDashboardsList = ({
         sourceEntryPoint,
       });
     } catch (err) {
-      console.error('Error checking dashboard compatibility:', err);
+      logger.error('Error checking dashboard compatibility:', err);
 
       const errorMessage = isFetchError(err) ? err.data?.message : 'Failed to check compatibility';
       const errorCode = isFetchError(err) ? err.data?.code : undefined;

--- a/public/app/features/dashboard/dashgrid/DashboardLibrary/api/compatibilityApi.ts
+++ b/public/app/features/dashboard/dashgrid/DashboardLibrary/api/compatibilityApi.ts
@@ -6,6 +6,10 @@ import { type DashboardJson } from 'app/features/manage-dashboards/types';
  * Represents a datasource mapping for compatibility checking.
  * Maps dashboard datasource references to actual datasource instances.
  */
+import { createStructuredLogger } from '@grafana/data';
+
+const logger = createStructuredLogger('features.dashboards');
+
 export interface DatasourceMapping {
   /** Unique identifier of the datasource */
   uid: string;
@@ -138,7 +142,7 @@ export async function checkDashboardCompatibility(
     return response;
   } catch (error) {
     // Log error for debugging
-    console.error('Dashboard compatibility check failed:', error);
+    logger.error('Dashboard compatibility check failed:', error);
 
     // Re-throw original error for caller to handle
     throw error;

--- a/public/app/features/dashboard/dashgrid/DashboardLibrary/api/dashboardLibraryApi.ts
+++ b/public/app/features/dashboard/dashgrid/DashboardLibrary/api/dashboardLibraryApi.ts
@@ -8,6 +8,10 @@ import { type GnetDashboard, type GnetDashboardsResponse, type Link } from '../t
  * Panel types that are known to allow JavaScript code execution.
  * These panels are filtered out due to security concerns.
  */
+import { createStructuredLogger } from '@grafana/data';
+
+const logger = createStructuredLogger('features.dashboards');
+
 const UNSAFE_PANEL_TYPE_SLUGS = [
   'aceiot-svg-panel',
   'ae3e-plotly-panel',
@@ -102,7 +106,7 @@ export async function fetchCommunityDashboards(
   }
 
   // Fallback for unexpected response format
-  console.warn('Unexpected API response format from Grafana.com:', result);
+  logger.warn('Unexpected API response format from Grafana.com:', result);
   return {
     page: params.page,
     pages: 1,
@@ -127,7 +131,7 @@ export async function fetchProvisionedDashboards(datasourceType: string): Promis
     });
     return Array.isArray(dashboards) ? dashboards.filter((dashboard) => !dashboard.removed) : [];
   } catch (error) {
-    console.error('Error loading provisioned dashboards', error);
+    logger.error('Error loading provisioned dashboards', error);
     return [];
   }
 }
@@ -144,7 +148,7 @@ const filterNonSafeDashboards = (dashboards: GnetDashboard[], dataSourceType?: s
     if (unsafePanelTypes.length > 0) {
       unsafeDashboardsCount++;
 
-      console.warn(
+      logger.warn(
         `Community dashboard ${item.id} ${item.name} filtered out due to panel types ${item.panelTypeSlugs?.join(', ')} that can embed JavaScript`
       );
 

--- a/public/app/features/dashboard/dashgrid/DashboardLibrary/utils/communityDashboardHelpers.ts
+++ b/public/app/features/dashboard/dashgrid/DashboardLibrary/utils/communityDashboardHelpers.ts
@@ -1,4 +1,4 @@
-import { type PanelModel } from '@grafana/data';
+import { type PanelModel, createStructuredLogger } from '@grafana/data';
 import { t } from '@grafana/i18n';
 import { locationService } from '@grafana/runtime';
 import { createErrorNotification } from 'app/core/copy/appNotification';
@@ -21,6 +21,8 @@ import { type GnetDashboard, type Link } from '../types';
 
 import { type InputMapping, tryAutoMapDatasources, parseConstantInputs, isDataSourceInput } from './autoMapDatasources';
 import type { AssistantSource } from './templateDashboardHelpers';
+
+const logger = createStructuredLogger('features.dashboards');
 
 export const DEFAULT_SORT_ORDER = 'downloads';
 export const DEFAULT_SORT_DIRECTION = 'desc';
@@ -165,7 +167,7 @@ function canPanelContainJS(panel: PanelModel): boolean {
   try {
     panelJson = JSON.stringify(panelWithoutSanitizedFields);
   } catch (e) {
-    console.warn('Failed to stringify panel', e);
+    logger.warn('Failed to stringify panel', e);
     return true;
   }
 
@@ -196,7 +198,7 @@ function canPanelContainJS(panel: PanelModel): boolean {
 
   const hasSuspiciousValue = valuePatterns.some((pattern) => {
     if (pattern.test(panelJson)) {
-      console.warn('Panel contains JavaScript code in value');
+      logger.warn('Panel contains JavaScript code in value');
       return true;
     }
     return false;
@@ -204,7 +206,7 @@ function canPanelContainJS(panel: PanelModel): boolean {
 
   const hasSuspiciousKey = keyPatterns.some((pattern) => {
     if (pattern.test(panelJson)) {
-      console.warn('Panel contains JavaScript code in key');
+      logger.warn('Panel contains JavaScript code in key');
       return true;
     }
     return false;
@@ -320,7 +322,7 @@ export async function onUseCommunityDashboard({
       }
     }
   } catch (err) {
-    console.error('Error loading community dashboard:', err);
+    logger.error('Error loading community dashboard:', err);
     dispatch(
       notifyApp(
         createErrorNotification(t('dashboard-library.community-error-title', 'Error loading community dashboard'))

--- a/public/app/features/dashboard/services/DashboardAnalyticsAggregator.ts
+++ b/public/app/features/dashboard/services/DashboardAnalyticsAggregator.ts
@@ -14,6 +14,10 @@ import {
 /**
  * Panel metrics structure for analytics
  */
+import { createStructuredLogger } from '@grafana/data';
+
+const logger = createStructuredLogger('features.dashboards');
+
 interface PanelAnalyticsMetrics {
   panelId: string;
   panelKey: string;
@@ -109,7 +113,7 @@ export class DashboardAnalyticsAggregator implements performanceUtils.ScenePerfo
     // Aggregate panel metrics without verbose logging (handled by ScenePerformanceLogger)
     const panel = this.panelMetrics.get(data.panelKey);
     if (!panel) {
-      console.warn('Panel not found for operation completion:', data.panelKey);
+      logger.warn('Panel not found for operation completion:', data.panelKey);
       return;
     }
 

--- a/public/app/features/dashboard/services/DashboardLoaderSrv.ts
+++ b/public/app/features/dashboard/services/DashboardLoaderSrv.ts
@@ -1,4 +1,4 @@
-import { AppEvents, dateMath, type UrlQueryMap, type UrlQueryValue } from '@grafana/data';
+import { AppEvents, dateMath, type UrlQueryMap, type UrlQueryValue, createStructuredLogger } from '@grafana/data';
 import { config, getBackendSrv, isFetchError, locationService } from '@grafana/runtime';
 import { type Spec as DashboardV2Spec } from '@grafana/schema/apis/dashboard.grafana.app/v2';
 import { backendSrv } from 'app/core/services/backend_srv';
@@ -14,6 +14,8 @@ import { DashboardVersionError, type DashboardWithAccessInfo } from '../api/type
 
 import { getDashboardSrv } from './DashboardSrv';
 import { getDashboardSnapshotSrv } from './SnapshotSrv';
+
+const logger = createStructuredLogger('features.dashboards');
 
 type ScriptedDashboardExecution = { data: DashboardDataDTO };
 
@@ -75,7 +77,7 @@ abstract class DashboardLoaderSrvBase<T> implements DashboardLoaderSrvLike<T> {
           };
         },
         (err) => {
-          console.error('Script dashboard error ' + err);
+          logger.error('Script dashboard error ' + err);
           appEvents.emit(AppEvents.alertError, [
             'Script Error',
             'Please make sure it exists and returns a valid dashboard',
@@ -177,7 +179,7 @@ export class DashboardLoaderSrv extends DashboardLoaderSrvBase<DashboardDTO> {
           return await api.getDashboardDTO(uid, params);
         } catch (e) {
           if (isFetchError(e) && !(e instanceof DashboardVersionError)) {
-            console.error('Failed to load dashboard', e);
+            logger.error('Failed to load dashboard', e);
             e.isHandled = true;
             if (e.status === 404) {
               appEvents.emit(AppEvents.alertError, ['Dashboard not found']);
@@ -242,7 +244,7 @@ export class DashboardLoaderSrvV2 extends DashboardLoaderSrvBase<DashboardWithAc
           return await api.getDashboardDTO(uid, params);
         } catch (e) {
           if (isFetchError(e) && !(e instanceof DashboardVersionError)) {
-            console.error('Failed to load dashboard', e);
+            logger.error('Failed to load dashboard', e);
             e.isHandled = true;
             if (e.status === 404) {
               appEvents.emit(AppEvents.alertError, ['Dashboard not found']);

--- a/public/app/features/dashboard/services/performanceUtils.ts
+++ b/public/app/features/dashboard/services/performanceUtils.ts
@@ -1,10 +1,12 @@
-import { store } from '@grafana/data';
+import { store, createStructuredLogger } from '@grafana/data';
 import { performanceUtils, writePerformanceLog } from '@grafana/scenes';
 
 /**
  * Utility function to register a performance observer with the global tracker
  * Reduces duplication between ScenePerformanceLogger and DashboardAnalyticsAggregator
  */
+const perfLog = createStructuredLogger('features.dashboards');
+
 export function registerPerformanceObserver(
   observer: performanceUtils.ScenePerformanceObserver,
   loggerName: string
@@ -85,11 +87,9 @@ export function writePerformanceGroupStart(logger: string, message: string): voi
 export function writePerformanceGroupLog(logger: string, message: string, data?: unknown): void {
   if (isPerformanceLoggingEnabled()) {
     if (data) {
-      // eslint-disable-next-line no-console
-      console.log(message, data);
+      perfLog.info(message, data);
     } else {
-      // eslint-disable-next-line no-console
-      console.log(message);
+      perfLog.info(message);
     }
   }
 }
@@ -117,7 +117,7 @@ export function createPerformanceMark(name: string, timestamp?: number): void {
       }
     }
   } catch (error) {
-    console.error(`❌ Failed to create performance mark: ${name}`, { timestamp, error });
+    perfLog.error(`❌ Failed to create performance mark: ${name}`, { timestamp, error });
   }
 }
 
@@ -134,6 +134,6 @@ export function createPerformanceMeasure(name: string, startMark: string, endMar
       }
     }
   } catch (error) {
-    console.error(`❌ Failed to create performance measure: ${name}`, { startMark, endMark, error });
+    perfLog.error(`❌ Failed to create performance measure: ${name}`, { startMark, endMark, error });
   }
 }

--- a/public/app/features/dashboard/state/DashboardModel.ts
+++ b/public/app/features/dashboard/state/DashboardModel.ts
@@ -14,6 +14,7 @@ import {
   type TimeZone,
   type TypedVariableModel,
   type UrlQueryValue,
+  createStructuredLogger,
 } from '@grafana/data';
 import { type PromQuery } from '@grafana/prometheus';
 import { RefreshEvent, TimeRangeUpdatedEvent } from '@grafana/runtime';
@@ -48,6 +49,8 @@ import { DashboardMigrator } from './DashboardMigrator';
 import { PanelModel } from './PanelModel';
 import { type TimeModel } from './TimeModel';
 import { deleteScopeVars, isOnTheSameGridRow } from './utils';
+
+const logger = createStructuredLogger('features.dashboards');
 
 export interface CloneOptions {
   saveVariables?: boolean;
@@ -1053,13 +1056,13 @@ export class DashboardModel implements TimeModel {
 
   /** @deprecated */
   on<T>(event: AppEvent<T>, callback: (payload?: T) => void) {
-    console.log('DashboardModel.on is deprecated use events.subscribe');
+    logger.info('DashboardModel.on is deprecated use events.subscribe');
     this.events.on(event, callback);
   }
 
   /** @deprecated */
   off<T>(event: AppEvent<T>, callback: (payload?: T) => void) {
-    console.log('DashboardModel.off is deprecated');
+    logger.info('DashboardModel.off is deprecated');
     this.events.off(event, callback);
   }
 

--- a/public/app/features/datasources/components/EditDataSource.tsx
+++ b/public/app/features/datasources/components/EditDataSource.tsx
@@ -10,6 +10,7 @@ import {
   PluginExtensionPoints,
   type PluginExtensionDataSourceConfigContext,
   DataSourceUpdatedSuccessfully,
+  createStructuredLogger,
 } from '@grafana/data';
 import { usePluginComponents, type UsePluginComponentsResult } from '@grafana/runtime';
 import { useDataSourceInstanceSettings } from '@grafana/runtime/unstable';
@@ -44,6 +45,8 @@ import { DataSourcePluginSettings } from './DataSourcePluginSettings';
 import { DataSourcePluginState } from './DataSourcePluginState';
 import { DataSourceReadOnlyMessage } from './DataSourceReadOnlyMessage';
 import { DataSourceTestingStatus } from './DataSourceTestingStatus';
+
+const logger = createStructuredLogger('features.datasources');
 
 export type Props = {
   // The ID of the data source
@@ -196,7 +199,7 @@ export function EditDataSourceView({
         return;
       }
       retryAdvisorCheck(dataSource.uid).catch((error) => {
-        console.warn('Error retrying datasource advisor check', error);
+        logger.warn('Error retrying datasource advisor check', error);
       });
       onTest();
     },

--- a/public/app/features/dimensions/editors/FileUploader.tsx
+++ b/public/app/features/dimensions/editors/FileUploader.tsx
@@ -1,12 +1,14 @@
 import { css } from '@emotion/css';
 import { type Dispatch, type SetStateAction, useState } from 'react';
 
-import { type GrafanaTheme2 } from '@grafana/data';
+import { type GrafanaTheme2, createStructuredLogger } from '@grafana/data';
 import { Trans, t } from '@grafana/i18n';
 import { FileDropzone, useStyles2, Button, type DropzoneFile, Field } from '@grafana/ui';
 import { SanitizedSVG } from 'app/core/components/SVG/SanitizedSVG';
 
 import { MediaType } from '../types';
+
+const logger = createStructuredLogger('features.dimensions');
 
 interface Props {
   setFormData: Dispatch<SetStateAction<FormData>>;
@@ -47,7 +49,7 @@ export const FileUploader = ({ mediaType, setFormData, setUpload, error }: Props
   const onFileRemove = (file: DropzoneFile) => {
     fetch(`/api/storage/delete/upload/${file.file.name}`, {
       method: 'DELETE',
-    }).catch((error) => console.error('cannot delete file', error));
+    }).catch((error) => logger.error('cannot delete file', error));
   };
 
   const acceptableFiles =

--- a/public/app/features/dimensions/editors/ResourcePickerPopover.tsx
+++ b/public/app/features/dimensions/editors/ResourcePickerPopover.tsx
@@ -4,7 +4,7 @@ import { FocusScope } from '@react-aria/focus';
 import { useOverlay } from '@react-aria/overlays';
 import { useRef, useState } from 'react';
 
-import { type GrafanaTheme2 } from '@grafana/data';
+import { type GrafanaTheme2, createStructuredLogger } from '@grafana/data';
 import { Trans } from '@grafana/i18n';
 import { config, getBackendSrv } from '@grafana/runtime';
 import { Button, useStyles2, getPortalContainer } from '@grafana/ui';
@@ -14,6 +14,8 @@ import { type MediaType, PickerTabType, type ResourceFolderName } from '../types
 import { FileUploader } from './FileUploader';
 import { FolderPickerTab } from './FolderPickerTab';
 import { URLPickerTab } from './URLPickerTab';
+
+const logger = createStructuredLogger('features.dimensions');
 
 interface Props {
   value?: string; //img/icons/unicons/0-plus.svg
@@ -140,7 +142,7 @@ export const ResourcePickerPopover = (props: Props) => {
                           .then(() => onChange(`${config.appUrl}api/storage/read/${data.path}`))
                           .then(() => hidePopper?.());
                       })
-                      .catch((err) => console.error(err));
+                      .catch((err) => logger.error(err));
                   } else {
                     onChange(newValue);
                     hidePopper?.();

--- a/public/app/features/explore/Logs/LogsMetaRow.tsx
+++ b/public/app/features/explore/Logs/LogsMetaRow.tsx
@@ -1,7 +1,15 @@
 import { css } from '@emotion/css';
 import { memo } from 'react';
 
-import { LogsDedupStrategy, type LogsMetaItem, LogsMetaKind, type Labels, store, shallowCompare } from '@grafana/data';
+import {
+  LogsDedupStrategy,
+  type LogsMetaItem,
+  LogsMetaKind,
+  type Labels,
+  store,
+  shallowCompare,
+  createStructuredLogger,
+} from '@grafana/data';
 import { t } from '@grafana/i18n';
 import { Button, useStyles2 } from '@grafana/ui';
 
@@ -10,6 +18,8 @@ import { MetaInfoText, type MetaItemProps } from '../MetaInfoText';
 
 import { type LogsVisualisationType } from './constants';
 import { SETTINGS_KEYS } from './utils/logs';
+
+const logger = createStructuredLogger('features.explore');
 
 const getStyles = () => ({
   metaContainer: css({
@@ -119,6 +129,6 @@ function renderMetaItem(value: string | number | Labels, kind: LogsMetaKind, log
   if (kind === LogsMetaKind.Error) {
     return <span className="logs-meta-item__error">{value.toString()}</span>;
   }
-  console.error(`Meta type ${typeof value} ${value} not recognized.`);
+  logger.error(`Meta type ${typeof value} ${value} not recognized.`);
   return <></>;
 }

--- a/public/app/features/explore/Logs/LogsTableWrap.tsx
+++ b/public/app/features/explore/Logs/LogsTableWrap.tsx
@@ -14,6 +14,7 @@ import {
   type SplitOpen,
   store,
   type TimeRange,
+  createStructuredLogger,
 } from '@grafana/data';
 import { t } from '@grafana/i18n';
 import { reportInteraction } from '@grafana/runtime';
@@ -27,6 +28,8 @@ import { parseLogsFrame } from 'app/features/logs/logsFrame';
 
 import { LogsTable } from './LogsTable';
 import { SETTING_KEY_ROOT } from './utils/logs';
+
+const logger = createStructuredLogger('features.explore');
 
 interface Props {
   logsFrames: DataFrame[];
@@ -385,7 +388,7 @@ export function LogsTableWrap(props: Props) {
   // Toggle a column on or off when the user interacts with an element in the multi-select sidebar
   const toggleColumn = (columnName: FieldName) => {
     if (!columnsWithMeta || !(columnName in columnsWithMeta)) {
-      console.warn('failed to get column', columnsWithMeta);
+      logger.warn('failed to get column', columnsWithMeta);
       return;
     }
 

--- a/public/app/features/explore/Logs/utils/table/logsTable.ts
+++ b/public/app/features/explore/Logs/utils/table/logsTable.ts
@@ -1,6 +1,8 @@
-import { type DataFrame, FieldType, getFieldDisplayName, LogsSortOrder } from '@grafana/data';
+import { type DataFrame, FieldType, getFieldDisplayName, LogsSortOrder, createStructuredLogger } from '@grafana/data';
 import { type TableSortByFieldState } from '@grafana/schema/dist/esm/common/common.gen';
 import { LOGS_DATAPLANE_TIMESTAMP_NAME } from 'app/features/logs/logsFrame';
+
+const logger = createStructuredLogger('features.explore');
 
 function getDefaultSortBy(dataFrame: DataFrame | undefined, logsSortOrder: LogsSortOrder): TableSortByFieldState[] {
   const field = dataFrame?.fields.find((field) => field.type === FieldType.time);
@@ -34,7 +36,7 @@ export const getDefaultTableSortBy = (
         return parsed;
       }
     } catch (e) {
-      console.error('failed to parse table sort from local storage!', e);
+      logger.error('failed to parse table sort from local storage!', e);
     }
   }
 

--- a/public/app/features/explore/PrometheusListView/utils/getRawPrometheusListItemsFromDataFrame.ts
+++ b/public/app/features/explore/PrometheusListView/utils/getRawPrometheusListItemsFromDataFrame.ts
@@ -1,6 +1,8 @@
-import { type DataFrame, formattedValueToString } from '@grafana/data';
+import { type DataFrame, formattedValueToString, createStructuredLogger } from '@grafana/data';
 
 import { type instantQueryRawVirtualizedListData } from '../RawListContainer';
+
+const logger = createStructuredLogger('features.explore');
 
 type instantQueryMetricList = { [index: string]: { [index: string]: instantQueryRawVirtualizedListData } };
 
@@ -51,7 +53,7 @@ export const getRawPrometheusListItemsFromDataFrame = (dataFrame: DataFrame): in
             }
           }
         } else {
-          console.warn('Field display method is missing!');
+          logger.warn('Field display method is missing!');
         }
       }
     }

--- a/public/app/features/explore/QueryLibrary/OpenQueryLibraryExposedComponent.tsx
+++ b/public/app/features/explore/QueryLibrary/OpenQueryLibraryExposedComponent.tsx
@@ -7,6 +7,9 @@ import { ToolbarButton } from '@grafana/ui';
 
 import { useQueryLibraryContext } from './QueryLibraryContext';
 
+import { createStructuredLogger } from '@grafana/data';
+const logger = createStructuredLogger('features.explore');
+
 interface Props {
   className?: string;
   context?: string;
@@ -81,7 +84,7 @@ export const OpenQueryLibraryExposedComponent = ({
   }, [context, datasourceFilters, onSelectQuery, openDrawer, query]);
 
   if (!queryLibraryEnabled) {
-    console.warn(
+    logger.warn(
       '[OpenQueryLibraryExposedComponent]: Attempted to use unsupported exposed component. Query library is not enabled.'
     );
     return null;

--- a/public/app/features/explore/TraceView/components/CriticalPath/index.tsx
+++ b/public/app/features/explore/TraceView/components/CriticalPath/index.tsx
@@ -40,6 +40,10 @@ import sanitizeOverFlowingChildren from './utils/sanitizeOverFlowingChildren';
  * At this point, it uses returningChildStartTime (startTime of spanC) to select another child that finished
  * immediately before the LFC's start.
  */
+import { createStructuredLogger } from '@grafana/data';
+
+const logger = createStructuredLogger('features.explore');
+
 const computeCriticalPath = (
   spanMap: Map<string, TraceSpan>,
   spanId: string,
@@ -104,7 +108,7 @@ function criticalPathForTrace(trace: Trace) {
       criticalPath = computeCriticalPath(sanitizedSpanMap, rootSpanId, criticalPath);
     } catch (error) {
       /* eslint-disable no-console */
-      console.log('error while computing critical path for a trace', error);
+      logger.info('error while computing critical path for a trace', error);
     }
   }
   return criticalPath;

--- a/public/app/features/explore/TraceView/components/ScrollManager.tsx
+++ b/public/app/features/explore/TraceView/components/ScrollManager.tsx
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import { createStructuredLogger } from '@grafana/data';
+
 import type TNil from './types/TNil';
 import { type TraceSpan, type TraceSpanReference, type Trace } from './types/trace';
 
@@ -25,6 +27,8 @@ import { type TraceSpan, type TraceSpanReference, type Trace } from './types/tra
  * allows that state info to be accessed in a loosely coupled fashion on an
  * as-needed basis.
  */
+const logger = createStructuredLogger('features.explore');
+
 export type Accessors = {
   getViewRange: () => [number, number];
   getSearchedSpanIDs: () => Set<string> | TNil;
@@ -105,8 +109,7 @@ export default class ScrollManager {
     const isUp = direction < 0;
     const position = xrs.getRowPosition(rowIndex);
     if (!position) {
-      // eslint-disable-next-line no-console
-      console.warn('Invalid row index');
+      logger.warn('Invalid row index');
       return;
     }
     let { y } = position;

--- a/public/app/features/explore/TraceView/components/TraceTimelineViewer/ListView/index.tsx
+++ b/public/app/features/explore/TraceView/components/TraceTimelineViewer/ListView/index.tsx
@@ -18,6 +18,9 @@ import type TNil from '../../types/TNil';
 
 import Positions from './Positions';
 
+import { createStructuredLogger } from '@grafana/data';
+const logger = createStructuredLogger('features.explore');
+
 type TWrapperProps = {
   style: React.CSSProperties;
   ref: (elm: HTMLDivElement) => void;
@@ -387,8 +390,7 @@ export default class ListView extends React.Component<TListViewProps> {
         // use `.getAttribute(...)` instead of `.dataset` for jest / JSDOM
         const itemKey = node.getAttribute('data-item-key');
         if (!itemKey) {
-          // eslint-disable-next-line no-console
-          console.warn('itemKey not found');
+          logger.warn('itemKey not found');
           continue;
         }
         // measure the first child, if it's available, otherwise the node itself

--- a/public/app/features/explore/TraceView/components/model/link-patterns.tsx
+++ b/public/app/features/explore/TraceView/components/model/link-patterns.tsx
@@ -16,6 +16,9 @@ import { uniq as _uniq } from 'lodash';
 
 import { type Trace } from '../types/trace';
 
+import { createStructuredLogger } from '@grafana/data';
+const logger = createStructuredLogger('features.explore');
+
 const parameterRegExp = /#\{([^{}]*)\}/g;
 
 type ProcessedTemplate = {
@@ -109,8 +112,7 @@ export function processLinkPattern(pattern: any): ProcessedLinkPattern | null {
       parameters: _uniq(url.parameters.concat(text.parameters)),
     };
   } catch (error) {
-    // eslint-disable-next-line no-console
-    console.error(`Ignoring invalid link pattern: ${error}`, pattern);
+    logger.error(`Ignoring invalid link pattern: ${error}`, pattern);
     return null;
   }
 }

--- a/public/app/features/explore/TraceView/components/model/transform-trace-data.tsx
+++ b/public/app/features/explore/TraceView/components/model/transform-trace-data.tsx
@@ -15,7 +15,7 @@
 import { isEqual as _isEqual } from 'lodash';
 
 // @ts-ignore
-import { type TraceKeyValuePair } from '@grafana/data';
+import { type TraceKeyValuePair, createStructuredLogger } from '@grafana/data';
 
 import { AGGREGATION_PREFIX } from '../constants/aggregation';
 import { getTraceSpanIdsAsTree } from '../selectors/trace';
@@ -32,6 +32,8 @@ import { getConfigValue } from '../utils/config/get-config';
 import { getServiceDisplayName } from '../utils/service-name';
 
 import { getTraceName } from './trace-viewer';
+
+const logger = createStructuredLogger('features.explore');
 
 function asTagArray(tags: unknown): TraceKeyValuePair[] {
   return Array.isArray(tags) ? tags : [];
@@ -187,11 +189,9 @@ export default function transformTraceData(data: TraceResponse | undefined): Tra
     // make sure span IDs are unique
     const idCount = spanIdCounts.get(spanID);
     if (idCount != null) {
-      // eslint-disable-next-line no-console
-      console.warn(`Dupe spanID, ${idCount + 1} x ${spanID}`, span, spanMap.get(spanID));
+      logger.warn(`Dupe spanID, ${idCount + 1} x ${spanID}`, span, spanMap.get(spanID));
       if (_isEqual(span, spanMap.get(spanID))) {
-        // eslint-disable-next-line no-console
-        console.warn('\t two spans with same ID have `isEqual(...) === true`');
+        logger.warn('\t two spans with same ID have `isEqual(...) === true`');
       }
       spanIdCounts.set(spanID, idCount + 1);
       spanID = `${spanID}_${idCount}`;

--- a/public/app/features/explore/TraceView/createSpanLink.tsx
+++ b/public/app/features/explore/TraceView/createSpanLink.tsx
@@ -12,6 +12,7 @@ import {
   type ScopedVars,
   type SplitOpen,
   type TimeRange,
+  createStructuredLogger,
 } from '@grafana/data';
 import { t } from '@grafana/i18n';
 import {
@@ -39,6 +40,8 @@ import { type Trace, type TraceSpan, type TraceSpanReference } from './component
  * Linked datasource settings must be resolved by the caller (e.g. via {@link useDataSourceInstanceSettings})
  * because the datasource APIs are async.
  */
+const logger = createStructuredLogger('features.explore');
+
 export function createSpanLinkFactory({
   splitOpenFn,
   traceToLogsOptions,
@@ -129,7 +132,7 @@ export function createSpanLinkFactory({
         spanLinks.push.apply(spanLinks, newSpanLinks);
       } catch (error) {
         // It's fairly easy to crash here for example if data source defines wrong interpolation in the data link
-        console.error(error);
+        logger.error(error);
         return spanLinks;
       }
     }

--- a/public/app/features/explore/hooks/useExplorePageContext.ts
+++ b/public/app/features/explore/hooks/useExplorePageContext.ts
@@ -1,10 +1,12 @@
 import { useEffect, useState } from 'react';
 
 import { createAssistantContextItem, type ChatContextItem, useProvidePageContext } from '@grafana/assistant';
-import { type DataSourceApi } from '@grafana/data';
+import { type DataSourceApi, createStructuredLogger } from '@grafana/data';
 import { getDataSourceInstanceSettings } from '@grafana/runtime/unstable';
 import { type DataQuery } from '@grafana/schema';
 import { type ExploreItemState } from 'app/types/explore';
+
+const logger = createStructuredLogger('features.explore');
 
 export function useExplorePageContext(panes: Array<[string, ExploreItemState]>): void {
   const [items, setItems] = useState<ChatContextItem[]>([]);
@@ -118,7 +120,7 @@ function getDisplayText(query: DataQuery, ds?: DataSourceApi): string | undefine
   try {
     return ds?.getQueryDisplayText?.(query);
   } catch (error) {
-    console.error(error);
+    logger.error(error);
     return undefined;
   }
 }

--- a/public/app/features/explore/state/correlations.ts
+++ b/public/app/features/explore/state/correlations.ts
@@ -4,7 +4,7 @@ import {
   type CorrelationSpec,
   generatedAPI as correlationsAPIv0alpha1,
 } from '@grafana/api-clients/rtkq/correlations/v0alpha1';
-import { type DataLinkTransformationConfig } from '@grafana/data';
+import { type DataLinkTransformationConfig, createStructuredLogger } from '@grafana/data';
 import { type CorrelationData, reportInteraction, config } from '@grafana/runtime';
 import { getDataSourceInstance } from '@grafana/runtime/unstable';
 import { createErrorNotification } from 'app/core/copy/appNotification';
@@ -22,6 +22,8 @@ import { runQueries } from './query';
 /**
  * Creates an observable that emits correlations once they are loaded
  */
+const logger = createStructuredLogger('features.explore');
+
 export const getCorrelations = (exploreId: string) => {
   return new Observable<CorrelationData[]>((subscriber) => {
     const existingCorrelations = store.getState().explore.panes[exploreId]?.correlations;
@@ -117,7 +119,7 @@ export function saveCurrentCorrelation(
           dispatch(
             notifyApp(createErrorNotification('Error creating correlation', getMessageFromError(response.error)))
           );
-          console.error(response.error);
+          logger.error(response.error);
         }
       } else {
         const correlation: CreateCorrelationParams = {
@@ -145,7 +147,7 @@ export function saveCurrentCorrelation(
           })
           .catch((err) => {
             dispatch(notifyApp(createErrorNotification('Error creating correlation', err)));
-            console.error(err);
+            logger.error(err);
           });
       }
     }

--- a/public/app/features/explore/state/query.ts
+++ b/public/app/features/explore/state/query.ts
@@ -18,6 +18,7 @@ import {
   type QueryFixAction,
   type ScopedVars,
   type SupplementaryQueryType,
+  createStructuredLogger,
 } from '@grafana/data';
 import { combinePanelData } from '@grafana/o11y-ds-frontend';
 import { config } from '@grafana/runtime';
@@ -68,6 +69,8 @@ import { createCacheKey, filterLogRowsByIndex, getCorrelationsData, getResultsFr
 /**
  * Derives from explore state if a given Explore pane is waiting for more data to be received
  */
+const logger = createStructuredLogger('features.explore');
+
 export const selectIsWaitingForData = (exploreId: string) => {
   return (state: StoreState) => {
     const panelState = state.explore.panes[exploreId];
@@ -675,7 +678,7 @@ export const runQueries = createAsyncThunk<void, RunQueriesOptions>(
         error(error) {
           dispatch(notifyApp(createErrorNotification('Query processing error', error)));
           dispatch(changeLoadingStateAction({ exploreId, loadingState: LoadingState.Error }));
-          console.error(error);
+          logger.error(error);
         },
         complete() {
           // In case we don't get any response at all but the observable completed, make sure we stop loading state.
@@ -797,7 +800,7 @@ export const runLoadMoreLogsQueries = createAsyncThunk<void, RunLoadMoreLogsQuer
       error(error) {
         dispatch(notifyApp(createErrorNotification('Query processing error', error)));
         dispatch(changeLoadingStateAction({ exploreId, loadingState: LoadingState.Error }));
-        console.error(error);
+        logger.error(error);
       },
       complete() {
         dispatch(changeLoadingStateAction({ exploreId, loadingState: LoadingState.Done }));

--- a/public/app/features/explore/state/utils.ts
+++ b/public/app/features/explore/state/utils.ts
@@ -20,6 +20,7 @@ import {
   toUtc,
   type URLRange,
   type URLRangeValue,
+  createStructuredLogger,
 } from '@grafana/data';
 import { getDataSourceInstance } from '@grafana/runtime/unstable';
 import { type DataQuery, type DataSourceJsonData, type DataSourceRef, type TimeZone } from '@grafana/schema';
@@ -33,6 +34,8 @@ import { setLastUsedDatasourceUID } from '../../../core/utils/explore';
 import { loadSupplementaryQueries } from '../utils/supplementaryQueries';
 
 import { DEFAULT_RANGE } from './constants';
+
+const logger = createStructuredLogger('features.explore');
 
 export const MAX_HISTORY_AUTOCOMPLETE_ITEMS = 100;
 
@@ -117,7 +120,7 @@ export async function loadAndInitDatasource(
       instance.init();
     } catch (err) {
       // TODO: should probably be handled better
-      console.error(err);
+      logger.error(err);
     }
   }
 

--- a/public/app/features/expressions/components/QueryToolbox.tsx
+++ b/public/app/features/expressions/components/QueryToolbox.tsx
@@ -1,11 +1,13 @@
 import { css } from '@emotion/css';
 import { useCallback, useEffect, useRef, useState, type JSX } from 'react';
 
-import { type GrafanaTheme2 } from '@grafana/data';
+import { type GrafanaTheme2, createStructuredLogger } from '@grafana/data';
 import { t } from '@grafana/i18n';
 import { IconButton, useStyles2, Stack, InlineToast, Tooltip, Icon } from '@grafana/ui';
 
 import { type SqlExpressionQuery } from '../types';
+
+const logger = createStructuredLogger('features.expressions');
 
 interface QueryToolboxProps {
   onFormatCode?: () => void;
@@ -39,7 +41,7 @@ export const QueryToolbox = ({ onFormatCode, onExpand, isExpanded, query }: Quer
       await navigator.clipboard.writeText(query.expression ?? '');
       setShowCopySuccess(true);
     } catch (e) {
-      console.error(e);
+      logger.error(e);
     }
   }, [query.expression]);
 

--- a/public/app/features/expressions/components/SqlExpressions/hooks/useFunctionSignatures.ts
+++ b/public/app/features/expressions/components/SqlExpressions/hooks/useFunctionSignatures.ts
@@ -6,6 +6,10 @@ import { type SqlFunctionSignature } from '../SqlEditor/signatureHelp';
  * Lazily loads the SQL function signature metadata, keeping the large table out
  * of the chunk unless the CodeMirror editor is active.
  */
+import { createStructuredLogger } from '@grafana/data';
+
+const logger = createStructuredLogger('features.expressions');
+
 export function useFunctionSignatures(enabled: boolean): SqlFunctionSignature[] | undefined {
   const [functionSignatures, setFunctionSignatures] = useState<SqlFunctionSignature[]>();
 
@@ -23,7 +27,7 @@ export function useFunctionSignatures(enabled: boolean): SqlFunctionSignature[] 
         }
       })
       .catch((error) => {
-        console.warn('Failed to load SQL function signatures for signature help', error);
+        logger.warn('Failed to load SQL function signatures for signature help', error);
       });
 
     return () => {

--- a/public/app/features/geo/gazetteer/gazetteer.ts
+++ b/public/app/features/geo/gazetteer/gazetteer.ts
@@ -1,12 +1,21 @@
 import { getCenter } from 'ol/extent';
 import { type Geometry, Point } from 'ol/geom';
 
-import { type DataFrame, type Field, FieldType, type KeyValue, toDataFrame } from '@grafana/data';
+import {
+  type DataFrame,
+  type Field,
+  FieldType,
+  type KeyValue,
+  toDataFrame,
+  createStructuredLogger,
+} from '@grafana/data';
 
 import { frameFromGeoJSON } from '../format/geojson';
 import { pointFieldFromLonLat, pointFieldFromGeohash } from '../format/utils';
 
 import { loadWorldmapPoints } from './worldmap';
+
+const logger = createStructuredLogger('features.geo');
 
 export interface PlacenameInfo {
   point: () => Point | undefined; // lon, lat (WGS84)
@@ -227,7 +236,7 @@ export async function getGazetteer(path?: string): Promise<Gazetteer> {
       const data = await response.json();
       lookup = loadGazetteer(path, data);
     } catch (err) {
-      console.warn('Error loading placename lookup', path, err);
+      logger.warn('Error loading placename lookup', path, err);
       lookup = {
         path,
         error: 'Error loading URL',

--- a/public/app/features/inspector/InspectJSONTab.tsx
+++ b/public/app/features/inspector/InspectJSONTab.tsx
@@ -4,7 +4,7 @@ import { useAsync } from 'react-use';
 import AutoSizer from 'react-virtualized-auto-sizer';
 import { firstValueFrom } from 'rxjs';
 
-import { AppEvents, type PanelData, type SelectableValue, LoadingState } from '@grafana/data';
+import { AppEvents, type PanelData, type SelectableValue, LoadingState, createStructuredLogger } from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';
 import { Trans, t } from '@grafana/i18n';
 import { locationService } from '@grafana/runtime';
@@ -19,6 +19,8 @@ import { reportPanelInspectInteraction } from '../search/page/reporting';
 
 import { InspectTab } from './types';
 import { getPrettyJSON } from './utils/utils';
+
+const logger = createStructuredLogger('features.inspector');
 
 enum ShowContent {
   PanelJSON = 'panel',
@@ -104,7 +106,7 @@ export function InspectJSONTab({ panel, dashboard, data, onClose }: Props) {
           appEvents.emit(AppEvents.alertSuccess, ['Panel model updated']);
         }
       } catch (err) {
-        console.error('Error applying updates', err);
+        logger.error('Error applying updates', err);
         appEvents.emit(AppEvents.alertError, ['Invalid JSON text']);
       }
 

--- a/public/app/features/library-panels/components/LibraryPanelsView/actions.ts
+++ b/public/app/features/library-panels/components/LibraryPanelsView/actions.ts
@@ -7,6 +7,9 @@ import { deleteLibraryPanel as apiDeleteLibraryPanel, getLibraryPanels } from '.
 
 import { initialLibraryPanelsViewState, initSearch, searchCompleted } from './reducer';
 
+import { createStructuredLogger } from '@grafana/data';
+const logger = createStructuredLogger('features.library-panels');
+
 type SearchDispatchResult = (dispatch: Dispatch<Action>, abortController?: AbortController) => void;
 
 interface SearchArgs {
@@ -54,7 +57,7 @@ export function searchForLibraryPanels(args: SearchArgs): SearchDispatchResult {
         }
 
         // For real errors, log and show error to user
-        console.error('Error fetching library panels:', err);
+        logger.error('Error fetching library panels:', err);
 
         // Update state to show empty results
         return of(searchCompleted({ ...initialLibraryPanelsViewState, page: args.page, perPage: args.perPage }));
@@ -78,7 +81,7 @@ export function deleteLibraryPanel(uid: string, args: SearchArgs) {
       await apiDeleteLibraryPanel(uid);
       searchForLibraryPanels(args)(dispatch);
     } catch (e) {
-      console.error(e);
+      logger.error(e);
     }
   };
 }

--- a/public/app/features/live/centrifuge/LiveDataStream.ts
+++ b/public/app/features/live/centrifuge/LiveDataStream.ts
@@ -11,6 +11,7 @@ import {
   type LiveChannelId,
   LoadingState,
   StreamingDataFrame,
+  createStructuredLogger,
 } from '@grafana/data';
 import { getStreamingFrameOptions } from '@grafana/data/internal';
 import {
@@ -23,6 +24,8 @@ import {
 import { StreamingResponseDataType } from '../data/utils';
 
 import { type DataStreamSubscriptionKey, type StreamingDataQueryResponse } from './service';
+
+const logger = createStructuredLogger('features.live');
 
 const bufferIfNot =
   (canEmitObservable: Observable<boolean>) =>
@@ -154,7 +157,7 @@ export class LiveDataStream<T = unknown> {
   };
 
   private onError = (err: unknown) => {
-    console.log('LiveQuery [error]', { err }, this.deps.channelId);
+    logger.info('LiveQuery [error]', { err }, this.deps.channelId);
     this.stream.next({
       type: InternalStreamMessageType.Error,
       error: toDataQueryError(err),
@@ -163,7 +166,7 @@ export class LiveDataStream<T = unknown> {
   };
 
   private onComplete = () => {
-    console.log('LiveQuery [complete]', this.deps.channelId);
+    logger.info('LiveQuery [complete]', this.deps.channelId);
     this.shutdown();
   };
 
@@ -280,7 +283,7 @@ export class LiveDataStream<T = unknown> {
       }
 
       if (!messages.length) {
-        console.warn(`expected to find at least one non error message ${messages.map(({ type }) => type)}`);
+        logger.warn(`expected to find at least one non error message ${messages.map(({ type }) => type)}`);
         // send empty frame
         return {
           key: subKey,
@@ -358,7 +361,7 @@ export class LiveDataStream<T = unknown> {
 
         const newValueSameSchemaMessages = filterMessages(messages, InternalStreamMessageType.NewValuesSameSchema);
         if (newValueSameSchemaMessages.length !== messages.length) {
-          console.warn(`unsupported message type ${messages.map(({ type }) => type)}`);
+          logger.warn(`unsupported message type ${messages.map(({ type }) => type)}`);
         }
 
         return getNewValuesSameSchemaResponseData(newValueSameSchemaMessages);

--- a/public/app/features/live/centrifuge/channel.ts
+++ b/public/app/features/live/centrifuge/channel.ts
@@ -18,11 +18,14 @@ import {
   type LiveChannelAddress,
   type DataFrameJSON,
   isValidLiveChannelAddress,
+  createStructuredLogger,
 } from '@grafana/data';
 
 /**
  * Internal class that maps Centrifuge support to GrafanaLive
  */
+const logger = createStructuredLogger('features.live');
+
 export class CentrifugeLiveChannel<T = any> {
   readonly currentStatus: LiveChannelStatusEvent;
 
@@ -81,7 +84,7 @@ export class CentrifugeLiveChannel<T = any> {
           this.sendStatus();
         }
       } catch (err) {
-        console.log('publish error', this.addr, err);
+        logger.info('publish error', this.addr, err);
         this.currentStatus.error = err;
         this.currentStatus.timestamp = Date.now();
         this.sendStatus();

--- a/public/app/features/live/centrifuge/service.ts
+++ b/public/app/features/live/centrifuge/service.ts
@@ -16,6 +16,7 @@ import {
   LiveChannelConnectionState,
   type LiveChannelId,
   toLiveChannelId,
+  createStructuredLogger,
 } from '@grafana/data';
 import {
   type FetchResponse,
@@ -33,6 +34,8 @@ import { type StreamingResponseData } from '../data/utils';
 
 import { LiveDataStream } from './LiveDataStream';
 import { CentrifugeLiveChannel } from './channel';
+
+const logger = createStructuredLogger('features.live');
 
 export type CentrifugeSrvDeps = {
   grafanaAuthToken: string | null;
@@ -126,7 +129,7 @@ export class CentrifugeService implements CentrifugeSrv {
   };
 
   private onServerSideMessage = (context: ServerPublicationContext) => {
-    console.log('Publication from server-side channel', context);
+    logger.info('Publication from server-side channel', context);
   };
 
   private onError = (context: ErrorContext) => {

--- a/public/app/features/live/dashboard/dashboardWatcher.ts
+++ b/public/app/features/live/dashboard/dashboardWatcher.ts
@@ -9,6 +9,7 @@ import {
   type LiveChannelEvent,
   LiveChannelScope,
   generateUUID,
+  createStructuredLogger,
 } from '@grafana/data';
 import { getGrafanaLiveSrv, locationService } from '@grafana/runtime';
 import { appEvents } from 'app/core/app_events';
@@ -22,6 +23,8 @@ import { type DashboardEvent, DashboardEventAction } from './types';
 
 // sessionId is not a security-sensitive value.
 // It is used for filtering out dashboard edit events from the same browsing session
+const logger = createStructuredLogger('features.live');
+
 const sessionId = generateUUID();
 
 class DashboardWatcher {
@@ -137,7 +140,7 @@ class DashboardWatcher {
 
             const dash = getDashboardSrv().getCurrent();
             if (dash?.uid !== event.message.uid) {
-              console.log('dashboard event for different dashboard?', event, dash);
+              logger.info('dashboard event for different dashboard?', event, dash);
               return;
             }
 

--- a/public/app/features/live/live.ts
+++ b/public/app/features/live/live.ts
@@ -1,10 +1,12 @@
 import { map } from 'rxjs';
 
-import { toLiveChannelId, StreamingDataFrame } from '@grafana/data';
+import { toLiveChannelId, StreamingDataFrame, createStructuredLogger } from '@grafana/data';
 import { type BackendSrv, type GrafanaLiveSrv } from '@grafana/runtime';
 
 import { type CentrifugeSrv, type StreamingDataQueryResponse } from './centrifuge/service';
 import { isStreamingResponseData, StreamingResponseDataType } from './data/utils';
+
+const logger = createStructuredLogger('features.live');
 
 type GrafanaLiveServiceDeps = {
   centrifugeSrv: CentrifugeSrv;
@@ -30,7 +32,7 @@ export class GrafanaLiveService implements GrafanaLiveSrv {
     const updateBuffer = (next: StreamingDataQueryResponse): void => {
       const data = next.data[0];
       if (!buffer && !isStreamingResponseData(data, StreamingResponseDataType.FullFrame)) {
-        console.warn(`expected first packet to contain a full frame, received ${data?.type}`);
+        logger.warn(`expected first packet to contain a full frame, received ${data?.type}`);
         return;
       }
 

--- a/public/app/features/logs/components/fieldSelector/LogListFieldSelector.tsx
+++ b/public/app/features/logs/components/fieldSelector/LogListFieldSelector.tsx
@@ -2,7 +2,7 @@ import { useBooleanFlagValue } from '@openfeature/react-sdk';
 import { Resizable, type ResizeCallback } from 're-resizable';
 import { useCallback, useLayoutEffect, useMemo, useState } from 'react';
 
-import { type DataFrame, store } from '@grafana/data';
+import { type DataFrame, store, createStructuredLogger } from '@grafana/data';
 import { t } from '@grafana/i18n';
 import { reportInteraction } from '@grafana/runtime';
 import { getDragStyles, IconButton, useStyles2 } from '@grafana/ui';
@@ -20,6 +20,8 @@ import { getSuggestedFieldsFromLogList } from './suggestedFields';
 /**
  * FieldSelector wrapper for the LogList visualization.
  */
+const logger = createStructuredLogger('features.logs');
+
 interface LogListFieldSelectorProps {
   containerElement: HTMLDivElement;
   logs: LogListModel[];
@@ -116,9 +118,7 @@ export const LogListFieldSelector = ({ containerElement, dataFrames, logs }: Log
   const fields = useMemo(() => getFieldsWithStats(dataFrames), [dataFrames]);
 
   if (!onClickShowField || !onClickHideField || !setDisplayedFields) {
-    console.warn(
-      'LogListFieldSelector: Missing required props: onClickShowField, onClickHideField, setDisplayedFields'
-    );
+    logger.warn('LogListFieldSelector: Missing required props: onClickShowField, onClickHideField, setDisplayedFields');
     return null;
   }
   if (sidebarHeight === 0) {

--- a/public/app/features/logs/components/panel/grammar.ts
+++ b/public/app/features/logs/components/panel/grammar.ts
@@ -1,10 +1,12 @@
 import { type Grammar } from 'prismjs';
 
-import { escapeRegex, parseFlags } from '@grafana/data';
+import { escapeRegex, parseFlags, createStructuredLogger } from '@grafana/data';
 
 import { type LogListModel } from './processing';
 
 // The Logs grammar is used for highlight in the logs panel
+const logger = createStructuredLogger('features.logs');
+
 const logsGrammar: Grammar = {
   'log-token-key': /(\b|\B)[\w_]+(?=\s*=)/gi,
   'log-token-string': /"(?!:)([^'"])*?"(?!:)/g,
@@ -64,7 +66,7 @@ export const generateTextMatchGrammar = (highlightWords: string[] | undefined = 
       try {
         return new RegExp(`(?:${cleaned})`, flags);
       } catch (e) {
-        console.error(`generateTextMatchGrammar: cannot generate regular expression from /${cleaned}/${flags}`, e);
+        logger.error(`generateTextMatchGrammar: cannot generate regular expression from /${cleaned}/${flags}`, e);
       }
       return undefined;
     })
@@ -74,7 +76,7 @@ export const generateTextMatchGrammar = (highlightWords: string[] | undefined = 
     try {
       expressions.push(new RegExp(escapeRegex(search), 'gi'));
     } catch (e) {
-      console.error(`generateTextMatchGrammar: cannot generate regular expression from /${search}/gi`, e);
+      logger.error(`generateTextMatchGrammar: cannot generate regular expression from /${search}/gi`, e);
     }
   }
   if (!expressions.length) {

--- a/public/app/features/logs/components/panel/panelState/getLogsPanelState.ts
+++ b/public/app/features/logs/components/panel/panelState/getLogsPanelState.ts
@@ -1,4 +1,6 @@
-import { urlUtil } from '@grafana/data';
+import { urlUtil, createStructuredLogger } from '@grafana/data';
+
+const logger = createStructuredLogger('features.logs');
 
 interface LogsPermalinkUrlState {
   logs?: {
@@ -18,7 +20,7 @@ export function getLogsPanelState(): LogsPermalinkUrlState | undefined {
     try {
       return JSON.parse(panelStateEncoded[0]);
     } catch (e) {
-      console.error('error parsing logsPanelState', e);
+      logger.error('error parsing logsPanelState', e);
     }
   }
 

--- a/public/app/features/logs/components/panel/virtualization.ts
+++ b/public/app/features/logs/components/panel/virtualization.ts
@@ -1,10 +1,12 @@
 import ansicolor from 'ansicolor';
 
-import { BusEventWithPayload, type GrafanaTheme2 } from '@grafana/data';
+import { BusEventWithPayload, type GrafanaTheme2, createStructuredLogger } from '@grafana/data';
 
 import { type LogLineTimestampResolution } from './LogLine';
 import { type LogListFontSize } from './LogList';
 import { type LogListModel } from './processing';
+
+const logger = createStructuredLogger('features.logs');
 
 export const LOG_LIST_MIN_WIDTH = 35 * 8;
 // Controls the space between fields in the log line, timestamp, level, displayed fields, and log line body
@@ -73,7 +75,7 @@ export class LogLineVirtualization {
     const domCharWidth = this.measureTextWidthWithDOM('e');
     const diff = domCharWidth - canvasCharWidth;
     if (diff >= 0.1) {
-      console.warn('Virtualized log list: falling back to DOM for measurement');
+      logger.warn('Virtualized log list: falling back to DOM for measurement');
       this.measurementMode = 'dom';
     }
   };

--- a/public/app/features/logs/utils.ts
+++ b/public/app/features/logs/utils.ts
@@ -30,6 +30,7 @@ import {
   type Field,
   type LogsMetaItem,
   store,
+  createStructuredLogger,
 } from '@grafana/data';
 import { t } from '@grafana/i18n';
 import { FlagKeys, getFeatureFlagClient } from '@grafana/runtime/internal';
@@ -50,6 +51,8 @@ import { DATAPLANE_LABELS_NAME, DATAPLANE_LABEL_TYPES_NAME, parseLogsFrame } fro
  * Example: `getLogLevel('WARN 1999-12-31 this is great') // LogLevel.warn`
  * @deprecated
  */
+const logger = createStructuredLogger('features.logs');
+
 export function getLogLevel(line: string): LogLevel {
   const enabled = getFeatureFlagClient().getBooleanValue(FlagKeys.GrafanaLogLevelInference, false);
   if (!enabled) {
@@ -400,10 +403,10 @@ export function getLogLevelInfo(dataFrame: DataFrame, allDataFrames: DataFrame[]
   const valueField = fieldCache.getFirstFieldOfType(FieldType.number);
 
   if (!timeField) {
-    console.error('Time field missing in data frame');
+    logger.error('Time field missing in data frame');
   }
   if (!valueField) {
-    console.error('Value field missing in data frame');
+    logger.error('Value field missing in data frame');
   }
 
   const level = valueField ? getFieldDisplayName(valueField, dataFrame, allDataFrames) : 'logs';

--- a/public/app/features/loki-helpers/mergeResponses.ts
+++ b/public/app/features/loki-helpers/mergeResponses.ts
@@ -10,7 +10,10 @@ import {
   type QueryResultMetaNotice,
   type QueryResultMetaStat,
   shallowCompare,
+  createStructuredLogger,
 } from '@grafana/data';
+
+const logger = createStructuredLogger('features.loki-helpers');
 
 function getFrameKey(frame: DataFrame): string | undefined {
   // Metric range query data
@@ -100,7 +103,7 @@ function mergeFrames(dest: DataFrame, source: DataFrame) {
   const sourceIdField = source.fields.find((field) => field.type === FieldType.string && field.name === 'id');
 
   if (!destTimeField || !sourceTimeField) {
-    console.error(new Error(`Time fields not found in the data frames`));
+    logger.error(new Error(`Time fields not found in the data frames`));
     return;
   }
 

--- a/public/app/features/panel-screenshot/PanelScreenshotServiceImpl.ts
+++ b/public/app/features/panel-screenshot/PanelScreenshotServiceImpl.ts
@@ -1,8 +1,10 @@
-import { type PanelPlugin, type PanelScreenshotContext } from '@grafana/data';
+import { type PanelPlugin, type PanelScreenshotContext, createStructuredLogger } from '@grafana/data';
 import { type PanelScreenshotOptions, type PanelScreenshotService, reportInteraction } from '@grafana/runtime';
 import { isSceneObject } from '@grafana/scenes';
 
 import { syncGetPanelPlugin } from '../plugins/importPanelPlugin';
+
+const logger = createStructuredLogger('features.panel-screenshot');
 
 const LOSSY_QUALITY = 0.92;
 
@@ -115,7 +117,7 @@ function warnOnMimeMismatch(blob: Blob, format: Format, panelType: string): void
   if (!actual || actual === expected) {
     return;
   }
-  console.warn(
+  logger.warn(
     `[panel-screenshot] plugin "${panelType}" returned ${actual} but ${expected} was requested. ` +
       'Update onScreenshot to honour the requested format, or return null to defer to the default renderer.'
   );

--- a/public/app/features/panel/panellinks/linkSuppliers.ts
+++ b/public/app/features/panel/panellinks/linkSuppliers.ts
@@ -10,12 +10,15 @@ import {
   type LinkModelSupplier,
   type ScopedVar,
   type ScopedVars,
+  createStructuredLogger,
 } from '@grafana/data';
 import { t } from '@grafana/i18n';
 import { type VizPanel } from '@grafana/scenes';
 import { dashboardSceneGraph } from 'app/features/dashboard-scene/utils/dashboardSceneGraph';
 
 import { getLinkSrv } from './link_srv';
+
+const logger = createStructuredLogger('features.panel');
 
 interface SeriesVars {
   name?: string;
@@ -123,7 +126,7 @@ export const getFieldLinksSupplier = (value: FieldDisplay): LinkModelSupplier<Fi
           };
         }
       } else {
-        console.log('VALUE', value);
+        logger.info('VALUE', value);
       }
 
       const replace: InterpolateFunction = (value: string, vars: ScopedVars | undefined, fmt?: string | Function) => {

--- a/public/app/features/panel/suggestions/getAllSuggestions.ts
+++ b/public/app/features/panel/suggestions/getAllSuggestions.ts
@@ -7,12 +7,15 @@ import {
   type PanelPluginVisualizationSuggestion,
   type PreferredVisualisationType,
   VisualizationSuggestionScore,
+  createStructuredLogger,
 } from '@grafana/data';
 import { t } from '@grafana/i18n';
 import { getListedPanelPluginMetas, getPanelPluginMeta } from '@grafana/runtime/internal';
 import { appEvents } from 'app/core/app_events';
 import { isBuiltinPluginPath } from 'app/features/plugins/built_in_plugins';
 import { importPanelPlugin } from 'app/features/plugins/importPanelPlugin';
+
+const logger = createStructuredLogger('features.panel');
 
 interface PluginLoadResult {
   plugins: PanelPlugin[];
@@ -51,7 +54,7 @@ export async function loadPlugins(pluginIds: string[]): Promise<PluginLoadResult
       plugins.push(settled.value);
     } else {
       const pluginId = pluginIds[i];
-      console.error(`Failed to load ${pluginId} for visualization suggestions:`, settled.reason);
+      logger.error(`Failed to load ${pluginId} for visualization suggestions:`, settled.reason);
 
       if (await isBuiltInPlugin(pluginId)) {
         hasErrors = true;
@@ -156,7 +159,7 @@ export async function getAllSuggestions(series?: DataFrame[]): Promise<Suggestio
         list.push(...suggestions);
       }
     } catch (e) {
-      console.warn(`error when loading suggestions from plugin "${plugin.meta.id}"`, e);
+      logger.warn(`error when loading suggestions from plugin "${plugin.meta.id}"`, e);
       pluginSuggestionsError = true;
     }
   }

--- a/public/app/features/plugins/admin/api.ts
+++ b/public/app/features/plugins/admin/api.ts
@@ -1,4 +1,4 @@
-import { type PluginError, renderMarkdown } from '@grafana/data';
+import { type PluginError, renderMarkdown, createStructuredLogger } from '@grafana/data';
 import { getBackendSrv, isFetchError } from '@grafana/runtime';
 import { installPluginMeta, logPluginMetaError, uninstallPluginMeta } from '@grafana/runtime/internal';
 import { accessControlQueryParam } from 'app/core/utils/accessControl';
@@ -16,6 +16,8 @@ import {
   type InstancePlugin,
   type ProvisionedPlugin,
 } from './types';
+
+const logger = createStructuredLogger('features.plugins');
 
 export async function getPluginDetails(id: string): Promise<CatalogPluginDetails> {
   const remote = await getRemotePlugin(id);
@@ -92,7 +94,7 @@ export async function getRemotePlugins(): Promise<RemotePlugin[]> {
     if (isFetchError(error)) {
       // It can happen that GCOM is not available, in that case we show a limited set of information to the user.
       error.isHandled = true;
-      console.error('Failed to fetch plugins from catalog (default https://grafana.com/api/plugins)');
+      logger.error('Failed to fetch plugins from catalog (default https://grafana.com/api/plugins)');
       return [];
     }
 
@@ -272,9 +274,9 @@ export async function getPluginEntitlement(id: string): Promise<boolean> {
       if (error.status === 401 || error.status === 403 || error.status === 404) {
         return false;
       }
-      console.warn(`Failed to fetch entitlement for plugin "${id}" (status ${error.status})`);
+      logger.warn(`Failed to fetch entitlement for plugin "${id}" (status ${error.status})`);
     } else {
-      console.warn(`Failed to fetch entitlement for plugin "${id}": unexpected error`);
+      logger.warn(`Failed to fetch entitlement for plugin "${id}": unexpected error`);
     }
     return false;
   }

--- a/public/app/features/plugins/admin/components/GetStartedWithPlugin/GetStartedWithApp.tsx
+++ b/public/app/features/plugins/admin/components/GetStartedWithPlugin/GetStartedWithApp.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-import { type PluginMeta } from '@grafana/data';
+import { type PluginMeta, createStructuredLogger } from '@grafana/data';
 import { Trans } from '@grafana/i18n';
 import { updateAppPluginSettings } from '@grafana/runtime/unstable';
 import { Button } from '@grafana/ui';
@@ -9,6 +9,8 @@ import { AccessControlAction } from 'app/types/accessControl';
 
 import { usePluginConfig } from '../../hooks/usePluginConfig';
 import { type CatalogPlugin } from '../../types';
+
+const logger = createStructuredLogger('features.plugins');
 
 type Props = {
   plugin: CatalogPlugin;
@@ -67,6 +69,6 @@ const updatePluginSettingsAndReload = async (id: string, data: Partial<PluginMet
     // Reloading the page as the plugin meta changes made here wouldn't be propagated throughout the app.
     window.location.reload();
   } catch (e) {
-    console.error('Error while updating the plugin', e);
+    logger.error('Error while updating the plugin', e);
   }
 };

--- a/public/app/features/plugins/admin/pages/Browse.tsx
+++ b/public/app/features/plugins/admin/pages/Browse.tsx
@@ -2,7 +2,7 @@ import { css } from '@emotion/css';
 import { useId, useState } from 'react';
 import { useLocation } from 'react-router-dom-v5-compat';
 
-import { type SelectableValue, type GrafanaTheme2, type PluginType } from '@grafana/data';
+import { type SelectableValue, type GrafanaTheme2, type PluginType, createStructuredLogger } from '@grafana/data';
 import { Trans, t } from '@grafana/i18n';
 import { locationSearchToObject } from '@grafana/runtime';
 import { Select, RadioButtonGroup, useStyles2, Tooltip, Field, TextLink } from '@grafana/ui';
@@ -20,6 +20,8 @@ import { UpdateAllModal } from '../components/UpdateAllModal';
 import { Sorters } from '../helpers';
 import { useHistory } from '../hooks/useHistory';
 import { useGetAll, useGetUpdatable, useIsRemotePluginsAvailable } from '../state/hooks';
+
+const logger = createStructuredLogger('features.plugins');
 
 export default function Browse() {
   const location = useLocation();
@@ -72,7 +74,7 @@ export default function Browse() {
 
   // How should we handle errors?
   if (error) {
-    console.error(error.message);
+    logger.error(error.message);
     return null;
   }
 

--- a/public/app/features/plugins/admin/state/actions.ts
+++ b/public/app/features/plugins/admin/state/actions.ts
@@ -1,7 +1,7 @@
 import { createAction, createAsyncThunk, type Update } from '@reduxjs/toolkit';
 import { from, forkJoin, timeout, lastValueFrom, catchError, of } from 'rxjs';
 
-import { type PanelPlugin, type PluginError } from '@grafana/data';
+import { type PanelPlugin, type PluginError, createStructuredLogger } from '@grafana/data';
 import { config, getBackendSrv, isFetchError } from '@grafana/runtime';
 import { refetchPanelPluginMetas } from '@grafana/runtime/internal';
 import { importPanelPlugin } from 'app/features/plugins/importPanelPlugin';
@@ -31,6 +31,8 @@ import {
 } from '../types';
 
 // Fetches
+const logger = createStructuredLogger('features.plugins');
+
 export const fetchAll = createAsyncThunk(`${STATE_PREFIX}/fetchAll`, async (_, thunkApi) => {
   try {
     thunkApi.dispatch({ type: `${STATE_PREFIX}/fetchLocal/pending` });
@@ -46,7 +48,7 @@ export const fetchAll = createAsyncThunk(`${STATE_PREFIX}/fetchAll`, async (_, t
     const remote$ = from(getRemotePlugins()).pipe(
       catchError((err) => {
         thunkApi.dispatch({ type: `${STATE_PREFIX}/fetchRemote/rejected` });
-        console.error(err);
+        logger.error(err);
         return of([]);
       })
     );
@@ -121,7 +123,7 @@ export const fetchAll = createAsyncThunk(`${STATE_PREFIX}/fetchAll`, async (_, t
           }
         },
         (error) => {
-          console.log(error);
+          logger.info(error);
           thunkApi.dispatch({ type: `${STATE_PREFIX}/fetchLocal/rejected` });
           thunkApi.dispatch({ type: `${STATE_PREFIX}/fetchRemote/rejected` });
           return thunkApi.rejectWithValue('Unknown error.');
@@ -219,7 +221,7 @@ export const install = createAsyncThunk<
 
     return { id, changes };
   } catch (e) {
-    console.error(e);
+    logger.error(e);
     if (isFetchError(e)) {
       // add id to identify errors in multiple requests
       e.data.id = id;
@@ -246,7 +248,7 @@ export const uninstall = createAsyncThunk<Update<CatalogPlugin, string>, string>
         changes: { isInstalled: false, installedVersion: undefined, isFullyInstalled: false },
       };
     } catch (e) {
-      console.error(e);
+      logger.error(e);
 
       return thunkApi.rejectWithValue('Unknown error.');
     }

--- a/public/app/features/plugins/components/AppRootPage.tsx
+++ b/public/app/features/plugins/components/AppRootPage.tsx
@@ -13,6 +13,7 @@ import {
   OrgRole,
   PluginType,
   PluginContextProvider,
+  createStructuredLogger,
 } from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';
 import { Trans, t } from '@grafana/i18n';
@@ -43,6 +44,8 @@ import { PluginErrorBoundary } from './PluginErrorBoundary';
 import { buildPluginPageContext, PluginPageContext } from './PluginPageContext';
 import { pluginNavFallbacks } from './pluginNavFallbacks';
 import { RestrictedGrafanaApisProvider } from './restrictedGrafanaApis/RestrictedGrafanaApisProvider';
+
+const logger = createStructuredLogger('features.plugins');
 
 interface Props {
   // The ID of the plugin we would like to load and display
@@ -274,7 +277,7 @@ async function loadAppPlugin(pluginId: string, dispatch: React.Dispatch<AnyActio
     );
     const error = err instanceof Error ? err : new Error(getMessageFromError(err));
     getLogger('features.plugins').logError(error);
-    console.error(error);
+    logger.error(error);
   }
 }
 

--- a/public/app/features/plugins/components/PluginErrorBoundary.tsx
+++ b/public/app/features/plugins/components/PluginErrorBoundary.tsx
@@ -1,6 +1,8 @@
 import * as React from 'react';
 
-import { PluginContext } from '@grafana/data';
+import { PluginContext, createStructuredLogger } from '@grafana/data';
+
+const logger = createStructuredLogger('features.plugins');
 
 interface PluginErrorBoundaryProps {
   children: React.ReactNode;
@@ -32,7 +34,7 @@ export class PluginErrorBoundary extends React.Component<PluginErrorBoundaryProp
     if (this.props.onError) {
       this.props.onError(error, info);
     } else {
-      console.error(`Plugin "${this.context?.meta.id}" failed to load:`, error, info);
+      logger.error(`Plugin "${this.context?.meta.id}" failed to load:`, error, info);
     }
 
     this.setState({ error, errorInfo: info });

--- a/public/app/features/plugins/components/restrictedGrafanaApis/dashboardMutation/dashboardMutationApi.ts
+++ b/public/app/features/plugins/components/restrictedGrafanaApis/dashboardMutation/dashboardMutationApi.ts
@@ -21,6 +21,9 @@ import type { NotebookScene } from 'app/features/notebook/scene/NotebookScene';
 
 import { allMutationCommands } from './commandRegistry';
 
+import { createStructuredLogger } from '@grafana/data';
+const logger = createStructuredLogger('features.plugins');
+
 let _client: MutationClient | null = null;
 
 provideMutationClientFactory((sceneObject, resource) => {
@@ -33,7 +36,7 @@ provideMutationClientFactory((sceneObject, resource) => {
       _client = new DashboardMutationClient(sceneObject as DashboardScene);
     }
   } catch (error) {
-    console.error('Failed to register Dashboard Mutation API:', error);
+    logger.error('Failed to register Dashboard Mutation API:', error);
   }
 
   return () => {

--- a/public/app/features/plugins/extensions/logs/LogViewFilters.tsx
+++ b/public/app/features/plugins/extensions/logs/LogViewFilters.tsx
@@ -1,10 +1,12 @@
 import { isEmpty } from 'lodash';
 import { type ReactElement, useId, useMemo } from 'react';
 
-import { type DataFrame, type SelectableValue } from '@grafana/data';
+import { type DataFrame, type SelectableValue, createStructuredLogger } from '@grafana/data';
 import { t } from '@grafana/i18n';
 import { type SceneDataProvider } from '@grafana/scenes';
 import { InlineField, InlineFieldRow, MultiSelect } from '@grafana/ui';
+
+const logger = createStructuredLogger('features.plugins');
 
 export type LogFilter = {
   pluginIds?: Set<string>;
@@ -96,7 +98,7 @@ function useLogFilters(
 
   return useMemo(() => {
     if (data && data?.series.length > 1) {
-      console.warn('LogViewFilter does not support multiple series in query result.');
+      logger.warn('LogViewFilter does not support multiple series in query result.');
     }
 
     const frame = data?.series[0];

--- a/public/app/features/plugins/extensions/logs/log.ts
+++ b/public/app/features/plugins/extensions/logs/log.ts
@@ -2,9 +2,11 @@ import { isString } from 'lodash';
 import { nanoid } from 'nanoid';
 import { type Observable, ReplaySubject } from 'rxjs';
 
-import { type Labels, LogLevel } from '@grafana/data';
+import { type Labels, LogLevel, createStructuredLogger } from '@grafana/data';
 import { config } from '@grafana/runtime';
 import { getLogger } from '@grafana/runtime/unstable';
+
+const logger = createStructuredLogger('features.plugins');
 
 export type ExtensionsLogItem = {
   level: LogLevel;
@@ -41,7 +43,7 @@ export class ExtensionsLog {
 
   warning(message: string, labels?: Labels): void {
     getLogger('ui-extension-logs').logWarning(message, { ...this.baseLabels, ...labels });
-    config.buildInfo.env === 'development' && console.warn(message, { ...this.baseLabels, ...labels });
+    config.buildInfo.env === 'development' && logger.warn(message, { ...this.baseLabels, ...labels });
     this.log(LogLevel.warning, message, labels);
   }
 
@@ -49,7 +51,7 @@ export class ExtensionsLog {
     // TODO: If Faro has console instrumentation, then the following will track the same error message twice
     // (first: `monitoringLogger.logError()`, second: `console.error()` which gets picked up by Faro)
     getLogger('ui-extension-logs').logError(new Error(message), { ...this.baseLabels, ...labels });
-    console.error(message, { ...this.baseLabels, ...labels });
+    logger.error(message, { ...this.baseLabels, ...labels });
     this.log(LogLevel.error, message, labels);
   }
 

--- a/public/app/features/plugins/extensions/utils.tsx
+++ b/public/app/features/plugins/extensions/utils.tsx
@@ -15,6 +15,7 @@ import {
   PluginExtensionTypes,
   type PluginMeta,
   urlUtil,
+  createStructuredLogger,
 } from '@grafana/data';
 import { reportInteraction, config } from '@grafana/runtime';
 import { getAppPluginMetas } from '@grafana/runtime/internal';
@@ -44,13 +45,15 @@ import { type ExtensionsLog, log as baseLog } from './logs/log';
 import { type AddedLinkRegistryItem } from './registry/AddedLinksRegistry';
 import { assertIsNotPromise, assertStringProps, isPromise } from './validators';
 
+const logger = createStructuredLogger('features.plugins');
+
 export function handleErrorsInFn(fn: Function, errorMessagePrefix = '') {
   return (...args: unknown[]) => {
     try {
       return fn(...args);
     } catch (e) {
       if (e instanceof Error) {
-        console.warn(`${errorMessagePrefix}${e.message}`);
+        logger.warn(`${errorMessagePrefix}${e.message}`);
       }
     }
   };
@@ -117,7 +120,7 @@ export const wrapWithPluginContext = <T,>({
     }
 
     if (error) {
-      log.error(`Could not fetch plugin meta information for "${pluginId}", aborting. (${error.message})`, {
+      logger.error(`Could not fetch plugin meta information for "${pluginId}", aborting. (${error.message})`, {
         stack: error.stack ?? '',
         message: error.message,
       });
@@ -125,7 +128,7 @@ export const wrapWithPluginContext = <T,>({
     }
 
     if (!fetchedPluginMeta) {
-      log.error(`Fetched plugin meta information is empty for "${pluginId}", aborting.`);
+      logger.error(`Fetched plugin meta information is empty for "${pluginId}", aborting.`);
       return null;
     }
 
@@ -309,7 +312,7 @@ export function getMutationObserverProxy<T extends object>(obj: T, options?: Pro
     defineProperty(target, prop, descriptor) {
       // because immer (used by RTK) calls Object.isFrozen and Object.freeze we know that defineProperty will be called
       // behind the scenes as well so we only log message with debug level to minimize the noise and false positives
-      log.debug(
+      logger.debug(
         `Attempted to define object property "${String(prop)}" from ${source} with id ${pluginId} and version ${pluginVersion}`,
         {
           stack: new Error().stack ?? '',
@@ -465,7 +468,7 @@ export function getLinkExtensionOverrides(
     };
   } catch (error) {
     if (error instanceof Error) {
-      log.error(`Failed to configure link with title "${config.title}"`, {
+      logger.error(`Failed to configure link with title "${config.title}"`, {
         stack: error.stack ?? '',
         message: error.message,
       });
@@ -526,13 +529,13 @@ function getLinkExtensionOnClick(
         },
       };
 
-      log.debug(`onClick '${config.title}' at '${extensionPointId}'`);
+      logger.debug(`onClick '${config.title}' at '${extensionPointId}'`);
       const result = onClick(event, helpers);
 
       if (isPromise(result)) {
         result.catch((error) => {
           if (error instanceof Error) {
-            log.error(error.message, {
+            logger.error(error.message, {
               message: error.message,
               stack: error.stack ?? '',
             });
@@ -541,7 +544,7 @@ function getLinkExtensionOnClick(
       }
     } catch (error) {
       if (error instanceof Error) {
-        log.error(error.message, {
+        logger.error(error.message, {
           message: error.message,
           stack: error.stack ?? '',
         });

--- a/public/app/features/plugins/importer/addTranslationsToI18n.ts
+++ b/public/app/features/plugins/importer/addTranslationsToI18n.ts
@@ -4,6 +4,9 @@ import { addResourceBundle } from '@grafana/i18n/internal';
 import { SystemJS } from '../loader/systemjs';
 import { resolveModulePath } from '../loader/utils';
 
+import { createStructuredLogger } from '@grafana/data';
+const logger = createStructuredLogger('features.plugins');
+
 interface AddTranslationsToI18nOptions {
   resolvedLanguage: string;
   fallbackLanguage: string;
@@ -26,14 +29,14 @@ export async function addTranslationsToI18n({
   const path = resolvedPath ?? fallbackPath;
 
   if (!path) {
-    console.warn(`Could not find any translation for plugin ${pluginId}`, { resolvedLanguage, fallbackLanguage });
+    logger.warn(`Could not find any translation for plugin ${pluginId}`, { resolvedLanguage, fallbackLanguage });
     return;
   }
 
   try {
     const module = await SystemJS.import(resolveModulePath(path));
     if (!module.default) {
-      console.warn(`Could not find default export for plugin ${pluginId}`, {
+      logger.warn(`Could not find default export for plugin ${pluginId}`, {
         resolvedLanguage,
         fallbackLanguage,
         path,
@@ -44,7 +47,7 @@ export async function addTranslationsToI18n({
     const language = resolvedPath ? resolvedLanguage : fallbackLanguage;
     addResourceBundle(language, pluginId, module.default);
   } catch (error) {
-    console.warn(`Could not load translation for plugin ${pluginId}`, {
+    logger.warn(`Could not load translation for plugin ${pluginId}`, {
       resolvedLanguage,
       fallbackLanguage,
       error,

--- a/public/app/features/plugins/importer/importPluginModule.ts
+++ b/public/app/features/plugins/importer/importPluginModule.ts
@@ -12,6 +12,9 @@ import { shouldLoadPluginInFrontendSandbox } from '../sandbox/sandboxPluginLoade
 import { addTranslationsToI18n } from './addTranslationsToI18n';
 import { type PluginImportInfo } from './types';
 
+import { createStructuredLogger } from '@grafana/data';
+const logger = createStructuredLogger('features.plugins');
+
 export async function importPluginModule({
   path,
   pluginId,
@@ -78,7 +81,7 @@ export async function importPluginModule({
       errorMessage = `Could not load plugin. Updating the "${pluginName}" plugin to the latest version may fix the problem.`;
     }
     let error = new Error(errorMessage, { cause: e });
-    console.error(error);
+    logger.error(error);
     getLogger('features.plugins').logError(error, {
       path,
       pluginId,

--- a/public/app/features/plugins/importer/pluginImporter.ts
+++ b/public/app/features/plugins/importer/pluginImporter.ts
@@ -11,6 +11,7 @@ import {
   PluginLoadingStrategy,
   type PluginMeta,
   throwIfAngular,
+  createStructuredLogger,
 } from '@grafana/data';
 import { config } from '@grafana/runtime';
 import { getLogger } from '@grafana/runtime/unstable';
@@ -21,6 +22,8 @@ import { getPluginExtensionRegistries } from '../extensions/registry/setup';
 
 import { importPluginModule } from './importPluginModule';
 import { type PluginImporter, type PostImportStrategy, type PreImportStrategy } from './types';
+
+const logger = createStructuredLogger('features.plugins');
 
 const defaultPreImport: PreImportStrategy = (plugin) => {
   throwIfAngular(plugin);
@@ -56,7 +59,7 @@ const panelPluginPostImport: PostImportStrategy<PanelPlugin, PanelPluginMeta> = 
     throw new Error('missing export: plugin');
   } catch (error) {
     // TODO, maybe a different error plugin
-    console.warn('Error loading panel plugin: ' + meta.id, error);
+    logger.warn('Error loading panel plugin: ' + meta.id, error);
     return getPanelPluginLoadError(meta, error);
   }
 };

--- a/public/app/features/plugins/loader/pluginLoader.mock.ts
+++ b/public/app/features/plugins/loader/pluginLoader.mock.ts
@@ -1,6 +1,9 @@
 import { http, HttpResponse } from 'msw';
 import { setupServer } from 'msw/node';
 
+import { createStructuredLogger } from '@grafana/data';
+const logger = createStructuredLogger('features.plugins');
+
 const mockSystemModule = `System.register(['./dependencyA'], function (_export, _context) {
   "use strict";
 
@@ -17,7 +20,7 @@ const mockSystemModule = `System.register(['./dependencyA'], function (_export, 
 
 const mockAmdModule = `define([], function() {
   return function() {
-    console.log('AMD module loaded');
+    logger.info('AMD module loaded');
     var pluginPath = "/public/plugins/";
   }
 });`;

--- a/public/app/features/plugins/loader/systemjsHooks.ts
+++ b/public/app/features/plugins/loader/systemjsHooks.ts
@@ -1,4 +1,4 @@
-import { PluginLoadingStrategy } from '@grafana/data';
+import { PluginLoadingStrategy, createStructuredLogger } from '@grafana/data';
 import { config } from '@grafana/runtime';
 
 import { transformPluginSourceForCDN } from '../cdn/utils';
@@ -11,6 +11,8 @@ import { SystemJS } from './systemjs';
 import { sharedDependenciesMap } from './sharedDependencies';
 import { type SystemJSWithLoaderHooks } from './types';
 import { buildImportMap, isHostedOnCDN } from './utils';
+
+const logger = createStructuredLogger('features.plugins');
 
 export function initSystemJSHooks() {
   const imports = buildImportMap(sharedDependenciesMap);
@@ -102,7 +104,7 @@ export function decorateSystemJSResolve(
       const url = originalResolve.apply(this, [resolvedUrl, parentUrl]);
       return resolvePluginUrlWithCache(url);
     }
-    console.warn(`SystemJS: failed to resolve '${id}'`);
+    logger.warn(`SystemJS: failed to resolve '${id}'`);
     return id;
   }
 }

--- a/public/app/features/plugins/loader/utils.ts
+++ b/public/app/features/plugins/loader/utils.ts
@@ -5,6 +5,9 @@ import { sandboxPluginDependencies } from '../sandbox/pluginDependencies';
 import { SHARED_DEPENDENCY_PREFIX } from './constants';
 import { SystemJS } from './systemjs';
 
+import { createStructuredLogger } from '@grafana/data';
+const logger = createStructuredLogger('features.plugins');
+
 export function buildImportMap(importMap: Record<string, System.Module>) {
   return Object.keys(importMap).reduce<Record<string, string>>((acc, key) => {
     // Use the 'package:' prefix to act as a URL instead of a bare specifier
@@ -29,7 +32,7 @@ function addPreload(id: string, preload: (() => Promise<System.Module>) | System
   try {
     resolvedId = SystemJS.resolve(id);
   } catch (e) {
-    console.log(e);
+    logger.info(e);
   }
 
   if (resolvedId && SystemJS.has(resolvedId)) {

--- a/public/app/features/plugins/pluginPreloader.ts
+++ b/public/app/features/plugins/pluginPreloader.ts
@@ -4,6 +4,9 @@ import { contextSrv } from 'app/core/services/context_srv';
 
 import { pluginImporter } from './importer/pluginImporter';
 
+import { createStructuredLogger } from '@grafana/data';
+const logger = createStructuredLogger('features.plugins');
+
 const preloadPromises = new Map<string, Promise<void>>();
 
 export const clearPreloadedPluginsCache = () => {
@@ -33,6 +36,6 @@ async function preload(config: AppPluginConfig): Promise<void> {
       return;
     }
 
-    console.error(`[Plugins] Failed to preload plugin: ${config.path} (version: ${config.version})`, error);
+    logger.error(`[Plugins] Failed to preload plugin: ${config.path} (version: ${config.version})`, error);
   }
 }

--- a/public/app/features/plugins/sandbox/distortions.ts
+++ b/public/app/features/plugins/sandbox/distortions.ts
@@ -61,6 +61,9 @@ import { logWarning, unboxRegexesFromMembraneProxy } from './utils';
  * The code in this file defines that generalDistortionMap.
  */
 
+import { createStructuredLogger } from '@grafana/data';
+const logger = createStructuredLogger('features.plugins');
+
 type DistortionMap = Map<
   unknown,
   (originalAttrOrMethod: unknown, pluginMeta: SandboxPluginMeta, sandboxEnv?: SandboxEnvironment) => unknown
@@ -140,7 +143,7 @@ function distortConsole(distortions: DistortionMap) {
       const pluginId = meta.id;
 
       function sandboxLog(...args: unknown[]) {
-        console.log(`[plugin ${pluginId}]`, ...args);
+        logger.info(`[plugin ${pluginId}]`, ...args);
       }
       return {
         log: sandboxLog,
@@ -170,7 +173,7 @@ function distortAlert(distortions: DistortionMap) {
     });
 
     return function (...args: unknown[]) {
-      console.log(`[plugin ${pluginId}]`, ...args);
+      logger.info(`[plugin ${pluginId}]`, ...args);
     };
   }
   const descriptor = Object.getOwnPropertyDescriptor(window, 'alert');

--- a/public/app/features/plugins/sandbox/sandboxPluginLoader.ts
+++ b/public/app/features/plugins/sandbox/sandboxPluginLoader.ts
@@ -1,7 +1,7 @@
 import createVirtualEnvironment from '@locker/near-membrane-dom';
 import { type ProxyTarget } from '@locker/near-membrane-shared';
 
-import { type BootData } from '@grafana/data';
+import { type BootData, createStructuredLogger } from '@grafana/data';
 import { config } from '@grafana/runtime';
 import { defaultTrustedTypesPolicy } from 'app/core/trustedTypePolicies';
 
@@ -26,6 +26,8 @@ import {
 import { logError, logInfo } from './utils';
 
 // Loads near membrane custom formatter for near membrane proxy objects.
+const logger = createStructuredLogger('features.plugins');
+
 if (process.env.NODE_ENV !== 'production') {
   require('@locker/near-membrane-dom/custom-devtools-formatter');
 }
@@ -139,7 +141,7 @@ async function doImportPluginModuleInSandbox(meta: SandboxPluginMeta): Promise<S
               `Error in ${meta.id}: Plugins should not use window.grafanaBootData. Use "config" from "@grafana/runtime" instead.`
             );
           } else {
-            console.error(
+            logger.error(
               `${meta.id.toUpperCase()}: Plugins should not use window.grafanaBootData. Use "config" from "@grafana/runtime" instead.`
             );
           }

--- a/public/app/features/profile/api.ts
+++ b/public/app/features/profile/api.ts
@@ -4,11 +4,14 @@ import { type UserDTO, type UserOrg, type UserSession } from 'app/types/user';
 
 import { type ChangePasswordFields, type ProfileUpdateFields } from './types';
 
+import { createStructuredLogger } from '@grafana/data';
+const logger = createStructuredLogger('features.profile');
+
 async function changePassword(payload: ChangePasswordFields): Promise<void> {
   try {
     await getBackendSrv().put('/api/user/password', payload);
   } catch (err) {
-    console.error(err);
+    logger.error(err);
   }
 }
 
@@ -42,7 +45,7 @@ async function updateUserProfile(payload: ProfileUpdateFields): Promise<void> {
   try {
     await getBackendSrv().put('/api/user', payload);
   } catch (err) {
-    console.error(err);
+    logger.error(err);
   }
 }
 

--- a/public/app/features/provisioning/components/Shared/SaveProvisionedResourceDrawer.test.tsx
+++ b/public/app/features/provisioning/components/Shared/SaveProvisionedResourceDrawer.test.tsx
@@ -396,7 +396,10 @@ describe('SaveProvisionedResourceDrawer', () => {
     });
 
     expect(screen.queryByRole('heading', { name: /provisioned/i })).not.toBeInTheDocument();
-    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('unknown.example.com/v1'));
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('unknown.example.com/v1'),
+      expect.objectContaining({ source: 'features.provisioning' })
+    );
     warnSpy.mockRestore();
   });
 });

--- a/public/app/features/provisioning/components/Shared/SaveProvisionedResourceDrawer.tsx
+++ b/public/app/features/provisioning/components/Shared/SaveProvisionedResourceDrawer.tsx
@@ -41,6 +41,10 @@ import { slugifyForFilename } from '../utils/path';
 import { ResourceEditFormSharedFields } from './ResourceEditFormSharedFields';
 
 /** Commit action handled by this drawer. */
+import { createStructuredLogger } from '@grafana/data';
+
+const logger = createStructuredLogger('features.provisioning');
+
 type ProvisionedResourceAction = 'create' | 'update' | 'delete';
 
 /**
@@ -298,7 +302,7 @@ export function SaveProvisionedResourceDrawer(props: SaveProvisionedResourceDraw
     // new kind wired into a page before its registry entry exists. Warn in dev so it's a visible signal
     // rather than a silent no-op where the user clicks save/delete and nothing happens.
     if (process.env.NODE_ENV !== 'production') {
-      console.warn(
+      logger.warn(
         `SaveProvisionedResourceDrawer: no registered provisioning kind for "${props.resource.apiVersion}"/"${props.resource.kind}"; the drawer will not render.`
       );
     }

--- a/public/app/features/query/components/QueryGroup.tsx
+++ b/public/app/features/query/components/QueryGroup.tsx
@@ -12,6 +12,7 @@ import {
   getDefaultTimeRange,
   LoadingState,
   type PanelData,
+  createStructuredLogger,
 } from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';
 import { Trans, t } from '@grafana/i18n';
@@ -35,6 +36,8 @@ import { updateQueries } from '../state/updateQueries';
 import { GroupActionComponents } from './QueryActionComponent';
 import { QueryEditorRows } from './QueryEditorRows';
 import { QueryGroupOptionsEditor } from './QueryGroupOptions';
+
+const logger = createStructuredLogger('features.query');
 
 export interface Props {
   queryRunner: PanelQueryRunner;
@@ -123,7 +126,7 @@ export class QueryGroup extends PureComponent<Props, State> {
         defaultDataSource,
       });
     } catch (error) {
-      console.error('failed to load data source', error);
+      logger.error('failed to load data source', error);
     }
   }
 

--- a/public/app/features/query/state/DashboardQueryRunner/LegacyAnnotationQueryRunner.ts
+++ b/public/app/features/query/state/DashboardQueryRunner/LegacyAnnotationQueryRunner.ts
@@ -1,11 +1,13 @@
 import { from, type Observable, of } from 'rxjs';
 import { catchError } from 'rxjs/operators';
 
-import { type AnnotationEvent, type DataSourceApi } from '@grafana/data';
+import { type AnnotationEvent, type DataSourceApi, createStructuredLogger } from '@grafana/data';
 import { shouldUseLegacyRunner } from 'app/features/annotations/standardAnnotationSupport';
 
 import { type AnnotationQueryRunner, type AnnotationQueryRunnerOptions } from './types';
 import { handleAnnotationQueryRunnerError } from './utils';
+
+const logger = createStructuredLogger('features.query');
 
 export class LegacyAnnotationQueryRunner implements AnnotationQueryRunner {
   canRun(datasource?: DataSourceApi): boolean {
@@ -26,13 +28,13 @@ export class LegacyAnnotationQueryRunner implements AnnotationQueryRunner {
     }
 
     if (datasource?.annotationQuery === undefined) {
-      console.warn('datasource does not have an annotation query');
+      logger.warn('datasource does not have an annotation query');
       return of([]);
     }
 
     const annotationQuery = datasource.annotationQuery({ range, rangeRaw: range.raw, annotation, dashboard });
     if (annotationQuery === undefined) {
-      console.warn('datasource does not have an annotation query');
+      logger.warn('datasource does not have an annotation query');
       return of([]);
     }
 

--- a/public/app/features/query/state/DashboardQueryRunner/utils.ts
+++ b/public/app/features/query/state/DashboardQueryRunner/utils.ts
@@ -1,7 +1,7 @@
 import { cloneDeep } from 'lodash';
 import { type Observable, of } from 'rxjs';
 
-import { type AnnotationEvent, type AnnotationQuery, type DataSourceApi } from '@grafana/data';
+import { type AnnotationEvent, type AnnotationQuery, type DataSourceApi, createStructuredLogger } from '@grafana/data';
 import { config, toDataQueryError } from '@grafana/runtime';
 import { dispatch } from 'app/store/store';
 
@@ -9,6 +9,8 @@ import { createErrorNotification } from '../../../../core/copy/appNotification';
 import { notifyApp } from '../../../../core/reducers/appNotification';
 
 import { type DashboardQueryRunnerWorkerResult } from './types';
+
+const logger = createStructuredLogger('features.query');
 
 export function handleAnnotationQueryRunnerError(err: any): Observable<AnnotationEvent[]> {
   if (err.cancelled) {
@@ -38,7 +40,7 @@ export function handleDashboardQueryRunnerWorkerError(err: any): Observable<Dash
 
 function notifyWithError(title: string, err: any) {
   const error = toDataQueryError(err);
-  console.error('handleAnnotationQueryRunnerError', error);
+  logger.error('handleAnnotationQueryRunnerError', error);
   const notification = createErrorNotification(title, error.message);
   dispatch(notifyApp(notification));
 }

--- a/public/app/features/query/state/PanelQueryRunner.ts
+++ b/public/app/features/query/state/PanelQueryRunner.ts
@@ -29,6 +29,7 @@ import {
   type ApplyFieldOverrideOptions,
   type StreamingDataFrame,
   DataTopic,
+  createStructuredLogger,
 } from '@grafana/data';
 import { toDataQueryError } from '@grafana/runtime';
 import { ExpressionDatasourceRef } from '@grafana/runtime/internal';
@@ -42,6 +43,8 @@ import { type PanelModel } from '../../dashboard/state/PanelModel';
 import { getDashboardQueryRunner } from './DashboardQueryRunner/DashboardQueryRunner';
 import { mergePanelAndDashData } from './mergePanelAndDashData';
 import { runRequest } from './runRequest';
+
+const logger = createStructuredLogger('features.query');
 
 export interface QueryRunnerOptions<
   TQuery extends DataQuery = DataQuery,
@@ -257,7 +260,7 @@ export class PanelQueryRunner {
         return { ...data, series, annotations };
       }),
       catchError((err) => {
-        console.warn('Error running transformation:', err);
+        logger.warn('Error running transformation:', err);
         return of({
           ...data,
           state: LoadingState.Error,

--- a/public/app/features/query/state/QueryRunner.ts
+++ b/public/app/features/query/state/QueryRunner.ts
@@ -14,6 +14,7 @@ import {
   LoadingState,
   type DataSourceRef,
   preProcessPanelData,
+  createStructuredLogger,
 } from '@grafana/data';
 import { getTemplateSrv } from '@grafana/runtime';
 import { getDatasourceSrv } from 'app/features/plugins/datasource_srv';
@@ -21,6 +22,8 @@ import { getDatasourceSrv } from 'app/features/plugins/datasource_srv';
 import { getNextRequestId } from './PanelQueryRunner';
 import { setStructureRevision } from './processing/revision';
 import { runRequest } from './runRequest';
+
+const logger = createStructuredLogger('features.query');
 
 export class QueryRunner implements QueryRunnerSrv {
   private subject: ReplaySubject<PanelData>;
@@ -113,7 +116,7 @@ export class QueryRunner implements QueryRunnerSrv {
             },
           });
         },
-        error: (error) => console.error('PanelQueryRunner Error', error),
+        error: (error) => logger.error('PanelQueryRunner Error', error),
       });
   }
 

--- a/public/app/features/query/state/runRequest.ts
+++ b/public/app/features/query/state/runRequest.ts
@@ -17,6 +17,7 @@ import {
   LoadingState,
   type PanelData,
   type TimeRange,
+  createStructuredLogger,
 } from '@grafana/data';
 import { config, isMigrationHandler, migrateRequest, toDataQueryError, isExpressionReference } from '@grafana/runtime';
 import { backendSrv } from 'app/core/services/backend_srv';
@@ -26,6 +27,8 @@ import { type ExpressionQuery } from 'app/features/expressions/types';
 
 import { cancelNetworkRequestsOnUnsubscribe } from './processing/canceler';
 import { emitDataRequestEvent } from './queryAnalytics';
+
+const logger = createStructuredLogger('features.query');
 
 type MapOfResponsePackets = { [str: string]: DataQueryResponse };
 
@@ -161,7 +164,7 @@ export function runRequest(
     }),
     // handle errors
     catchError((err) => {
-      console.error('runRequest.catchError', err);
+      logger.error('runRequest.catchError', err);
       return of({
         ...state.panelData,
         state: LoadingState.Error,

--- a/public/app/features/scopes/ScopesApiClient.ts
+++ b/public/app/features/scopes/ScopesApiClient.ts
@@ -1,4 +1,4 @@
-import { type Scope, type ScopeDashboardBinding, type ScopeNode } from '@grafana/data';
+import { type Scope, type ScopeDashboardBinding, type ScopeNode, createStructuredLogger } from '@grafana/data';
 import { FlagKeys, getFeatureFlagClient } from '@grafana/runtime/internal';
 import { scopeAPIv0alpha1 } from 'app/api/clients/scope/v0alpha1';
 import type { FindDefaultScope } from 'app/api/clients/scope/v0alpha1/endpoints.gen';
@@ -6,6 +6,8 @@ import { getMessageFromError } from 'app/core/utils/errors';
 import { dispatch } from 'app/store/store';
 
 import { type ScopeNavigation } from './dashboards/types';
+
+const logger = createStructuredLogger('features.scopes');
 
 export class ScopesApiClient {
   /**
@@ -35,7 +37,7 @@ export class ScopesApiClient {
       // Check if the data is actually an error response (Kubernetes Status object)
       if (this.isStatusError(result.data)) {
         const errorMessage = getMessageFromError(result.data);
-        console.error(`Failed to fetch %s:`, context, errorMessage);
+        logger.error(`Failed to fetch %s:`, context, errorMessage);
         return undefined;
       }
       return result.data;
@@ -43,7 +45,7 @@ export class ScopesApiClient {
 
     if ('error' in result) {
       const errorMessage = getMessageFromError(result.error);
-      console.error(`Failed to fetch %s:`, context, errorMessage);
+      logger.error(`Failed to fetch %s:`, context, errorMessage);
     }
 
     return undefined;
@@ -55,7 +57,7 @@ export class ScopesApiClient {
       return this.extractDataOrHandleError(result, `scope: ${name}`);
     } catch (err) {
       const errorMessage = getMessageFromError(err);
-      console.error('Failed to fetch scope:', name, errorMessage);
+      logger.error('Failed to fetch scope:', name, errorMessage);
       return undefined;
     } finally {
       // Unsubscribe for extra safety, even though with subscribe: false and awaiting,
@@ -75,7 +77,7 @@ export class ScopesApiClient {
 
       if (successfulScopes.length < scopesIds.length) {
         const failedCount = scopesIds.length - successfulScopes.length;
-        console.warn(
+        logger.warn(
           'Failed to fetch',
           failedCount,
           'of',
@@ -88,7 +90,7 @@ export class ScopesApiClient {
       return successfulScopes;
     } catch (err) {
       const errorMessage = getMessageFromError(err);
-      console.error('Failed to fetch multiple scopes:', scopesIds, errorMessage);
+      logger.error('Failed to fetch multiple scopes:', scopesIds, errorMessage);
       return [];
     }
   }
@@ -111,13 +113,13 @@ export class ScopesApiClient {
 
       if ('error' in result) {
         const errorMessage = getMessageFromError(result.error);
-        console.error('Failed to fetch multiple scope nodes:', names, errorMessage);
+        logger.error('Failed to fetch multiple scope nodes:', names, errorMessage);
       }
 
       return [];
     } catch (err) {
       const errorMessage = getMessageFromError(err);
-      console.error('Failed to fetch multiple scope nodes:', names, errorMessage);
+      logger.error('Failed to fetch multiple scope nodes:', names, errorMessage);
       return [];
     } finally {
       // Unsubscribe for extra safety, even though with subscribe: false and awaiting,
@@ -171,7 +173,7 @@ export class ScopesApiClient {
         }
         contextParts.push('limit=' + limit);
         const context = contextParts.join(', ');
-        console.error('Failed to fetch scope nodes:', context, errorMessage);
+        logger.error('Failed to fetch scope nodes:', context, errorMessage);
       }
 
       return [];
@@ -186,7 +188,7 @@ export class ScopesApiClient {
       }
       contextParts.push('limit=' + limit);
       const context = contextParts.join(', ');
-      console.error('Failed to fetch scope nodes:', context, errorMessage);
+      logger.error('Failed to fetch scope nodes:', context, errorMessage);
       return [];
     } finally {
       // Unsubscribe for extra safety, even though with subscribe: false and awaiting,
@@ -214,13 +216,13 @@ export class ScopesApiClient {
 
       if ('error' in result) {
         const errorMessage = getMessageFromError(result.error);
-        console.error('Failed to fetch dashboards for scopes:', scopeNames, errorMessage);
+        logger.error('Failed to fetch dashboards for scopes:', scopeNames, errorMessage);
       }
 
       return [];
     } catch (err) {
       const errorMessage = getMessageFromError(err);
-      console.error('Failed to fetch dashboards for scopes:', scopeNames, errorMessage);
+      logger.error('Failed to fetch dashboards for scopes:', scopeNames, errorMessage);
       return [];
     } finally {
       // Unsubscribe for extra safety, even though with subscribe: false and awaiting,
@@ -253,13 +255,13 @@ export class ScopesApiClient {
 
       if ('error' in result) {
         const errorMessage = getMessageFromError(result.error);
-        console.error('Failed to fetch scope navigations for scopes:', scopeNames, errorMessage);
+        logger.error('Failed to fetch scope navigations for scopes:', scopeNames, errorMessage);
       }
 
       return [];
     } catch (err) {
       const errorMessage = getMessageFromError(err);
-      console.error('Failed to fetch scope navigations for scopes:', scopeNames, errorMessage);
+      logger.error('Failed to fetch scope navigations for scopes:', scopeNames, errorMessage);
       return [];
     } finally {
       // Unsubscribe for extra safety, even though with subscribe: false and awaiting,
@@ -312,7 +314,7 @@ export class ScopesApiClient {
       return name;
     } catch (err) {
       const errorMessage = getMessageFromError(err);
-      console.error('Failed to fetch default scope:', errorMessage);
+      logger.error('Failed to fetch default scope:', errorMessage);
       return undefined;
     } finally {
       subscription.unsubscribe();
@@ -328,7 +330,7 @@ export class ScopesApiClient {
       return this.extractDataOrHandleError(result, `scope node: ${scopeNodeId}`);
     } catch (err) {
       const errorMessage = getMessageFromError(err);
-      console.error('Failed to fetch scope node:', scopeNodeId, errorMessage);
+      logger.error('Failed to fetch scope node:', scopeNodeId, errorMessage);
       return undefined;
     } finally {
       // Unsubscribe for extra safety, even though with subscribe: false and awaiting,

--- a/public/app/features/scopes/ScopesService.ts
+++ b/public/app/features/scopes/ScopesService.ts
@@ -10,6 +10,9 @@ import { deserializeFolderPath, serializeFolderPath } from './dashboards/scopeNa
 import { type ScopesSelectorService } from './selector/ScopesSelectorService';
 import { type ScopesMap, type SelectedScope } from './selector/types';
 
+import { createStructuredLogger } from '@grafana/data';
+const logger = createStructuredLogger('features.scopes');
+
 export interface State {
   enabled: boolean;
   readOnly: boolean;
@@ -102,7 +105,7 @@ export class ScopesService implements ScopesContextValue {
           const tree = this.selectorService.state.tree;
           if (derivedNodeId && tree) {
             this.selectorService.resolvePathToRoot(derivedNodeId, tree, firstApplied.scopeId).catch((error) => {
-              console.error('Failed to pre-load node path from defaultPath', error);
+              logger.error('Failed to pre-load node path from defaultPath', error);
             });
           }
         }
@@ -112,7 +115,7 @@ export class ScopesService implements ScopesContextValue {
     // Preload scope node (which loads parent too)
     if (scopeNodeId) {
       this.selectorService.resolvePathToRoot(scopeNodeId, this.selectorService.state.tree!).catch((error) => {
-        console.error('Failed to pre-load node path', error);
+        logger.error('Failed to pre-load node path', error);
       });
     }
 
@@ -294,7 +297,7 @@ export class ScopesService implements ScopesContextValue {
               // calls elsewhere in this file so a rejection from either
               // fetchDefaultScope or the changeScopes chain above is logged
               // instead of surfacing as an unhandled rejection.
-              console.error('Failed to apply default scope:', err);
+              logger.error('Failed to apply default scope:', err);
             });
         }
         // Defer the URL write when scope metadata has not loaded yet.

--- a/public/app/features/scopes/selector/ScopesSelectorService.ts
+++ b/public/app/features/scopes/selector/ScopesSelectorService.ts
@@ -1,4 +1,4 @@
-import { type ScopeNode, store as storeImpl } from '@grafana/data';
+import { type ScopeNode, store as storeImpl, createStructuredLogger } from '@grafana/data';
 import { config, locationService } from '@grafana/runtime';
 import { type performanceUtils } from '@grafana/scenes';
 import { getDashboardSceneProfiler } from 'app/features/dashboard/services/DashboardProfiler';
@@ -21,6 +21,8 @@ import {
   treeNodeAtPath,
 } from './scopesTreeUtils';
 import { type NodesMap, type ScopesMap, type SelectedScope, type TreeNode } from './types';
+
+const logger = createStructuredLogger('features.scopes');
 
 export interface ScopesSelectorServiceState {
   // Used to indicate loading of the scopes themselves for example when applying them.
@@ -99,7 +101,7 @@ export class ScopesSelectorService extends ScopesServiceBase<ScopesSelectorServi
       }
       return node;
     } catch (error) {
-      console.error('Failed to load node', error);
+      logger.error('Failed to load node', error);
       return undefined;
     }
   };
@@ -107,7 +109,7 @@ export class ScopesSelectorService extends ScopesServiceBase<ScopesSelectorServi
   private getNodePath = async (scopeNodeId: string, visited: Set<string> = new Set()): Promise<ScopeNode[]> => {
     // Protect against circular references
     if (visited.has(scopeNodeId)) {
-      console.error('Circular reference detected in node path', scopeNodeId);
+      logger.error('Circular reference detected in node path', scopeNodeId);
       return [];
     }
 
@@ -440,7 +442,7 @@ export class ScopesSelectorService extends ScopesServiceBase<ScopesSelectorServi
 
     // Validate API response is an array
     if (!Array.isArray(fetchedScopes)) {
-      console.error('Expected fetchedScopes to be an array, got:', typeof fetchedScopes);
+      logger.error('Expected fetchedScopes to be an array, got:', typeof fetchedScopes);
       this.updateState({ scopes: newScopesState, loading: false });
       return;
     }
@@ -603,7 +605,7 @@ export class ScopesSelectorService extends ScopesServiceBase<ScopesSelectorServi
           newTree = expandNodes(newTree, parentPath);
         }
       } catch (error) {
-        console.error('Failed to expand to selected scope', error);
+        logger.error('Failed to expand to selected scope', error);
       }
     }
 

--- a/public/app/features/scopes/selector/scopesTreeUtils.ts
+++ b/public/app/features/scopes/selector/scopesTreeUtils.ts
@@ -1,10 +1,12 @@
-import { type ScopeNode } from '@grafana/data';
+import { type ScopeNode, createStructuredLogger } from '@grafana/data';
 
 import { type NodesMap, type TreeNode } from './types';
 
 /**
  * Creates a deep copy of the node tree with expanded prop set to false.
  */
+const logger = createStructuredLogger('features.scopes');
+
 export function closeNodes(tree: TreeNode): TreeNode {
   const node = { ...tree };
   node.expanded = false;
@@ -125,7 +127,7 @@ export const insertPathNodesIntoTree = (tree: TreeNode, path: ScopeNode[]) => {
     newTree = modifyTreeNodeAtPath(newTree, pathSlice, (treeNode) => {
       treeNode.children = { ...treeNode.children };
       if (!childNodeName) {
-        console.warn('Failed to insert full path into tree. Did not find child to' + stringPath[index]);
+        logger.warn('Failed to insert full path into tree. Did not find child to' + stringPath[index]);
         treeNode.childrenLoaded = treeNode.childrenLoaded ?? false;
         return;
       }

--- a/public/app/features/scopes/selector/useScopeNode.ts
+++ b/public/app/features/scopes/selector/useScopeNode.ts
@@ -1,10 +1,12 @@
 import { useEffect, useState } from 'react';
 
-import { type ScopeNode } from '@grafana/data';
+import { type ScopeNode, createStructuredLogger } from '@grafana/data';
 
 import { useScopesServices } from '../ScopesContextProvider';
 
 // Light wrapper around the scopesSelectorService.getScopeNode to make it easier to use in the UI.
+const logger = createStructuredLogger('features.scopes');
+
 export function useScopeNode(scopeNodeId?: string) {
   const [node, setNode] = useState<ScopeNode | undefined>(undefined);
   const [isLoading, setIsLoading] = useState(false);
@@ -21,7 +23,7 @@ export function useScopeNode(scopeNodeId?: string) {
         const node = await scopesSelectorService.getScopeNode(scopeNodeId);
         setNode(node);
       } catch (error) {
-        console.error('Failed to load node', error);
+        logger.error('Failed to load node', error);
       } finally {
         setIsLoading(false);
       }

--- a/public/app/features/search/service/deletedDashboardsCache.ts
+++ b/public/app/features/search/service/deletedDashboardsCache.ts
@@ -24,6 +24,10 @@ import { DELETED_BY_REMOVED, DELETED_BY_UNKNOWN } from './utils';
  * over the cached `TableResponse` + Map lookups, no network. This lets
  * `DELETED_BY_UNKNOWN` entries self-heal across calls when IAM retries succeed.
  */
+import { createStructuredLogger } from '@grafana/data';
+
+const logger = createStructuredLogger('features.search');
+
 class DeletedDashboardsCache {
   private tableCache: TableResponse | null = null;
   private tablePromise: Promise<TableResponse> | null = null;
@@ -123,7 +127,7 @@ class DeletedDashboardsCache {
         rows: Array.from(deduped.values()),
       };
     } catch (error) {
-      console.error('Failed to fetch deleted dashboards:', error);
+      logger.error('Failed to fetch deleted dashboards:', error);
       return EMPTY_TABLE_RESPONSE;
     }
   }
@@ -220,7 +224,7 @@ export async function resolveDeletedByDisplayMap(
   } catch (error) {
     // `Promise.allSettled` cannot reject; this catches synchronous throws from `dispatch()`
     // itself. Mark every UID unknown so callers render placeholders, not raw UIDs.
-    console.error('Failed to resolve deleted dashboard user displays:', getMessageFromError(error));
+    logger.error('Failed to resolve deleted dashboard user displays:', getMessageFromError(error));
     for (const uid of toFetch) {
       result.set(uid, DELETED_BY_UNKNOWN);
     }
@@ -233,12 +237,12 @@ function extractDisplayData(
   settled: PromiseSettledResult<{ data?: DisplayList; error?: unknown }>
 ): DisplayList | undefined {
   if (settled.status === 'rejected') {
-    console.error('Failed to resolve deleted dashboard user displays:', getMessageFromError(settled.reason));
+    logger.error('Failed to resolve deleted dashboard user displays:', getMessageFromError(settled.reason));
     return undefined;
   }
   // RTK Query query thunks resolve (do not reject) on request errors — surface them explicitly.
   if (settled.value.error) {
-    console.error('Failed to resolve deleted dashboard user displays:', getMessageFromError(settled.value.error));
+    logger.error('Failed to resolve deleted dashboard user displays:', getMessageFromError(settled.value.error));
     return undefined;
   }
   return settled.value.data;

--- a/public/app/features/search/service/unified.ts
+++ b/public/app/features/search/service/unified.ts
@@ -12,6 +12,7 @@ import {
   DataFrameView,
   getDisplayProcessor,
   type SelectableValue,
+  createStructuredLogger,
 } from '@grafana/data';
 import { t } from '@grafana/i18n';
 import { config, getBackendSrv } from '@grafana/runtime';
@@ -34,6 +35,8 @@ import {
   type SearchResultMeta,
 } from './types';
 import { appendFrame, filterSearchResults, replaceCurrentFolderQuery } from './utils';
+
+const logger = createStructuredLogger('features.search');
 
 const searchURI = `${v0alphaBaseURL}/search`;
 
@@ -204,7 +207,7 @@ export class UnifiedSearcher implements GrafanaSearcher {
         const resp = await this.fetchResponse(nextPageUrl);
         const frame = toDashboardResults(resp, query.sort ?? '');
         if (!frame) {
-          console.log('no results', frame);
+          logger.info('no results', frame);
           return;
         }
 

--- a/public/app/features/search/service/utils.ts
+++ b/public/app/features/search/service/utils.ts
@@ -1,5 +1,5 @@
 import { type ManagedBy } from '@grafana/api-clients/rtkq/dashboard/v0alpha1';
-import { type DataFrame, type DataFrameView, type IconName, fuzzySearch } from '@grafana/data';
+import { type DataFrame, type DataFrameView, type IconName, fuzzySearch, createStructuredLogger } from '@grafana/data';
 import { type DashboardViewItemWithUIItems } from 'app/features/browse-dashboards/types';
 import {
   isSharedWithMe,
@@ -21,6 +21,8 @@ import { type SearchHit } from './unified';
  * display entry — typically because the account (user, service account, API key, ...) was
  * deleted. Chosen with NUL delimiters so it cannot collide with any real display name.
  */
+const logger = createStructuredLogger('features.search');
+
 export const DELETED_BY_REMOVED = '\u0000__grafana_deleted_account__\u0000';
 
 /**
@@ -67,7 +69,7 @@ async function getCurrentFolderUID(): Promise<string | undefined> {
     }
     return Promise.resolve(dash?.meta?.folderUid);
   } catch (e) {
-    console.error(e);
+    logger.error(e);
   }
   return undefined;
 }

--- a/public/app/features/serviceaccounts/ServiceAccountCreatePage.tsx
+++ b/public/app/features/serviceaccounts/ServiceAccountCreatePage.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useState, type JSX } from 'react';
 import { FormProvider, useForm } from 'react-hook-form';
 
-import { OrgRole } from '@grafana/data';
+import { OrgRole, createStructuredLogger } from '@grafana/data';
 import { Trans, t } from '@grafana/i18n';
 import { config, getBackendSrv, locationService } from '@grafana/runtime';
 import { Button, Input, Field, FieldSet } from '@grafana/ui';
@@ -15,6 +15,8 @@ import { type Role, AccessControlAction } from 'app/types/accessControl';
 import { type ServiceAccountDTO, type ServiceAccountCreateApiResponse } from 'app/types/serviceaccount';
 
 import { OrgRolePicker } from '../admin/OrgRolePicker';
+
+const logger = createStructuredLogger('features.serviceaccounts');
 
 export interface Props {}
 
@@ -68,7 +70,7 @@ export const ServiceAccountCreatePage = ({}: Props): JSX.Element => {
           setRoleOptions(options);
         }
       } catch (e) {
-        console.error('Error loading options', e); // TODO: handle error
+        logger.error('Error loading options', e); // TODO: handle error
       }
     }
     if (contextSrv.licensedAccessControlEnabled()) {
@@ -101,7 +103,7 @@ export const ServiceAccountCreatePage = ({}: Props): JSX.Element => {
           await updateUserRoles(pendingRoles, newAccount.id, newAccount.orgId);
         }
       } catch (e) {
-        console.error(e); // TODO: handle error
+        logger.error(e); // TODO: handle error
       }
       locationService.push(`/org/serviceaccounts/${response.uid}`);
     },

--- a/public/app/features/serviceaccounts/components/ServiceAccountProfile.tsx
+++ b/public/app/features/serviceaccounts/components/ServiceAccountProfile.tsx
@@ -1,7 +1,7 @@
 import { css } from '@emotion/css';
 import { useEffect, useState, type JSX } from 'react';
 
-import { type GrafanaTheme2, type OrgRole, type TimeZone, dateTimeFormat } from '@grafana/data';
+import { type GrafanaTheme2, type OrgRole, type TimeZone, dateTimeFormat, createStructuredLogger } from '@grafana/data';
 import { Trans, t } from '@grafana/i18n';
 import { Label, TextLink, useStyles2 } from '@grafana/ui';
 import { fetchRoleOptions } from 'app/core/components/RolePicker/api';
@@ -11,6 +11,8 @@ import { type ServiceAccountDTO } from 'app/types/serviceaccount';
 
 import { ServiceAccountProfileRow } from './ServiceAccountProfileRow';
 import { ServiceAccountRoleRow } from './ServiceAccountRoleRow';
+
+const logger = createStructuredLogger('features.serviceaccounts');
 
 interface Props {
   serviceAccount: ServiceAccountDTO;
@@ -39,7 +41,7 @@ export function ServiceAccountProfile({ serviceAccount, timeZone, onChange }: Pr
           setRoleOptions(options);
         }
       } catch (e) {
-        console.error('Error loading options for service account');
+        logger.error('Error loading options for service account');
       }
     }
     if (contextSrv.licensedAccessControlEnabled()) {

--- a/public/app/features/serviceaccounts/state/actions.ts
+++ b/public/app/features/serviceaccounts/state/actions.ts
@@ -21,6 +21,9 @@ import {
   stateFilterChanged,
 } from './reducers';
 
+import { createStructuredLogger } from '@grafana/data';
+const logger = createStructuredLogger('features.serviceaccounts');
+
 const BASE_URL = `/api/serviceaccounts`;
 
 export function fetchACOptions(): ThunkResult<void> {
@@ -31,7 +34,7 @@ export function fetchACOptions(): ThunkResult<void> {
         dispatch(acOptionsLoaded(options));
       }
     } catch (error) {
-      console.error(error);
+      logger.error(error);
     }
   };
 }
@@ -76,7 +79,7 @@ export function fetchServiceAccounts(
         dispatch(serviceAccountsFetched(result));
       }
     } catch (error) {
-      console.error(error);
+      logger.error(error);
     } finally {
       dispatch(serviceAccountsFetchEnd());
     }

--- a/public/app/features/serviceaccounts/state/actionsServiceAccountPage.ts
+++ b/public/app/features/serviceaccounts/state/actionsServiceAccountPage.ts
@@ -12,6 +12,9 @@ import {
   serviceAccountTokensLoaded,
 } from './reducers';
 
+import { createStructuredLogger } from '@grafana/data';
+const logger = createStructuredLogger('features.serviceaccounts');
+
 const BASE_URL = `/api/serviceaccounts`;
 
 export function loadServiceAccount(saUid: string): ThunkResult<void> {
@@ -21,7 +24,7 @@ export function loadServiceAccount(saUid: string): ThunkResult<void> {
       const response = await getBackendSrv().get(`${BASE_URL}/${saUid}`, accessControlQueryParam());
       dispatch(serviceAccountLoaded(response));
     } catch (error) {
-      console.error(error);
+      logger.error(error);
     } finally {
       dispatch(serviceAccountFetchEnd());
     }
@@ -69,7 +72,7 @@ export function loadServiceAccountTokens(saUid: string): ThunkResult<void> {
       const response = await getBackendSrv().get(`${BASE_URL}/${saUid}/tokens`);
       dispatch(serviceAccountTokensLoaded(response));
     } catch (error) {
-      console.error(error);
+      logger.error(error);
     }
   };
 }

--- a/public/app/features/stars/hooks.ts
+++ b/public/app/features/stars/hooks.ts
@@ -8,7 +8,7 @@ import {
 } from '@grafana/api-clients/internal/rtkq/legacy/user';
 import { API_GROUP as DASHBOARD_API_GROUP } from '@grafana/api-clients/rtkq/dashboard/v0alpha1';
 import { API_GROUP as FOLDER_API_GROUP } from '@grafana/api-clients/rtkq/folder/v1beta1';
-import { type IconName, locationUtil } from '@grafana/data';
+import { type IconName, locationUtil, createStructuredLogger } from '@grafana/data';
 import { config } from '@grafana/runtime';
 import { useAddStarMutation, useRemoveStarMutation, useListStarsQuery } from 'app/api/clients/collections/v1alpha1';
 import { setStarred, setStarredItems, type StarredNavItem } from 'app/core/reducers/navBarTree';
@@ -19,6 +19,8 @@ import { getIconForKind } from 'app/features/search/service/utils';
 import { dispatch } from 'app/store/store';
 
 import { findStarredNames, userStarsFieldSelector } from './utils';
+
+const logger = createStructuredLogger('features.stars');
 
 type StarItemArgs = {
   id: string;
@@ -238,7 +240,7 @@ export const useSyncStarredItemsInNav = () => {
         setSearchFailed(false);
       })
       .catch((err) => {
-        console.error('Failed to sync starred items to nav', err);
+        logger.error('Failed to sync starred items to nav', err);
         // Resolve the loading state rather than showing it forever
         setHasSynced(true);
         setSearchFailed(true);

--- a/public/app/features/teams/TeamList.tsx
+++ b/public/app/features/teams/TeamList.tsx
@@ -39,6 +39,9 @@ import { EnterpriseAuthFeaturesCard } from '../admin/EnterpriseAuthFeaturesCard'
 import { TeamDeleteModal } from './TeamDeleteModal';
 import { useDeleteTeam, useGetTeams } from './hooks';
 
+import { createStructuredLogger } from '@grafana/data';
+const logger = createStructuredLogger('features.teams');
+
 type Cell<T extends keyof TeamWithRoles = keyof TeamWithRoles> = CellProps<TeamWithRoles, TeamWithRoles[T]>;
 
 export interface State {
@@ -234,7 +237,7 @@ const TeamList = () => {
                   'Failed to check if the team owns folders. Please try again.'
                 )
               );
-              console.error(error);
+              logger.error(error);
               return;
             }
 

--- a/public/app/features/templating/formatVariableValue.ts
+++ b/public/app/features/templating/formatVariableValue.ts
@@ -5,6 +5,9 @@ import { isAdHoc } from '../variables/guard';
 
 import { getVariableWrapper } from './LegacyVariableWrapper';
 
+import { createStructuredLogger } from '@grafana/data';
+const logger = createStructuredLogger('features.templating');
+
 export function formatVariableValue(value: any, format?: any, variable?: any, text?: string): string {
   // for some scopedVars there is no variable
   variable = variable || {};
@@ -42,7 +45,7 @@ export function formatVariableValue(value: any, format?: any, variable?: any, te
   let formatItem = formatRegistry.getIfExists(format);
 
   if (!formatItem) {
-    console.error(`Variable format ${format} not found. Using glob format as fallback.`);
+    logger.error(`Variable format ${format} not found. Using glob format as fallback.`);
     formatItem = formatRegistry.get(VariableFormatID.Glob);
   }
 

--- a/public/app/features/theme-playground/ThemePlayground.tsx
+++ b/public/app/features/theme-playground/ThemePlayground.tsx
@@ -1,7 +1,7 @@
 import { css } from '@emotion/css';
 import { useId, useState } from 'react';
 
-import { createTheme, type GrafanaTheme2, type NewThemeOptions } from '@grafana/data';
+import { createTheme, type GrafanaTheme2, type NewThemeOptions, createStructuredLogger } from '@grafana/data';
 import { NewThemeOptionsSchema } from '@grafana/data/internal';
 import aubergine from '@grafana/data/themes/definitions/aubergine.json';
 import debug from '@grafana/data/themes/definitions/debug.json';
@@ -33,6 +33,8 @@ import { HOME_NAV_ID } from '../../core/reducers/navModel';
 import { getNavModel } from '../../core/selectors/navModel';
 import { ThemeProvider } from '../../core/utils/ConfigProvider';
 import { useDispatch, useSelector } from '../../types/store';
+
+const logger = createStructuredLogger('features.theme-playground');
 
 const themeMap: Record<string, NewThemeOptions> = {
   dark: {
@@ -74,7 +76,7 @@ const experimentalDefinitions: Record<string, unknown> = {
 for (const [name, json] of Object.entries(experimentalDefinitions)) {
   const result = NewThemeOptionsSchema.safeParse(json);
   if (!result.success) {
-    console.error(`Invalid theme definition for theme ${name}: ${result.error.message}`);
+    logger.error(`Invalid theme definition for theme ${name}: ${result.error.message}`);
   } else {
     themeMap[result.data.id] = result.data;
   }

--- a/public/app/features/transformers/editors/FilterByNameTransformerEditor.tsx
+++ b/public/app/features/transformers/editors/FilterByNameTransformerEditor.tsx
@@ -6,11 +6,14 @@ import {
   getFieldDisplayName,
   stringToJsRegex,
   type SelectableValue,
+  createStructuredLogger,
 } from '@grafana/data';
 import { type FilterFieldsByNameTransformerOptions } from '@grafana/data/internal';
 import { t } from '@grafana/i18n';
 import { getTemplateSrv } from '@grafana/runtime';
 import { Input, FilterPill, InlineFieldRow, InlineField, InlineSwitch, Select } from '@grafana/ui';
+
+const logger = createStructuredLogger('features.transformers');
 
 interface FilterByNameTransformerEditorProps extends TransformerUIProps<FilterFieldsByNameTransformerOptions> {}
 
@@ -94,7 +97,7 @@ export class FilterByNameTransformerEditor extends React.PureComponent<
           }
         }
       } catch (error) {
-        console.error(error);
+        logger.error(error);
       }
     }
 

--- a/public/app/features/transformers/extractFields/fieldExtractors.ts
+++ b/public/app/features/transformers/extractFields/fieldExtractors.ts
@@ -1,6 +1,15 @@
-import { escapeStringForRegex, Registry, type RegistryItem, stringStartsAsRegEx, stringToJsRegex } from '@grafana/data';
+import {
+  escapeStringForRegex,
+  Registry,
+  type RegistryItem,
+  stringStartsAsRegEx,
+  stringToJsRegex,
+  createStructuredLogger,
+} from '@grafana/data';
 
 import { type ExtractFieldsOptions, FieldExtractorID } from './types';
+
+const logger = createStructuredLogger('features.transformers');
 
 type Parser = (v: string) => Record<string, any> | undefined;
 
@@ -29,7 +38,7 @@ const extRegExp: FieldExtractor = {
         regex = stringToJsRegex(options.regExp!);
       } catch (error) {
         if (error instanceof Error) {
-          console.warn(error.message);
+          logger.warn(error.message);
         }
       }
     }

--- a/public/app/features/variables/pickers/OptionsPicker/OptionsPicker.tsx
+++ b/public/app/features/variables/pickers/OptionsPicker/OptionsPicker.tsx
@@ -8,6 +8,7 @@ import {
   type VariableOption,
   type VariableWithMultiSupport,
   type VariableWithOptions,
+  createStructuredLogger,
 } from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';
 import { ClickOutsideWrapper } from '@grafana/ui';
@@ -28,6 +29,8 @@ import { type NavigationKey, type VariablePickerProps } from '../types';
 
 import { commitChangesToVariable, filterOrSearchOptions, navigateOptions, openOptions } from './actions';
 import { initialOptionPickerState, type OptionsPickerState, toggleAllOptions, toggleOption } from './reducer';
+
+const logger = createStructuredLogger('features.variables');
 
 const styles = {
   variableLinkWrapper: css({
@@ -59,7 +62,7 @@ export const optionPickerFactory = <Model extends VariableWithOptions | Variable
   const mapStateToProps = (state: StoreState, ownProps: OwnProps) => {
     const { rootStateKey } = ownProps.variable;
     if (!rootStateKey) {
-      console.error('OptionPickerFactory: variable has no rootStateKey');
+      logger.error('OptionPickerFactory: variable has no rootStateKey');
       return {
         picker: initialOptionPickerState,
       };
@@ -94,7 +97,7 @@ export const optionPickerFactory = <Model extends VariableWithOptions | Variable
 
     function onHideOptions() {
       if (!variable.rootStateKey) {
-        console.error('Variable has no rootStateKey');
+        logger.error('Variable has no rootStateKey');
         return;
       }
       commitChangesToVariable(variable.rootStateKey, onVariableChange);
@@ -124,7 +127,7 @@ export const optionPickerFactory = <Model extends VariableWithOptions | Variable
 
     function onNavigate(key: NavigationKey, clearOthers: boolean) {
       if (!variable.rootStateKey) {
-        console.error('Variable has no rootStateKey');
+        logger.error('Variable has no rootStateKey');
         return;
       }
       navigateOptions(variable.rootStateKey, key, clearOthers);

--- a/public/app/features/variables/pickers/OptionsPicker/actions.ts
+++ b/public/app/features/variables/pickers/OptionsPicker/actions.ts
@@ -1,6 +1,12 @@
 import { debounce, trim } from 'lodash';
 
-import { isEmptyObject, containsSearchFilter, type VariableWithOptions, type VariableOption } from '@grafana/data';
+import {
+  isEmptyObject,
+  containsSearchFilter,
+  type VariableWithOptions,
+  type VariableOption,
+  createStructuredLogger,
+} from '@grafana/data';
 import { type StoreState, type ThunkDispatch, type ThunkResult } from 'app/types/store';
 
 import { variableAdapters } from '../../adapters';
@@ -22,6 +28,8 @@ import {
   updateOptionsFromSearch,
   updateSearchQuery,
 } from './reducer';
+
+const logger = createStructuredLogger('features.variables');
 
 export const navigateOptions = (rootStateKey: string, key: NavigationKey, clearOthers: boolean): ThunkResult<void> => {
   return async (dispatch, getState) => {
@@ -180,7 +188,7 @@ const searchForOptions = async (
 
     dispatch(toKeyedAction(key, updateOptionsFromSearch(updated.options)));
   } catch (error) {
-    console.error(error);
+    logger.error(error);
   }
 };
 

--- a/public/app/features/variables/query/operators.ts
+++ b/public/app/features/variables/query/operators.ts
@@ -9,6 +9,7 @@ import {
   type MetricFindValue,
   type PanelData,
   type QueryVariableModel,
+  createStructuredLogger,
 } from '@grafana/data';
 import { type ThunkDispatch } from 'app/types/store';
 
@@ -17,6 +18,8 @@ import { toKeyedAction } from '../state/keyedVariablesReducer';
 import { type getTemplatedRegex, toKeyedVariableIdentifier, toVariablePayload } from '../utils';
 
 import { updateVariableOptions } from './reducer';
+
+const logger = createStructuredLogger('features.variables');
 
 export function toMetricFindValuesOperator(): OperatorFunction<PanelData, MetricFindValue[]> {
   return (source) => source.pipe(map(toMetricFindValues));
@@ -110,7 +113,7 @@ export function updateOptionsState(args: {
       map((results) => {
         const { variable, dispatch, getTemplatedRegexFunc } = args;
         if (!variable.rootStateKey) {
-          console.error('updateOptionsState: variable.rootStateKey is not defined');
+          logger.error('updateOptionsState: variable.rootStateKey is not defined');
           return;
         }
         const templatedRegex = getTemplatedRegexFunc(variable);

--- a/public/app/features/variables/state/actions.ts
+++ b/public/app/features/variables/state/actions.ts
@@ -19,6 +19,7 @@ import {
   type VariableOption,
   VariableRefresh,
   type VariableWithOptions,
+  createStructuredLogger,
 } from '@grafana/data';
 import { locationService, logWarning } from '@grafana/runtime';
 import { notifyApp } from 'app/core/reducers/appNotification';
@@ -79,6 +80,8 @@ import {
 } from './transactionReducer';
 import { type KeyedVariableIdentifier } from './types';
 import { cleanVariables } from './variablesReducer';
+
+const logger = createStructuredLogger('features.variables');
 
 export const initDashboardTemplating = (key: string, dashboard: DashboardModel): ThunkResult<void> => {
   return (dispatch, getState) => {
@@ -661,7 +664,7 @@ export const onTimeRangeUpdated =
       await Promise.all(promises);
       dependencies.events.publish(new VariablesTimeRangeProcessDone({ variableIds }));
     } catch (error) {
-      console.error(error);
+      logger.error(error);
       dispatch(notifyApp(createVariableErrorNotification('Template variable service failed', error)));
     }
   };
@@ -815,7 +818,7 @@ export const initVariablesTransaction =
       dispatch(toKeyedAction(uid, variablesCompleteTransaction({ uid })));
     } catch (err) {
       dispatch(notifyApp(createVariableErrorNotification('Templating init failed', err)));
-      console.error(err);
+      logger.error(err);
     }
   };
 
@@ -885,7 +888,7 @@ export const updateOptions =
       dispatch(toKeyedAction(rootStateKey, variableStateFailed(toVariablePayload(identifier, { error }))));
 
       if (!rethrow) {
-        console.error(error);
+        logger.error(error);
         dispatch(notifyApp(createVariableErrorNotification('Error updating options:', error, identifier)));
       }
 
@@ -965,7 +968,7 @@ export function upgradeLegacyQueries(
       );
     } catch (err) {
       dispatch(notifyApp(createVariableErrorNotification('Failed to upgrade legacy queries', err)));
-      console.error(err);
+      logger.error(err);
     }
   };
 }

--- a/public/app/features/variables/switch/SwitchVariablePicker.tsx
+++ b/public/app/features/variables/switch/SwitchVariablePicker.tsx
@@ -1,10 +1,12 @@
 import { type ChangeEvent, type ReactElement, useCallback } from 'react';
 
-import { type SwitchVariableModel } from '@grafana/data';
+import { type SwitchVariableModel, createStructuredLogger } from '@grafana/data';
 import { Switch } from '@grafana/ui';
 
 import { variableAdapters } from '../adapters';
 import { type VariablePickerProps } from '../pickers/types';
+
+const logger = createStructuredLogger('features.variables');
 
 export interface Props extends VariablePickerProps<SwitchVariableModel> {}
 
@@ -12,7 +14,7 @@ export function SwitchVariablePicker({ variable, onVariableChange }: Props): Rea
   const updateVariable = useCallback(
     (event: ChangeEvent<HTMLInputElement>) => {
       if (!variable.rootStateKey) {
-        console.error('Cannot update variable without rootStateKey');
+        logger.error('Cannot update variable without rootStateKey');
         return;
       }
 

--- a/public/app/features/variables/textbox/TextBoxVariablePicker.tsx
+++ b/public/app/features/variables/textbox/TextBoxVariablePicker.tsx
@@ -8,7 +8,7 @@ import {
   useState,
 } from 'react';
 
-import { type TextBoxVariableModel, isEmptyObject } from '@grafana/data';
+import { type TextBoxVariableModel, isEmptyObject, createStructuredLogger } from '@grafana/data';
 import { t } from '@grafana/i18n';
 import { Input } from '@grafana/ui';
 import { useDispatch } from 'app/types/store';
@@ -19,6 +19,8 @@ import { type VariablePickerProps } from '../pickers/types';
 import { toKeyedAction } from '../state/keyedVariablesReducer';
 import { changeVariableProp } from '../state/sharedReducer';
 import { toVariablePayload } from '../utils';
+
+const logger = createStructuredLogger('features.variables');
 
 export interface Props extends VariablePickerProps<TextBoxVariableModel> {}
 
@@ -31,7 +33,7 @@ export function TextBoxVariablePicker({ variable, onVariableChange, readOnly }: 
 
   const updateVariable = useCallback(() => {
     if (!variable.rootStateKey) {
-      console.error('Cannot update variable without rootStateKey');
+      logger.error('Cannot update variable without rootStateKey');
       return;
     }
 

--- a/public/app/index.ts
+++ b/public/app/index.ts
@@ -10,6 +10,10 @@ import { initPreferences } from './initPreferences';
 import { patchFetchForLegacyAPIMode } from './legacyAPIHandling';
 
 // Check if we are hosting files on cdn and set webpack public path
+import { createStructuredLogger } from '@grafana/data';
+
+const logger = createStructuredLogger('features.app');
+
 if (window.public_cdn_path) {
   __webpack_public_path__ = window.public_cdn_path;
 }
@@ -49,7 +53,7 @@ bootstrapWindowData().catch((error) => {
   const isRedirect = error && error.redirect && typeof error.redirect === 'string';
   // If a redirect was thrown, just ignore this. The index.html will handle the redirect
   if (!isRedirect) {
-    console.error('Error bootstrapping Grafana', error);
+    logger.error('Error bootstrapping Grafana', error);
     window.__grafana_load_failed(error);
   }
 });

--- a/public/app/initPreferences.ts
+++ b/public/app/initPreferences.ts
@@ -1,5 +1,8 @@
 import type { Preferences } from '@grafana/api-clients/rtkq/preferences/v1';
 
+import { createStructuredLogger } from '@grafana/data';
+const logger = createStructuredLogger('features.app');
+
 export const initPreferences = async (): Promise<Preferences | undefined> => {
   const preferences = await fetchMergedPreferences();
   if (!preferences) {
@@ -51,7 +54,7 @@ export async function fetchMergedPreferences(): Promise<Preferences | undefined>
     }
     return await resp.json();
   } catch (err) {
-    console.warn('Failed to fetch merged preferences', err);
+    logger.warn('Failed to fetch merged preferences', err);
     return undefined;
   }
 }

--- a/public/app/legacyAPIHandling.ts
+++ b/public/app/legacyAPIHandling.ts
@@ -1,5 +1,9 @@
 // Controlled by the `grafana.frontendLegacyAPIHandling` feature flag, monkey-patches
 // fetch to log or block calls to legacy /api/ endpoints
+import { createStructuredLogger } from '@grafana/data';
+
+const logger = createStructuredLogger('features.app');
+
 export function patchFetchForLegacyAPIMode() {
   const mode = window.__grafanaLegacyAPIMode;
   if (mode !== 'log' && mode !== 'block') {
@@ -21,7 +25,7 @@ export function patchFetchForLegacyAPIMode() {
       return Promise.reject(new Error(`Request to legacy api ${url.pathname} blocked`));
     }
 
-    console.warn(`Request made to legacy api ${url.pathname}`);
+    logger.warn(`Request made to legacy api ${url.pathname}`);
     return originalFetch(input, init);
   };
 }

--- a/public/app/plugins/datasource/azuremonitor/azure_monitor/azure_monitor_datasource.ts
+++ b/public/app/plugins/datasource/azuremonitor/azure_monitor/azure_monitor_datasource.ts
@@ -1,7 +1,7 @@
 import { find } from 'lodash';
 
 import { type AzureCredentials } from '@grafana/azure-sdk';
-import { type ScopedVars } from '@grafana/data';
+import { type ScopedVars, createStructuredLogger } from '@grafana/data';
 import { DataSourceWithBackend, getTemplateSrv, type TemplateSrv, type VariableInterpolation } from '@grafana/runtime';
 
 import { getCredentials } from '../credentials';
@@ -33,6 +33,8 @@ import migrateQuery from '../utils/migrateQuery';
 
 import ResponseParser from './response_parser';
 import UrlBuilder from './url_builder';
+
+const logger = createStructuredLogger('plugins.datasources');
 
 const defaultDropdownValue = 'select';
 
@@ -263,7 +265,7 @@ export default class AzureMonitorDatasource extends DataSourceWithBackend<
         return result;
       })
       .catch((reason) => {
-        console.error(`Failed to get metric namespaces: ${reason}`);
+        logger.error(`Failed to get metric namespaces: ${reason}`);
         return [];
       });
   }

--- a/public/app/plugins/datasource/azuremonitor/components/LogsQueryEditor/LogsQueryEditor.tsx
+++ b/public/app/plugins/datasource/azuremonitor/components/LogsQueryEditor/LogsQueryEditor.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 
-import { type PanelData, type TimeRange } from '@grafana/data';
+import { type PanelData, type TimeRange, createStructuredLogger } from '@grafana/data';
 import { Trans } from '@grafana/i18n';
 import { EditorFieldGroup, EditorRow, EditorRows } from '@grafana/plugin-ui';
 import { config, getTemplateSrv } from '@grafana/runtime';
@@ -25,6 +25,8 @@ import { TimeManagement } from './TimeManagement';
 import { onLoad, setBasicLogsQuery, setFormatAs, setKustoQuery } from './setQueryValue';
 import useMigrations from './useMigrations';
 import { shouldShowBasicLogsToggle } from './utils';
+
+const logger = createStructuredLogger('plugins.datasources');
 
 interface LogsQueryEditorProps {
   query: AzureMonitorQuery;
@@ -193,11 +195,11 @@ const LogsQueryEditor = ({
           setDataIngestedWarning(null);
         }
       } catch (err) {
-        console.error(err);
+        logger.error(err);
       }
     };
 
-    getBasicLogsUsage(query).catch((err) => console.error(err));
+    getBasicLogsUsage(query).catch((err) => logger.error(err));
   }, [datasource.azureLogAnalyticsDatasource, query, showBasicLogsToggle, from, to]);
   let portalLinkButton = null;
 

--- a/public/app/plugins/datasource/azuremonitor/components/LogsQueryEditor/QueryField.tsx
+++ b/public/app/plugins/datasource/azuremonitor/components/LogsQueryEditor/QueryField.tsx
@@ -7,6 +7,9 @@ import { type AzureQueryEditorFieldProps } from '../../types/types';
 
 import { setKustoQuery } from './setQueryValue';
 
+import { createStructuredLogger } from '@grafana/data';
+const logger = createStructuredLogger('plugins.datasources');
+
 interface MonacoEditorValues {
   editor: MonacoEditor;
   monaco: Monaco;
@@ -29,11 +32,11 @@ const QueryField = ({ query, onQueryChange, schema }: AzureQueryEditorFieldProps
           await kustoMode.setSchema(schema);
         }
       } catch (err) {
-        console.error(err);
+        logger.error(err);
       }
     };
 
-    setupEditor(monaco, schema).catch((err) => console.error(err));
+    setupEditor(monaco, schema).catch((err) => logger.error(err));
   }, [schema, monaco]);
 
   const handleEditorMount = useCallback((editor: MonacoEditor, monaco: Monaco) => {

--- a/public/app/plugins/datasource/azuremonitor/credentials.ts
+++ b/public/app/plugins/datasource/azuremonitor/credentials.ts
@@ -10,6 +10,9 @@ import { config } from '@grafana/runtime';
 
 import { type AzureMonitorDataSourceInstanceSettings, type AzureMonitorDataSourceSettings } from './types/types';
 
+import { createStructuredLogger } from '@grafana/data';
+const logger = createStructuredLogger('plugins.datasources');
+
 export function getCredentials(
   options: AzureMonitorDataSourceSettings | AzureMonitorDataSourceInstanceSettings
 ): AzureCredentials {
@@ -57,7 +60,7 @@ function getLegacyCredentials(
     return { authType: options.jsonData.azureAuthType };
   } catch (e) {
     if (e instanceof Error) {
-      console.error('Unable to restore legacy credentials: %s', e.message);
+      logger.error('Unable to restore legacy credentials: %s', e.message);
     }
     return undefined;
   }

--- a/public/app/plugins/datasource/azuremonitor/resourcePicker/resourcePickerData.ts
+++ b/public/app/plugins/datasource/azuremonitor/resourcePicker/resourcePickerData.ts
@@ -26,6 +26,9 @@ import {
   type ResourceGraphFilters,
 } from '../types/types';
 
+import { createStructuredLogger } from '@grafana/data';
+const logger = createStructuredLogger('plugins.datasources');
+
 const logsSupportedResourceTypesKusto = logsResourceTypes.map((v) => `"${v}"`).join(',');
 
 export type ResourcePickerQueryType = 'logs' | 'metrics' | 'traces';
@@ -355,7 +358,7 @@ export default class ResourcePickerData extends DataSourceWithBackend<
           }
         }
       } catch (e) {
-        console.warn(`Failed to fetch metric namespaces for region ${region}, falling back to predefined list:`, e);
+        logger.warn(`Failed to fetch metric namespaces for region ${region}, falling back to predefined list:`, e);
       }
     };
 

--- a/public/app/plugins/datasource/cloudwatch/components/shared/LogGroups/LogGroupsField.tsx
+++ b/public/app/plugins/datasource/cloudwatch/components/shared/LogGroups/LogGroupsField.tsx
@@ -18,6 +18,9 @@ import { LogGroupQueryScopeSelector } from './LogGroupQueryScopeSelector';
 import { LogGroupsSelector } from './LogGroupsSelector';
 import { SelectedLogGroups } from './SelectedLogGroups';
 
+import { createStructuredLogger } from '@grafana/data';
+const logger = createStructuredLogger('plugins.datasources');
+
 type Props = {
   datasource: CloudWatchDatasource;
   onChange: (logGroups: LogGroup[]) => void;
@@ -92,7 +95,7 @@ export const LogGroupsField = ({
           onChange([...logGroups, ...variables.map((v) => ({ name: v, arn: v }))]);
         })
         .catch((err) => {
-          console.error(err);
+          logger.error(err);
         });
     }
   }, [datasource, legacyLogGroupNames, logGroups, onChange, region, loadingLogGroupsStarted]);

--- a/public/app/plugins/datasource/cloudwatch/tracking.ts
+++ b/public/app/plugins/datasource/cloudwatch/tracking.ts
@@ -1,4 +1,4 @@
-import { type DashboardLoadedEvent } from '@grafana/data';
+import { type DashboardLoadedEvent, createStructuredLogger } from '@grafana/data';
 import { config, reportInteraction } from '@grafana/runtime';
 
 import {
@@ -15,6 +15,8 @@ import { migrateMetricQuery } from './migrations/metricQueryMigrations';
 import pluginJson from './plugin.json';
 import { type CloudWatchQuery } from './types';
 import { filterMetricsQuery } from './utils/utils';
+
+const logger = createStructuredLogger('plugins.datasources');
 
 type CloudWatchOnDashboardLoadedTrackingEvent = {
   grafana_version?: string;
@@ -146,7 +148,7 @@ export const onDashboardLoadedHandler = ({
 
     reportInteraction('grafana_ds_cloudwatch_dashboard_loaded', e);
   } catch (error) {
-    console.error('error in cloudwatch tracking handler', error);
+    logger.error('error in cloudwatch tracking handler', error);
   }
 };
 

--- a/public/app/plugins/datasource/cloudwatch/utils/datalinks.ts
+++ b/public/app/plugins/datasource/cloudwatch/utils/datalinks.ts
@@ -6,12 +6,15 @@ import {
   FieldType,
   type ScopedVars,
   type TimeRange,
+  createStructuredLogger,
 } from '@grafana/data';
 import { config, getDataSourceSrv } from '@grafana/runtime';
 
 import { type AwsUrl, encodeUrl } from '../aws_url';
 import { type CloudWatchLogsQuery } from '../dataquery.gen';
 import { type CloudWatchQuery } from '../types';
+
+const logger = createStructuredLogger('plugins.datasources');
 
 type ReplaceFn = (
   target?: string,
@@ -67,7 +70,7 @@ async function createInternalXrayLink(datasourceUid: string, region: string): Pr
   try {
     ds = await getDataSourceSrv().get(datasourceUid);
   } catch (e) {
-    console.error('Could not load linked xray data source, it was probably deleted after it was linked', e);
+    logger.error('Could not load linked xray data source, it was probably deleted after it was linked', e);
     return undefined;
   }
 

--- a/public/app/plugins/datasource/cloudwatch/variables.ts
+++ b/public/app/plugins/datasource/cloudwatch/variables.ts
@@ -7,6 +7,7 @@ import {
   type DataQueryResponse,
   type MetricFindValue,
   type SelectableValue,
+  createStructuredLogger,
 } from '@grafana/data';
 
 import { VariableQueryEditor } from './components/VariableQueryEditor/VariableQueryEditor';
@@ -17,6 +18,8 @@ import { migrateVariableQuery } from './migrations/variableQueryMigrations';
 import { type ResourcesAPI } from './resources/ResourcesAPI';
 import { standardStatistics } from './standardStatistics';
 import { type VariableQuery, VariableQueryType } from './types';
+
+const logger = createStructuredLogger('plugins.datasources');
 
 export class CloudWatchVariableSupport extends CustomVariableSupport<CloudWatchDatasource, VariableQuery> {
   constructor(private readonly resources: ResourcesAPI) {
@@ -57,7 +60,7 @@ export class CloudWatchVariableSupport extends CustomVariableSupport<CloudWatchD
           return this.handleAccountsQuery(query);
       }
     } catch (error) {
-      console.error(`Could not run CloudWatchMetricFindQuery ${query}`, error);
+      logger.error(`Could not run CloudWatchMetricFindQuery ${query}`, error);
       return [];
     }
   }

--- a/public/app/plugins/datasource/dashboard/datasource.ts
+++ b/public/app/plugins/datasource/dashboard/datasource.ts
@@ -20,6 +20,7 @@ import {
   ValueMatcherID,
   type DataSourceGetDrilldownsApplicabilityOptions,
   type DrilldownsApplicability,
+  createStructuredLogger,
 } from '@grafana/data';
 import {
   isSceneObject,
@@ -37,6 +38,8 @@ import {
 import { MIXED_REQUEST_PREFIX } from '../mixed/MixedDataSource';
 
 import { type DashboardQuery } from './types';
+
+const logger = createStructuredLogger('plugins.datasources');
 
 function isSameRange(a: TimeRange | undefined, b: TimeRange | undefined): boolean {
   if (!a?.from || !a?.to || !b?.from || !b?.to) {
@@ -313,7 +316,7 @@ export class DashboardDatasource extends DataSourceApi<DashboardQuery> {
         options: { value: filter.value },
       });
     } catch (error) {
-      console.warn('Failed to create value matcher for filter:', filter, error);
+      logger.warn('Failed to create value matcher for filter:', filter, error);
       return null;
     }
   }

--- a/public/app/plugins/datasource/grafana-testdata-datasource/components/RawFrameEditor.tsx
+++ b/public/app/plugins/datasource/grafana-testdata-datasource/components/RawFrameEditor.tsx
@@ -1,11 +1,13 @@
 import { isArray } from 'lodash';
 import { useState } from 'react';
 
-import { dataFrameToJSON, toDataFrame, toDataFrameDTO } from '@grafana/data';
+import { dataFrameToJSON, toDataFrame, toDataFrameDTO, createStructuredLogger } from '@grafana/data';
 import { toDataQueryResponse } from '@grafana/runtime';
 import { Alert, CodeEditor } from '@grafana/ui';
 
 import { type EditorProps } from '../QueryEditor';
+
+const logger = createStructuredLogger('plugins.datasources');
 
 export const RawFrameEditor = ({ onChange, query }: EditorProps) => {
   const [error, setError] = useState<string>();
@@ -35,8 +37,8 @@ export const RawFrameEditor = ({ onChange, query }: EditorProps) => {
       }
 
       if (data) {
-        console.log('Original', json);
-        console.log('Save', data);
+        logger.info('Original', json);
+        logger.info('Save', data);
         setError(undefined);
         setWarning('Converted to direct frame result');
         onChange({ ...query, rawFrameContent: JSON.stringify(data, null, 2) });
@@ -45,7 +47,7 @@ export const RawFrameEditor = ({ onChange, query }: EditorProps) => {
 
       setError('Unable to read dataframes in text');
     } catch (e) {
-      console.log('Error parsing json', e);
+      logger.info('Error parsing json', e);
       setError('Enter JSON array of data frames (or raw query results body)');
       setWarning(undefined);
     }

--- a/public/app/plugins/datasource/grafana-testdata-datasource/runStreams.ts
+++ b/public/app/plugins/datasource/grafana-testdata-datasource/runStreams.ts
@@ -17,11 +17,14 @@ import {
   getDisplayProcessor,
   createTheme,
   generateUUID,
+  createStructuredLogger,
 } from '@grafana/data';
 import { getBackendSrv } from '@grafana/runtime';
 
 import { getRandomLine } from './LogIpsum';
 import { type TestDataDataQuery, type StreamingQuery } from './dataquery';
+
+const logger = createStructuredLogger('plugins.datasources');
 
 export const defaultStreamQuery: StreamingQuery = {
   type: 'signal',
@@ -125,7 +128,7 @@ function runSignalStream(
     setTimeout(pushNextEvent, 5);
 
     return () => {
-      console.log('unsubscribing to stream ' + streamId);
+      logger.info('unsubscribing to stream ' + streamId);
       clearTimeout(timeoutId);
     };
   });
@@ -171,7 +174,7 @@ function runLogsStream(
     setTimeout(pushNextEvent, 5);
 
     return () => {
-      console.log('unsubscribing to stream ' + streamId);
+      logger.info('unsubscribing to stream ' + streamId);
       clearTimeout(timeoutId);
     };
   });
@@ -219,7 +222,7 @@ function runWatchStream(
       .subscribe({
         next: (chunk) => {
           if (!chunk.data || !chunk.ok) {
-            console.info('chunk missing data', chunk);
+            logger.info('chunk missing data', chunk);
             return;
           }
           decoder
@@ -240,21 +243,21 @@ function runWatchStream(
                     state: LoadingState.Streaming,
                   });
                 } catch (err) {
-                  console.warn('error parsing line', line, err);
+                  logger.warn('error parsing line', line, err);
                 }
               }
             });
         },
         error: (err) => {
-          console.warn('error in stream', streamId, err);
+          logger.warn('error in stream', streamId, err);
         },
         complete: () => {
-          console.info('complete stream', streamId);
+          logger.info('complete stream', streamId);
         },
       });
 
     return () => {
-      console.log('unsubscribing to stream', streamId);
+      logger.info('unsubscribing to stream', streamId);
       sub.unsubscribe();
     };
   });
@@ -314,7 +317,7 @@ function runFetchStream(
       });
 
       if (value.done) {
-        console.log('Finished stream');
+        logger.info('Finished stream');
         subscriber.complete(); // necessary?
         return;
       }
@@ -335,7 +338,7 @@ function runFetchStream(
 
     return () => {
       // Cancel fetch?
-      console.log('unsubscribing to stream ' + streamId);
+      logger.info('unsubscribing to stream ' + streamId);
     };
   });
 }
@@ -368,7 +371,7 @@ function runTracesStream(
     setTimeout(pushNextEvent, 5);
 
     return () => {
-      console.log('unsubscribing to stream ' + streamId);
+      logger.info('unsubscribing to stream ' + streamId);
       clearTimeout(timeoutId);
     };
   });

--- a/public/app/plugins/datasource/grafana/components/QueryEditor.tsx
+++ b/public/app/plugins/datasource/grafana/components/QueryEditor.tsx
@@ -7,6 +7,7 @@ import {
   rangeUtil,
   type DataQueryRequest,
   type Field,
+  createStructuredLogger,
 } from '@grafana/data';
 import { config } from '@grafana/runtime';
 import { InlineField, Select, Alert, Input, InlineFieldRow, Stack, InlineLabel } from '@grafana/ui';
@@ -16,6 +17,8 @@ import { type GrafanaDatasource } from '../datasource';
 import { defaultQuery, type GrafanaQuery, GrafanaQueryType } from '../types';
 
 import { RandomWalkEditor } from './RandomWalkEditor';
+
+const logger = createStructuredLogger('plugins.datasources');
 
 interface Props extends QueryEditorProps<GrafanaDatasource, GrafanaQuery> {}
 
@@ -138,7 +141,7 @@ export const QueryEditor = memo(function QueryEditor(props: Props) {
         try {
           buffer = rangeUtil.intervalToSeconds(txt) * 1000;
         } catch (err) {
-          console.warn('ERROR', err);
+          logger.warn('ERROR', err);
         }
       }
       onChange({

--- a/public/app/plugins/datasource/graphite/datasource.ts
+++ b/public/app/plugins/datasource/graphite/datasource.ts
@@ -22,6 +22,7 @@ import {
   type ScopedVars,
   type TimeRange,
   toDataFrame,
+  createStructuredLogger,
 } from '@grafana/data';
 import {
   type BackendSrvRequest,
@@ -55,6 +56,8 @@ import {
 } from './types';
 import { reduceError } from './utils';
 import { DEFAULT_GRAPHITE_VERSION } from './versions';
+
+const logger = createStructuredLogger('plugins.datasources');
 
 const GRAPHITE_TAG_COMPARATORS = {
   '=': AbstractLabelOperator.Equal,
@@ -583,7 +586,7 @@ export class GraphiteDatasource
       return this.events({ range: range, tags: tags }).then((results) => {
         const list = [];
         if (!isArray(results.data)) {
-          console.error(`Unable to get annotations.`);
+          logger.error(`Unable to get annotations.`);
           return [];
         }
         for (let i = 0; i < results.data.length; i++) {
@@ -1075,7 +1078,7 @@ export class GraphiteDatasource
         this.funcDefs = gfunc.parseFuncDefs(functions);
         return this.funcDefs;
       } catch (error) {
-        console.error('Fetching graphite functions error', error);
+        logger.error('Fetching graphite functions error', error);
         this.funcDefs = gfunc.getFuncDefs(this.graphiteVersion);
         return this.funcDefs;
       }
@@ -1094,7 +1097,7 @@ export class GraphiteDatasource
           return this.funcDefs;
         }),
         catchError((error) => {
-          console.error('Fetching graphite functions error', error);
+          logger.error('Fetching graphite functions error', error);
           this.funcDefs = gfunc.getFuncDefs(this.graphiteVersion);
           return of(this.funcDefs);
         })

--- a/public/app/plugins/datasource/graphite/graphite_query.ts
+++ b/public/app/plugins/datasource/graphite/graphite_query.ts
@@ -1,6 +1,6 @@
 import { compact, each, findIndex, flatten, get, join, keyBy, last, map, reduce, without } from 'lodash';
 
-import { type ScopedVars } from '@grafana/data';
+import { type ScopedVars, createStructuredLogger } from '@grafana/data';
 import { type TemplateSrv } from '@grafana/runtime';
 
 import { type GraphiteDatasource } from './datasource';
@@ -8,6 +8,8 @@ import { type FuncInstance } from './gfunc';
 import { type AstNode, Parser } from './parser';
 import { type GraphiteSegment } from './types';
 import { arrayMove } from './utils';
+
+const logger = createStructuredLogger('plugins.datasources');
 
 export type GraphiteTagOperator = '=' | '=~' | '!=' | '!=~';
 
@@ -94,7 +96,7 @@ export default class GraphiteQuery {
       }
     } catch (err) {
       if (err instanceof Error) {
-        console.error('error parsing target:', err.message);
+        logger.error('error parsing target:', err.message);
         this.error = err.message;
       }
       this.target.textEditor = true;

--- a/public/app/plugins/panel/canvas/components/connections/Connections.tsx
+++ b/public/app/plugins/panel/canvas/components/connections/Connections.tsx
@@ -31,6 +31,9 @@ import {
   updateConnectionsAfterGroupMove as sharedUpdateGroup,
 } from './connectionMovementUtils';
 
+import { createStructuredLogger } from '@grafana/data';
+const logger = createStructuredLogger('plugins.panels');
+
 export const CONNECTION_VERTEX_ID = 'vertex';
 export const CONNECTION_VERTEX_ADD_ID = 'vertexAdd';
 const CONNECTION_VERTEX_ORTHO_TOLERANCE = 0.05; // Cartesian ratio against vertical or horizontal tolerance
@@ -135,7 +138,7 @@ export class Connections {
     let element: ElementState | undefined = this.findElementTarget(event.target);
 
     if (!element) {
-      console.log('no element');
+      logger.info('no element');
       return;
     }
 
@@ -144,7 +147,7 @@ export class Connections {
     } else {
       this.connectionSource = element;
       if (!this.connectionSource) {
-        console.log('no connection source');
+        logger.info('no connection source');
         return;
       }
     }

--- a/public/app/plugins/panel/canvas/components/connections/Connections2.tsx
+++ b/public/app/plugins/panel/canvas/components/connections/Connections2.tsx
@@ -33,6 +33,9 @@ import {
   updateConnectionsAfterGroupMove as sharedUpdateGroup,
 } from './connectionMovementUtils';
 
+import { createStructuredLogger } from '@grafana/data';
+const logger = createStructuredLogger('plugins.panels');
+
 const CONNECTION_VERTEX_ORTHO_TOLERANCE = 0.05; // Cartesian ratio against vertical or horizontal tolerance
 const CONNECTION_VERTEX_SNAP_TOLERANCE = (5 / 180) * Math.PI; // Multi-segment snapping angle in radians to trigger vertex removal
 
@@ -128,7 +131,7 @@ export class Connections2 {
     let element: ElementState | undefined = this.findElementTarget(event.target);
 
     if (!element) {
-      console.log('no element');
+      logger.info('no element');
       return;
     }
 
@@ -137,7 +140,7 @@ export class Connections2 {
     } else {
       this.connectionSource = element;
       if (!this.connectionSource) {
-        console.log('no connection source');
+        logger.info('no connection source');
         return;
       }
     }

--- a/public/app/plugins/panel/canvas/editor/element/elementEditor.tsx
+++ b/public/app/plugins/panel/canvas/editor/element/elementEditor.tsx
@@ -1,6 +1,6 @@
 import { get as lodashGet } from 'lodash';
 
-import { type NestedPanelOptions, type NestedValueAccess } from '@grafana/data';
+import { type NestedPanelOptions, type NestedValueAccess, createStructuredLogger } from '@grafana/data';
 import { t } from '@grafana/i18n';
 import { type CanvasElementOptions } from 'app/features/canvas/element';
 import {
@@ -17,6 +17,8 @@ import { getElementTypes } from '../../utils';
 import { optionBuilder } from '../options';
 
 import { PlacementEditor } from './PlacementEditor';
+
+const logger = createStructuredLogger('plugins.panels');
 
 export interface CanvasEditorOptions {
   element: ElementState;
@@ -45,7 +47,7 @@ export function getElementEditor(opts: CanvasEditorOptions): NestedPanelOptions<
         if (path === 'type' && value) {
           const layer = canvasElementRegistry.getIfExists(value);
           if (!layer) {
-            console.warn('layer does not exist', value);
+            logger.warn('layer does not exist', value);
             return;
           }
           options = {

--- a/public/app/plugins/panel/canvas/editor/element/utils.ts
+++ b/public/app/plugins/panel/canvas/editor/element/utils.ts
@@ -1,4 +1,4 @@
-import { AppEvents, textUtil } from '@grafana/data';
+import { AppEvents, textUtil, createStructuredLogger } from '@grafana/data';
 import { type BackendSrvRequest, getBackendSrv, getTemplateSrv } from '@grafana/runtime';
 import { appEvents } from 'app/core/app_events';
 import { createAbsoluteUrl, type RelativeUrl } from 'app/features/alerting/unified/utils/url';
@@ -7,6 +7,8 @@ import { getDashboardSrv } from 'app/features/dashboard/services/DashboardSrv';
 import { HttpRequestMethod } from '../../panelcfg.gen';
 
 import { type APIEditorConfig } from './APIEditor';
+
+const logger = createStructuredLogger('plugins.panels');
 
 type IsLoadingCallback = (loading: boolean) => void;
 
@@ -23,7 +25,7 @@ export const callApi = (api: APIEditorConfig, updateLoadingStateCallback?: IsLoa
     .subscribe({
       error: (error) => {
         appEvents.emit(AppEvents.alertError, ['An error has occurred. Check console output for more details.']);
-        console.error('API call error: ', error);
+        logger.error('API call error: ', error);
         updateLoadingStateCallback && updateLoadingStateCallback(false);
       },
       complete: () => {

--- a/public/app/plugins/panel/canvas/editor/layer/TreeNavigationEditor.tsx
+++ b/public/app/plugins/panel/canvas/editor/layer/TreeNavigationEditor.tsx
@@ -3,7 +3,7 @@ import { Global } from '@emotion/react';
 import Tree, { type TreeNodeProps } from '@rc-component/tree';
 import { type Key, useEffect, useMemo, useState } from 'react';
 
-import { type GrafanaTheme2, type StandardEditorProps } from '@grafana/data';
+import { type GrafanaTheme2, type StandardEditorProps, createStructuredLogger } from '@grafana/data';
 import { Trans, t } from '@grafana/i18n';
 import { config } from '@grafana/runtime';
 import { Button, Icon, Stack, useStyles2, useTheme2 } from '@grafana/ui';
@@ -19,6 +19,8 @@ import { type TreeViewEditorProps } from '../element/elementEditor';
 
 import { TreeNodeTitle } from './TreeNodeTitle';
 import { getTreeData, onNodeDrop, type TreeElement } from './tree';
+
+const logger = createStructuredLogger('plugins.panels');
 
 let allowSelection = true;
 
@@ -130,7 +132,7 @@ export const TreeNavigationEditor = ({ item }: StandardEditorProps<unknown, Tree
     if (layer.scene) {
       frameSelection(layer.scene);
     } else {
-      console.warn('no scene!');
+      logger.warn('no scene!');
     }
   };
 

--- a/public/app/plugins/panel/canvas/editor/layer/layerEditor.tsx
+++ b/public/app/plugins/panel/canvas/editor/layer/layerEditor.tsx
@@ -1,6 +1,6 @@
 import { get as lodashGet } from 'lodash';
 
-import { type NestedPanelOptions, type NestedValueAccess } from '@grafana/data';
+import { type NestedPanelOptions, type NestedValueAccess, createStructuredLogger } from '@grafana/data';
 import { t } from '@grafana/i18n';
 import { type ElementState } from 'app/features/canvas/runtime/element';
 import { FrameState } from 'app/features/canvas/runtime/frame';
@@ -12,6 +12,8 @@ import { PlacementEditor } from '../element/PlacementEditor';
 import { optionBuilder } from '../options';
 
 import { TreeNavigationEditor } from './TreeNavigationEditor';
+
+const logger = createStructuredLogger('plugins.panels');
 
 export interface LayerEditorProps {
   scene: Scene;
@@ -53,7 +55,7 @@ export function getLayerEditor(opts: InstanceState): NestedPanelOptions<LayerEdi
       },
       onChange: (path, value) => {
         if (path === 'type' && value) {
-          console.warn('unable to change layer type');
+          logger.warn('unable to change layer type');
           return;
         }
         const c = setOptionImmutably(options, path, value);

--- a/public/app/plugins/panel/dashlist/migrations.ts
+++ b/public/app/plugins/panel/dashlist/migrations.ts
@@ -1,8 +1,10 @@
-import { type PanelModel } from '@grafana/data';
+import { type PanelModel, createStructuredLogger } from '@grafana/data';
 import { getBackendSrv } from '@grafana/runtime';
 import { type FolderDTO } from 'app/types/folders';
 
 import { type Options } from './panelcfg.gen';
+
+const logger = createStructuredLogger('plugins.panels');
 
 async function getFolderUID(folderID: number): Promise<string> {
   // folderID 0 is always the fake General/Dashboards folder, which always has a UID of empty string
@@ -67,7 +69,7 @@ export async function dashlistMigrationHandler(panel: PanelModel<Options> & Angu
       newOptions.folderUID = folderUID;
       delete newOptions.folderId;
     } catch (err) {
-      console.warn('Dashlist: Error migrating folder ID to UID', err);
+      logger.warn('Dashlist: Error migrating folder ID to UID', err);
     }
   }
 

--- a/public/app/plugins/panel/geomap/GeomapPanel.tsx
+++ b/public/app/plugins/panel/geomap/GeomapPanel.tsx
@@ -15,7 +15,7 @@ import { Component, type ReactNode } from 'react';
 import * as React from 'react';
 import { Subscription } from 'rxjs';
 
-import { DataHoverEvent, type PanelData, type PanelProps } from '@grafana/data';
+import { DataHoverEvent, type PanelData, type PanelProps, createStructuredLogger } from '@grafana/data';
 import { t } from '@grafana/i18n';
 import { config, locationService } from '@grafana/runtime';
 import { type PanelContext, PanelContextRoot } from '@grafana/ui';
@@ -49,6 +49,8 @@ import {
 import { centerPointRegistry, MapCenterID } from './view';
 
 // Allows multiple panels to share the same view instance
+const logger = createStructuredLogger('plugins.panels');
+
 let sharedView: View | undefined = undefined;
 
 type Props = PanelProps<Options>;
@@ -327,7 +329,7 @@ export class GeomapPanel extends Component<Props, State> {
         layers.push(await initLayer(this, map, lyr, false));
       }
     } catch (ex) {
-      console.error('error loading layers', ex);
+      logger.error('error loading layers', ex);
     }
 
     for (const lyr of layers) {

--- a/public/app/plugins/panel/geomap/layers/basemaps/maplibre.ts
+++ b/public/app/plugins/panel/geomap/layers/basemaps/maplibre.ts
@@ -1,9 +1,11 @@
 import LayerGroup from 'ol/layer/Group';
 import { apply } from 'ol-mapbox-style';
 
-import { type MapLayerRegistryItem } from '@grafana/data';
+import { type MapLayerRegistryItem, createStructuredLogger } from '@grafana/data';
 
 // MapLibre Style Specification constants
+const logger = createStructuredLogger('plugins.panels');
+
 const LAYER_TYPE_BACKGROUND = 'background';
 const PAINT_BACKGROUND_OPACITY = 'background-opacity';
 
@@ -61,7 +63,7 @@ const maplibreLayer: MapLayerRegistryItem<Partial<MaplibreConfig>> = {
         try {
           const res = await fetch(cfg.url);
           if (!res.ok) {
-            console.warn(`Failed to load MapLibre style from ${cfg.url}: ${res.status} ${res.statusText}`);
+            logger.warn(`Failed to load MapLibre style from ${cfg.url}: ${res.status} ${res.statusText}`);
             // Try fallback approach
             await tryFallbackApply();
             return;
@@ -82,7 +84,7 @@ const maplibreLayer: MapLayerRegistryItem<Partial<MaplibreConfig>> = {
           await apply(layer, style, { styleUrl: cfg.url, accessToken: cfg.accessToken });
           applyNoRepeat();
         } catch (error) {
-          console.warn('Failed to parse or apply MapLibre style JSON:', error);
+          logger.warn('Failed to parse or apply MapLibre style JSON:', error);
           // Try fallback approach
           await tryFallbackApply();
         }
@@ -93,7 +95,7 @@ const maplibreLayer: MapLayerRegistryItem<Partial<MaplibreConfig>> = {
           await apply(layer, cfg.url, { accessToken: cfg.accessToken });
           applyNoRepeat();
         } catch (fallbackError) {
-          console.warn('Failed to load MapLibre style from both JSON and direct URL approaches:', fallbackError);
+          logger.warn('Failed to load MapLibre style from both JSON and direct URL approaches:', fallbackError);
         }
       };
 

--- a/public/app/plugins/panel/geomap/style/markers.ts
+++ b/public/app/plugins/panel/geomap/style/markers.ts
@@ -2,12 +2,14 @@ import { Fill, RegularShape, Stroke, Circle, Style, Icon, Text } from 'ol/style'
 import type { FlatStyle } from 'ol/style/flat';
 import tinycolor from 'tinycolor2';
 
-import { Registry, type RegistryItem, textUtil } from '@grafana/data';
+import { Registry, type RegistryItem, textUtil, createStructuredLogger } from '@grafana/data';
 import { config } from '@grafana/runtime';
 import { getPublicOrAbsoluteUrl } from 'app/features/dimensions/resource';
 
 import { defaultStyleConfig, DEFAULT_SIZE, type StyleConfigValues, type StyleMaker } from './types';
 import { getDisplacement } from './utils';
+
+const logger = createStructuredLogger('plugins.panels');
 
 interface SymbolMaker extends RegistryItem {
   aliasIds: string[];
@@ -297,7 +299,7 @@ async function prepareSVG(url: string, size?: number, backgroundOpacity?: number
       return `data:image/svg+xml,${svgURI}`;
     })
     .catch((error) => {
-      console.error(error); // eslint-disable-line no-console
+      logger.error(error);
       return '';
     });
 }

--- a/public/app/plugins/panel/geomap/style/utils.test.ts
+++ b/public/app/plugins/panel/geomap/style/utils.test.ts
@@ -189,12 +189,18 @@ describe('style utils', () => {
 
     it('returns null and warns for 5+ value rgba inputs', () => {
       expect(getRGBValues('rgba(1, 2, 3, 4, 5)')).toBeNull();
-      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('Unsupported color format'));
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('Unsupported color format'),
+        expect.objectContaining({ source: 'plugins.panels' })
+      );
     });
 
     it('returns null and warns for non-hex / non-rgb color strings', () => {
       expect(getRGBValues('hsl(0, 100%, 50%)')).toBeNull();
-      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('Unsupported color format'));
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('Unsupported color format'),
+        expect.objectContaining({ source: 'plugins.panels' })
+      );
     });
   });
 });

--- a/public/app/plugins/panel/geomap/style/utils.ts
+++ b/public/app/plugins/panel/geomap/style/utils.ts
@@ -14,6 +14,10 @@ import {
 } from './types';
 
 /** Indicate if the style wants to show text values */
+import { createStructuredLogger } from '@grafana/data';
+
+const logger = createStructuredLogger('plugins.panels');
+
 export function styleUsesText(config: StyleConfig): boolean {
   const text = config?.text;
   if (!text) {
@@ -106,7 +110,7 @@ export function getRGBValues(colorString: string): ColorValue | null {
 
   // Handle other color formats if needed
   else {
-    console.warn(`Unsupported color format: ${colorString}`);
+    logger.warn(`Unsupported color format: ${colorString}`);
   }
   return null;
 }
@@ -142,10 +146,10 @@ function getRGBFromRGBString(rgbString: string): ColorValue | null {
         a: parseFloat(matches[3]), // Using parseFloat for alpha as it can be decimal (0-1)
       };
     } else {
-      console.warn(`Unsupported color format: ${rgbString}`);
+      logger.warn(`Unsupported color format: ${rgbString}`);
     }
   } else {
-    console.warn(`Unsupported color format: ${rgbString}`);
+    logger.warn(`Unsupported color format: ${rgbString}`);
   }
   return null;
 }

--- a/public/app/plugins/panel/geomap/utils/layers.ts
+++ b/public/app/plugins/panel/geomap/utils/layers.ts
@@ -3,7 +3,14 @@ import type BaseLayer from 'ol/layer/Base';
 import LayerGroup from 'ol/layer/Group';
 import WebGLPointsLayer from 'ol/layer/WebGLPoints';
 
-import { getFrameMatchers, type MapLayerHandler, type MapLayerOptions, type PanelData, textUtil } from '@grafana/data';
+import {
+  getFrameMatchers,
+  type MapLayerHandler,
+  type MapLayerOptions,
+  type PanelData,
+  textUtil,
+  createStructuredLogger,
+} from '@grafana/data';
 import { config } from '@grafana/runtime';
 
 import { type GeomapPanel } from '../GeomapPanel';
@@ -13,6 +20,8 @@ import { type MapLayerState } from '../types';
 
 import { captureLayerAttribution, updateAttributionVisibility } from './attribution';
 import { getNextLayerName } from './utils';
+
+const logger = createStructuredLogger('plugins.panels');
 
 const layerStateMap = new WeakMap<BaseLayer, MapLayerState>();
 
@@ -90,7 +99,7 @@ async function updateLayer(panel: GeomapPanel, uid: string, newOptions: MapLayer
     // initialize with new data
     applyLayerFilter(info.handler, newOptions, panel.props.data);
   } catch (err) {
-    console.warn('ERROR', err); // eslint-disable-line no-console
+    logger.warn('ERROR', err);
     return false;
   }
 

--- a/public/app/plugins/panel/heatmap/HeatmapPanel.tsx
+++ b/public/app/plugins/panel/heatmap/HeatmapPanel.tsx
@@ -1,7 +1,7 @@
 import { css } from '@emotion/css';
 import { useMemo, useRef, useState } from 'react';
 
-import { DashboardCursorSync, type PanelProps, type TimeRange } from '@grafana/data';
+import { DashboardCursorSync, type PanelProps, type TimeRange, createStructuredLogger } from '@grafana/data';
 import { PanelDataErrorView } from '@grafana/runtime';
 import { type LegendPlacement, type ScaleDistributionConfig } from '@grafana/schema';
 import {
@@ -30,6 +30,8 @@ import { quantizeScheme } from './palettes';
 import { type Options } from './panelcfg.gen';
 import { calculateYSizeDivisor, prepConfig } from './utils';
 
+const logger = createStructuredLogger('plugins.panels');
+
 interface HeatmapPanelProps extends PanelProps<Options> {}
 
 type HeatmapDataForViz = Required<Pick<HeatmapData, 'heatmap'>> & Omit<HeatmapData, 'warning' | 'heatmap'>;
@@ -54,7 +56,7 @@ export const HeatmapPanel = (props: HeatmapPanelProps) => {
         timeRange,
       });
     } catch (ex) {
-      console.error(ex);
+      logger.error(ex);
       return { warning: `${ex}` };
     }
   }, [data.series, data.annotations, options, palette, theme, replaceVariables, timeRange]);

--- a/public/app/plugins/panel/live/LivePanel.tsx
+++ b/public/app/plugins/panel/live/LivePanel.tsx
@@ -17,6 +17,7 @@ import {
   applyFieldOverrides,
   type LiveChannelAddress,
   StreamingDataFrame,
+  createStructuredLogger,
 } from '@grafana/data';
 import { Trans, t } from '@grafana/i18n';
 import { config, getGrafanaLiveSrv } from '@grafana/runtime';
@@ -26,6 +27,8 @@ import { TablePanel } from '../table/TablePanel';
 
 import { LivePublish } from './LivePublish';
 import { type LivePanelOptions, MessageDisplayMode, MessagePublishMode } from './types';
+
+const logger = createStructuredLogger('plugins.panels');
 
 interface Props extends PanelProps<LivePanelOptions> {}
 
@@ -72,7 +75,7 @@ export class LivePanel extends PureComponent<Props, State> {
       } else if (isLiveChannelMessageEvent(event)) {
         this.setState({ message: event.message, changed: Date.now() });
       } else {
-        console.log('ignore', event);
+        logger.info('ignore', event);
       }
     },
   };
@@ -87,7 +90,7 @@ export class LivePanel extends PureComponent<Props, State> {
   async loadChannel() {
     const addr = this.props.options?.channel;
     if (!isValidLiveChannelAddress(addr)) {
-      console.log('INVALID', addr);
+      logger.info('INVALID', addr);
       this.unsubscribe();
       this.setState({
         addr: undefined,
@@ -96,13 +99,13 @@ export class LivePanel extends PureComponent<Props, State> {
     }
 
     if (isEqual(addr, this.state.addr)) {
-      console.log('Same channel', this.state.addr);
+      logger.info('Same channel', this.state.addr);
       return;
     }
 
     const live = getGrafanaLiveSrv();
     if (!live) {
-      console.log('INVALID', addr);
+      logger.info('INVALID', addr);
       this.unsubscribe();
       this.setState({
         addr: undefined,
@@ -111,7 +114,7 @@ export class LivePanel extends PureComponent<Props, State> {
     }
     this.unsubscribe();
 
-    console.log('LOAD', addr);
+    logger.info('LOAD', addr);
 
     // Subscribe to new events
     try {

--- a/public/app/plugins/panel/live/LivePublish.tsx
+++ b/public/app/plugins/panel/live/LivePublish.tsx
@@ -1,11 +1,13 @@
 import { useMemo } from 'react';
 
-import { type LiveChannelAddress, isValidLiveChannelAddress } from '@grafana/data';
+import { type LiveChannelAddress, isValidLiveChannelAddress, createStructuredLogger } from '@grafana/data';
 import { Trans } from '@grafana/i18n';
 import { getBackendSrv, getGrafanaLiveSrv } from '@grafana/runtime';
 import { CodeEditor, Button } from '@grafana/ui';
 
 import { MessagePublishMode } from './types';
+
+const logger = createStructuredLogger('plugins.panels');
 
 interface Props {
   height: number;
@@ -46,7 +48,7 @@ export function LivePublish({ height, mode, body, addr, onSave }: Props) {
     }
 
     const rsp = await getGrafanaLiveSrv().publish(addr, body);
-    console.log('onPublishClicked (response from publish)', rsp);
+    logger.info('onPublishClicked (response from publish)', rsp);
   };
 
   return (

--- a/public/app/plugins/panel/logs/LogsPanel.tsx
+++ b/public/app/plugins/panel/logs/LogsPanel.tsx
@@ -29,6 +29,7 @@ import {
   rangeUtil,
   transformDataFrame,
   store,
+  createStructuredLogger,
 } from '@grafana/data';
 import { getAppEvents } from '@grafana/runtime';
 import { usePanelContext, useStyles2 } from '@grafana/ui';
@@ -63,6 +64,8 @@ import {
   type onNewLogsReceivedType,
 } from './types';
 import { useDatasourcesFromTargets } from './useDatasourcesFromTargets';
+
+const logger = createStructuredLogger('plugins.panels');
 
 interface LogsPanelProps extends PanelProps<Options> {
   /**
@@ -417,7 +420,7 @@ export const LogsPanel = ({ data, timeZone, fieldConfig, options, onOptionsChang
         }
       } catch (e) {
         errored = true;
-        console.error(e);
+        logger.error(e);
       } finally {
         setLoadMoreState(errored ? LoadingState.Error : LoadingState.Done);
         loadingRef.current = false;
@@ -615,7 +618,7 @@ async function requestMoreLogs(
   for (const uid in targetGroups) {
     const dataSource = dataSourcesMap.get(panelData.request.targets[0].refId);
     if (!dataSource) {
-      console.warn(`Could not resolve data source for target ${panelData.request.targets[0].refId}`);
+      logger.warn(`Could not resolve data source for target ${panelData.request.targets[0].refId}`);
       continue;
     }
     dataRequests.push(

--- a/public/app/plugins/panel/logstable/LogDetailsContext.tsx
+++ b/public/app/plugins/panel/logstable/LogDetailsContext.tsx
@@ -1,7 +1,9 @@
 import { createContext, type ReactNode, useCallback, useContext, useEffect, useState } from 'react';
 
-import { store } from '@grafana/data';
+import { store, createStructuredLogger } from '@grafana/data';
 import { type LogListModel } from 'app/features/logs/components/panel/processing';
+
+const logger = createStructuredLogger('plugins.panels');
 
 export interface LogDetailsContextData {
   currentLog: LogListModel | undefined;
@@ -106,7 +108,7 @@ export const LogDetailsContextProvider = ({
       }
       const log = typeof logRef === 'number' ? logs.at(logRef) : logRef;
       if (!log) {
-        console.error(`LogDetailsContext: undefined log with reference ${logRef}`);
+        logger.error(`LogDetailsContext: undefined log with reference ${logRef}`);
         return;
       }
       const found = showDetails.find((stateLog) => stateLog.uid === log.uid);

--- a/public/app/plugins/panel/logstable/fieldSelector/buildColumnsWithMeta.ts
+++ b/public/app/plugins/panel/logstable/fieldSelector/buildColumnsWithMeta.ts
@@ -1,6 +1,8 @@
-import { type DataFrame, type FieldWithIndex } from '@grafana/data';
+import { type DataFrame, type FieldWithIndex, createStructuredLogger } from '@grafana/data';
 import { type FieldNameMeta, type FieldNameMetaStore } from 'app/features/explore/Logs/LogsTableWrap';
 import { LOG_LINE_BODY_FIELD_NAME } from 'app/features/logs/components/fieldSelector/logFields';
+
+const logger = createStructuredLogger('plugins.panels');
 
 type FieldName = string;
 
@@ -104,7 +106,7 @@ export const buildColumnsWithMeta = (
       pendingLabelState[logsFrameFields.bodyField.name].active = true;
       pendingLabelState[logsFrameFields.bodyField.name].index = idx;
     } else {
-      console.error(`Unknown field ${fieldName}`, { pendingLabelState, displayedFields });
+      logger.error(`Unknown field ${fieldName}`, { pendingLabelState, displayedFields });
     }
   });
 

--- a/public/app/plugins/panel/logstable/hooks/useExtractFields.ts
+++ b/public/app/plugins/panel/logstable/hooks/useExtractFields.ts
@@ -11,12 +11,15 @@ import {
   type TimeZone,
   transformDataFrame,
   useDataLinksContext,
+  createStructuredLogger,
 } from '@grafana/data';
 import { getTemplateSrv } from '@grafana/runtime';
 import { useTheme2 } from '@grafana/ui';
 
 import { getLogsTableFieldConfigRegistry } from '../logsTableFieldConfig';
 import { extractLogsFieldsTransform } from '../transforms/extractLogsFieldsTransform';
+
+const logger = createStructuredLogger('plugins.panels');
 
 interface Props {
   rawTableFrame: DataFrame | null;
@@ -61,7 +64,7 @@ export function useExtractFields({ rawTableFrame, fieldConfig, timeZone, replace
         }
       })
       .catch((err) => {
-        console.error('LogsTable: Extract fields transform error', err);
+        logger.error('LogsTable: Extract fields transform error', err);
       });
   }, [dataLinkPostProcessor, fieldConfig, isMounted, loadingState, rawTableFrame, replaceVariables, theme, timeZone]);
 

--- a/public/app/plugins/panel/logstable/hooks/useOrganizeFields.tsx
+++ b/public/app/plugins/panel/logstable/hooks/useOrganizeFields.tsx
@@ -3,7 +3,7 @@ import { useEffect, useState } from 'react';
 import useMountedState from 'react-use/lib/useMountedState';
 import { lastValueFrom } from 'rxjs';
 
-import { type DataFrame, type FieldConfigSource, transformDataFrame } from '@grafana/data';
+import { type DataFrame, type FieldConfigSource, transformDataFrame, createStructuredLogger } from '@grafana/data';
 import { type CustomCellRendererProps, TableCellDisplayMode } from '@grafana/ui';
 import { type LogsFrame } from 'app/features/logs/logsFrame';
 
@@ -16,6 +16,8 @@ import { getDisplayedFields } from '../options/getDisplayedFields';
 import type { Options as LogsTableOptions } from '../panelcfg.gen';
 import { organizeLogsFieldsTransform } from '../transforms/organizeLogsFieldsTransform';
 import { type BuildLinkToLogLine, isBuildLinkToLogLine } from '../types';
+
+const logger = createStructuredLogger('plugins.panels');
 
 interface Props {
   extractedFrame: DataFrame | null;
@@ -68,7 +70,7 @@ export function useOrganizeFields({
         }
       })
       .catch((err) => {
-        console.error('LogsTable: Organize fields transform error', err);
+        logger.error('LogsTable: Organize fields transform error', err);
       });
   }, [
     bodyFieldName,

--- a/public/app/plugins/panel/logstable/rows/LogsTableRowActionButtons.tsx
+++ b/public/app/plugins/panel/logstable/rows/LogsTableRowActionButtons.tsx
@@ -1,13 +1,15 @@
 import { css } from '@emotion/css';
 import { useCallback } from 'react';
 
-import { type GrafanaTheme2 } from '@grafana/data';
+import { type GrafanaTheme2, createStructuredLogger } from '@grafana/data';
 import { t } from '@grafana/i18n';
 import { ClipboardButton, type CustomCellRendererProps, IconButton, useTheme2 } from '@grafana/ui';
 import { type LogsFrame } from 'app/features/logs/logsFrame';
 
 import { useLogDetailsContext } from '../LogDetailsContext';
 import { type BuildLinkToLogLine } from '../types';
+
+const logger = createStructuredLogger('plugins.panels');
 
 interface Props extends CustomCellRendererProps {
   buildLinkToLog?: BuildLinkToLogLine;
@@ -64,7 +66,7 @@ export function LogsTableRowActionButtons(props: Props) {
                 if (logId) {
                   return buildLinkToLog(logId) ?? '';
                 } else {
-                  console.error('failed to copy log line link!');
+                  logger.error('failed to copy log line link!');
                 }
                 return '';
               }}

--- a/public/app/plugins/panel/news/utils.ts
+++ b/public/app/plugins/panel/news/utils.ts
@@ -1,6 +1,8 @@
-import { FieldType, type DataFrame, dateTime } from '@grafana/data';
+import { FieldType, type DataFrame, dateTime, createStructuredLogger } from '@grafana/data';
 
 import { type Feed } from './types';
+
+const logger = createStructuredLogger('plugins.panels');
 
 export function feedToDataFrame(feed: Feed): DataFrame {
   const date: number[] = [];
@@ -23,7 +25,7 @@ export function feedToDataFrame(feed: Feed): DataFrame {
         content.push(body);
       }
     } catch (err) {
-      console.warn('Error reading news item:', err, item);
+      logger.warn('Error reading news item:', err, item);
     }
   }
 

--- a/public/app/plugins/panel/table/migrations.ts
+++ b/public/app/plugins/panel/table/migrations.ts
@@ -10,6 +10,7 @@ import {
   type DataFrame,
   FieldType,
   ByNamesMatcherMode,
+  createStructuredLogger,
 } from '@grafana/data';
 import { type ReduceTransformerOptions } from '@grafana/data/internal';
 
@@ -20,10 +21,12 @@ import { type Options } from './panelcfg.gen';
  * The models do not match, so this process will delegate to the old implementation when
  * a saved table configuration exists.
  */
+const logger = createStructuredLogger('plugins.panels');
+
 export const tableMigrationHandler = (panel: PanelModel<Options>): Partial<Options> => {
   // Table was saved as an angular table, lets just swap to the 'table-old' panel
   if (!panel.pluginVersion && 'columns' in panel) {
-    console.log('Was angular table', panel);
+    logger.info('Was angular table', panel);
   }
 
   // ensure overrides array exists before applying rest of overrides

--- a/public/app/plugins/panel/timeseries/NullsThresholdInput.tsx
+++ b/public/app/plugins/panel/timeseries/NullsThresholdInput.tsx
@@ -1,8 +1,10 @@
 import * as React from 'react';
 
-import { rangeUtil } from '@grafana/data';
+import { rangeUtil, createStructuredLogger } from '@grafana/data';
 import { t } from '@grafana/i18n';
 import { Input } from '@grafana/ui';
+
+const logger = createStructuredLogger('plugins.panels');
 
 export enum InputPrefix {
   LessThan = 'lessthan',
@@ -31,7 +33,7 @@ export const NullsThresholdInput = ({ value, onChange, inputPrefix, isTime }: Pr
           val = Number(txt);
         }
       } catch (err) {
-        console.warn('ERROR', err);
+        logger.warn('ERROR', err);
       }
     }
     onChange(val);

--- a/public/app/plugins/panel/timeseries/migrations.ts
+++ b/public/app/plugins/panel/timeseries/migrations.ts
@@ -15,6 +15,7 @@ import {
   ReducerID,
   type Threshold,
   ThresholdsMode,
+  createStructuredLogger,
 } from '@grafana/data';
 import {
   LegendDisplayMode,
@@ -44,6 +45,8 @@ import { type GrafanaQuery, GrafanaQueryType } from 'app/plugins/datasource/graf
 
 import { defaultGraphConfig } from './config';
 import { type Options } from './panelcfg.gen';
+
+const logger = createStructuredLogger('plugins.panels');
 
 let dashboardRefreshDebouncer: ReturnType<typeof setTimeout> | null = null;
 
@@ -283,7 +286,7 @@ function graphToTimeseriesOptions(angular: any): {
             });
             break;
           default:
-            console.log('Ignore override migration:', seriesOverride.alias, p, v);
+            logger.info('Ignore override migration:', seriesOverride.alias, p, v);
         }
       }
       if (dashOverride) {

--- a/public/app/plugins/panel/timeseries/plugins/AnnotationsPlugin.tsx
+++ b/public/app/plugins/panel/timeseries/plugins/AnnotationsPlugin.tsx
@@ -4,7 +4,7 @@ import { createPortal } from 'react-dom';
 import tinycolor from 'tinycolor2';
 import uPlot from 'uplot';
 
-import { colorManipulator, type DataFrame, type InterpolateFunction } from '@grafana/data';
+import { colorManipulator, type DataFrame, type InterpolateFunction, createStructuredLogger } from '@grafana/data';
 import { type TimeZone, type VizAnnotations } from '@grafana/schema';
 import {
   DEFAULT_ANNOTATION_COLOR,
@@ -28,6 +28,8 @@ import {
   shouldRenderAnnotationLine,
   shouldRenderAnnotationRegion,
 } from './utils';
+
+const logger = createStructuredLogger('plugins.panels');
 
 interface AnnotationsPluginProps {
   config: UPlotConfigBuilder;
@@ -200,7 +202,7 @@ export const AnnotationsPlugin = ({
                   try {
                     ctx.fillStyle = colorManipulator.alpha(color, regionOpacity ?? 0.1);
                   } catch (e) {
-                    console.error(`Invalid color: ${color}.`, e);
+                    logger.error(`Invalid color: ${color}.`, e);
                     ctx.fillStyle = colorManipulator.alpha(DEFAULT_ANNOTATION_COLOR_HEX8, regionOpacity ?? 0.1);
                   }
 

--- a/public/app/plugins/panel/timeseries/plugins/annotations/useAnnotationClustering.tsx
+++ b/public/app/plugins/panel/timeseries/plugins/annotations/useAnnotationClustering.tsx
@@ -1,11 +1,13 @@
 import { useMemo } from 'react';
 import uPlot from 'uplot';
 
-import { type DataFrame, FieldType } from '@grafana/data';
+import { type DataFrame, FieldType, createStructuredLogger } from '@grafana/data';
 import { maybeSortFrame } from '@grafana/data/internal';
 import { type TimeRange2 } from '@grafana/ui/internal';
 
 import { DEFAULT_CLUSTERING_ANNOTATION_SPACING } from './constants';
+
+const logger = createStructuredLogger('plugins.panels');
 
 interface Props {
   annotations: DataFrame[];
@@ -120,7 +122,7 @@ export const useAnnotationClustering = ({ annotations, clusteringMode, plotWidth
       }
     } else if (clusteringMode === ClusteringMode.Hover) {
       // Have the tooltip be clustered, but not the annotations: https://github.com/grafana/grafana/issues/119436
-      console.warn('Hover mode not implemented');
+      logger.warn('Hover mode not implemented');
     }
 
     // Sort clustered frames

--- a/public/boot/index.ts
+++ b/public/boot/index.ts
@@ -1,5 +1,13 @@
 import { type Display } from '@grafana/api-clients/rtkq/iam/v0alpha1';
-import { type OrgRole, type CurrentUserDTO, type GrafanaConfig, type NavLinkDTO } from '@grafana/data';
+import {
+  type OrgRole,
+  type CurrentUserDTO,
+  type GrafanaConfig,
+  type NavLinkDTO,
+  createStructuredLogger,
+} from '@grafana/data';
+
+const logger = createStructuredLogger('boot');
 
 const publicDashboardAccessToken = window.__grafanaPublicDashboardAccessToken;
 // Grafana can only fail to load once
@@ -11,7 +19,7 @@ window.__grafana_load_failed = function (err: unknown) {
     return;
   }
   hasFailedToBoot = true;
-  console.error('Failed to load Grafana', err);
+  logger.error('Failed to load Grafana', err);
   document.querySelector('.fs-variant-loader')?.classList.add('fs-hidden');
   document.querySelector('.fs-variant-error')?.classList.remove('fs-hidden');
 
@@ -23,7 +31,7 @@ window.__grafana_load_failed = function (err: unknown) {
     method: 'GET',
     cache: 'no-store',
   }).catch((err) => {
-    console.error('Failed to report boot error to backend: ', err);
+    logger.error('Failed to report boot error to backend: ', err);
   });
 };
 
@@ -98,7 +106,7 @@ async function rotateExpiredSession() {
     }
     // Just ignore any errors in session rotation. The user can just log in again.
   } catch (error) {
-    console.warn('Failed to rotate session', error);
+    logger.warn('Failed to rotate session', error);
   }
 }
 
@@ -340,6 +348,6 @@ window.__grafana_boot_data_promise.catch((err) => {
     return;
   }
 
-  console.error('__grafana_boot_data_promise rejected', err);
+  logger.error('__grafana_boot_data_promise rejected', err);
   window.__grafana_load_failed(err);
 });

--- a/public/swagger/K8sNameLookup.tsx
+++ b/public/swagger/K8sNameLookup.tsx
@@ -1,9 +1,11 @@
 import { useEffect, useState } from 'react';
 
-import { type SelectableValue } from '@grafana/data';
+import { type SelectableValue, createStructuredLogger } from '@grafana/data';
 import { Select } from '@grafana/ui';
 
 import { NamespaceContext, ResourceContext } from './plugins';
+
+const logger = createStructuredLogger('features.app');
 
 type Props = {
   value?: string;
@@ -41,12 +43,12 @@ export function K8sNameLookup(props: Props) {
           },
         });
         if (!response.ok) {
-          console.warn('error loading names');
+          logger.warn('error loading names');
           setLoading(false);
           return;
         }
         const table = await response.json();
-        console.log('LIST', url, table);
+        logger.info('LIST', url, table);
         const options: Array<SelectableValue<string>> = [];
         if (table.rows?.length) {
           for (const row of table.rows) {

--- a/public/swagger/SwaggerPage.tsx
+++ b/public/swagger/SwaggerPage.tsx
@@ -4,7 +4,7 @@ import { useState } from 'react';
 import { useAsync } from 'react-use';
 import SwaggerUI from 'swagger-ui-react';
 
-import { createTheme, monacoLanguageRegistry, type SelectableValue } from '@grafana/data';
+import { createTheme, monacoLanguageRegistry, type SelectableValue, createStructuredLogger } from '@grafana/data';
 import { Trans } from '@grafana/i18n';
 import { getFeatureFlagClient } from '@grafana/runtime/internal';
 import { Icon, Stack, Select, UserIcon, type UserView, Button } from '@grafana/ui';
@@ -12,6 +12,8 @@ import { setMonacoEnv } from 'app/core/monacoEnv';
 import { ThemeProvider } from 'app/core/utils/ConfigProvider';
 
 import { NamespaceContext, WrappedPlugins } from './plugins';
+
+const logger = createStructuredLogger('features.app');
 
 export const Page = () => {
   const theme = createTheme({ colors: { mode: 'light' } });
@@ -57,7 +59,7 @@ export const Page = () => {
   const namespace = useAsync(async () => {
     const response = await fetch('api/frontend/settings');
     if (!response.ok) {
-      console.warn('No settings found');
+      logger.warn('No settings found');
       return 'default';
     }
     const val = await response.json();
@@ -67,7 +69,7 @@ export const Page = () => {
   useAsync(async () => {
     const response = await fetch('api/user');
     if (!response.ok) {
-      console.warn('No user found, show login button');
+      logger.warn('No user found, show login button');
       return;
     }
     const val = await response.json();

--- a/public/swagger/plugins.tsx
+++ b/public/swagger/plugins.tsx
@@ -5,6 +5,10 @@ import { CodeEditor, type Monaco } from '@grafana/ui';
 import { K8sNameLookup } from './K8sNameLookup';
 
 // swagger does not have types
+import { createStructuredLogger } from '@grafana/data';
+
+const logger = createStructuredLogger('features.app');
+
 interface UntypedProps {
   [k: string]: any;
 }
@@ -63,7 +67,7 @@ export const WrappedPlugins = function () {
           if (mime) {
             v = mime.get('schema').toJS();
           }
-          console.log('RequestBody', v, mime, props);
+          logger.info('RequestBody', v, mime, props);
         }
         // console.log('RequestBody PROPS', props);
         return (
@@ -75,7 +79,7 @@ export const WrappedPlugins = function () {
 
       modelExample: (Original: React.ElementType) => (props: UntypedProps) => {
         if (props.isExecute && props.schema) {
-          console.log('modelExample PROPS', props);
+          logger.info('modelExample PROPS', props);
           return (
             <SchemaContext.Provider value={props.schema.toJS()}>
               <Original {...props} />
@@ -128,7 +132,7 @@ export const WrappedPlugins = function () {
                     },
                   });
                 };
-                console.log('CodeEditor', schema);
+                logger.info('CodeEditor', schema);
 
                 return (
                   <CodeEditor


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
**What is this feature?**

Replaces production `console.log` / `console.warn` / `console.error` / `console.info` / `console.debug` call sites with a structured logger that records **level**, **source**, **message**, and **context**.

The API is `createStructuredLogger(source)` from `@grafana/data`. After `initializeLoggersRegistry()`, those records are also forwarded to Faro via the existing `grafana.frontend` monitoring logger. Browser output still goes through a default console sink so developers keep readable logs.

**Why do we need this feature?**

Ad-hoc `console.*` calls have no source tag, no stable context shape, and never reach Faro. A single logger API makes frontend logs searchable and keeps Faro and the browser console in sync.

**Who is this feature for?**

Grafana core developers and anyone debugging or ingesting frontend logs.

**Which issue(s) does this PR fix?**:

Fixes #

**Special notes for your reviewer:**

- Console remains only in logging sinks (`createStructuredLogger` default sink, Faro `logToConsole`, logger registry bootstrap warnings), CLI/build scripts, Storybook stories, E2E/unit test helpers, and `BrowseConsoleBackend` (its job is to print Echo events).
- `@grafana/i18n` cannot import `@grafana/data` (cycle), so it has a small local logger with the same `{ source }` payload shape.
- `console.groupCollapsed` / `console.groupEnd` in performance profiling are unchanged; they are grouping APIs, not log lines.
- Tests that asserted exact `console.*` arguments now also expect `{ source }`.

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a notable improvement, it's added to our What's New doc.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6541f420-f847-44ef-b48a-361ce1d9c32d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6541f420-f847-44ef-b48a-361ce1d9c32d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

